### PR TITLE
Implement the Acos function for IntTensor on the CPU #830

### DIFF
--- a/syft/tensor/int_tensor.py
+++ b/syft/tensor/int_tensor.py
@@ -1,6 +1,7 @@
 import numpy as np
 import syft.controller
 from .base_tensor import BaseTensor
+from .float_tensor import FloatTensor
 
 class IntTensor(BaseTensor):
     def __init__(self, data, data_is_pointer=False):
@@ -46,6 +47,18 @@ class IntTensor(BaseTensor):
             Output tensor
         """
         return self.no_params_func("abs_", return_response=True)
+
+    def acos(self):
+        """
+        Returns a new tensor with the arccosine of the elements of input.
+        Parameters
+        ----------
+        Returns
+        -------
+        FloatTensor
+            Output tensor
+        """
+        return self.no_params_func("acos", return_response=True, return_type='FloatTensor')
 
     def cos(self):
         """


### PR DESCRIPTION
# Description

This pull request resolves issue #830 . This pull request is the PySyft portion of the implementation. See the pull request https://github.com/OpenMined/OpenMined/pull/411 for the unity portion.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Created and ran unit tests in unity
- [x] Created and ran integration tests in Openmined/integration
- [x] Created an example in Openmined/notebooks/tests/Test Tensor Function Implementation.ipynb 

**Test Configuration**:
* CPU: Macbook Pro (intel core i7)
* GPU: AMD Radeon R9 M370X
* PySyft Version: 0.1
* Unity Version: 2017.2.0f3
* OpenMined Unity App Version: Latest

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
