### PR TITLE
add instructions to install test-requirements before running tests in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ make custom docker=pysyft
 
 ```sh
 cd PySyft
+pip install -r test-requirements.txt
 make test
 ```
 


### PR DESCRIPTION
I was trying to setup development environment for myself, found that pip install -r test-requirements.txt was missing. So I edited it and created a pull request. 