### PR TITLE
only docker needed as dependency 

### DIFF
--- a/Development-Dockerfile
+++ b/Development-Dockerfile
@@ -1,11 +1,23 @@
-FROM alpine:edge
-RUN ["apk", "add", "--no-cache", "python3", "python3-dev", "musl-dev", "linux-headers", "g++", "gmp-dev", "mpfr-dev", "mpc1-dev", "ca-certificates", "openblas-dev", "gfortran"]
+FROM openmined/pysyft:edge
 
-RUN ["mkdir", "/PySyft"]
-COPY requirements.txt /PySyft
+RUN apk add --no-cache git
 
-WORKDIR /PySyft
-RUN ["pip3", "install", "-r", "requirements.txt"]
-COPY . /PySyft
-RUN ["python3", "setup.py", "install"]
-RUN ["pip3", "install", "jupyter"]
+
+ENV PYSYFT_DIR /src/PySyft
+ENV CAPSULE_DIR /src/Capsule
+
+
+## Capsule dependency
+
+RUN mkdir $CAPSULE_DIR
+WORKDIR $CAPSULE_DIR
+RUN git clone https://github.com/OpenMined/Capsule.git .
+RUN pip3 install -r requirements.txt
+RUN python3 setup.py install
+
+## PySyft Dependency
+WORKDIR $PYSYFT_DIR
+
+EXPOSE 8888
+
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
 FROM alpine:edge
-RUN ["apk", "add", "--no-cache", "python3", "python3-dev", "musl-dev", "linux-headers", "g++", "gmp-dev", "mpfr-dev", "mpc1-dev", "ca-certificates", "openblas-dev", "gfortran"]
+RUN apk add --no-cache python3 python3-dev \
+                    musl-dev linux-headers g++ \
+                    gmp-dev mpfr-dev mpc1-dev \
+                    ca-certificates openblas-dev gfortran
 
-RUN ["mkdir", "/PySyft"]
-COPY requirements.txt /PySyft
+RUN mkdir /src
 
-WORKDIR /PySyft
-RUN ["pip3", "install", "-r", "requirements.txt"]
-COPY . /PySyft
-RUN ["python3", "setup.py", "install"]
+ENV PYSYFT_DIR /src/PySyft
+
+## PySyft Dependency
+RUN mkdir $PYSYFT_DIR
+WORKDIR $PYSYFT_DIR
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+COPY . .
+RUN python3 setup.py install
+
+EXPOSE 8888
+
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
-.PHONY: test run local
+.PHONY: test run create-custom-image run-custom
 
 test:
-	pytest && pytest --flake8
+	@# Remove pyc files to avoid conflict if tests are run locally before
+	@find . -name '*.pyc' -exec rm -f '{}' \;
+	@docker run --rm -it -v $(PWD)/:/src/PySyft -w /src/PySyft openmined/pysyft-dev:edge pytest --flake8
 run:
-	docker run --rm -it -v $(PWD)/notebooks:/notebooks -w /notebooks -p 8888:8888 openmined/pysyft-dev:edge jupyter notebook --ip=0.0.0.0 --allow-root
-custom:
-	docker run --rm -it -v $(PWD)/notebooks:/notebooks -w /notebooks -p 8888:8888 $(docker) jupyter notebook --ip=0.0.0.0 --allow-root
+	docker run --rm -ti -v $(PWD)/notebooks:/notebooks -w /notebooks -p 8888:8888 openmined/pysyft-dev:edge
+
+create-custom-image:
+	docker build -f Development-Dockerfile -t pysyft-dev:local .
+
+run-custom:
+	docker run --rm -it -v $(PWD)/notebooks:/notebooks -w /notebooks -p 8888:8888 pysyft-dev:local jupyter notebook --ip=0.0.0.0 --allow-root

--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ run:
 create-custom-image:
 	docker build -f Development-Dockerfile -t pysyft-dev:local .
 
-run-custom:
+run-custom: create-custom-image
 	docker run --rm -it -v $(PWD)/notebooks:/notebooks -w /notebooks -p 8888:8888 pysyft-dev:local jupyter notebook --ip=0.0.0.0 --allow-root

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Syft
 
 [![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-7A5979.svg)](https://openmined.slack.com/messages/team_pysyft)
@@ -7,67 +8,33 @@
 
 The goal of this library is to give the user the ability to efficiently train Deep Learning models in a homomorphically encrypted state without needing to be an expert in either. Furthermore, by understanding the characteristics of both Deep Learning and Homomorphic Encryption, we hope to find very performant combinations of the two.  See [notebooks](./notebooks) folder for tutorials on how to use the library.
 
-- [Setup](#setup-install-instructions)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
+- [Setup](#setup)
 - [Usage](#usage)
-  - [Start](#start)
-  - [Tests](#tests)
 - [For Contributors](#for-contributors)
 - [Relevant Literature](#relevant-literature)
 - [License](#license)
 
 ## Setup
 
-### Prerequisites
+- If you don't already have Docker, install it from [here](https://www.docker.com/community-edition).  
 
-- PySyft is based on Python 3.X.
-- Install base libraries first - https://github.com/OpenMined/PySonar/blob/master/README.md#base-libraries
-- You need to install this library locally before running any of the notebooks this repository or the [main demonstration](https://github.com/OpenMined/sonar):
+- Ensure that Docker is installed and running properly by checking the version: 
 
 ```sh
-# Get dependencies ready
-pip install -r requirements.txt
-# install the lib locally
-python setup.py install
+docker -v
 ```
 
-### Installation
-
-The recommended method is using Docker (works on all major operating systems).
-
-#### For Docker Users
-
-Install Docker from [its website](https://www.docker.com/).
-For macOS users with [Homebrew](https://brew.sh/) installed, use `brew cask install docker`. Once installed, launch the Docker application. Ensure that docker is installed and running properly by checking the version: `docker -v`.
-
-#### For Anaconda Users
-
+It should return something like:
 ```
-bash install_for_anaconda_users.sh
+Docker version 17.07.0-ce, build 87847530f7
 ```
 
-Note: If you are having trouble with installation, after you run the above script, while you try to import Syft in your Jupyter notebook, try this: 
-
-```
-source activate openmined  # activate your env, if you haven't already
-pip install ipykernel
-python -m ipykernel install --user --name=openmined
-```
-
-##### Windows
-
-```sh
-conda install -c conda-forge gmpy2
-pip install -r requirements.txt
-python setup.py install
-```
 
 ## Usage
 
-### Start
+#### Start Jupyter Notebook
 
-Then, run:
+Run:
 
 ```sh
 git clone https://github.com/OpenMined/PySyft.git
@@ -75,18 +42,24 @@ cd PySyft
 make run
 ```
 
-If you want create a local Docker with Jupyter:
+It you want to build a Docker image based on your changes, you can run the following:
+
 ```sh
-docker build -f Development-Dockerfile -t "pysyft" .
-make custom docker=pysyft
+# Create the image
+make create-custom-image
+
+# Use your image
+make run-custom 
 ```
 
-### Tests
+#### Tests
 
 ```sh
 cd PySyft
 make test
 ```
+
+
 
 ## For Contributors
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The goal of this library is to give the user the ability to efficiently train De
 
 - [Setup](#setup)
 - [Usage](#usage)
+- [Advanced](#advanced)
 - [For Contributors](#for-contributors)
 - [Relevant Literature](#relevant-literature)
 - [License](#license)
@@ -28,7 +29,6 @@ It should return something like:
 ```
 Docker version 17.07.0-ce, build 87847530f7
 ```
-
 
 ## Usage
 
@@ -59,6 +59,21 @@ cd PySyft
 make test
 ```
 
+## Advanced
+
+If you want to install PySyft from source locally on your system you will need the following requirements:
+
+- Python 3.X
+- Install base libraries first - https://github.com/OpenMined/PySonar/blob/master/README.md#base-libraries- 
+- Install PySyft by running:
+```sh
+# Get dependencies ready
+pip install -r requirements.txt
+# install the lib locally
+python setup.py install
+```
+- To start the notebooks in the repository just run `jupyter notebook`
+- To execute the tests run `pytest --flake8`
 
 
 ## For Contributors

--- a/install_for_anaconda_users.sh
+++ b/install_for_anaconda_users.sh
@@ -1,8 +1,0 @@
-conda create -n openmined python=3.6
-source activate openmined
-conda install -c anaconda mpc
-conda install -c anaconda gmp
-conda install -c anaconda mpfr
-conda install gmpy2 --channel conda-forge
-pip install -r requirements.txt
-python setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ clint
 pytest-flake8
 pytest
 sklearn
+jupyter

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,0 @@
--r ./requirements.txt
-
-# Everything for testing purposes
-line_profiler
-pytest


### PR DESCRIPTION
As a user who wants to test or contribute on the project, I only need to install Docker as a dependency. 
All requirements are included in the Docker images.

Development workflow for a new user is as follows:

- Pull repo
- Install Docker
- Run `make run` starts a notebook using `pytest-dev:edge` image and local notebook source.
- Run `make test` starts the test suite on the local source code 


Docker image details:
- If the image is run without parameters it will automatically launch jupyter notebook on the root repo directory.
- There are two docker images:
  - Dockerfile --> pysyft
  - Development-Dockerfile --> pysyft-dev
- `pysyft-dev` inherits from `pysyft` image and includes extra development requirements 

- To compile a local docker image run `make create-custom-image`
- To use the local image run `make run-custom`

Closes  #270 
