### PR TITLE
do not use hard coded type sizes

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -3095,7 +3095,7 @@ class TensorBase(object):
             return NotImplemented
 
         out = self.data.strides
-        output = tuple(map(lambda x: int(x / 8), out))
+        output = tuple(map(lambda x: int(x / self.data.dtype.itemsize), out))
 
         if dim is None:
             return output
@@ -3565,7 +3565,7 @@ class TensorBase(object):
 
             _stride = stride
             if stride is not None:
-                _stride = np.multiply(stride, 8)
+                _stride = np.multiply(stride, self.data.dtype.itemsize)
 
             offset_nd = offset * self.data.dtype.itemsize
             self.data = np.ndarray(shape=size,


### PR DESCRIPTION
<!--
Thanks for submitting a PR. Please make sure  that you have read the contribution guidelines: https://github.com/OpenMined/Docs/blob/master/contributing/guidelines.md
-->


<!-- Example: Fixes #334 -->


#### What does your implementation fix? 

We should not use hard coded type sizes in the library. This fix uses the host architecture type size.



<!--
Please note that we are a small team of volunteers so patience is
essential; We value all the contributions, no matter how small they are. 
If we are slow to review, either the pull request needs 
some tweaking,convincing, etc. 
or probably the reviewers could be busy. In any
case, we hope for your understanding in the process.

However If you feel that  this needs to be fastened up.
Reachout to us on our slack #pysyft channel.

Thanks for the contribution!
-->