### PR TITLE
CI setup: automated docker build, tests, and docker image hosting (issue #119)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,12 @@ jobs:
       - deploy:
           name: Push application Docker image
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               docker login -e "${DOCKERHUB_EMAIL}" -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
-              docker tag pysyft "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-              docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+              docker tag pysyft "${DOCKERHUB_REPO}:edge"
+              docker push "${DOCKERHUB_REPO}:edge"
+            elif [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login -e "${DOCKERHUB_EMAIL}" -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
+              docker tag pysyft "${DOCKERHUB_REPO}:latest"
+              docker push "${DOCKERHUB_REPO}:latest"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            docker run -it pysyft pytest tests/test_tensor.py
+            docker run -it pysyft pytest && py.test --flake8
       - deploy:
           name: Push application Docker image
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:edge
 RUN ["apk", "add", "--no-cache", "python3", "python3-dev", "musl-dev", "linux-headers", "g++", "gmp-dev", "mpfr-dev", "mpc1-dev", "ca-certificates"]
 
-RUN ["mkdir", "/syft"]
-COPY requirements.txt /syft
+RUN ["mkdir", "/PySyft"]
+COPY requirements.txt /PySyft
 
-WORKDIR /syft
+WORKDIR /PySyft
 RUN ["pip3", "install", "-r", "requirements.txt"]
-COPY . /syft
+COPY . /PySyft
 RUN ["python3", "setup.py", "install"]

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     scripts=['bin/syft_cmd'],
     install_requires=requirements,
     setup_requires=['pytest-runner'],
-    tests_require=['pytest']
+    tests_require=['pytest', 'pytest-flake8']
 )


### PR DESCRIPTION
Fixes #119

Next steps:

- You'll need to go to https://circleci.com/vcs-authorize/ and sign in with an GitHub account that is admin on the PySyft repository, and follow instruction in the UI to enable CI for the PySyft project.

- Once done, you need to store the dockerhub environment variables into the circleci UI under the project settings.

- You can see a preview of what the result look like [here.](https://circleci.com/gh/cypherai/PySyft/9?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). Tests are currently failing because of the indentation error (see PR #149).