### PR TITLE
add PEP8 style pytest in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test run local
 
 test:
-	pytest
+	pytest && pytest --flake8
 run:
 	docker run --rm -it -v $(PWD)/notebooks:/notebooks -w /notebooks -p 8888:8888 openmined/pysyft jupyter notebook --ip=0.0.0.0 --allow-root
 custom:


### PR DESCRIPTION
While #270 is being reviewed I think it's important/urgent to have a `make test` consistent with Travis.