### PR TITLE
Request: Fixing Some Methods in Tensor.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,9 +113,5 @@ lastfailed
 !.vscode/extensions.json
 .history
 
-<<<<<<< HEAD
-# for some Temporary objects created by some extension in vscode
-=======
 # for some Temporary objects created by some extensions in vscode
->>>>>>> 6c35e0ae9b95729ae5bba9f380b8f412a9c5d396
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ lastfailed
 .history
 
 # for some Temporary objects created by some extension in vscode
+.DS_Store

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -480,12 +480,13 @@ class TensorBase(object):
 
         Returns
         -------
-        Tensor Data
+        TensorBase:
+            Output Tensor
         """
         if self.encrypted:
             return NotImplemented
         self.data = np.absolute(self.data)
-        return self.data
+        return self
 
     def nelement(self):
         """Returns the total number of elements in the tensor."""
@@ -523,7 +524,7 @@ class TensorBase(object):
         """
         if self.encrypted:
             return NotImplemented
-        return np.sqrt(self.data)
+        return TensorBase(np.sqrt(self.data))
 
     def sqrt_(self):
         """
@@ -534,10 +535,12 @@ class TensorBase(object):
 
         Returns
         -------
+        Caller with values in-place
         """
         if self.encrypted:
             return NotImplemented
         self.data = np.sqrt(self.data)
+        return self
 
     def dim(self):
         """
@@ -654,7 +657,7 @@ class TensorBase(object):
             return NotImplemented
 
         self.data.fill(0)
-        return self.data
+        return self
 
     def addmm(self, tensor2, mat, beta=1, alpha=1):
         """
@@ -1181,20 +1184,22 @@ class TensorBase(object):
 
         Returns
         -------
+        Caller with values in-place
         """
         num_dims = len(self.data.shape)
         axes = list(range(num_dims))
 
         if dim0 >= num_dims:
-            print("dimension 0 out of range")
+            raise ValueError("dimension 0 out of range")
         elif dim1 >= num_dims:
-            print("dimension 1 out of range")
+            raise ValueError("dimension 1 out of range")
         elif self.encrypted:
-            raise NotImplemented
+            return NotImplemented
         else:
             axes[dim0] = dim1
             axes[dim1] = dim0
             self.data = np.transpose(self.data, axes=tuple(axes))
+        return self
 
     def t(self):
         """
@@ -1218,8 +1223,10 @@ class TensorBase(object):
 
         Returns
         -------
+        Caller with values in-place
         """
         self.transpose_(0, 1)
+        return self
 
     def unsqueeze(self, dim):
         """
@@ -1235,7 +1242,6 @@ class TensorBase(object):
         Returns
         -------
         Output Tensor
-
         """
         return syft.unsqueeze(self.data, dim)
 
@@ -1250,15 +1256,17 @@ class TensorBase(object):
 
         Returns
         -------
+        Caller with values in-place
         """
         num_dims = len(self.data.shape)
 
         if dim >= num_dims or dim < 0:
-            print("dimension out of range")
+            raise ValueError("dimension out of range")
         elif self.encrypted:
             raise NotImplemented
         else:
             self.data = np.expand_dims(self.data, dim)
+        return self
 
     def exp(self):
         """
@@ -1401,6 +1409,7 @@ class TensorBase(object):
         if self.encrypted:
             return NotImplemented
         self.data = 1 / np.sqrt(self.data)
+        return self
 
     def sign(self):
         """
@@ -1432,6 +1441,7 @@ class TensorBase(object):
         if self.encrypted:
             return NotImplemented
         self.data = np.sign(self.data)
+        return self
 
     def to_numpy(self):
         """
@@ -1478,6 +1488,7 @@ class TensorBase(object):
         if self.encrypted:
             return NotImplemented
         self.data = 1 / np.array(self.data)
+        return self
 
     def log(self):
         """
@@ -2117,6 +2128,10 @@ class TensorBase(object):
         Parameters
         ----------
         size:
+
+        Returns
+        -------
+        Caller with values in-place
         """
         input_size = np.prod(size)
         extension = input_size - self.data.size
@@ -2125,15 +2140,15 @@ class TensorBase(object):
             if extension > 0:
                 data = np.append(flattened, np.zeros(extension))
                 self.data = data.reshape(*size)
-                print(self.data)
+                return self
             elif extension < 0:
                 size_ = self.data.size + extension
                 self.data = flattened[:size_]
                 self.data = self.data.reshape(*size)
-                print(self.data)
+                return self
             else:
                 self.data = self.data.reshape(*size)
-                print(self.data)
+                return self
         else:
             raise ValueError('negative dimension not allowed')
 
@@ -2147,9 +2162,11 @@ class TensorBase(object):
 
         Returns
         -------
+        Caller with values in-place
         """
         size = tensor.data.shape
         self.resize_(size)
+        return self
 
     def round(self, decimals=0):
         """

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -1397,12 +1397,6 @@ class TensorBase(object):
 
         return syft.mm(self, tensor2)
 
-    def index(self, m):
-        """Selects elements from this Tensor using a binary mask or along a given dimension."""
-        if self.encrypted:
-            return NotImplemented
-        return TensorBase(self.data[m])
-
 
 def mv(tensormat, tensorvector):
     """ matrix and vector multiplication """

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -1353,6 +1353,12 @@ class TensorBase(object):
 
         return syft.mm(self, tensor2)
 
+    def index(self, m):
+        """Selects elements from this Tensor using a binary mask or along a given dimension."""
+        if self.encrypted:
+            return NotImplemented
+        return TensorBase(self.data[m])
+
 
 def mv(tensormat, tensorvector):
     """ matrix and vector multiplication """

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1087,6 +1087,19 @@ class mm_test(unittest.TestCase):
         out = t1.mm(t2)
         self.assertTrue(np.alltrue(out.data == [[5, 8, 11], [8, 13, 18], [11, 18, 25]]))
 
+class index_test(unittest.TestCase):
+    def test_index_1d(self):
+        t = TensorBase(np.array([1, 2, 3]))
+        result = t.index(1)
+        expected = 2
+        self.assertTrue(result.data, expected)
+    def test_index_2d(self):
+        t = TensorBase(np.array([[1., 2., 3.],[4., 5., 6.]]))
+        result = t.index(1)
+        expected = np.array([4., 5., 6.])
+        self.assertTrue(result, TensorBase(expected))
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1110,19 +1110,6 @@ class mm_test(unittest.TestCase):
         out = t1.mm(t2)
         self.assertTrue(np.alltrue(out.data == [[5, 8, 11], [8, 13, 18], [11, 18, 25]]))
 
-class index_test(unittest.TestCase):
-    def test_index_1d(self):
-        t = TensorBase(np.array([1, 2, 3]))
-        result = t.index(1)
-        expected = 2
-        self.assertTrue(result.data, expected)
-    def test_index_2d(self):
-        t = TensorBase(np.array([[1., 2., 3.],[4., 5., 6.]]))
-        result = t.index(1)
-        expected = np.array([4., 5., 6.])
-        self.assertTrue(result, TensorBase(expected))
-
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -115,10 +115,10 @@ class CeilTests(unittest.TestCase):
 class ZeroTests(unittest.TestCase):
     def test_zero(self):
         t = TensorBase(np.array([13, 42, 1024]))
-        self.assertTrue(syft.equal(t.zero_(), [0, 0, 0]))
+        self.assertTrue(syft.equal(t.zero_(), TensorBase([0, 0, 0])))
 
         t = TensorBase(np.array([13.1, 42.2, 1024.4]))
-        self.assertTrue(syft.equal(t.zero_(), [0.0, 0.0, 0.0]))
+        self.assertTrue(syft.equal(t.zero_(), TensorBase([0.0, 0.0, 0.0])))
 
 
 class FloorTests(unittest.TestCase):
@@ -193,11 +193,11 @@ class DivTests(unittest.TestCase):
 class AbsTests(unittest.TestCase):
     def test_abs(self):
         t = TensorBase(np.array([-1, -2, 3]))
-        self.assertTrue(np.array_equal(t.abs(), [1, 2, 3]))
+        self.assertTrue(np.array_equal(t.abs(), TensorBase([1, 2, 3])))
 
     def test_abs_(self):
         t = TensorBase(np.array([-1, -2, 3]))
-        self.assertTrue(np.array_equal(t.abs_(), t.data))
+        self.assertTrue(np.array_equal(t.abs_(), TensorBase([1, 2, 3])))
 
 
 class ShapeTests(unittest.TestCase):
@@ -210,12 +210,12 @@ class SqrtTests(unittest.TestCase):
     def test_sqrt(self):
         t = TensorBase(np.array([[0, 4], [9, 16]]))
 
-        self.assertTrue(syft.equal(t.sqrt(), ([[0, 2], [3, 4]])))
+        self.assertTrue(syft.equal(t.sqrt(), TensorBase([[0, 2], [3, 4]])))
 
     def test_sqrt_(self):
         t = TensorBase(np.array([[0, 4], [9, 16]]))
         t.sqrt_()
-        self.assertTrue(syft.equal(t, ([[0, 2], [3, 4]])))
+        self.assertTrue(syft.equal(t, TensorBase([[0, 2], [3, 4]])))
 
 
 class SumTests(unittest.TestCase):


### PR DESCRIPTION
After communicating with @bharathgs about `tensor.py`, I fixed a bug in `sqrt()` method which should return a `TensorBase` but is returning Numpy `np.sqrt(self.data)`.

Going through `tensor.py`, I also found out that some in-place methods do not return anything. The corresponding methods in PyTorch usually return `self`, therefore I adjusted the documentation for some methods and added `return self` when appropriate. The corresponding unit tests in `test_tensor.py` are also fixed when necessary.

Please let me know if these adjustments are appropriate or not and I can keep improving the pull request. Thank you for your time and help!

List of methods adjusted:
`sqrt`: return `Tensor` instead of Numpy
`sqrt_`: return `self`
`abs`: return `Tensor`
`abs_`: return `self`
`zero_`: return `self` instead of `self.data`
`transpose_`: return `self`; raise `ValueError` instead of just `print`
`t_`: return `self`
`unsqueeze_`: return `self`; raise `ValueError` instead of just `print`
`rsqrt_`: return `self`
`reciprocal_`: return `self`
`resize_`: return `self` instead of just `print`
`resize_as_`: return `self`