### PR TITLE
Implement default stride functionality for TensorBase

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3379,6 +3379,39 @@ class TensorBase(object):
 
         return TensorBase(np.concatenate(sub_arrays, axis=dim))
 
+    def stride(self, dim=None):
+        """
+        Returns the number of jumps necessary to go from element
+        to the next one in the specific dimension. 
+        A stride in a form of a tuple for all dimensions is returned
+        when no dim is passed, an integer is returned otherwise.
+
+        Note that while OpenMined and Torch return the numeric value of the jumps needed, 
+        while NumPy returns the strides as the number of jumps in bytes in the memory.
+
+        Parameters
+        ----------
+        dim: The dimension of the stride
+
+        Returns
+        -------
+        Integer:
+            Stride of the passed dimension, when a dim is passed
+        OR
+        Tuple of Integers:
+            Stride of all dimensions, when no dim is passed
+        """
+        if self.encrypted:
+            return NotImplemented
+
+        if dim is not None:
+            if dim > self.dim():
+                raise Exception("Invalid argument: \'dim\'' is greater than \'self.dim()\'")
+
+            return self.data.strides[dim] / 8
+
+        return [x / 8 for x in self.data.strides]
+
 
 def numel(self):
     """

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1540,6 +1540,33 @@ class unfold_Test(unittest.TestCase):
                                        t1_unfolded_actual_2))
 
 
+class strideTests(unittest.TestCase):
+    def test_all_1d(self):
+        t = TensorBase(np.array([1, 2, 3]))
+        self.assertTrue(syft.equal(t.stride(), (1, )))
+
+    def test_all_2d(self):
+        t = TensorBase(np.array([[1, 2], [3, 4]]))
+        self.assertTrue(syft.equal(t.stride(), (2, 1)))
+
+    def test_all_3d(self):
+        t = TensorBase(np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]))
+        self.assertTrue(syft.equal(t.stride(), (4, 2, 1)))
+
+    def test_1_3d(self):
+        t = TensorBase(np.array([[[3, 4], [5, 6]], [[7, 8], [9, 0]]]))
+        self.assertTrue(syft.equal(t.stride(0), 4))
+
+    def test_minus_1(self):
+        t = TensorBase(np.array([1, 2, 3]))
+        self.assertTrue(syft.equal(t.stride(-1), 1))
+
+    def test_out_of_bounds(self):
+        t = TensorBase(np.array([1, 2, 3]))
+        with pytest.raises(Exception) as oops:
+            t.stride(4)
+
+
 if __name__ == "__main__":
 
     unittest.main()


### PR DESCRIPTION
Hi, this resolves issue #100.

I found out that NumPy and Torch have slightly different implementations of the stride functionality and I adjusted TensorBase to be in line with Torch's implementation. :smiley: happy times