### PR TITLE
Fix indentation & name

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -182,16 +182,12 @@ class TensorBase(object):
         else:
             return self.data.sum(axis=dim)
 
-
-  def ceil(self):
-    """Returns the ceilling of the input tensor elementwise."""
-    
+    def ceil(self):
+        """Returns the ceilling of the input tensor elementwise."""
         if self.encrypted:
             return NotImplemented
         return np.ceil(self.data)
 
-
-     
     def addmm(self,tensor2,mat,beta=1,alpha=1):
         """Performs ((Mat*Beta)+((Tensor1.Tensor2)*Alpha)) and  returns the result as a Tensor
             Tensor1.Tensor2 is performed as Matrix product of two array The behavior depends on the arguments in the following way.

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -28,7 +28,7 @@ class AddTests(unittest.TestCase):
 class CeilTests(unittest.TestCase):
     def testCeil(self):
         t = TensorBase(np.array([1.4,2.7,6.2]))
-        self.assertTrue(syft.equal(t.ceil_(),[2,3,7]))
+        self.assertTrue(syft.equal(t.ceil(),[2,3,7]))
 
 
 class SubTests(unittest.TestCase):


### PR DESCRIPTION
Tests were failing:

```
$ git clone -b develop https://github.com/OpenMined/PySyft.git PySyftclean && cd PySyftclean && pytest
Cloning into 'PySyftclean'...
remote: Counting objects: 792, done.
remote: Compressing objects: 100% (60/60), done.
remote: Total 792 (delta 48), reused 61 (delta 25), pack-reused 707
Receiving objects: 100% (792/792), 756.57 KiB | 1.04 MiB/s, done.
Resolving deltas: 100% (429/429), done.
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
rootdir: /Users/swaroop/personal/openmined/PySyftclean, inifile:
collected 0 items / 2 errors

=========================================================================== ERRORS ============================================================================
_____________________________________________________________ ERROR collecting tests/test_math.py _____________________________________________________________
../../../anaconda/envs/openmined/lib/python3.6/site-packages/_pytest/python.py:395: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
../../../anaconda/envs/openmined/lib/python3.6/site-packages/py/_path/local.py:662: in pyimport
    __import__(modname)
<frozen importlib._bootstrap>:961: in _find_and_load
    ???
<frozen importlib._bootstrap>:950: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:646: in _load_unlocked
    ???
<frozen importlib._bootstrap>:616: in _load_backward_compatible
    ???
../../../anaconda/envs/openmined/lib/python3.6/site-packages/_pytest/assertion/rewrite.py:212: in load_module
    py.builtin.exec_(co, mod.__dict__)
tests/test_math.py:5: in <module>
    import syft
../PySyft/syft/__init__.py:1: in <module>
    from .tensor import *
E     File "/Users/swaroop/personal/openmined/PySyft/syft/tensor.py", line 186
E       def ceil(self):
E                     ^
E   IndentationError: unindent does not match any outer indentation level
____________________________________________________________ ERROR collecting tests/test_tensor.py ____________________________________________________________
../../../anaconda/envs/openmined/lib/python3.6/site-packages/_pytest/python.py:395: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
../../../anaconda/envs/openmined/lib/python3.6/site-packages/py/_path/local.py:662: in pyimport
    __import__(modname)
<frozen importlib._bootstrap>:961: in _find_and_load
    ???
<frozen importlib._bootstrap>:950: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:646: in _load_unlocked
    ???
<frozen importlib._bootstrap>:616: in _load_backward_compatible
    ???
../../../anaconda/envs/openmined/lib/python3.6/site-packages/_pytest/assertion/rewrite.py:212: in load_module
    py.builtin.exec_(co, mod.__dict__)
tests/test_tensor.py:1: in <module>
    from syft import TensorBase
../PySyft/syft/__init__.py:1: in <module>
    from .tensor import *
E     File "/Users/swaroop/personal/openmined/PySyft/syft/tensor.py", line 186
E       def ceil(self):
E                     ^
E   IndentationError: unindent does not match any outer indentation level
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=================================================================== 2 error in 0.39 seconds ===================================================================
```