### PR TITLE
Revert string formatting for TensorBase narrow TypeError

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3015,11 +3015,12 @@ class TensorBase(object):
         if self.encrypted:
             raise NotImplemented
         if not isinstance(dim, int) or not isinstance(start, int) or not isinstance(length, int):
-            raise TypeError(("narrow received an invalid combination of arguments:\n"
-                             f"  got ({dim.__class__.__name__} dim, "
-                             f"{start.__class__.__name__} start, "
-                             f"{length.__class__.__name__} length), "
-                             "but expected (int dim, int start, int length)"))
+            raise TypeError(("narrow received an invalid combination of arguments:\n" 
+                             "    got ({} dim, {} start, {} length), " 
+                             " but expected (int dim, int start, int length)"
+                             .format(dim.__class__.__name__,
+                                     start.__class__.__name__,
+                                     length.__class__.__name__)))
         if dim >= self.data.ndim or dim < -self.data.ndim:
             raise IndexError("dim value is out of range")
         if start >= self.data.shape[dim] or start < 0:

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3015,8 +3015,8 @@ class TensorBase(object):
         if self.encrypted:
             raise NotImplemented
         if not isinstance(dim, int) or not isinstance(start, int) or not isinstance(length, int):
-            raise TypeError(("narrow received an invalid combination of arguments:\n" 
-                             "    got ({} dim, {} start, {} length), " 
+            raise TypeError(("narrow received an invalid combination of arguments:\n"
+                             "    got ({} dim, {} start, {} length), "
                              " but expected (int dim, int start, int length)"
                              .format(dim.__class__.__name__,
                                      start.__class__.__name__,


### PR DESCRIPTION
The Last formatting style was Python 3.6 based which broke things in Python 3.5. So reverted it to Python 3.5 style formatting.

**From**
`if not isinstance(dim, int) or not isinstance(start, int) or not isinstance(length, int):
            raise TypeError(("narrow received an invalid combination of arguments:\n"
                             f"  got ({dim.__class__.__name__} dim, "
                             f"{start.__class__.__name__} start, "
                             f"{length.__class__.__name__} length), "
                             "but expected (int dim, int start, int length)"))`

**to this**

`if not isinstance(dim, int) or not isinstance(start, int) or not isinstance(length, int):
            raise TypeError(("narrow received an invalid combination of arguments:\n" 
                             "    got ({} dim, {} start, {} length), " 
                             " but expected (int dim, int start, int length)"
                             .format(dim.__class__.__name__,
                                     start.__class__.__name__,
                                     length.__class__.__name__)))`