### PR TITLE
Keras: Add activation functions to Dense Layer

### DIFF
--- a/syft/interfaces/keras/layers/dense.py
+++ b/syft/interfaces/keras/layers/dense.py
@@ -29,6 +29,10 @@ class Dense(object):
 				self.syft_activation = nn.ReLU()
 			elif(self.activation_str == 'softmax'):
 				self.syft_activation = nn.Softmax()
+			elif(self.activation_str == 'sigmoid'):
+				self.syft_activation = nn.Sigmoid()
+			elif(self.activation_str == 'tanh'):
+				self.syft_activation = nn.Tanh()
 			self.ordered_syft.append(self.syft_activation)
 		else:
 			self.syft_activation = None

--- a/syft/interfaces/keras/models/sequential.py
+++ b/syft/interfaces/keras/models/sequential.py
@@ -2,6 +2,8 @@ import syft
 import syft.nn as nn
 import sys
 from syft.interfaces.keras.layers import Log
+from syft import FloatTensor
+import numpy as np
 
 class Sequential(object):
 
@@ -62,6 +64,12 @@ class Sequential(object):
 		return final_loss
 
 	def predict(self,x):
+
+		if(type(x) == list):
+			x = np.array(x).astype('float')
+		if(type(x) == np.array or type(x) == np.ndarray):
+			x = FloatTensor(x,autograd=True, delete_after_use=False)
+
 		return self.syft.forward(input=x)
 
 	def get_weights(self):


### PR DESCRIPTION
Hello,

This PR add the following features to the Keras interface:

- Add activation functions Sigmoid and Tanh to Dense layer
- In the predict function, if the input is an np.array, it will be transformed to FloatTensor (forward function expect a FLoatTensor) 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Using Jupyer Notebook

**Test Configuration**:
* CPU:
* GPU:
* PySyft Version:
* Unity Version:
* OpenMined Unity App Version:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
