### PR TITLE
Quick docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ The goal of this library is to give the user the ability to efficiently train De
 
 - Make sure Python 3.5+ in installed on your machine by checking `python3 --version`
 - Set up a virtual environment for the Python libraries (optional, recommended)
-- Install our OpenMined Unity app by following the guidelines [here]
-(https://github.com/OpenMined/OpenMined)
+- Install our OpenMined Unity app by following the guidelines [here](https://github.com/OpenMined/OpenMined)
 
 ### Python Requirements
 


### PR DESCRIPTION
# Description

The Markdown formatting for the link to the Unity app install instructions was not displaying correctly.

Fixes # (NA)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [NA] Test A
- [NA] Test B

**Test Configuration**: NA
* CPU: NA
* GPU: NA
* PySyft Version: NA
* Unity Version: NA
* OpenMined Unity App Version: NA

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
