### PR TITLE
feat: keras interface predict function update

### DIFF
--- a/syft/interfaces/keras/models/sequential.py
+++ b/syft/interfaces/keras/models/sequential.py
@@ -66,7 +66,7 @@ class Sequential(object):
 		if(type(x) == np.array or type(x) == np.ndarray):
 			x = FloatTensor(x,autograd=True, delete_after_use=False)
 
-		return self.syft.forward(input=x)
+		return self.syft.forward(input=x).to_numpy()
 
 	def get_weights(self):
 		return self.syft.parameters()


### PR DESCRIPTION
Hello,

Sorry for the small PR.  For the Keras interface, the predict function returns now a numpy array like in the Keras library, instead of a FloatTensor. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] With notebook

**Test Configuration**:
* CPU:
* GPU:
* PySyft Version:
* Unity Version:
* OpenMined Unity App Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
