### PR TITLE
Fixed 'high is out of bounds for int32' in spdz/repo.py & spdz/scaler.py

### DIFF
--- a/syft/mpc/spdz/repo.py
+++ b/syft/mpc/spdz/repo.py
@@ -42,12 +42,11 @@ class MPCRepo(object):
         return self.create_natural_with_shares(shares)
 
     def create_natural_with_shares(self, shares):
-		
-		try:
-			id = np.random.randint(0, 2**32)
-		except Exception as e:
-			id = np.random.randint(0, 2**32, dtype=np.int64)
-			
+        try:
+            id = np.random.randint(0, 2**32)
+        except Exception as e:
+            id = np.random.randint(0, 2**32, dtype=np.int64)
+
         self.create_share(id, shares[0])
         self.another_party[0].create_share(id, shares[1])
         return MPCNatural(id, self)
@@ -82,7 +81,7 @@ class MPCRepo(object):
     def mult(self, new_id, x, y, populate_to_another_party=False):
 
         a, b, c = self.generate_multiplication_triple()
-		
+
 		try:
 			new_id1 = np.random.randint(0, 2**32)
 			d = self.sub(new_id1, x, a.id, True)
@@ -102,9 +101,9 @@ class MPCRepo(object):
 			new_id6 = np.random.randint(0, 2**32)
 			new_id7 = np.random.randint(0, 2**32)
 			result = self.add(new_id7, s.id, self.add(new_id6, t.id, self.add_public(new_id5, c.id, r, True).id, True).id, True)
-		
+
 		except Exception as e:
-			
+
 			new_id1 = np.random.randint(0, 2**32, dtype=np.int64)
 			d = self.sub(new_id1, x, a.id, True)
 			new_id2 = np.random.randint(0, 2**32, dtype=np.int64)

--- a/syft/mpc/spdz/repo.py
+++ b/syft/mpc/spdz/repo.py
@@ -42,8 +42,12 @@ class MPCRepo(object):
         return self.create_natural_with_shares(shares)
 
     def create_natural_with_shares(self, shares):
-
-        id = np.random.randint(0, 2**32)
+		
+		try:
+			id = np.random.randint(0, 2**32)
+		except Exception as e:
+			id = np.random.randint(0, 2**32, dtype=np.int64)
+			
         self.create_share(id, shares[0])
         self.another_party[0].create_share(id, shares[1])
         return MPCNatural(id, self)
@@ -78,25 +82,47 @@ class MPCRepo(object):
     def mult(self, new_id, x, y, populate_to_another_party=False):
 
         a, b, c = self.generate_multiplication_triple()
+		
+		try:
+			new_id1 = np.random.randint(0, 2**32)
+			d = self.sub(new_id1, x, a.id, True)
+			new_id2 = np.random.randint(0, 2**32)
+			e = self.sub(new_id2, y, b.id, True)
 
-        new_id1 = np.random.randint(0, 2**32)
-        d = self.sub(new_id1, x, a.id, True)
-        new_id2 = np.random.randint(0, 2**32)
-        e = self.sub(new_id2, y, b.id, True)
+			delta = self.reconstruct([self.ints[d.id], self.another_party[0].ints[d.id]])
+			epsilon = self.reconstruct([self.ints[e.id], self.another_party[0].ints[e.id]])
 
-        delta = self.reconstruct([self.ints[d.id], self.another_party[0].ints[d.id]])
-        epsilon = self.reconstruct([self.ints[e.id], self.another_party[0].ints[e.id]])
+			r = delta * epsilon % Q
+			new_id3 = np.random.randint(0, 2**32)
+			s = self.mult_public(new_id3, a.id, epsilon, True)
+			new_id4 = np.random.randint(0, 2**32)
+			t = self.mult_public(new_id4, b.id, delta, True)
 
-        r = delta * epsilon % Q
-        new_id3 = np.random.randint(0, 2**32)
-        s = self.mult_public(new_id3, a.id, epsilon, True)
-        new_id4 = np.random.randint(0, 2**32)
-        t = self.mult_public(new_id4, b.id, delta, True)
+			new_id5 = np.random.randint(0, 2**32)
+			new_id6 = np.random.randint(0, 2**32)
+			new_id7 = np.random.randint(0, 2**32)
+			result = self.add(new_id7, s.id, self.add(new_id6, t.id, self.add_public(new_id5, c.id, r, True).id, True).id, True)
+		
+		except Exception as e:
+			
+			new_id1 = np.random.randint(0, 2**32, dtype=np.int64)
+			d = self.sub(new_id1, x, a.id, True)
+			new_id2 = np.random.randint(0, 2**32, dtype=np.int64)
+			e = self.sub(new_id2, y, b.id, True)
 
-        new_id5 = np.random.randint(0, 2**32)
-        new_id6 = np.random.randint(0, 2**32)
-        new_id7 = np.random.randint(0, 2**32)
-        result = self.add(new_id7, s.id, self.add(new_id6, t.id, self.add_public(new_id5, c.id, r, True).id, True).id, True)
+			delta = self.reconstruct([self.ints[d.id], self.another_party[0].ints[d.id]])
+			epsilon = self.reconstruct([self.ints[e.id], self.another_party[0].ints[e.id]])
+
+			r = delta * epsilon % Q
+			new_id3 = np.random.randint(0, 2**32, dtype=np.int64)
+			s = self.mult_public(new_id3, a.id, epsilon, True)
+			new_id4 = np.random.randint(0, 2**32, dtype=np.int64)
+			t = self.mult_public(new_id4, b.id, delta, True)
+
+			new_id5 = np.random.randint(0, 2**32, dtype=np.int64)
+			new_id6 = np.random.randint(0, 2**32, dtype=np.int64)
+			new_id7 = np.random.randint(0, 2**32, dtype=np.int64)
+			result = self.add(new_id7, s.id, self.add(new_id6, t.id, self.add_public(new_id5, c.id, r, True).id, True).id, True)
 
         return self.truncate(result)
 

--- a/syft/mpc/spdz/scalar.py
+++ b/syft/mpc/spdz/scalar.py
@@ -43,7 +43,10 @@ class MPCNatural(object):
             return self.repo.div_public(new_id, self.id, x, True)
 
     def gen_rand_id(self, length=2**32):
-        return np.random.randint(0, length)
+		try:
+			return np.random.randint(0, length)
+		except Exception as e:
+			return np.random.randint(0, length, dtype=np.int64)
 
     def get(self):
         return sum(self.get_shares()) % Q


### PR DESCRIPTION
Adjusted the type of ids to prevent the 'high is out of bounds for int32' error which occurs in windows