### PR TITLE
Implement TensorBase eq()/eq_() functionality with tests

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -1200,6 +1200,21 @@ class TensorBase(object):
         out_flat = [s if m == 0 else source_iter.__next__().item() for m, s in mask_self_iter]
         self.data = np.reshape(out_flat, self.data.shape)
 
+    def eq(self, t):
+        """Returns a new Tensor having boolean True values where an element of the calling tensor is equal to the second Tensor, False otherwise.
+        The second Tensor can be a number or a tensor whose shape is broadcastable with the calling Tensor."""
+        if self.encrypted:
+            return NotImplemented
+        return TensorBase(np.equal(self.data, _ensure_tensorbase(t).data))
+
+    def eq_(self, t):
+        """Writes in-place, boolean True values where an element of the calling tensor is equal to the second Tensor, False otherwise.
+        The second Tensor can be a number or a tensor whose shape is broadcastable with the calling Tensor."""
+        if self.encrypted:
+            return NotImplemented
+        self.data = np.equal(self.data, _ensure_tensorbase(t).data)
+        return self
+
 
 def mv(tensormat, tensorvector):
     """ matrix and vector multiplication """

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -908,5 +908,29 @@ class masked_scatter_Tests(unittest.TestCase):
         self.assertTrue(np.array_equal(t, TensorBase([[1, 2, 3], [1, 1, 1]])))
 
 
+class eqTests(unittest.TestCase):
+    def testEqWithTensor(self):
+        t1 = TensorBase(np.arange(5))
+        t2 = TensorBase(np.arange(5)[-1::-1])
+        truth_values = t1.eq(t2)
+        self.assertEqual(truth_values, [False, False, True, False, False])
+
+    def testEqWithNumber(self):
+        t1 = TensorBase(np.arange(5))
+        truth_values = t1.eq(1)
+        self.assertEqual(truth_values, [False, True, False, False, False])
+
+    def testEqInPlaceWithTensor(self):
+        t1 = TensorBase(np.arange(5))
+        t2 = TensorBase(np.arange(5)[-1::-1])
+        t1.eq_(t2)
+        self.assertEqual(t1, [False, False, True, False, False])
+
+    def testEqInPlaceWithNumber(self):
+        t1 = TensorBase(np.arange(5))
+        t1.eq_(1)
+        self.assertEqual(t1, [False, True, False, False, False])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes #39.
It has the same structure than the already implemented gt()/gt_() operation.