### PR TITLE
Add capsule dependency for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The goal of this library is to give the user the ability to efficiently train De
 - PySyft is based on Python 3.X.
 - Install base libraries first - https://github.com/OpenMined/PySonar/blob/master/README.md#base-libraries
 - You need to install this library locally before running any of the notebooks this repository or the [main demonstration](https://github.com/OpenMined/sonar):
+- Install [Capsule](https://github.com/OpenMined/Capsule) dependency if you are going to develop and run tests.
 
 ```sh
 # Get dependencies ready


### PR DESCRIPTION
While #270 is reviewed the readme should contain Capsule dependency as it is required for tests