### PR TITLE
add `size()`

### DIFF
--- a/syft/syft.py
+++ b/syft/syft.py
@@ -114,6 +114,16 @@ class FloatTensor():
     def sin_(self):
         return self.no_params_func("sin_")
 
+    def size(self):
+        """
+        Returns the size of the self tensor as a FloatTensor.
+
+        Note:
+            The returned value currently is a FloatTensor because it leverages
+            the messaging mechanism with Unity.
+        """
+        return self.no_params_func("size", return_response=True)
+
     def sqrt(self):
         return self.no_params_func("sqrt", return_response=True)
 


### PR DESCRIPTION
As per https://github.com/OpenMined/PySyft/issues/586

`size()` returns a FloatTensor that basically contains `int`s (note that Pytorch has a SizeTensor for this). For the moment, I guess using FloatTensor is sufficient, and it leverages the messaging mechanism with Unity.

The corresponding PR in OpenMined is https://github.com/OpenMined/OpenMined/pull/128

Acceptance criteria:
- [ ] an integration test in PySyft demonstrating the correct CPU and GPU operation implemented over a FloatTensor while connected to a Unity backend
- [x] a Unit Test in OpenMined/OpenMined demonstrating the correct operation on a FloatTensor
- [x] inline documentation in the python code. For inspiration on inline documentation, please check out PyTorch's documentation for this operator.
- [x] Link your Pull Request back to the Issue so that it gets closed appropriately when the PR is merged.