### PR TITLE
Added split, squeeze and expand_as functions for TensorBase #97, #99 and #42

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -807,3 +807,21 @@ class TensorBase(object):
             return NotImplemented
         else:
             return self.data.size
+        
+    def split(self, split_size, dim=0):
+        """Returns tuple of tensors of equally sized tensor/chunks (if possible)"""
+        if self.encrypted:
+            return NotImplemented
+        splits = np.array_split(self.data, split_size, axis=0)
+        tensors = list()
+        for s in splits: 
+            tensors.append(TensorBase(s))
+        tensors_tuple = tuple(tensors)
+        return tensors_tuple
+    
+    def squeeze(self, axis=None):
+        """Returns a new tensor with all the single-dimensional entries removed"""
+        if self.encrypted:
+            return NotImplemented
+        out = np.squeeze(self.data, axis=axis)
+        return TensorBase(out)

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -807,18 +807,18 @@ class TensorBase(object):
             return NotImplemented
         else:
             return self.data.size
-        
+
     def split(self, split_size, dim=0):
         """Returns tuple of tensors of equally sized tensor/chunks (if possible)"""
         if self.encrypted:
             return NotImplemented
         splits = np.array_split(self.data, split_size, axis=0)
         tensors = list()
-        for s in splits: 
+        for s in splits:
             tensors.append(TensorBase(s))
         tensors_tuple = tuple(tensors)
         return tensors_tuple
-    
+
     def squeeze(self, axis=None):
         """Returns a new tensor with all the single-dimensional entries removed"""
         if self.encrypted:

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -825,3 +825,14 @@ class TensorBase(object):
             return NotImplemented
         out = np.squeeze(self.data, axis=axis)
         return TensorBase(out)
+
+    def expand_as(self, tensor):
+        """Returns a new tensor with the expanded size as of the specified (input) tensor"""
+        if self.encrypted:
+            return NotImplemented
+        shape = tensor.data.shape
+        neg_shapes = np.where(shape == -1)[0]
+        if len(neg_shapes) > 1:
+            shape[neg_shapes] = self.data.shape[neg_shapes]
+        out = np.broadcast_to(self.data, shape)
+        return TensorBase(out)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -630,5 +630,13 @@ class squeezeTests(unittest.TestCase):
         self.assertTrue(np.array_equal(t2.data, np.array([[[0., 0.], [0., 0.]], [[0., 0.], [0., 0.]]])))
 
 
+class expandAsTests(unittest.TestCase):
+    def testExpandAs(self):
+        t1 = TensorBase(np.array([[1], [2], [3]]))
+        t2 = TensorBase(np.zeros((3, 4)))
+        t3 = t1.expand_as(t2)
+        self.assertTrue(np.array_equal(t2.data.shape, t3.data.shape))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -625,9 +625,10 @@ class splitTests(unittest.TestCase):
 
 class squeezeTests(unittest.TestCase):
     def testSqueeze(self):
-        t1 = TensorBase(np.zeros((2,1,2,1,2)))
+        t1 = TensorBase(np.zeros((2, 1, 2, 1, 2)))
         t2 = t1.squeeze()
         self.assertTrue(np.array_equal(t2.data, np.array([[[0., 0.], [0., 0.]], [[0., 0.], [0., 0.]]])))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -616,5 +616,18 @@ class nonzeroTests(unittest.TestCase):
         self.assertTrue(np.array_equal(t2.data, np.array([[0, 1, 1], [0, 1, 2]])))
 
 
+class splitTests(unittest.TestCase):
+    def testSplit(self):
+        t1 = TensorBase(np.arange(8.0))
+        t2 = t1.split(4)
+        self.assertTrue(np.array_equal(t2, tuple((np.array([0., 1.]), np.array([2., 3.]), np.array([4., 5.]), np.array([6., 7.])))))
+
+
+class squeezeTests(unittest.TestCase):
+    def testSqueeze(self):
+        t1 = TensorBase(np.zeros((2,1,2,1,2)))
+        t2 = t1.squeeze()
+        self.assertTrue(np.array_equal(t2.data, np.array([[[0., 0.], [0., 0.]], [[0., 0.], [0., 0.]]])))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added implementation of split, squeeze and expand_as functions for TensorBase along with tests.