### PR TITLE
set default of delete_after_use to False

### DIFF
--- a/syft/tensor.py
+++ b/syft/tensor.py
@@ -97,7 +97,7 @@ class IntTensor():
             return " - non-contiguous - "
 
 class FloatTensor():
-    def __init__(self, data, autograd=False, data_is_pointer=False, delete_after_use=True):
+    def __init__(self, data, autograd=False, data_is_pointer=False, delete_after_use=False):
         self.controller = syft.controller
         self.delete_after_use = delete_after_use
         if (data is not None and not data_is_pointer):


### PR DESCRIPTION
# Description
When doing a certain operation twice, Unity will automatically re-use the tensor (saving memory). However since we remove tensors that are not being used anymore in Python this can cause problems. Example:
```
a = FloatTensor(data)
b = a.max()
c = a.max()
```
Now b and c both refer to the same tensor and if we delete variable b: `del b`, the tensor that b refers to will be removed as well and running: `print(c)` will result in an error as the tensor c refers to doesn't exist anymore.
 
To fix this I propose setting `delete_after_use` to `False` by default and setting this to `True` whenever possible. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
