### PR TITLE
Fixing random sampling

### DIFF
--- a/syft/tensor/float_tensor.py
+++ b/syft/tensor/float_tensor.py
@@ -467,9 +467,9 @@ class FloatTensor(BaseTensor):
         """
         return self.no_params_func("floor_")
 
-    def random_(self):
+    def random_(self, start=0, end=None):
         """
-        Returns a tensor filled with random numbers from a uniform distribution on the interval [0,1)
+        Returns a tensor filled with random integers from the range [start, ..., end - 1]
         The shape of the tensor is defined by the varargs sizes.
         ----------
         Returns
@@ -477,7 +477,13 @@ class FloatTensor(BaseTensor):
         FloatTensor
             Caller with values inplace
         """
-        return self.no_params_func("random_")
+        if not isinstance(start, int):
+            raise TypeError('Method `random_` requires int for start, not {}'.format(type(start)))
+        if not isinstance(end, [int, type(None)]):
+            raise(TypeError('Method `random_ requires an int or None for end, not {}'.format(type(end))))
+        if end is None:
+            return self.params_func("random_", params=[start])
+        return self.params_func("random_", params=[start, end])
 
     def round(self):
         """
@@ -858,6 +864,18 @@ class FloatTensor(BaseTensor):
 
     def triu_(self, k=0):
         return self.params_func("triu_", [k])
+
+    def uniform_(self, start=0, end=1):
+        """
+        Returns a tensor filled with random numbers from a uniform distribution on the interval [start,end)
+        The shape of the tensor is defined by the varargs sizes.
+        ----------
+        Returns
+        -------
+        FloatTensor
+            Caller with values inplace
+        """
+        return self.params_func("uniform_", params=[start, end])
 
     def unsqueeze(self,dim):
         return self.params_func("unsqueeze", [dim], return_response=True)


### PR DESCRIPTION
# Description

Previously, `random_` was ported from PyTorch as sampling from a uniform distribution over `[0,1)`.  This is incorrect, as PyTorch's `uniform_` method accomplishes this, while `random_` samples integers from the range `[start, end)`.  Additionally, `random_` was incorrectly using `no_params_function`, while the backend was expecting parameters for `start` and `end`.

I've fixed `random_`, and also added a Python equivalent of `uniform_`.

Accompanies OpenMined/OpenMined#405.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Played around with instantiating FloatTensor and stress testing with different input types for both methods. Tested in accordance with OpenMined/OpenMined#405.

**Test Configuration**:
* CPU: Mac OS X -- 2.8 GHz Intel Core i7
* GPU: AMD Radeon R9 M370X 2 GB & Intel Iris Pro 1536 MB
* PySyft Version: ???
* Unity Version: 2017.3.0f3
* OpenMined Unity App Version: ???

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
