### PR TITLE
Use shortcircuit logic to optimize function call

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -92,8 +92,7 @@ def equal(tensor1, tensor2):
         return NotImplemented
 
     left = tensor1.data.shape == tensor2.data.shape
-    right = np.allclose(tensor1.data, tensor2.data)
-    return left and right
+    return left and np.allclose(tensor1.data, tensor2.data)
 
 
 class TensorBase(object):


### PR DESCRIPTION
Using shortcircuit logic prevents a call to np.allclose which would be unnecessary when the shapes don't match.

This also prevents a ValueError: operands could not be broadcast together with shapes when comparing tensors with different shapes.