### PR TITLE
implement __getitem__ for grid class to retrieve experiments

### DIFF
--- a/syft/grid/grid.py
+++ b/syft/grid/grid.py
@@ -16,6 +16,19 @@ class Grid():
         self.controller = syft.controller
         self.jobId = None
 
+    def __getitem__(self, key):
+        if not os.path.exists(".openmined/grid/experiments.json"):
+            print(f'{Back.RED}{Fore.WHITE} No experiments found {Style.RESET_ALL}')
+            return
+
+        with open('.openmined/grid/experiments.json', 'r') as outfile:
+            d = json.loads(outfile.read())
+            for i, experiment in enumerate(d):
+                if key == i:
+                    return experiment["uuid"]
+                elif key == experiment["name"]:
+                    return experiment["uuid"]
+
     def configuration(self, model, lr, criterion, iters):
         configuration = GridConfiguration(model, lr, criterion, iters)
         return configuration


### PR DESCRIPTION
# Description
Added `__getitem__` to the grid class that can be used to retrieve the address of an experiment either by using the name `g['experiment1']` or by using the number in the list of experiments `g[0]`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested in the grid example notebook by creating an experiment with a certain name and then trying to retrieve the address using `g['experiment_name']` and then also by trying `g[0]` which returns the same address.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
