### PR TITLE
Remove capsule dependency from notebooks

### DIFF
--- a/notebooks/Syft - Paillier Encrypted Linear Classification.ipynb
+++ b/notebooks/Syft - Paillier Encrypted Linear Classification.ipynb
@@ -6,9 +6,7 @@
    "source": [
     "# Paillier Encrypted Linear Classification Example\n",
     "\n",
-    "DISCLAIMER: This is a proof-of-concept implementation. It does not represent a remotely product ready implementation or follow proper conventions for security, convenience, or scalability. It is part of a broader proof-of-concept demonstrating the vision of the OpenMined project, its major moving parts, and how they might work together.\n",
-    "\n",
-    "NOTE: One needs [capusle](https://github.com/OpenMined/Capsule) to establish a client for decryption and re-encryption of weights.\n"
+    "DISCLAIMER: This is a proof-of-concept implementation. It does not represent a remotely product ready implementation or follow proper conventions for security, convenience, or scalability. It is part of a broader proof-of-concept demonstrating the vision of the OpenMined project, its major moving parts, and how they might work together."
    ]
   },
   {
@@ -21,9 +19,8 @@
    "source": [
     "from syft.he.paillier import KeyPair\n",
     "from syft.nn.linear import LinearClassifier\n",
-    "import numpy as np\n",
-    "\n",
-    "from capsule.zmq_client import LocalCapsuleClient "
+    "from syft.he.keys import Paillier\n",
+    "import numpy as np"
    ]
   },
   {
@@ -34,8 +31,8 @@
    },
    "outputs": [],
    "source": [
-    "capsule = LocalCapsuleClient()\n",
-    "model = LinearClassifier(n_inputs=4, n_labels=2, capsule_client=capsule)\n",
+    "pk, sk = Paillier()\n",
+    "model = LinearClassifier(n_inputs=4, n_labels=2)\n",
     "epochs = 3"
    ]
   },
@@ -47,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "model = model.encrypt()"
+    "model = model.encrypt(pk)"
    ]
   },
   {
@@ -58,8 +55,8 @@
    },
    "outputs": [],
    "source": [
-    "input = np.array([[0,0,1,1],[0,0,1,0],[1,0,1,1],[0,0,1,0]])\n",
-    "target = np.array([[0,1],[0,0],[1,1],[0,0]])"
+    "input = np.array([[0,0,1,1],[0,0,1,0]])\n",
+    "target = np.array([[0,1],[0,0]])"
    ]
   },
   {
@@ -82,7 +79,7 @@
    },
    "outputs": [],
    "source": [
-    "model = model.decrypt()"
+    "model = model.decrypt(sk)"
    ]
   },
   {

--- a/notebooks/Syft - Paillier Homographic Encrypted Linear Classification example .ipynb
+++ b/notebooks/Syft - Paillier Homographic Encrypted Linear Classification example .ipynb
@@ -20,10 +20,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from capsule.zmq_client import LocalCapsuleClient\n",
     "import syft as sy\n",
     "from sklearn.datasets import load_diabetes\n",
-    "from syft.nn.linear import LinearClassifier"
+    "from syft.nn.linear import LinearClassifier\n",
+    "from syft.he.keys import Paillier"
    ]
   },
   {
@@ -32,8 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc = LocalCapsuleClient()\n",
-    "pk = cc.keygen()"
+    "pk, sk = Paillier()"
    ]
   },
   {
@@ -44,7 +43,8 @@
    },
    "outputs": [],
    "source": [
-    "model = LinearClassifier(n_inputs=10,n_labels=1).encrypt(pk)"
+    "n_inputs = 2\n",
+    "model = LinearClassifier(n_inputs=n_inputs,n_labels=1).encrypt(pk)"
    ]
   },
   {
@@ -66,7 +66,7 @@
    "source": [
     "diabetes = load_diabetes()\n",
     "target = diabetes.target\n",
-    "input = diabetes.data"
+    "input = diabetes.data[:, :n_inputs]"
    ]
   },
   {
@@ -76,7 +76,7 @@
    "outputs": [],
    "source": [
     "for i in range(5):\n",
-    "    print(\"Grads:\" + str((model.learn(input=input[i],target=target[i],alpha=0.5))))"
+    "    model.learn(input=input,target=target,alpha=0.5)"
    ]
   },
   {
@@ -87,7 +87,7 @@
    },
    "outputs": [],
    "source": [
-    "model = model.decrypt(cc)"
+    "model = model.decrypt(sk)"
    ]
   },
   {


### PR DESCRIPTION
#### Reference Issue
- Addresses #384 
#### What does your implementation fix? 
- Removes capsule dependencies from the following notebooks
  - [Syft - Paillier Homographic Encrypted Linear Classification example ](https://github.com/OpenMined/PySyft/blob/master/notebooks/Syft%20-%20Paillier%20Homographic%20Encrypted%20Linear%20Classification%20example%20.ipynb)
  - [Syft - Paillier Encrypted Linear Classification](https://github.com/OpenMined/PySyft/blob/master/notebooks/Syft%20-%20Paillier%20Encrypted%20Linear%20Classification.ipynb)
#### Explain your changes.
Use `syft.he.keys.Paillier` instead of capsule to get the keys