### PR TITLE
Implemented hyperparameter forwarding Keras

### DIFF
--- a/syft/interfaces/keras/models/sequential.py
+++ b/syft/interfaces/keras/models/sequential.py
@@ -34,7 +34,7 @@ class Sequential(object):
 	def summary(self):
 		self.syft.summary()
 
-	def compile(self,loss,optimizer,metrics,alpha=0.01):
+	def compile(self,loss,optimizer,metrics):
 		if(not self.compiled):
 			self.compiled = True
 
@@ -45,7 +45,7 @@ class Sequential(object):
 			self.optimizer = optimizer
 			self.metrics = metrics
 
-			self.optimizer.init(syft_params=self.syft.parameters(),alpha=alpha)
+			self.optimizer.init(syft_params=self.syft.parameters())
 		else:
 			sys.stderr.write("Warning: Model already compiled... please rebuild from scratch if you need to change things")
 

--- a/syft/interfaces/keras/optimizers/sgd.py
+++ b/syft/interfaces/keras/optimizers/sgd.py
@@ -2,8 +2,8 @@ import syft.optim as optim
 
 class SGD(object):
 
-	def __init__(self):
-		""
+	def __init__(self, **hyperparameters):
+		self.hyperparameters = hyperparameters
 
-	def init(self, syft_params, alpha):
-		self.syft = optim.SGD(syft_params,alpha)
+	def init(self, syft_params):
+		self.syft = optim.SGD(syft_params,**self.hyperparameters)


### PR DESCRIPTION
Implemented hyperparameter forwarding Keras
# Description
I noticed it wasn't possible to forward any hyperparameters like lr, momentum and decay to the optimizer in Keras. So I added keyword arguments to the optimizer and unpack them when calling the syft function.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested in the Keras notebook.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
