### PR TITLE
remove cached pyc files before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ develop:
 	python3 setup.py develop
 
 test:
+	@# Remove pyc files to avoid conflict if tests are run locally
+	@# and inside container at the same time
+	@find . -name '*.pyc' -exec rm -f '{}' \;
 	pip3 install -r test-requirements.txt
 	pytest && pytest --flake8
 


### PR DESCRIPTION
If I run tests locally then inside the container (or other way around) I get the following error. 

```
tests/test_integrations_locally.py _____________________________________________________________
import file mismatch:                                                                                                                                                         
imported module 'PySyft.tests.test_integrations_locally' has this __file__ attribute:                                                                                         
  /src/PySyft/tests/test_integrations_locally.py                                                                                                                              
which is not the same as the test file we want to collect:                                                                                                                    
  /home/spike/projects/PySyft/tests/test_integrations_locally.py                                                                                                              
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules      
```                                                                        

This situation could easilly happen if someone installs and tests locally then switches to Docker or the opposite. 

The test rule in the Makefile should delete the pyc files. 