### PR TITLE
bugfix: do not delete results for inline aritmetic operations

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -1297,7 +1297,10 @@ class FloatTensor():
 
         response = self.controller.send_json(
             self.cmd(operation_cmd, [parameter]))  # sends the command
-        return FloatTensor(data=int(response), data_is_pointer=True)
+        if int(response) == self.id:
+            return self
+        else:
+            return FloatTensor(data=int(response), data_is_pointer=True)
 
     def delete_tensor(self):
         """


### PR DESCRIPTION
# Description

Fixes a bug: for inline arithmetic operations, no new python FloatTensor should be created. Otherwise, the first version of the tensor in python will be deleted, causing the Tensor in C# to be deleted aswell.

## Type of change

- Bug fix 

# How Has This Been Tested?

Tested in Syft Tensor Example Notebook.ipynb

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
