### PR TITLE
Add shape mismatch tests

### DIFF
--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -235,8 +235,18 @@ class EqualTests(unittest.TestCase):
         t2 = TensorBase(np.array([1, 4, 3]))
         self.assertFalse(syft.equal(t1, t2))
 
+    def test_shape_not_equal(self):
+        t1 = TensorBase(np.array([1, 2]))
+        t2 = TensorBase(np.array([1, 4, 3]))
+        self.assertFalse(syft.equal(t1, t2))
+        
     def test_inequality_operation(self):
         t1 = TensorBase(np.array([1, 2, 3]))
+        t2 = TensorBase(np.array([1, 4, 5]))
+        self.assertTrue(t1 != t2)
+        
+    def test_shape_inequality_operation(self):
+        t1 = TensorBase(np.array([1, 2]))
         t2 = TensorBase(np.array([1, 4, 5]))
         self.assertTrue(t1 != t2)
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -239,12 +239,12 @@ class EqualTests(unittest.TestCase):
         t1 = TensorBase(np.array([1, 2]))
         t2 = TensorBase(np.array([1, 4, 3]))
         self.assertFalse(syft.equal(t1, t2))
-        
+
     def test_inequality_operation(self):
         t1 = TensorBase(np.array([1, 2, 3]))
         t2 = TensorBase(np.array([1, 4, 5]))
         self.assertTrue(t1 != t2)
-        
+
     def test_shape_inequality_operation(self):
         t1 = TensorBase(np.array([1, 2]))
         t2 = TensorBase(np.array([1, 4, 5]))


### PR DESCRIPTION
Added a couple of tests in which we check tensors of different shapes for inequality.
The test should return the correct result and not throw ValueError from np.allclose.