### PR TITLE
Create a BaseTensor class

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -327,6 +327,18 @@ class IntTensor(BaseTensor):
             'tensorIndexParams': params}
         return cmd
 
+    def gpu(self):
+        """
+        Returns a GPU copy of this storage if it's not already on the GPU
+        Parameters
+        ----------
+        Returns
+        -------
+        IntTensor
+            Output tensor
+        """
+        return self.no_params_func("gpu")
+
     def is_contiguous(self):
         return True
 

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -24,6 +24,20 @@ class BaseTensor():
         else:
             return self.__class__(data=int(response), data_is_pointer=True)
 
+    def __add__(self, x):
+        """
+        Performs element-wise addition arithmetic between two tensors
+        Parameters
+        ----------
+        x : BaseTensor (Subclass)
+            The Second tensor to perform addition with.
+        Returns
+        -------
+        BaseTensor (Subclass)
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "add", False)
+
 class IntTensor(BaseTensor):
     def __init__(self, data, data_is_pointer=False):
         self.controller = syft.controller
@@ -41,20 +55,6 @@ class IntTensor(BaseTensor):
                                                      "shape": self.data.shape}))
         elif (data_is_pointer):
             self.id = int(data)
-
-    def __add__(self, x):
-        """
-        Performs element-wise addition arithmetic between two tensors
-        Parameters
-        ----------
-        x : IntTensor
-            The Second tensor to perform addition with.
-        Returns
-        -------
-        IntTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "add", False)
 
     def autograd(self, state):
         "do nothing"
@@ -132,7 +132,7 @@ class IntTensor(BaseTensor):
         else:
             return " - non-contiguous - "
 
-class FloatTensor():
+class FloatTensor(BaseTensor):
     def __init__(self, data, autograd=False, data_is_pointer=False, delete_after_use=True):
         self.controller = syft.controller
         self.delete_after_use = delete_after_use
@@ -343,20 +343,6 @@ class FloatTensor():
                 return self
             else:
                 return False
-
-    def __add__(self, x):
-        """
-        Performs element-wise addition arithmetic between two tensors
-        Parameters
-        ----------
-        x : FloatTensor
-            The Second tensor to perform addition with.
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "add", False)
 
     def __iadd__(self, x):
         """
@@ -1315,28 +1301,7 @@ class FloatTensor():
         return self
 
     def no_params_func(self, name, return_response=False, return_type='FloatTensor', delete_after_use=True):
-        return (self.params_func(name, [], return_response, return_type, delete_after_use=delete_after_use)) 
-
-    def arithmetic_operation(self, x, name, inline=False):
-
-        operation_cmd = name
-
-        if (type(x) == FloatTensor):
-            operation_cmd += "_elem"
-            parameter = x.id
-        else:
-            operation_cmd += "_scalar"
-            parameter = str(x)
-
-        if (inline):
-            operation_cmd += "_"
-
-        response = self.controller.send_json(
-            self.cmd(operation_cmd, [parameter]))  # sends the command
-        if int(response) == self.id:
-            return self
-        else:
-            return FloatTensor(data=int(response), data_is_pointer=True)
+        return (self.params_func(name, [], return_response, return_type, delete_after_use=delete_after_use))
 
     def delete_tensor(self):
         """

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -20,6 +20,41 @@ class IntTensor():
         elif (data_is_pointer):
             self.id = int(data)
 
+    def __add__(self, x):
+        """
+        Performs element-wise addition arithmetic between two tensors
+        Parameters
+        ----------
+        x : IntTensor
+            The Second tensor to perform addition with.
+        Returns
+        -------
+        IntTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "add", False)
+
+    def arithmetic_operation(self, x, name, inline=False):
+
+        operation_cmd = name
+
+        if (type(x) == IntTensor):
+            operation_cmd += "_elem"
+            parameter = x.id
+        else:
+            operation_cmd += "_scalar"
+            parameter = str(x)
+
+        if (inline):
+            operation_cmd += "_"
+
+        response = self.controller.send_json(
+            self.cmd(operation_cmd, [parameter]))  # sends the command
+        if int(response) == self.id:
+            return self
+        else:
+            return IntTensor(data=int(response), data_is_pointer=True)
+
     def autograd(self, state):
         "do nothing"
 

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -2,7 +2,29 @@ import numpy as np
 
 import syft.controller
 
-class IntTensor():
+class BaseTensor():
+    def arithmetic_operation(self, x, name, inline=False):
+
+        operation_cmd = name
+
+        if (type(x) == type(self)):
+            operation_cmd += "_elem"
+            parameter = x.id
+        else:
+            operation_cmd += "_scalar"
+            parameter = str(x)
+
+        if (inline):
+            operation_cmd += "_"
+
+        response = self.controller.send_json(
+            self.cmd(operation_cmd, [parameter]))  # sends the command
+        if int(response) == self.id:
+            return self
+        else:
+            return self.__class__(data=int(response), data_is_pointer=True)
+
+class IntTensor(BaseTensor):
     def __init__(self, data, data_is_pointer=False):
         self.controller = syft.controller
 
@@ -33,27 +55,6 @@ class IntTensor():
             Output tensor
         """
         return self.arithmetic_operation(x, "add", False)
-
-    def arithmetic_operation(self, x, name, inline=False):
-
-        operation_cmd = name
-
-        if (type(x) == IntTensor):
-            operation_cmd += "_elem"
-            parameter = x.id
-        else:
-            operation_cmd += "_scalar"
-            parameter = str(x)
-
-        if (inline):
-            operation_cmd += "_"
-
-        response = self.controller.send_json(
-            self.cmd(operation_cmd, [parameter]))  # sends the command
-        if int(response) == self.id:
-            return self
-        else:
-            return IntTensor(data=int(response), data_is_pointer=True)
 
     def autograd(self, state):
         "do nothing"

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -43,11 +43,11 @@ class BaseTensor():
         Performs in place element-wise addition arithmetic between two tensors
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             The Second tensor to perform addition with.
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
         return self.arithmetic_operation(x, "add", True)
@@ -57,11 +57,11 @@ class BaseTensor():
         Performs division arithmetic between two tensors
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Second divident tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Output tensor
         """
         return self.arithmetic_operation(x, "div", False)
@@ -71,11 +71,11 @@ class BaseTensor():
         Performs division arithmetic between two tensors inplace.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Second divident tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
         return self.arithmetic_operation(x, "div", True)
@@ -86,11 +86,11 @@ class BaseTensor():
         returns a tensor with the result.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Exponent tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Output tensor
         """
         return self.arithmetic_operation(x, "pow", False)
@@ -101,11 +101,11 @@ class BaseTensor():
         returns a tensor with the result inplace.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Exponent tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
         return self.arithmetic_operation(x, "pow", True)
@@ -116,11 +116,11 @@ class BaseTensor():
         returns a tensor with the result.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Exponent tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Output tensor
         """
         return self.arithmetic_operation(x, "pow", False)
@@ -130,11 +130,11 @@ class BaseTensor():
         Takes the power of each element in input ('self') with 'x', inplace.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Exponent tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
         return self.arithmetic_operation(x, "pow", True)
@@ -144,11 +144,11 @@ class BaseTensor():
         Performs Modulus arithmetic operation between two tensors.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Dividend tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Output tensor
         """
         return self.arithmetic_operation(x, "remainder", False)
@@ -158,11 +158,11 @@ class BaseTensor():
         Performs Modulus arithmetic operation between two tensors inplace.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Dividend tensor
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
         return self.arithmetic_operation(x, "remainder", True)
@@ -172,11 +172,11 @@ class BaseTensor():
         Performs Multiplication arithmetic operation between two tensors.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Second tensor to be multiplied with.
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Output tensor
         """
         return self.arithmetic_operation(x, "mul", False)
@@ -186,11 +186,11 @@ class BaseTensor():
         Performs Multiplication arithmetic operation between two tensors inplace.
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             Second tensor to be multiplied with.
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
         return self.arithmetic_operation(x, "mul", True)
@@ -200,11 +200,11 @@ class BaseTensor():
         Performs element-wise substraction arithmetic between two tensors
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             The Second tensor to perform addition with.
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Output tensor
         """
         return self.arithmetic_operation(x, "sub", False)
@@ -214,11 +214,11 @@ class BaseTensor():
         Performs element-wise substraction arithmetic between two tensors
         Parameters
         ----------
-        x : FloatTensor
+        x : BaseTensor (Subclass)
             The Second tensor to perform addition with.
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
         return self.arithmetic_operation(x, "sub", True)
@@ -231,7 +231,7 @@ class BaseTensor():
         ----------
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Output tensor
         """
         return self.arithmetic_operation(divisor, "remainder")
@@ -243,10 +243,10 @@ class BaseTensor():
         ----------
         Returns
         -------
-        FloatTensor
+        BaseTensor (Subclass)
             Caller with values inplace
         """
-        return self.arithmetic_operation(divisor, "remainder", 'FloatTensor')
+        return self.arithmetic_operation(divisor, "remainder", True)
 
 class IntTensor(BaseTensor):
     def __init__(self, data, data_is_pointer=False):

--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -38,6 +38,216 @@ class BaseTensor():
         """
         return self.arithmetic_operation(x, "add", False)
 
+    def __iadd__(self, x):
+        """
+        Performs in place element-wise addition arithmetic between two tensors
+        Parameters
+        ----------
+        x : FloatTensor
+            The Second tensor to perform addition with.
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(x, "add", True)
+
+    def __truediv__(self, x):
+        """
+        Performs division arithmetic between two tensors
+        Parameters
+        ----------
+        x : FloatTensor
+            Second divident tensor
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "div", False)
+
+    def __itruediv__(self, x):
+        """
+        Performs division arithmetic between two tensors inplace.
+        Parameters
+        ----------
+        x : FloatTensor
+            Second divident tensor
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(x, "div", True)
+
+    def __pow__(self, x):
+        """
+        Takes the power of each element in input ('self') with 'x' and
+        returns a tensor with the result.
+        Parameters
+        ----------
+        x : FloatTensor
+            Exponent tensor
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "pow", False)
+
+    def __ipow__(self, x):
+        """
+        Takes the power of each element in input ('self') with 'x' and
+        returns a tensor with the result inplace.
+        Parameters
+        ----------
+        x : FloatTensor
+            Exponent tensor
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(x, "pow", True)
+
+    def pow(self, x):
+        """
+        Takes the power of each element in input ('self') with 'x' and
+        returns a tensor with the result.
+        Parameters
+        ----------
+        x : FloatTensor
+            Exponent tensor
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "pow", False)
+
+    def pow_(self, x):
+        """
+        Takes the power of each element in input ('self') with 'x', inplace.
+        Parameters
+        ----------
+        x : FloatTensor
+            Exponent tensor
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(x, "pow", True)
+
+    def __mod__(self, x):
+        """
+        Performs Modulus arithmetic operation between two tensors.
+        Parameters
+        ----------
+        x : FloatTensor
+            Dividend tensor
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "remainder", False)
+
+    def __imod__(self, x):
+        """
+        Performs Modulus arithmetic operation between two tensors inplace.
+        Parameters
+        ----------
+        x : FloatTensor
+            Dividend tensor
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(x, "remainder", True)
+
+    def __mul__(self, x):
+        """
+        Performs Multiplication arithmetic operation between two tensors.
+        Parameters
+        ----------
+        x : FloatTensor
+            Second tensor to be multiplied with.
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "mul", False)
+
+    def __imul__(self, x):
+        """
+        Performs Multiplication arithmetic operation between two tensors inplace.
+        Parameters
+        ----------
+        x : FloatTensor
+            Second tensor to be multiplied with.
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(x, "mul", True)
+
+    def __sub__(self, x):
+        """
+        Performs element-wise substraction arithmetic between two tensors
+        Parameters
+        ----------
+        x : FloatTensor
+            The Second tensor to perform addition with.
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(x, "sub", False)
+
+    def __isub__(self, x):
+        """
+        Performs element-wise substraction arithmetic between two tensors
+        Parameters
+        ----------
+        x : FloatTensor
+            The Second tensor to perform addition with.
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(x, "sub", True)
+
+    def remainder(self, divisor):
+        """
+        Computes the element-wise remainder of division.
+        inplace.
+        Parameters
+        ----------
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.arithmetic_operation(divisor, "remainder")
+
+    def remainder_(self, divisor):
+        """
+        Computes the element-wise remainder of division, inplace.
+        Parameters
+        ----------
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.arithmetic_operation(divisor, "remainder", 'FloatTensor')
+
 class IntTensor(BaseTensor):
     def __init__(self, data, data_is_pointer=False):
         self.controller = syft.controller
@@ -68,7 +278,7 @@ class IntTensor(BaseTensor):
         Iterable
             Output list
         """
-        return list(np.fromstring(self.get("shape")[:-1], sep=",").astype('int'))           
+        return list(np.fromstring(self.get("shape")[:-1], sep=",").astype('int'))
 
     def __repr__(self, verbose=True):
 
@@ -103,11 +313,11 @@ class IntTensor(BaseTensor):
         return self
 
     def no_params_func(self, name, return_response=False, return_type='IntTensor'):
-        return (self.params_func(name, [], return_response, return_type))        
+        return (self.params_func(name, [], return_response, return_type))
 
     def get(self, param_name="size", response_as_tensor=False, return_type='IntTensor'):
         return self.params_func(name="get", params=[param_name], return_response=True,
-                                return_type="string")        
+                                return_type="string")
 
     def cmd(self, functionCall, params=[]):
         cmd = {
@@ -140,7 +350,7 @@ class FloatTensor(BaseTensor):
 
             if (type(data) == list):
                 data = np.array(data)
-            
+
             data = data.astype('float')
 
             self.data = data
@@ -343,20 +553,6 @@ class FloatTensor(BaseTensor):
                 return self
             else:
                 return False
-
-    def __iadd__(self, x):
-        """
-        Performs in place element-wise addition arithmetic between two tensors
-        Parameters
-        ----------
-        x : FloatTensor
-            The Second tensor to perform addition with.
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(x, "add", True)
 
     def backward(self, grad=None):
         if (grad is None):
@@ -581,98 +777,11 @@ class FloatTensor(BaseTensor):
     def index_select(self, dim, indices):
         return self.params_func("index_select", [indices.id, dim], return_response=True)
 
-    def __truediv__(self, x):
-        """
-        Performs division arithmetic between two tensors
-        Parameters
-        ----------
-        x : FloatTensor
-            Second divident tensor
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "div", False)
-
-    def __itruediv__(self, x):
-        """
-        Performs division arithmetic between two tensors inplace.
-        Parameters
-        ----------
-        x : FloatTensor
-            Second divident tensor
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(x, "div", True)
-
     def keepgrad(self):
         if (self.get("keepgrad") == "1"):
             return True
         else:
             return False
-
-    def __pow__(self, x):
-        """
-        Takes the power of each element in input ('self') with 'x' and
-        returns a tensor with the result.
-        Parameters
-        ----------
-        x : FloatTensor
-            Exponent tensor
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "pow", False)
-
-    def __ipow__(self, x):
-        """
-        Takes the power of each element in input ('self') with 'x' and
-        returns a tensor with the result inplace.
-        Parameters
-        ----------
-        x : FloatTensor
-            Exponent tensor
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(x, "pow", True)
-
-    def pow(self, x):
-        """
-        Takes the power of each element in input ('self') with 'x' and
-        returns a tensor with the result.
-        Parameters
-        ----------
-        x : FloatTensor
-            Exponent tensor
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "pow", False)
-
-    def pow_(self, x):
-        """
-        Takes the power of each element in input ('self') with 'x', inplace.
-        Parameters
-        ----------
-        x : FloatTensor
-            Exponent tensor
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(x, "pow", True)
 
     def floor(self):
         """
@@ -715,7 +824,7 @@ class FloatTensor(BaseTensor):
         Parameters
         ----------
         Returns
-        ------- 
+        -------
         FloatTensor
             Output tensor
         """
@@ -749,62 +858,6 @@ class FloatTensor(BaseTensor):
 
     def grad(self):
         return self.get("grad", response_as_tensor=True)
-
-    def __mod__(self, x):
-        """
-        Performs Modulus arithmetic operation between two tensors.
-        Parameters
-        ----------
-        x : FloatTensor
-            Dividend tensor
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "remainder", False)
-
-    def __imod__(self, x):
-        """
-        Performs Modulus arithmetic operation between two tensors inplace.
-        Parameters
-        ----------
-        x : FloatTensor
-            Dividend tensor
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(x, "remainder", True)
-
-    def __mul__(self, x):
-        """
-        Performs Multiplication arithmetic operation between two tensors.
-        Parameters
-        ----------
-        x : FloatTensor
-            Second tensor to be multiplied with.
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "mul", False)
-
-    def __imul__(self, x):
-        """
-        Performs Multiplication arithmetic operation between two tensors inplace.
-        Parameters
-        ----------
-        x : FloatTensor
-            Second tensor to be multiplied with.
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(x, "mul", True)
 
     def __neg__(self):
         return self.neg()
@@ -852,7 +905,7 @@ class FloatTensor(BaseTensor):
         return self.params_func("norm", [dim, keepdim, p], return_response=True)
 
     def relu(self):
-        
+
         return self.no_params_func("relu", return_response=True)
 
     def rsqrt(self):
@@ -984,7 +1037,7 @@ class FloatTensor(BaseTensor):
 
     def softmax(self, dim=-1):
         return self.params_func("softmax", [dim], return_response=True)
-    
+
     def split(self, split_size_or_sections, dim=0):
         """
         Splits the tensor into chunks. If split_size_or_sections is an integer type, then tensor will be split into chunks of size split_size_or_sections (if possible). Last chunk will be smaller if the tensor size along a given dimension is not divisible by split_size. If split_size_or_sections is a list, then tensor will be split into len(split_size_or_sections) chunks with sizes in dim according to split_size_or_sections.
@@ -1005,7 +1058,7 @@ class FloatTensor(BaseTensor):
 
     def std(self, dim=-1, keepdim=False, unbiased=True):
         """
-        Returns the standard-deviation of each row of the input tensor in the given dimension dim. 
+        Returns the standard-deviation of each row of the input tensor in the given dimension dim.
 
         If unbiased is False, then the standard-deviation will be calculated via the biased estimator. Otherwise, Bessel’s correction will be used.
         Parameters
@@ -1085,37 +1138,9 @@ class FloatTensor(BaseTensor):
         else:
             return "--- non-contiguous tensor ---"
 
-    def __sub__(self, x):
-        """
-        Performs element-wise substraction arithmetic between two tensors
-        Parameters
-        ----------
-        x : FloatTensor
-            The Second tensor to perform addition with.
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(x, "sub", False)
-
-    def __isub__(self, x):
-        """
-        Performs element-wise substraction arithmetic between two tensors
-        Parameters
-        ----------
-        x : FloatTensor
-            The Second tensor to perform addition with.
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(x, "sub", True)
-
     def var(self, dim=-1, keepdim=False, unbiased=True):
         """
-        Returns the variance of each row of the input tensor in the given dimension dim. 
+        Returns the variance of each row of the input tensor in the given dimension dim.
 
         If unbiased is False, then the variance will be calculated via the biased estimator. Otherwise, Bessel’s correction will be used.
         Parameters
@@ -1177,7 +1202,7 @@ class FloatTensor(BaseTensor):
         return self.params_func("unsqueeze", [dim], return_response=True)
 
     def unsqueeze_(self,dim):
-        return self.params_func("unsqueeze_", [dim], return_response=True)        
+        return self.params_func("unsqueeze_", [dim], return_response=True)
 
     def zero_(self):
         """
@@ -1205,7 +1230,7 @@ class FloatTensor(BaseTensor):
             grad = 'None'
 
         co = str(self.creation_op())
-        
+
         desc = "[syft.FloatTensor:"+str(self.id)+" grad:" + grad + " size:" + type_str + " c:" + str(self.children()) + " p:" + str(self.creators()) + " init:" + co + "]" + "\n"
 
         if (verbose):
@@ -1237,7 +1262,7 @@ class FloatTensor(BaseTensor):
 
     def __str__(self):
         tensor_str = str(self.to_numpy()).replace("]", " ").replace("[", " ")
-        
+
         return tensor_str
 
     def get(self, param_name="size", response_as_tensor=False):
@@ -1471,31 +1496,6 @@ class FloatTensor(BaseTensor):
             Caller with values inplace
         """
         return self.no_params_func("rsqrt_")
-
-    def remainder(self, divisor):
-        """
-        Computes the element-wise remainder of division.
-        inplace.
-        Parameters
-        ----------
-        Returns
-        -------
-        FloatTensor
-            Output tensor
-        """
-        return self.arithmetic_operation(divisor, "remainder")
-
-    def remainder_(self, divisor):
-        """
-        Computes the element-wise remainder of division, inplace.
-        Parameters
-        ----------
-        Returns
-        -------
-        FloatTensor
-            Caller with values inplace
-        """
-        return self.arithmetic_operation(divisor, "remainder", 'FloatTensor')
 
     def sample(self,dim):
         """


### PR DESCRIPTION
# Description

Issue #760 

## Status

Moved all the `arithmetic_operation` methods into `BaseTensor` class and tested that `FloatTensor` is still working fine. Only `add` is done for `IntTensor` on the Unity side so far.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
