### PR TITLE
Add Set method on Tensor resolves #93

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3295,6 +3295,20 @@ class TensorBase(object):
             self.data = syft.math.renorm(self, p, dim, maxnorm).data
             return self
 
+    def stride(self):
+        """
+        Strides of tensor
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        Strides of the Tensor
+        """
+        if self.encrypted:
+            return NotImplemented
+        return self.data.strides
 
     def storage_offset(self):
         """

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3296,6 +3296,30 @@ class TensorBase(object):
             return self
 
 
+    def storage_offset(self):
+        """
+        Returns this tensor’s offset in the underlying
+        storage in terms of number of storage elements (not bytes).
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        Offset of the underlying storage
+        """
+        if self.encrypted:
+            return NotImplemented
+
+        # Base ndarray has 0 offset
+        if self.data.base is None:
+            return 0
+
+        offset_raw = len(self.data.base.tobytes()) - len(self.data.tobytes())
+        offset = offset_raw / self.data.dtype.itemsize
+
+        return offset
+
 def numel(self):
     """
     Returns the total number of elements in the input Tensor.

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1478,6 +1478,19 @@ class RenormTests(unittest.TestCase):
         self.assertTrue(np.allclose(t, np.array([[1.0, 2.0, 3.0], [2.735054, 3.418817, 4.102581]])))
 
 class StorageTests(unittest.TestCase):
+    def test_stride(self):
+        # int
+        t1 = TensorBase(np.array([1, 2, 3, 4]))
+        self.assertEqual(t1.stride(), (8,))
+
+        # float
+        t1 = TensorBase(np.array([1.0, 2.0, 3.0]))
+        self.assertEqual(t1.stride(), (8,))
+
+    def test_stride_encrypted(self):
+        t1 = TensorBase(np.array([1, 2, 3, 4]),  encrypted=True)
+        self.assertEqual(t1.stride(), NotImplemented)
+
     def test_storage_offset(self):
         # Test default offset = 0
         t = TensorBase(np.array([1, 2, 4, 4]))

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -5,6 +5,7 @@ from syft import tensor
 import numpy as np
 import math
 import pytest
+import struct
 
 
 # Here's our "unit tests".
@@ -1477,6 +1478,7 @@ class RenormTests(unittest.TestCase):
         t.renorm_(2, 0, 6)
         self.assertTrue(np.allclose(t, np.array([[1.0, 2.0, 3.0], [2.735054, 3.418817, 4.102581]])))
 
+
 class StorageTests(unittest.TestCase):
     def test_stride(self):
         # int
@@ -1488,33 +1490,196 @@ class StorageTests(unittest.TestCase):
         self.assertEqual(t1.stride(), (8,))
 
     def test_stride_encrypted(self):
-        t1 = TensorBase(np.array([1, 2, 3, 4]),  encrypted=True)
+        t1 = TensorBase(np.array([1, 2, 3, 4]), encrypted=True)
         self.assertEqual(t1.stride(), NotImplemented)
 
     def test_storage_offset(self):
+        # int
+        # create custom buffer
+        data = [7, 4, 5, 5, 8, 2, 1, 1, 4, 3, 9, 4, 9, 9, 3, 1]
+        buf = struct.pack('16i', *data)
+
+        # Use custom buffer and ndarray tensors
+        t1 = TensorBase(np.ndarray(shape=(4, 4), buffer=buf, dtype=np.int32))
+        t2 = TensorBase(np.array([[7, 4, 5, 5],
+                                  [8, 2, 1, 1],
+                                  [4, 3, 9, 4],
+                                  [9, 9, 3, 1]], dtype=np.int32))
+
         # Test default offset = 0
-        t = TensorBase(np.array([1, 2, 4, 4]))
-        self.assertEqual(t.storage_offset(), 0)
+        self.assertEqual(t1.storage_offset(), 0)
+        self.assertEqual(t2.storage_offset(), 0)
 
-        t1 = t[1:]
-        self.assertEqual(t1.storage_offset(), 1)
+        # value of first element in first row [7,4,5,5]
+        self.assertEqual(t1[0][0], 7)
+        self.assertEqual(t2[0][0], 7)
 
-        t2 = t[2:]
-        self.assertEqual(t2.storage_offset(), 2)
+        t1.set_(offset=8, size=(2, 4))
+        self.assertEqual(t1.storage_offset(), 8)
+        self.assertEqual(t1[0][0], 4)
 
-        t3 = t[3:]
-        self.assertEqual(t3.storage_offset(), 3)
+        t2.set_(offset=8, size=(2, 4))
+        self.assertEqual(t2.storage_offset(), 8)
+        self.assertEqual(t2[0][0], 4)
 
-        t4 = t[4:]
-        self.assertEqual(t4.storage_offset(), 4)
+        t1 = TensorBase(np.ndarray(shape=(4, 4), buffer=buf, dtype=np.int32))
+        t1.set_(offset=4, size=(3, 4))
+        self.assertEqual(t1.storage_offset(), 4)
+        self.assertEqual(t1[0][0], 8)
 
-
-
+        t2 = TensorBase(np.array([[7, 4, 5, 5],
+                                  [8, 2, 1, 1],
+                                  [4, 3, 9, 4],
+                                  [9, 9, 3, 1]], dtype=np.int32))
+        t2.set_(offset=4, size=(3, 4))
+        self.assertEqual(t2.storage_offset(), 4)
+        self.assertEqual(t2[0][0], 8)
 
     def test_storage_offset_encrypted(self):
-        t1 = TensorBase(np.array([1, 2, 4, 4]),  encrypted=True)
+        t1 = TensorBase(np.array([1, 2, 4, 4]), encrypted=True)
         res = t1.storage_offset()
         self.assertEqual(res, NotImplemented)
+
+    def test_tensor_set_encrypted(self):
+        t1 = TensorBase(np.array([]))
+        t2 = TensorBase(np.array([1, 2, 3, 4]), encrypted=True)
+        res = t1.set_(t2)
+        self.assertEqual(res, NotImplemented)
+
+        res = t2.set_(t1)
+        self.assertEqual(res, NotImplemented)
+
+    def test_tensor_set_tensor(self):
+        # begin test call signature
+        t1 = TensorBase([1, 2, 3, 4])
+
+        # test set offset without size
+        with pytest.raises(TypeError):
+            t1.set_(offset=2)
+
+        # test set strides without size
+        with pytest.raises(TypeError):
+            t1.set_(stride=(4))
+
+        # end test call signature
+
+        # tests on ints
+
+        # begin setting the underlying ndarray
+
+        t1 = TensorBase([])
+        t2 = TensorBase(np.array([1, 2, 3, 4]))
+        t1.set_(t2)
+
+        # memory location is the same
+        self.assertEqual(t1.data.__array_interface__['data'],
+                         t2.data.__array_interface__['data'])
+
+        # data is the same
+        print(t1.data)
+        print(t2.data)
+        self.assertTrue((t1.data == t2.data).all())
+        self.assertEqual(t1.data.dtype, np.int)
+
+        # stride and size is the same
+        self.assertEqual(t1.size(), t2.size())
+        self.assertEqual(t1.stride(), t2.stride())
+
+        # end setting the underlying ndarray
+
+        # begin set offset and size
+
+        t1 = TensorBase([1, 2, 3, 4])
+
+        # test set offset without size
+        with pytest.raises(TypeError):
+            t1.set_(offset=2)
+
+        t1 = TensorBase([1, 2, 3, 4])
+
+        t1.set_(offset=1, size=(3,))
+        self.assertEqual(t1[0], 2)
+        self.assertEqual(t1[2], 4)
+
+        with pytest.raises(IndexError):
+            t1[3]
+
+        # end set offset and size
+
+        # begin set strides
+
+        t1 = TensorBase([])
+        shape = (3, 4, 9, 10)
+        t2 = TensorBase(np.zeros(shape=(3, 4, 9, 10), dtype=np.int))
+
+        # set strides on new ndarray
+        strides = (10, 360, 90, 1)
+        size = (9, 3, 4, 10)
+        t1.set_(t2, 0, size, strides)
+        self.assertEqual(t1.data.base.__array_interface__['data'], t2.data.__array_interface__['data'])
+        self.assertEqual(t1.stride(), strides)
+
+        # set strides on underlying ndarray
+        t1 = TensorBase(np.zeros(shape=(3, 4, 9, 10))).uniform_()
+        strides = (10, 360, 90, 1)
+        size = (9, 3, 4, 10)
+
+        t1.set_(offset=0, size=size, stride=strides)
+        self.assertEqual(t1.stride(), strides)
+
+        # end set strides
+
+        # tests on floats #######
+
+        # begin setting the underlying ndarray
+
+        t1 = TensorBase([])
+        t2 = TensorBase(np.array([1.0, 2.0, 3.0]))
+        t1.set_(t2)
+        self.assertEqual(t1.data.__array_interface__['data'], t2.data.__array_interface__['data'])
+        self.assertTrue((t1.data == t2.data).all())
+        self.assertEqual(t1.data.dtype, np.float)
+        self.assertEqual(t1.size(), t2.size())
+        self.assertEqual(t1.stride(), t2.stride())
+
+        # end setting the underlying ndarray
+
+        # begin set offset and size
+
+        t2 = TensorBase(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+
+        t2.set_(offset=3, size=(3,))
+        self.assertEqual(t2[0], 4.0)
+        self.assertEqual(t2[2], 6.0)
+        with pytest.raises(IndexError):
+            t2[3]
+
+        # end set offset and size
+
+        # begin set strides
+
+        t1 = TensorBase([])
+        shape = (3, 4, 9, 10)
+        t2 = TensorBase(np.zeros(shape=shape, dtype=np.float))
+
+        # set strides on new ndarray
+        strides = (10, 360, 90, 1)
+        size = (9, 3, 4, 10)
+        t1.set_(t2, 0, size, strides)
+        self.assertEqual(t1.data.base.__array_interface__['data'],
+                         t2.data.__array_interface__['data'])
+        self.assertEqual(t1.stride(), strides)
+
+        # set strides on underlying ndarray
+        t1 = TensorBase(np.zeros(shape=shape, dtype=np.float))
+        strides = (10, 360, 90, 1)
+        size = (9, 3, 4, 10)
+
+        t1.set_(offset=0, size=size, stride=strides)
+        self.assertEqual(t1.stride(), strides)
+
+        # end set strides
+
 
 if __name__ == "__main__":
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1477,6 +1477,31 @@ class RenormTests(unittest.TestCase):
         t.renorm_(2, 0, 6)
         self.assertTrue(np.allclose(t, np.array([[1.0, 2.0, 3.0], [2.735054, 3.418817, 4.102581]])))
 
+class StorageTests(unittest.TestCase):
+    def test_storage_offset(self):
+        # Test default offset = 0
+        t = TensorBase(np.array([1, 2, 4, 4]))
+        self.assertEqual(t.storage_offset(), 0)
+
+        t1 = t[1:]
+        self.assertEqual(t1.storage_offset(), 1)
+
+        t2 = t[2:]
+        self.assertEqual(t2.storage_offset(), 2)
+
+        t3 = t[3:]
+        self.assertEqual(t3.storage_offset(), 3)
+
+        t4 = t[4:]
+        self.assertEqual(t4.storage_offset(), 4)
+
+
+
+
+    def test_storage_offset_encrypted(self):
+        t1 = TensorBase(np.array([1, 2, 4, 4]),  encrypted=True)
+        res = t1.storage_offset()
+        self.assertEqual(res, NotImplemented)
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
I included stride for #100  since it's required for the `set_` method. I can make a separate PR if needed. 

The methods added on TensorBase are:
- `storage_offset`
- `stride`
- `set_` 