### PR TITLE
Added PR and Issue Templates, which magically fill into all new bodies!

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,50 @@
+# Issue Template
+
+## Context
+### User Story:
+As a Data Scientist using PySyft's... <br>
+Enter what you would like to be implemented as a feature, in case of an issue regrading a bug in our code specify what is actually going wrong, here.
+
+
+
+Please delete (for bugs) or (for features) sections that are not relevant to the Issue you are creating.
+
+Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.
+
+**Test Configuration**:
+* CPU:
+* GPU:
+* PySyft Version:
+* Unity Version:
+* OpenMined Unity App Version:
+
+
+## Expected Behavior
+
+Please describe the behavior you are expecting
+
+## Current Behavior
+
+What is the current behavior?
+
+## Failure Information (for bugs)
+
+Please help provide information about the failure if this is a bug. If it is not a bug, please remove the rest of this template.
+
+### Steps to Reproduce (for bugs)
+
+Please provide detailed steps for reproducing the issue. (for bugs)
+
+1. step 1
+2. step 2
+3. you get it...
+
+### Failure Logs (for bugs)
+
+Please include any relevant log snippets or files here.
+
+
+### Relevant Literature or Examples (for features)
+* [How to Add a function to FloatTensor - Implementing a Function](https://docs.google.com/document/d/1WRd7gGLFN0Awtf86AICYIHtg3gfFWLBa5wYTthsB3i0/)
+* Please provide here an example of where a similar feature has already been implemented. 
+* Provide links to libraries which might be helpful for beginners who are trying to tackle this issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+* CPU:
+* GPU:
+* PySyft Version:
+* Unity Version:
+* OpenMined Unity App Version:
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
We are creating loads of Issue and PRs, manually sorting through would be a hassle in the future! I have added some templates, which use github's embeedded markdown thingy to magically fill in the PR and Issue body with their respective templates, giving a cleaner look to our Repos. 

But, Due to the way GitHub works I doubt if it would be possible 
1. To move these files to https://github.com/OpenMined/Docs.
2. Test if the templates actually work, without creating a new branch or merging them to master.

Templates and instructions to create more can be found at [here](https://github.com/embeddedartistry/embedded-resources).

And as always, I am open to any suggestions and improvements. 😅 