### PR TITLE
Implemented default rsqrt functionality for BaseTensor object#90

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -457,3 +457,16 @@ class TensorBase(object):
 
     def __repr__(self):
         return repr(self.data)
+
+    def rsqrt(self):
+        """Returns reciprocal of square root of Tensor element wise"""
+        if self.encrypted:
+            return NotImplemented
+        out = 1/np.sqrt(self.data)
+        return TensorBase(out)
+
+    def rsqrt_(self):
+        """Computes reciprocal of square root of Tensor elements inplace"""
+        if self.encrypted:
+            return NotImplemented
+        self.data = 1/np.sqrt(self.data)

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -462,11 +462,11 @@ class TensorBase(object):
         """Returns reciprocal of square root of Tensor element wise"""
         if self.encrypted:
             return NotImplemented
-        out = 1/np.sqrt(self.data)
+        out = 1 / np.sqrt(self.data)
         return TensorBase(out)
 
     def rsqrt_(self):
         """Computes reciprocal of square root of Tensor elements inplace"""
         if self.encrypted:
             return NotImplemented
-        self.data = 1/np.sqrt(self.data)
+        self.data = 1 / np.sqrt(self.data)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -317,3 +317,15 @@ class fracTests(unittest.TestCase):
         t3 = TensorBase(np.array([1.23, 4.56, 7.89]))
         t3.frac_()
         self.assertTrue(np.allclose(t3.data, [0.23, 0.56, 0.89]))
+        
+
+class rsqrtTests(unittest.TestCase):
+    def testrsqrt(self):
+        t1 = TensorBase(np.array([2, 3, 4]))
+        out = t1.rsqrt()
+        self.assertTrue(np.array_equal(out.data, [ 0.70710678,  0.57735027,  0.5       ]))
+
+    def testrsqrt_(self):
+        t1 = TensorBase(np.array([2, 3, 4]))
+        t1.rsqrt_()
+        self.assertTrue(np.array_equal(t1.data, [ 0.70710678,  0.57735027,  0.5       ]))

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -323,9 +323,9 @@ class rsqrtTests(unittest.TestCase):
     def testrsqrt(self):
         t1 = TensorBase(np.array([2, 3, 4]))
         out = t1.rsqrt()
-        self.assertTrue(np.array_equal(out.data, [ 0.70710678,  0.57735027,  0.5       ]))
+        self.assertTrue(np.allclose(out.data, [ 0.70710678,  0.57735027,  0.5       ]))
 
     def testrsqrt_(self):
         t1 = TensorBase(np.array([2, 3, 4]))
         t1.rsqrt_()
-        self.assertTrue(np.array_equal(t1.data, [ 0.70710678,  0.57735027,  0.5       ]))
+        self.assertTrue(np.allclose(t1.data, [ 0.70710678,  0.57735027,  0.5       ]))

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -317,15 +317,15 @@ class fracTests(unittest.TestCase):
         t3 = TensorBase(np.array([1.23, 4.56, 7.89]))
         t3.frac_()
         self.assertTrue(np.allclose(t3.data, [0.23, 0.56, 0.89]))
-        
+
 
 class rsqrtTests(unittest.TestCase):
     def testrsqrt(self):
         t1 = TensorBase(np.array([2, 3, 4]))
         out = t1.rsqrt()
-        self.assertTrue(np.allclose(out.data, [ 0.70710678,  0.57735027,  0.5       ]))
+        self.assertTrue(np.allclose(out.data, [0.70710678, 0.57735027, 0.5]))
 
     def testrsqrt_(self):
         t1 = TensorBase(np.array([2, 3, 4]))
         t1.rsqrt_()
-        self.assertTrue(np.allclose(t1.data, [ 0.70710678,  0.57735027,  0.5       ]))
+        self.assertTrue(np.allclose(t1.data, [0.70710678, 0.57735027, 0.5]))


### PR DESCRIPTION
1. added rsqrt() and rsqrt_() in syft/tensor.py
2. added class rsqrtTests() in tests/test_tensor.py