### PR TITLE
Fix hyperparameters parsing

### DIFF
--- a/syft/optim.py
+++ b/syft/optim.py
@@ -47,7 +47,7 @@ class SGD(Optimizer):
 	"""
 	def __init__(self, params, lr=0.01, momentum=0., decay=0.):
 		super(SGD, self).__init__()
-		self.init('sgd', params=self.get_param_ids(params), h_params=[lr, momentum, decay])
+		self.init('sgd', params=self.get_param_ids(params), h_params=[str(lr), str(momentum), str(decay)])
 
 
 class RMSProp(Optimizer):
@@ -56,7 +56,7 @@ class RMSProp(Optimizer):
 	"""
 	def __init__(self, params, lr=0.01, rho=0.9, epsilon=1e-8, decay=0.):
 		super(RMSProp, self).__init__()
-		self.init('rmsprop', params=self.get_param_ids(params), h_params=[lr, rho, epsilon, decay])
+		self.init('rmsprop', params=self.get_param_ids(params), h_params=[str(lr), str(rho), str(epsilon), str(decay)])
 
 
 class Adam(Optimizer):
@@ -65,4 +65,4 @@ class Adam(Optimizer):
 	"""
 	def __init__(self, params, lr=0.01, beta_1=0.9, beta_2=0.999, epsilon=1e-8, decay=0.):
 		super(Adam, self).__init__()
-		self.init('adam', params=self.get_param_ids(params), h_params=[lr, beta_1, beta_2, epsilon, decay])
+		self.init('adam', params=self.get_param_ids(params), h_params=[str(lr), str(beta_1), str(beta_2), str(epsilon), str(decay)])

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -675,17 +675,19 @@ class FloatTensor():
             Caller with values inplace
         """
         return self.no_params_func("floor_")
-    def random_(self):
+    def random_(self, start=.0, to=None):
         """
-        Returns a tensor filled with random numbers from a uniform distribution on the interval [0,1)
-        The shape of the tensor is defined by the varargs sizes.
+        Returns a tensor filled with numbers sampled from the discrete uniform distribution over [from, to - 1]. 
+        If not specified, the values are usually only bounded by self tensor’s data type. For floating point types, 
+        if unspecified, range will be [0, 2^mantissa] to ensure that every value is representable. 
         ----------
         Returns
         -------
         FloatTensor
             Caller with values inplace
         """
-        return self.no_params_func("random_")
+        params = [str(start), str(to)] if to else [str(start)]
+        return self.params_func("random_", params)
 
     def round(self):
         """
@@ -1071,6 +1073,9 @@ class FloatTensor():
             Output tensor
         """
         return self.no_params_func("transpose", return_response=True)
+
+    def T_(self):
+        return self.no_params_func("transpose_")
 
     def triu(self, k=0):
         return self.params_func("triu", [k], return_response=True)
@@ -1465,6 +1470,17 @@ class FloatTensor():
             Output tensor
         """
         return self.no_params_func("tanh", return_response=True)
+
+    def uniform_(self, start=.0, to=1.0):
+        """
+        Returns a tensor filled with numbers sampled from the uniform distribution:
+        ----------
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.params_func("uniform_", [str(start), str(to)])
 
     def squeeze(self, dim=-1):
         """

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import syft.controller
 
+
 class IntTensor():
     def __init__(self, data, data_is_pointer=False):
         self.controller = syft.controller
@@ -32,7 +33,7 @@ class IntTensor():
         Iterable
             Output list
         """
-        return list(np.fromstring(self.get("shape")[:-1], sep=",").astype('int'))           
+        return list(np.fromstring(self.get("shape")[:-1], sep=",").astype('int'))
 
     def __repr__(self, verbose=True):
 
@@ -44,7 +45,7 @@ class IntTensor():
 
         type_str = type_str[:-1]
 
-        desc = "[syft.IntTensor:"+str(self.id) + " size:" + type_str + "]" + "\n"
+        desc = "[syft.IntTensor:" + str(self.id) + " size:" + type_str + "]" + "\n"
 
         return tensor_str + "\n" + desc
 
@@ -59,7 +60,7 @@ class IntTensor():
             if (return_type == 'IntTensor'):
                 self.controller.log("IntTensor.__init__: {}".format(res))
                 return IntTensor(data=int(res), data_is_pointer=True)
-            elif(return_type == 'FloatTensor'):
+            elif (return_type == 'FloatTensor'):
                 self.controller.log("IntTensor.__init__: {}".format(res))
                 return FloatTensor(data=int(res), data_is_pointer=True)
             else:
@@ -67,11 +68,11 @@ class IntTensor():
         return self
 
     def no_params_func(self, name, return_response=False, return_type='IntTensor'):
-        return (self.params_func(name, [], return_response, return_type))        
+        return (self.params_func(name, [], return_response, return_type))
 
     def get(self, param_name="size", response_as_tensor=False, return_type='IntTensor'):
         return self.params_func(name="get", params=[param_name], return_response=True,
-                                return_type="string")        
+                                return_type="string")
 
     def cmd(self, functionCall, params=[]):
         cmd = {
@@ -85,7 +86,7 @@ class IntTensor():
         return True
 
     def to_numpy(self):
-        if(self.is_contiguous()):
+        if (self.is_contiguous()):
             res = self.controller.send_json({
                 'functionCall': 'to_numpy',
                 'objectType': 'IntTensor',
@@ -96,6 +97,7 @@ class IntTensor():
         else:
             return " - non-contiguous - "
 
+
 class FloatTensor():
     def __init__(self, data, autograd=False, data_is_pointer=False):
         self.controller = syft.controller
@@ -104,7 +106,7 @@ class FloatTensor():
 
             if (type(data) == list):
                 data = np.array(data)
-            
+
             data = data.astype('float')
 
             self.data = data
@@ -342,8 +344,9 @@ class FloatTensor():
         else:
             self.params_func(name="backward", params=[grad.id])
 
-    def batchify(self,dim,batch_size):
-        return self.controller.params_func(cmd_func=self.cmd,name="batchify", params=[dim,batch_size],return_type='FloatTensor_list')
+    def batchify(self, dim, batch_size):
+        return self.controller.params_func(cmd_func=self.cmd, name="batchify", params=[dim, batch_size],
+                                           return_type='FloatTensor_list')
 
     def ceil(self):
         """
@@ -369,7 +372,7 @@ class FloatTensor():
         """
         return self.no_params_func("ceil_")
 
-    def clamp(self, min = 'None', max = 'None'):
+    def clamp(self, min='None', max='None'):
         """
         Clamp all elements in input into the range [min, max]
         Parameters
@@ -383,7 +386,7 @@ class FloatTensor():
         FloatTensor
             Output tensor
         """
-        return self.params_func("clamp", [min,max], return_response=True)
+        return self.params_func("clamp", [min, max], return_response=True)
 
     def contiguous(self):
         """
@@ -534,7 +537,7 @@ class FloatTensor():
         """
         return self.no_params_func("exp_")
 
-    def expand(self,*args):
+    def expand(self, *args):
         """
         Returns the tensor, with values repeated across one dimension
         Parameters
@@ -675,19 +678,18 @@ class FloatTensor():
             Caller with values inplace
         """
         return self.no_params_func("floor_")
-    def random_(self, start=.0, to=None):
+
+    def random_(self):
         """
-        Returns a tensor filled with numbers sampled from the discrete uniform distribution over [from, to - 1]. 
-        If not specified, the values are usually only bounded by self tensor’s data type. For floating point types, 
-        if unspecified, range will be [0, 2^mantissa] to ensure that every value is representable. 
+        Returns a tensor filled with random numbers from a uniform distribution on the interval [0,1)
+        The shape of the tensor is defined by the varargs sizes.
         ----------
         Returns
         -------
         FloatTensor
             Caller with values inplace
         """
-        params = [str(start), str(to)] if to else [str(start)]
-        return self.params_func("random_", params)
+        return self.no_params_func("random_")
 
     def round(self):
         """
@@ -814,7 +816,7 @@ class FloatTensor():
         return self.no_params_func("neg_")
 
     def relu(self):
-        
+
         return self.no_params_func("relu", return_response=True)
 
     def rsqrt(self):
@@ -946,7 +948,7 @@ class FloatTensor():
 
     def softmax(self, dim=-1):
         return self.params_func("softmax", [dim], return_response=True)
-    
+
     def std(self, dim=-1):
         return self.params_func("std", [dim], return_response=True)
 
@@ -1001,7 +1003,7 @@ class FloatTensor():
         return self.no_params_func("trunc", return_response=True)
 
     def to_numpy(self):
-        if(self.is_contiguous()):
+        if (self.is_contiguous()):
             res = self.controller.send_json({
                 'functionCall': 'to_numpy',
                 'objectType': 'FloatTensor',
@@ -1074,20 +1076,17 @@ class FloatTensor():
         """
         return self.no_params_func("transpose", return_response=True)
 
-    def T_(self):
-        return self.no_params_func("transpose_")
-
     def triu(self, k=0):
         return self.params_func("triu", [k], return_response=True)
 
     def triu_(self, k=0):
         return self.params_func("triu_", [k])
 
-    def unsqueeze(self,dim):
+    def unsqueeze(self, dim):
         return self.params_func("unsqueeze", [dim], return_response=True)
 
-    def unsqueeze_(self,dim):
-        return self.params_func("unsqueeze_", [dim], return_response=True)        
+    def unsqueeze_(self, dim):
+        return self.params_func("unsqueeze_", [dim], return_response=True)
 
     def zero_(self):
         """
@@ -1115,20 +1114,21 @@ class FloatTensor():
             grad = 'None'
 
         co = str(self.creation_op())
-        
-        desc = "[syft.FloatTensor:"+str(self.id)+" grad:" + grad + " size:" + type_str + " c:" + str(self.children()) + " p:" + str(self.creators()) + " init:" + co + "]" + "\n"
+
+        desc = "[syft.FloatTensor:" + str(self.id) + " grad:" + grad + " size:" + type_str + " c:" + str(
+            self.children()) + " p:" + str(self.creators()) + " init:" + co + "]" + "\n"
 
         if (verbose):
             children = self.children()
             creators = self.creators()
 
-            if(len(children) > 0):
-                #tensor_str = "\n -------------------------------\n" + tensor_str
+            if (len(children) > 0):
+                # tensor_str = "\n -------------------------------\n" + tensor_str
                 desc += "\n\t-----------children-----------\n"
             for child_id in children:
                 desc += "\t" + syft.controller.get_tensor(child_id).__repr__(False)
-            if(len(children) > 0):
-                if(len(creators) > 0):
+            if (len(children) > 0):
+                if (len(creators) > 0):
 
                     desc += "\t------------------------------\n"
                 else:
@@ -1147,16 +1147,16 @@ class FloatTensor():
 
     def __str__(self):
         tensor_str = str(self.to_numpy()).replace("]", " ").replace("[", " ")
-        
+
         return tensor_str
 
     def get(self, param_name="size", response_as_tensor=False):
-        if(response_as_tensor):
+        if (response_as_tensor):
             return self.params_func(name="get", params=[param_name], return_response=True,
-                                return_type='FloatTensor', data_is_pointer=True)
+                                    return_type='FloatTensor', data_is_pointer=True)
         else:
             return self.params_func(name="get", params=[param_name], return_response=True,
-                                return_type='string', data_is_pointer=False)
+                                    return_type='string', data_is_pointer=False)
 
     def cpu(self):
         """
@@ -1190,7 +1190,7 @@ class FloatTensor():
             'tensorIndexParams': params}
         return cmd
 
-    def params_func(self, name, params, return_response=False, return_type='FloatTensor', data_is_pointer=True,):
+    def params_func(self, name, params, return_response=False, return_type='FloatTensor', data_is_pointer=True, ):
         # send the command
         res = self.controller.send_json(
             self.cmd(name, params=params))
@@ -1201,9 +1201,9 @@ class FloatTensor():
             if (return_type == 'IntTensor'):
                 self.controller.log("IntTensor.__init__: {}".format(res))
                 return IntTensor(data=int(res), data_is_pointer=data_is_pointer)
-            elif(return_type == 'FloatTensor'):
+            elif (return_type == 'FloatTensor'):
                 self.controller.log("FloatTensor.__init__: {}".format(res))
-                if(res == ''):
+                if (res == ''):
                     return None
                 return FloatTensor(data=int(res), data_is_pointer=data_is_pointer)
             else:
@@ -1211,7 +1211,7 @@ class FloatTensor():
         return self
 
     def no_params_func(self, name, return_response=False, return_type='FloatTensor'):
-        return (self.params_func(name, [], return_response, return_type)) 
+        return (self.params_func(name, [], return_response, return_type))
 
     def arithmetic_operation(self, x, name, inline=False):
 
@@ -1244,10 +1244,9 @@ class FloatTensor():
         self.controller = None
         self.id = None
 
-
     def is_contiguous(self):
         txt = (self.no_params_func("is_contiguous", return_response=True, return_type=None))
-        if(txt == 'True'):
+        if (txt == 'True'):
             return True
 
         else:
@@ -1424,7 +1423,7 @@ class FloatTensor():
         """
         return self.arithmetic_operation(divisor, "remainder", 'FloatTensor')
 
-    def sample(self,dim):
+    def sample(self, dim):
         """
         Samples the current tensor uniformly assuming each value is a binary probability.
         ----------
@@ -1470,17 +1469,6 @@ class FloatTensor():
             Output tensor
         """
         return self.no_params_func("tanh", return_response=True)
-
-    def uniform_(self, start=.0, to=1.0):
-        """
-        Returns a tensor filled with numbers sampled from the uniform distribution:
-        ----------
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.params_func("uniform_", [str(start), str(to)])
 
     def squeeze(self, dim=-1):
         """

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import syft.controller
 
-
 class IntTensor():
     def __init__(self, data, data_is_pointer=False):
         self.controller = syft.controller
@@ -33,7 +32,7 @@ class IntTensor():
         Iterable
             Output list
         """
-        return list(np.fromstring(self.get("shape")[:-1], sep=",").astype('int'))
+        return list(np.fromstring(self.get("shape")[:-1], sep=",").astype('int'))           
 
     def __repr__(self, verbose=True):
 
@@ -45,7 +44,7 @@ class IntTensor():
 
         type_str = type_str[:-1]
 
-        desc = "[syft.IntTensor:" + str(self.id) + " size:" + type_str + "]" + "\n"
+        desc = "[syft.IntTensor:"+str(self.id) + " size:" + type_str + "]" + "\n"
 
         return tensor_str + "\n" + desc
 
@@ -60,7 +59,7 @@ class IntTensor():
             if (return_type == 'IntTensor'):
                 self.controller.log("IntTensor.__init__: {}".format(res))
                 return IntTensor(data=int(res), data_is_pointer=True)
-            elif (return_type == 'FloatTensor'):
+            elif(return_type == 'FloatTensor'):
                 self.controller.log("IntTensor.__init__: {}".format(res))
                 return FloatTensor(data=int(res), data_is_pointer=True)
             else:
@@ -68,11 +67,11 @@ class IntTensor():
         return self
 
     def no_params_func(self, name, return_response=False, return_type='IntTensor'):
-        return (self.params_func(name, [], return_response, return_type))
+        return (self.params_func(name, [], return_response, return_type))        
 
     def get(self, param_name="size", response_as_tensor=False, return_type='IntTensor'):
         return self.params_func(name="get", params=[param_name], return_response=True,
-                                return_type="string")
+                                return_type="string")        
 
     def cmd(self, functionCall, params=[]):
         cmd = {
@@ -86,7 +85,7 @@ class IntTensor():
         return True
 
     def to_numpy(self):
-        if (self.is_contiguous()):
+        if(self.is_contiguous()):
             res = self.controller.send_json({
                 'functionCall': 'to_numpy',
                 'objectType': 'IntTensor',
@@ -97,7 +96,6 @@ class IntTensor():
         else:
             return " - non-contiguous - "
 
-
 class FloatTensor():
     def __init__(self, data, autograd=False, data_is_pointer=False):
         self.controller = syft.controller
@@ -106,7 +104,7 @@ class FloatTensor():
 
             if (type(data) == list):
                 data = np.array(data)
-
+            
             data = data.astype('float')
 
             self.data = data
@@ -344,9 +342,8 @@ class FloatTensor():
         else:
             self.params_func(name="backward", params=[grad.id])
 
-    def batchify(self, dim, batch_size):
-        return self.controller.params_func(cmd_func=self.cmd, name="batchify", params=[dim, batch_size],
-                                           return_type='FloatTensor_list')
+    def batchify(self,dim,batch_size):
+        return self.controller.params_func(cmd_func=self.cmd,name="batchify", params=[dim,batch_size],return_type='FloatTensor_list')
 
     def ceil(self):
         """
@@ -372,7 +369,7 @@ class FloatTensor():
         """
         return self.no_params_func("ceil_")
 
-    def clamp(self, min='None', max='None'):
+    def clamp(self, min = 'None', max = 'None'):
         """
         Clamp all elements in input into the range [min, max]
         Parameters
@@ -386,7 +383,7 @@ class FloatTensor():
         FloatTensor
             Output tensor
         """
-        return self.params_func("clamp", [min, max], return_response=True)
+        return self.params_func("clamp", [min,max], return_response=True)
 
     def contiguous(self):
         """
@@ -537,7 +534,7 @@ class FloatTensor():
         """
         return self.no_params_func("exp_")
 
-    def expand(self, *args):
+    def expand(self,*args):
         """
         Returns the tensor, with values repeated across one dimension
         Parameters
@@ -678,7 +675,6 @@ class FloatTensor():
             Caller with values inplace
         """
         return self.no_params_func("floor_")
-
     def random_(self):
         """
         Returns a tensor filled with random numbers from a uniform distribution on the interval [0,1)
@@ -816,7 +812,7 @@ class FloatTensor():
         return self.no_params_func("neg_")
 
     def relu(self):
-
+        
         return self.no_params_func("relu", return_response=True)
 
     def rsqrt(self):
@@ -948,7 +944,7 @@ class FloatTensor():
 
     def softmax(self, dim=-1):
         return self.params_func("softmax", [dim], return_response=True)
-
+    
     def std(self, dim=-1):
         return self.params_func("std", [dim], return_response=True)
 
@@ -1003,7 +999,7 @@ class FloatTensor():
         return self.no_params_func("trunc", return_response=True)
 
     def to_numpy(self):
-        if (self.is_contiguous()):
+        if(self.is_contiguous()):
             res = self.controller.send_json({
                 'functionCall': 'to_numpy',
                 'objectType': 'FloatTensor',
@@ -1082,11 +1078,11 @@ class FloatTensor():
     def triu_(self, k=0):
         return self.params_func("triu_", [k])
 
-    def unsqueeze(self, dim):
+    def unsqueeze(self,dim):
         return self.params_func("unsqueeze", [dim], return_response=True)
 
-    def unsqueeze_(self, dim):
-        return self.params_func("unsqueeze_", [dim], return_response=True)
+    def unsqueeze_(self,dim):
+        return self.params_func("unsqueeze_", [dim], return_response=True)        
 
     def zero_(self):
         """
@@ -1114,21 +1110,20 @@ class FloatTensor():
             grad = 'None'
 
         co = str(self.creation_op())
-
-        desc = "[syft.FloatTensor:" + str(self.id) + " grad:" + grad + " size:" + type_str + " c:" + str(
-            self.children()) + " p:" + str(self.creators()) + " init:" + co + "]" + "\n"
+        
+        desc = "[syft.FloatTensor:"+str(self.id)+" grad:" + grad + " size:" + type_str + " c:" + str(self.children()) + " p:" + str(self.creators()) + " init:" + co + "]" + "\n"
 
         if (verbose):
             children = self.children()
             creators = self.creators()
 
-            if (len(children) > 0):
-                # tensor_str = "\n -------------------------------\n" + tensor_str
+            if(len(children) > 0):
+                #tensor_str = "\n -------------------------------\n" + tensor_str
                 desc += "\n\t-----------children-----------\n"
             for child_id in children:
                 desc += "\t" + syft.controller.get_tensor(child_id).__repr__(False)
-            if (len(children) > 0):
-                if (len(creators) > 0):
+            if(len(children) > 0):
+                if(len(creators) > 0):
 
                     desc += "\t------------------------------\n"
                 else:
@@ -1147,16 +1142,16 @@ class FloatTensor():
 
     def __str__(self):
         tensor_str = str(self.to_numpy()).replace("]", " ").replace("[", " ")
-
+        
         return tensor_str
 
     def get(self, param_name="size", response_as_tensor=False):
-        if (response_as_tensor):
+        if(response_as_tensor):
             return self.params_func(name="get", params=[param_name], return_response=True,
-                                    return_type='FloatTensor', data_is_pointer=True)
+                                return_type='FloatTensor', data_is_pointer=True)
         else:
             return self.params_func(name="get", params=[param_name], return_response=True,
-                                    return_type='string', data_is_pointer=False)
+                                return_type='string', data_is_pointer=False)
 
     def cpu(self):
         """
@@ -1190,7 +1185,7 @@ class FloatTensor():
             'tensorIndexParams': params}
         return cmd
 
-    def params_func(self, name, params, return_response=False, return_type='FloatTensor', data_is_pointer=True, ):
+    def params_func(self, name, params, return_response=False, return_type='FloatTensor', data_is_pointer=True,):
         # send the command
         res = self.controller.send_json(
             self.cmd(name, params=params))
@@ -1201,9 +1196,9 @@ class FloatTensor():
             if (return_type == 'IntTensor'):
                 self.controller.log("IntTensor.__init__: {}".format(res))
                 return IntTensor(data=int(res), data_is_pointer=data_is_pointer)
-            elif (return_type == 'FloatTensor'):
+            elif(return_type == 'FloatTensor'):
                 self.controller.log("FloatTensor.__init__: {}".format(res))
-                if (res == ''):
+                if(res == ''):
                     return None
                 return FloatTensor(data=int(res), data_is_pointer=data_is_pointer)
             else:
@@ -1211,7 +1206,7 @@ class FloatTensor():
         return self
 
     def no_params_func(self, name, return_response=False, return_type='FloatTensor'):
-        return (self.params_func(name, [], return_response, return_type))
+        return (self.params_func(name, [], return_response, return_type)) 
 
     def arithmetic_operation(self, x, name, inline=False):
 
@@ -1244,9 +1239,10 @@ class FloatTensor():
         self.controller = None
         self.id = None
 
+
     def is_contiguous(self):
         txt = (self.no_params_func("is_contiguous", return_response=True, return_type=None))
-        if (txt == 'True'):
+        if(txt == 'True'):
             return True
 
         else:
@@ -1423,7 +1419,7 @@ class FloatTensor():
         """
         return self.arithmetic_operation(divisor, "remainder", 'FloatTensor')
 
-    def sample(self, dim):
+    def sample(self,dim):
         """
         Samples the current tensor uniformly assuming each value is a binary probability.
         ----------


### PR DESCRIPTION
# Description
I found out that the hyperparameters weren't correctly parsed by Unity causing a hyperparameter lr=0.1 to be parsed as 100000 causing `nan` errors. This was easily fixed by sending the hyperparameters as a string.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested running the optimizer notebooks and they worked now. Also logged the hyperparameters and the correct values were being parsed in Unity.
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

  