### PR TITLE
Remove redundant calls to `unittest.main`

### DIFF
--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -52,11 +52,3 @@ class MatmulTests(unittest.TestCase):
                                   [7.8, 8.9]]))
         self.assertTrue(syft.equal(syft.matmul(t1, t2), [[27.04, 30.7],
                                                          [54.82, 62.15]]))
-
-
-def main():
-    unittest.main()
-
-
-if __name__ == '__main__':
-    main()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -146,10 +146,3 @@ class addmm(unittest.TestCase):
         mat=TensorBase(np.array([[2,3],[3,4]]))
         t1.addmm_(t2,mat,beta=2,alpha=2)
         self.assertTrue(np.array_equal(t1.data,[[10,18],[12,20]]))
-
-def main():
-    unittest.main()
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Since we are invoking `pytest` which will use it's own test runner, we don't
need these declarations.