### PR TITLE
Reducing default epsilon for RMSProp and Adam to fit in float

### DIFF
--- a/syft/optim.py
+++ b/syft/optim.py
@@ -54,7 +54,7 @@ class RMSProp(Optimizer):
 	"""
 	RMSProp Optimizer
 	"""
-	def __init__(self, params, lr=0.01, rho=0.9, epsilon=1e-8, decay=0.):
+	def __init__(self, params, lr=0.01, rho=0.9, epsilon=1e-6, decay=0.):
 		super(RMSProp, self).__init__()
 		self.init('rmsprop', params=self.get_param_ids(params), h_params=[lr, rho, epsilon, decay])
 
@@ -63,6 +63,6 @@ class Adam(Optimizer):
 	"""
 	Adam Optimizer
 	"""
-	def __init__(self, params, lr=0.01, beta_1=0.9, beta_2=0.999, epsilon=1e-8, decay=0.):
+	def __init__(self, params, lr=0.01, beta_1=0.9, beta_2=0.999, epsilon=1e-6, decay=0.):
 		super(Adam, self).__init__()
 		self.init('adam', params=self.get_param_ids(params), h_params=[lr, beta_1, beta_2, epsilon, decay])


### PR DESCRIPTION
# Description

1e-8  = 0.00000001 which is too many digits for a float so the value of epsilon becomes 0
which can result in nan errors with RMSProp and Adam.
Not sure if there's an easy way to use doubles in this scenario so setting epsilon to 1e-6 for now

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
