### PR TITLE
Delete tensor after usage

### DIFF
--- a/syft/controller.py
+++ b/syft/controller.py
@@ -41,36 +41,36 @@ def cmd(functionCall, params=[]):
 
 # Introspection
 def num_models():
-    return no_params_func(cmd,"num_models",'int')
+    return no_params_func(cmd,"num_models",'int', delete_after_use=False)
 
 def get_model(id):
     return syft.nn.Model(id=int(id)).discover()
 
 def load(filename):
-    return params_func(cmd,"load_floattensor",params=[filename], return_type='FloatTensor')
+    return params_func(cmd,"load_floattensor",params=[filename], return_type='FloatTensor', delete_after_use=False)
 
 def save(x,filename):
     return x.save(filename)
 
 def num_tensors():
-    return no_params_func(cmd,"num_tensors",'int')
+    return no_params_func(cmd,"num_tensors",'int', delete_after_use=False)
 
 def new_tensors_allowed(allowed=None):
     if(allowed is None):
-        return no_params_func(cmd,"new_tensors_allowed",'bool')
+        return no_params_func(cmd,"new_tensors_allowed",'bool', delete_after_use=False)
     else:
         if(allowed):
-            return params_func(cmd, "new_tensors_allowed",["True"], 'bool')
+            return params_func(cmd, "new_tensors_allowed",["True"], 'bool', delete_after_use=False)
         else:
-            return params_func(cmd, "new_tensors_allowed",["False"], 'bool')
+            return params_func(cmd, "new_tensors_allowed",["False"], 'bool', delete_after_use=False)
 
 def get_tensor(id):
-    return syft.tensor.FloatTensor(data=int(id),data_is_pointer=True)
+    return syft.tensor.FloatTensor(data=int(id),data_is_pointer=True, delete_after_use=False)
 
 def __getitem__(id):
         return get_tensor(id)
 
-def params_func(cmd_func, name, params, return_type=None):
+def params_func(cmd_func, name, params, return_type=None, delete_after_use=True):
     # makes things fail gracefully - without this, interruping the process early
     # can cause the client and the server to go out of sync
     with DelayedKeyboardInterrupt():
@@ -92,7 +92,7 @@ def params_func(cmd_func, name, params, return_type=None):
             if(res != '-1' and res != ''):
                 if(verbose):
                     print("FloatTensor.__init__: " +  res)
-                return syft.tensor.FloatTensor(data=int(res),data_is_pointer=True)
+                return syft.tensor.FloatTensor(data=int(res),data_is_pointer=True, delete_after_use=delete_after_use)
             return None
         elif(return_type == 'IntTensor'):
             if(res != '-1' and res != ''):
@@ -143,6 +143,6 @@ def send_json(message,response=True):
             raise Exception(res)
         return res
 
-def no_params_func(cmd_func, name, return_type):
-    return params_func(cmd_func, name, [], return_type)
+def no_params_func(cmd_func, name, return_type, delete_after_use=True):
+    return params_func(cmd_func, name, [], return_type, delete_after_use)
 

--- a/syft/nn.py
+++ b/syft/nn.py
@@ -56,7 +56,7 @@ class Model():
 			return self.forward(args[0],args[1], args[2])
 
 	def parameters(self):
-		return self.sc.no_params_func(self.cmd, "params",return_type='FloatTensor_list')
+		return self.sc.no_params_func(self.cmd, "params",return_type='FloatTensor_list', delete_after_use=False)
 	
 	def num_parameters(self):
 		return self.sc.no_params_func(self.cmd,"param_count",return_type='int')
@@ -69,12 +69,12 @@ class Model():
 		if(type(input) == list):
 			input = np.array(input).astype('float')
 		if(type(input) == np.array or type(input) == np.ndarray):
-			input = FloatTensor(input,autograd=True)
+			input = FloatTensor(input,autograd=True, delete_after_use=False)
 
 		if(type(target) == list):
 			target = np.array(target).astype('float')
 		if(type(target) == np.array or type(target) == np.ndarray):
-			target = FloatTensor(target,autograd=True)	
+			target = FloatTensor(target,autograd=True, delete_after_use=False)
 
 
 		num_batches = self.sc.params_func(self.cmd,"prepare_to_fit",[input.id, target.id, criterion.id, optim.id, batch_size], return_type='int')
@@ -170,7 +170,7 @@ class Model():
 		return self.parameters()[idx]		
 
 	def activation(self):
-		return self.sc.no_params_func(self.cmd, "activation",return_type='FloatTensor')		
+		return self.sc.no_params_func(self.cmd, "activation",return_type='FloatTensor', delete_after_use=False)
 
 	def layer_type(self):
 		return self.sc.no_params_func(self.cmd,"model_type",return_type='string')
@@ -184,7 +184,7 @@ class Model():
 		return cmd
 
 	def forward(self, input):
-		return self.sc.params_func(self.cmd,"forward",[input.id],return_type='FloatTensor')	
+		return self.sc.params_func(self.cmd,"forward",[input.id],return_type='FloatTensor', delete_after_use=False)
 
 	def __repr__(self,verbose=True):
 
@@ -246,7 +246,7 @@ class Sequential(Model):
 				self.add(layer)
 
 	def add(self, model):
-		self.sc.params_func(self.cmd,"add",[model.id])
+		self.sc.params_func(self.cmd,"add",[model.id], delete_after_use=False)
 
 	def summary(self):
 		single = "_________________________________________________________________\n"
@@ -396,7 +396,7 @@ class MSELoss(Model):
 			self._layer_type = "mseloss"
 
 	def forward(self, input, target):
-		return self.sc.params_func(self.cmd, "forward", [input.id, target.id], return_type='FloatTensor')
+		return self.sc.params_func(self.cmd, "forward", [input.id, target.id], return_type='FloatTensor', delete_after_use=False)
 
 class NLLLoss(Model):
 	def __init__(self, id=None):
@@ -411,7 +411,7 @@ class NLLLoss(Model):
 			self._layer_type = "nllloss"
 
 	def forward(self, input, target):
-		return self.sc.params_func(self.cmd, "forward", [input.id, target.id], return_type='FloatTensor')
+		return self.sc.params_func(self.cmd, "forward", [input.id, target.id], return_type='FloatTensor', delete_after_use=False)
 
 
 class CrossEntropyLoss(Model):
@@ -431,6 +431,6 @@ class CrossEntropyLoss(Model):
 			self._layer_type = "crossentropyloss"
 
 	def forward(self, input, target):
-		return self.sc.params_func(self.cmd, "forward", [input.id, target.id], return_type='FloatTensor')
+		return self.sc.params_func(self.cmd, "forward", [input.id, target.id], return_type='FloatTensor', delete_after_use=False)
 
 

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -550,12 +550,6 @@ class FloatTensor():
         assert type(new_dim[0]) == int
         return self.params_func("expand", new_dim, return_response=True)
 
-    def fill_(self, data, starting_offset=0, length_to_fill=0):
-        if (type(data) == list):
-            data = np.array(data)
-        data = data.astype('float')
-        return self.params_funct("fill_", list(data.flatten()) + [starting_offset, length_to_fill])
-
     def index_add(self, indices, dim, x):
         return self.params_func("index_add", [indices.id, dim, x.id], return_response=True)
 
@@ -1240,14 +1234,9 @@ class FloatTensor():
         Returns
         -------
         """
-        print("Callingdelete densor")
         if (self.id is not None):
-            print("delete after use = ", self.delete_after_use)
             if self.delete_after_use:
-                print("Deleting tensor:", self.to_numpy())
-                print("ID:", self.id)
                 response = self.no_params_func("delete", return_response=True, return_type=str)
-                print("response: ",response)
         self.controller = None
         self.id = None
 


### PR DESCRIPTION
# Description
Implemented a function that deletes a tensor in Unity when the FloatTensor python object is deleted. Also added n argument "delete_after_usage" parameter to the FloatTensor object to make sure certain tensors related to the model are not deleted.

- Not a very clean implementation, maybe someone has a better idea to reduce the overhead of unused tensors.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran several demo notebooks that still seem to work, the necessary tensors are not deleted. Also tried creating tensors and then overwriting the variable in which case the tensor was deleted.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
