### PR TITLE
Serialize Public key Secret key with pickle

### DIFF
--- a/syft/he/paillier/keys.py
+++ b/syft/he/paillier/keys.py
@@ -47,9 +47,9 @@ class SecretKey(AbstractSecretKey):
         seckey_dict = pickle.loads(b)
         sk_record = seckey_dict['secret_key']
         sk = paillier.PaillierPrivateKey(
-                public_key=paillier.PaillierPublicKey(n=int(sk_record['n'])),
-                p=sk_record['p'],
-                q=sk_record['q'])
+            public_key=paillier.PaillierPublicKey(n=int(sk_record['n'])),
+            p=sk_record['p'],
+            q=sk_record['q'])
         return SecretKey(sk)
 
 

--- a/syft/he/paillier/keys.py
+++ b/syft/he/paillier/keys.py
@@ -37,15 +37,20 @@ class SecretKey(AbstractSecretKey):
     def serialize(self):
         seckey_dict = {}
         seckey_dict['secret_key'] = {
-            'n': self.sk.n
+            'p': self.sk.p,
+            'q': self.sk.q,
+            'n': self.sk.public_key.n
         }
         return pickle.dumps(seckey_dict)
 
     def deserialize(b):
         seckey_dict = pickle.loads(b)
         sk_record = seckey_dict['secret_key']
-        sk = paillier.PaillierPublicKey(n=int(sk_record['n']))
-        return PublicKey(sk)
+        sk = paillier.PaillierPrivateKey(
+                public_key=paillier.PaillierPublicKey(n=int(sk_record['n'])),
+                p=sk_record['p'],
+                q=sk_record['q'])
+        return SecretKey(sk)
 
 
 class PublicKey(AbstractPublicKey):

--- a/syft/he/paillier/keys.py
+++ b/syft/he/paillier/keys.py
@@ -1,6 +1,6 @@
 import phe as paillier
 import numpy as np
-import pickle
+import json
 import syft
 from .basic import Float, PaillierTensor
 from ...tensor import TensorBase
@@ -41,10 +41,10 @@ class SecretKey(AbstractSecretKey):
             'q': self.sk.q,
             'n': self.sk.public_key.n
         }
-        return pickle.dumps(seckey_dict)
+        return json.dumps(seckey_dict)
 
     def deserialize(b):
-        seckey_dict = pickle.loads(b)
+        seckey_dict = json.loads(b)
         sk_record = seckey_dict['secret_key']
         sk = paillier.PaillierPrivateKey(
             public_key=paillier.PaillierPublicKey(n=int(sk_record['n'])),
@@ -108,10 +108,10 @@ class PublicKey(AbstractPublicKey):
         pubkey_dict['public_key'] = {
             'n': self.pk.n
         }
-        return pickle.dumps(pubkey_dict)
+        return json.dumps(pubkey_dict)
 
     def deserialize(b):
-        pubkey_dict = pickle.loads(b)
+        pubkey_dict = json.loads(b)
         pk_record = pubkey_dict['public_key']
         pk = paillier.PaillierPublicKey(n=int(pk_record['n']))
         return PublicKey(pk)

--- a/syft/he/paillier/keys.py
+++ b/syft/he/paillier/keys.py
@@ -35,10 +35,17 @@ class SecretKey(AbstractSecretKey):
             return NotImplemented
 
     def serialize(self):
-        return pickle.dumps(self.sk)
+        seckey_dict = {}
+        seckey_dict['secret_key'] = {
+            'n': self.sk.n
+        }
+        return pickle.dumps(seckey_dict)
 
     def deserialize(b):
-        return SecretKey(pickle.loads(b))
+        seckey_dict = pickle.loads(b)
+        sk_record = seckey_dict['secret_key']
+        sk = paillier.PaillierPublicKey(n=int(sk_record['n']))
+        return PublicKey(sk)
 
 
 class PublicKey(AbstractPublicKey):
@@ -92,10 +99,17 @@ class PublicKey(AbstractPublicKey):
         return self.pk.encrypt(x)
 
     def serialize(self):
-        return pickle.dumps(self.pk)
+        pubkey_dict = {}
+        pubkey_dict['public_key'] = {
+            'n': self.pk.n
+        }
+        return pickle.dumps(pubkey_dict)
 
     def deserialize(b):
-        return PublicKey(pickle.loads(b))
+        pubkey_dict = pickle.loads(b)
+        pk_record = pubkey_dict['public_key']
+        pk = paillier.PaillierPublicKey(n=int(pk_record['n']))
+        return PublicKey(pk)
 
 
 class KeyPair(AbstractKeyPair):
@@ -104,8 +118,8 @@ class KeyPair(AbstractKeyPair):
         ""
 
     def deserialize(self, pubkey, seckey):
-        self.public_key = PublicKey(pickle.loads(pubkey))
-        self.secret_key = SecretKey(pickle.loads(seckey))
+        self.public_key = PublicKey.deserialize(pubkey)
+        self.secret_key = SecretKey.deserialize(seckey)
         return (self.public_key, self.secret_key)
 
     def generate(self, n_length=1024):

--- a/tests/test_paillier.py
+++ b/tests/test_paillier.py
@@ -187,3 +187,17 @@ class DivTests(unittest.TestCase):
 
         x /= 2
         self.assertTrue(s.decrypt(x) == np.array([1, 2, 3, 4, 5.]))
+
+
+class SerializeTest(unittest.TestCase):
+
+    def test_serialize(self):
+        pubkey, seckey = KeyPair().generate()
+
+        pk_serialized = pubkey.serialize()
+        sk_serialized = seckey.serialize()
+
+        pubkey2, seckey2 = KeyPair().deserialize(pk_serialized,
+                                                 sk_serialized)
+        self.assertTrue(pubkey.pk == pubkey2.pk and \
+                        seckey.sk == seckey2.sk)

--- a/tests/test_paillier.py
+++ b/tests/test_paillier.py
@@ -199,5 +199,5 @@ class SerializeTest(unittest.TestCase):
 
         pubkey2, seckey2 = KeyPair().deserialize(pk_serialized,
                                                  sk_serialized)
-        self.assertTrue(pubkey.pk == pubkey2.pk and \
+        self.assertTrue(pubkey.pk == pubkey2.pk and
                         seckey.sk == seckey2.sk)


### PR DESCRIPTION
**Added Serialization to Public and Secret keys.** 

**serialize()** in **PublicKey** class creates a dictionary taking n value of the key and pickles the dictionary.
**deserialize()** in **PublicKey** class loads the pickled dictionary taking n value out of it and create a new phe.PaillierPublicKey using the n value.

**serialize()** in **SecretKey** class creates a dictionary taking p, q value of the key and n value of the public key and pickles the dictionary.
**deserialize()** in **SecretKey** class loads the pickled dictionary taking the p, q, and n value out of it and create a new phe.PaillierPrivateKey as follows:
`k = paillier.PaillierPrivateKey(
                public_key=paillier.PaillierPublicKey(n=int(sk_record['n'])),
                p=sk_record['p'],
                q=sk_record['q'])
`

PS: This is my first PR on any project. I know there might be issues. Let me know if any comes in this one :)