### PR TITLE
Split tensor

### DIFF
--- a/syft/math.py
+++ b/syft/math.py
@@ -985,8 +985,7 @@ def split(tensor, split_size, axis=0):
         array to be divided into sub-arrays.
 
     split_size: int
-        the array will be divided into `split_size` equal arrays along `axis`. If split
-        cannot be done equally the last array will be smaller along the given axis.
+        size of single chunk
 
     axis: int, optional
         The axis along which to split, default is 0.
@@ -1000,14 +999,11 @@ def split(tensor, split_size, axis=0):
 
     length_along_axis = tensor.shape()[axis]
 
-    # calculate size of the biggest array after splitting
-    subdivision_size = (length_along_axis + split_size - 1) // split_size
-
-    # calculate number of full sized splits that will be formed
-    number_of_full_splits = length_along_axis // subdivision_size
+    # calculate number of splits!
+    num_splits = (length_along_axis + split_size - 1) // split_size
 
     # make array to pass to numpy array_split function
-    split_according = [subdivision_size * i for i in range(1, number_of_full_splits + 1)]
+    split_according = [split_size * i for i in range(1, num_splits)]
 
     list_ = np.array_split(tensor.data, split_according, axis)
 

--- a/syft/math.py
+++ b/syft/math.py
@@ -969,6 +969,7 @@ def zeros(dim):
     """
     return TensorBase(np.zeros(dim))
 
+
 def split(tensor, split_size, axis=0):
     """
     Splits the tensor into multiple equally sized chunks (if possible).
@@ -995,18 +996,19 @@ def split(tensor, split_size, axis=0):
     list: list of divided arrays
     """
     if axis < 0:
-        axis += len(tensor.shape())        
+        axis += len(tensor.shape())
+
     length_along_axis = tensor.shape()[axis]
 
-    # calculate size of the biggest array after splitting 
+    # calculate size of the biggest array after splitting
     subdivision_size = (length_along_axis + split_size - 1) // split_size
 
-    # calculate number of full sized splits that will be formed 
+    # calculate number of full sized splits that will be formed
     number_of_full_splits = length_along_axis // subdivision_size
 
     # make array to pass to numpy array_split function
-    split_according = [subdivision_size * i for i in range(1,number_of_full_splits + 1)]
-    
-    list_ = np.array_split(tensor.data,split_according,axis)
+    split_according = [subdivision_size * i for i in range(1, number_of_full_splits + 1)]
 
-    return list(map(lambda x: TensorBase(x),list_))
+    list_ = np.array_split(tensor.data, split_according, axis)
+
+    return list(map(lambda x: TensorBase(x), list_))

--- a/syft/math.py
+++ b/syft/math.py
@@ -968,3 +968,45 @@ def zeros(dim):
         Output Tensor
     """
     return TensorBase(np.zeros(dim))
+
+def split(tensor, split_size, axis=0):
+    """
+    Splits the tensor into multiple equally sized chunks (if possible).
+
+    Last chunk will be smaller if the tensor size along a given axis
+    is not divisible by `split_size`.
+
+    Returns a list of the split tensors
+
+    Parameters
+    ----------
+    tensor: TensorBase
+        array to be divided into sub-arrays.
+
+    split_size: int
+        the array will be divided into `split_size` equal arrays along `axis`. If split
+        cannot be done equally the last array will be smaller along the given axis.
+
+    axis: int, optional
+        The axis along which to split, default is 0.
+
+    Returns
+    -------
+    list: list of divided arrays
+    """
+    if axis < 0:
+        axis += len(tensor.shape())        
+    length_along_axis = tensor.shape()[axis]
+
+    # calculate size of the biggest array after splitting 
+    subdivision_size = (length_along_axis + split_size - 1) // split_size
+
+    # calculate number of full sized splits that will be formed 
+    number_of_full_splits = length_along_axis // subdivision_size
+
+    # make array to pass to numpy array_split function
+    split_according = [subdivision_size * i for i in range(1,number_of_full_splits + 1)]
+    
+    list_ = np.array_split(tensor.data,split_according,axis)
+
+    return list(map(lambda x: TensorBase(x),list_))

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3613,12 +3613,9 @@ class TensorBase(object):
 
         Parameters
         ----------
-        tensor: TensorBase
-            array to be divided into sub-arrays.
 
         split_size: int
-            the array will be divided into `split_size` equal arrays along `axis`. If split
-            cannot be done equally the last array will be smaller along the given axis.
+            size of single chunk
 
         axis: int, optional
             The axis along which to split, default is 0.

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3601,3 +3601,35 @@ class TensorBase(object):
 
         self.data.fill(0)
         return self
+
+    def split_(self, split_size, axis=0):
+        """
+        Splits the tensor into multiple equally sized chunks (if possible).
+
+        Last chunk will be smaller if the tensor size along a given axis
+        is not divisible by `split_size`.
+
+        Returns a list of the split tensors
+
+        Parameters
+        ----------
+        tensor: TensorBase
+            array to be divided into sub-arrays.
+
+        split_size: int
+            the array will be divided into `split_size` equal arrays along `axis`. If split
+            cannot be done equally the last array will be smaller along the given axis.
+
+        axis: int, optional
+            The axis along which to split, default is 0.
+
+        Returns
+        -------
+        list: list of divided arrays
+        """
+        if self.encrypted:
+            return NotImplemented
+
+        return syft.math.split(self, split_size, axis)
+
+

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3631,5 +3631,3 @@ class TensorBase(object):
             return NotImplemented
 
         return syft.math.split(self, split_size, axis)
-
-

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3038,29 +3038,6 @@ class TensorBase(object):
         else:
             return self.data.shape
 
-    def split(self, split_size, dim=0):
-        """
-        Returns tuple of tensors of equally sized tensor/chunks (if possible)
-
-        Parameters
-        ----------
-        split_size:
-
-        dim:
-
-        Returns
-        -------
-        Tuple of Tensors
-        """
-        if self.encrypted:
-            return NotImplemented
-        splits = np.array_split(self.data, split_size, axis=0)
-        tensors = list()
-        for s in splits:
-            tensors.append(TensorBase(s))
-        tensors_tuple = tuple(tensors)
-        return tensors_tuple
-
     def stride(self, dim=None):
         """
         Returns the jump necessary to go from one element to the next one in the specified dimension dim.
@@ -3602,7 +3579,7 @@ class TensorBase(object):
         self.data.fill(0)
         return self
 
-    def split_(self, split_size, axis=0):
+    def split(self, split_size, axis=0):
         """
         Splits the tensor into multiple equally sized chunks (if possible).
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -427,3 +427,17 @@ class MultinomialTests(unittest.TestCase):
         t2 = syft.math.multinomial(t1, len(t1))
         self.assertTupleEqual((len(t1),), t2.shape())
         self.assertTrue(np.all(t2.data >= 0) and np.all(t2.data <= len(t1)))
+
+
+class SplitTests(unittest.TestCase):
+    def test_split(self):
+        t = TensorBase(np.random.rand(7, 4))
+        split_size = 3
+        axis = 0
+        target_shapes = [(3, 4), (3, 4), (1, 4)]
+        splits = syft.math.split(t, split_size, axis)
+        start = 0
+        for target_shape, split in zip(target_shapes, splits):
+            self.assertTrue(syft.equal(split.shape(), target_shape))
+            self.assertTrue(syft.equal(t.narrow(axis, start, target_shape[axis]), split))
+            start += target_shape[axis]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -974,13 +974,6 @@ class CumprodTest(unittest.TestCase):
         self.assertTrue(np.equal(t1.cumprod_(dim=1), t3).all())
 
 
-class SplitTests(unittest.TestCase):
-    def test_split(self):
-        t1 = TensorBase(np.arange(8.0))
-        t2 = t1.split(4)
-        self.assertTrue(np.array_equal(t2, tuple((np.array([0., 1.]), np.array([2., 3.]), np.array([4., 5.]), np.array([6., 7.])))))
-
-
 class SqueezeTests(unittest.TestCase):
     def test_squeeze(self):
         t1 = TensorBase(np.zeros((2, 1, 2, 1, 2)))
@@ -1628,13 +1621,13 @@ class UnfoldTest(unittest.TestCase):
                                        t1_unfolded_actual_2))
 
 
-class SplitTests2(unittest.TestCase):
+class SplitTests(unittest.TestCase):
     def test_split(self):
         t = TensorBase(np.random.rand(10, 5))
         split_size = 3
         axis = 0
         target_shapes = [(3, 5), (3, 5), (3, 5), (1, 5)]
-        splits = syft.math.split(t, split_size, axis)
+        splits = t.split(split_size, axis)
         start = 0
         for target_shape, split in zip(target_shapes, splits):
             self.assertTrue(syft.equal(split.shape(), target_shape))

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1633,11 +1633,10 @@ class SplitTests2(unittest.TestCase):
         t = TensorBase(np.random.rand(10, 5))
         split_size = 3
         axis = 0
-        target_shapes = [(4, 5), (4, 5), (2, 5)]
+        target_shapes = [(3, 5), (3, 5), (3, 5), (1, 5)]
         splits = syft.math.split(t, split_size, axis)
         start = 0
         for target_shape, split in zip(target_shapes, splits):
-            print(split.shape())
             self.assertTrue(syft.equal(split.shape(), target_shape))
             self.assertTrue(syft.equal(t.narrow(axis, start, target_shape[axis]), split))
             start += target_shape[axis]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1627,18 +1627,19 @@ class UnfoldTest(unittest.TestCase):
         self.assertTrue(np.array_equal(t1_unfolded_expected_2,
                                        t1_unfolded_actual_2))
 
-class SplitTests(unittest.TestCase):
+
+class SplitTests2(unittest.TestCase):
     def test_split(self):
-        t = TensorBase(np.random.rand(10,5))
+        t = TensorBase(np.random.rand(10, 5))
         split_size = 3
         axis = 0
-        target_shapes = [(4,5),(4,5),(2,5)]
-        splits = syft.math.split(t,split_size,axis)
+        target_shapes = [(4, 5), (4, 5), (2, 5)]
+        splits = syft.math.split(t, split_size, axis)
         start = 0
         for target_shape, split in zip(target_shapes, splits):
             print(split.shape())
-            self.assertTrue(syft.equal(split.shape(),target_shape))
-            self.assertTrue(syft.equal(t.narrow(axis,start,target_shape[axis]),split))
+            self.assertTrue(syft.equal(split.shape(), target_shape))
+            self.assertTrue(syft.equal(t.narrow(axis, start, target_shape[axis]), split))
             start += target_shape[axis]
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1627,17 +1627,19 @@ class UnfoldTest(unittest.TestCase):
         self.assertTrue(np.array_equal(t1_unfolded_expected_2,
                                        t1_unfolded_actual_2))
 
-class SplitTests(unittest.Testcase):
+class SplitTests(unittest.TestCase):
     def test_split(self):
         t = TensorBase(np.random.rand(10,5))
         split_size = 3
         axis = 0
-        target_shapes = [(3,5),(3,5),(3,5),(1,5)]
+        target_shapes = [(4,5),(4,5),(2,5)]
         splits = syft.math.split(t,split_size,axis)
-        np_splits = np.array_split(t.data,split_size,axis)
-        for target_shape, split, np_split in zip(target_shapes, splits, np_splits):
+        start = 0
+        for target_shape, split in zip(target_shapes, splits):
+            print(split.shape())
             self.assertTrue(syft.equal(split.shape(),target_shape))
-            self.assertTrue(syft.equal(TensorBase(np_split),split))
+            self.assertTrue(syft.equal(t.narrow(axis,start,target_shape[axis]),split))
+            start += target_shape[axis]
 
 
 if __name__ == "__main__":

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1627,6 +1627,18 @@ class UnfoldTest(unittest.TestCase):
         self.assertTrue(np.array_equal(t1_unfolded_expected_2,
                                        t1_unfolded_actual_2))
 
+class SplitTests(unittest.Testcase):
+    def test_split(self):
+        t = TensorBase(np.random.rand(10,5))
+        split_size = 3
+        axis = 0
+        target_shapes = [(3,5),(3,5),(3,5),(1,5)]
+        splits = syft.math.split(t,split_size,axis)
+        np_splits = np.array_split(t.data,split_size,axis)
+        for target_shape, split, np_split in zip(target_shapes, splits, np_splits):
+            self.assertTrue(syft.equal(split.shape(),target_shape))
+            self.assertTrue(syft.equal(TensorBase(np_split),split))
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
This fixes #383 

#### What does your implementation fix? 
This add split functionality to default tensor type.

#### Explain your changes.
In syft.math it add a split function which uses numpy.array_split() for splitting the array into given axis into `split size` size of each chunk. The function returns a list containing divided sub-arrays. I had to some initial calculations to match the numpy api. 