### PR TITLE
Add unit tests for normal and normal_

### DIFF
--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -724,6 +724,21 @@ class geometricTests(unittest.TestCase):
         self.assertTrue(np.all(out.data > 0))
 
 
+class normalTests(unittest.TestCase):
+    def test_normal_(self):
+        t = TensorBase(np.zeros([1, 2, 3, 4]))
+        t.normal_(mu=0, sigma=1)
+        self.assertTupleEqual((1, 2, 3, 4), t.shape())
+        self.assertTrue(np.all(t.data != 0))
+
+    def test_normal(self):
+        t = TensorBase(np.zeros([1, 2, 3, 4]))
+        t1 = t.normal(mu=0, sigma=1)
+        self.assertTrue(np.array_equal(t.data, np.zeros([1, 2, 3, 4])))
+        self.assertTupleEqual((1, 2, 3, 4), t1.shape())
+        self.assertTrue(np.all(t1.data != 0))
+
+
 class fillTests(unittest.TestCase):
     def test_fill_(self):
         t1 = TensorBase(np.array([1, 2, 3, 4]))


### PR DESCRIPTION
Current implementations of `normal` and `normal_` were missing unit tests.