### PR TITLE
Add Makefile for ease of use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test run
+
+test:
+	pytest
+
+run:
+	docker run --rm -it -v $(PWD)/notebooks:/notebooks -w /notebooks -p 8888:8888 openmined/pysyft jupyter notebook --ip=0.0.0.0 --allow-root

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Then, run:
 
 ```sh
 git clone https://github.com/OpenMined/PySyft.git
-cd PySyft/notebooks/
-docker run --rm -it -v $PWD:/notebooks -w /notebooks -p 8888:8888 openmined/pysyft jupyter notebook --ip=0.0.0.0 --allow-root
+cd PySyft
+make run
 ```
 
 ## For Contributors


### PR DESCRIPTION
I find it convenient to jump into any repo and use `make test` and `make run`,
this makes it easy for new contributors as well.

Only caveat is that I don't know the Windows OS situation for using `make`.