### PR TITLE
Add python interface and unit test for unfold function 

### DIFF
--- a/syft/tensor/int_tensor.py
+++ b/syft/tensor/int_tensor.py
@@ -404,3 +404,19 @@ class IntTensor(BaseTensor):
         assert type(new_dim[0]) == int
         self.params_func("view_", new_dim, return_response=False)
         return self
+
+    def unfold(self, dim, size, step):
+        """
+        Returns a tensor which contains all slices of size `size` from `self` tensor in the dimension `dim`.
+        
+        Parameters:
+            dim (int) – dimension in which unfolding happens
+            size (int) – the size of each slice that is unfolded
+            step (int) – the step between each slice
+        ----------
+        Returns
+        -------
+        IntTensor
+            Output Tensor
+        """
+        return self.params_func("unfold", [dim, size, step], return_response=True)

--- a/tests/test_inttensor.py
+++ b/tests/test_inttensor.py
@@ -44,12 +44,19 @@ def test_view():
 
 def test_unfold():
     a = IntTensor(np.array([[-1, 2, 3, 5], [0, 4, 6, 7], [10, 3, 2, -5]], dtype=np.int32))
+
+    # Test1
     expected_a = IntTensor(np.array([[[-1, 2, 3, 5], [0, 4, 6, 7]], [[0, 4, 6, 7], [10, 3, 2, -5]]], dtype=np.int32))
     actual_a = a.unfold(0, 2, 1)
     assert(actual_a.equal(expected_a))
 
+    # Test2
     expected_a = IntTensor(np.array([[[-1, 2, 3], [0, 4, 6], [10, 3, 2]],
         [[2, 3, 5], [4, 6, 7], [3, 2, -5]]], dtype=np.int32))
-
     actual_a = a.unfold(1, 3, 1)
+    assert(actual_a.equal(expected_a))
+
+    # Test3
+    expected_a = IntTensor(np.array([[[-1, 2], [0, 4], [10, 3]], [[3, 5], [6, 7], [2, -5]]], dtype=np.int32))
+    actual_a = a.unfold(1, 2, 2)
     assert(actual_a.equal(expected_a))

--- a/tests/test_inttensor.py
+++ b/tests/test_inttensor.py
@@ -41,3 +41,15 @@ def test_view():
     a.view_(4, -1, 2)
     c_v_ground = IntTensor(np.array([[[9, 3], [1, 0]], [[6, 8], [6, 6]], [[1, 6], [8, 6]], [[5, 0], [2, 0]]]))
     assert(a.equal(c_v_ground))
+
+def test_unfold():
+    a = IntTensor(np.array([[-1, 2, 3, 5], [0, 4, 6, 7], [10, 3, 2, -5]], dtype=np.int32))
+    expected_a = IntTensor(np.array([[[-1, 2, 3, 5], [0, 4, 6, 7]], [[0, 4, 6, 7], [10, 3, 2, -5]]], dtype=np.int32))
+    actual_a = a.unfold(0, 2, 1)
+    assert(actual_a.equal(expected_a))
+
+    expected_a = IntTensor(np.array([[[-1, 2, 3], [0, 4, 6], [10, 3, 2]],
+        [[2, 3, 5], [4, 6, 7], [3, 2, -5]]], dtype=np.int32))
+
+    actual_a = a.unfold(1, 3, 1)
+    assert(actual_a.equal(expected_a))


### PR DESCRIPTION
# Description

This PR solves issue #1266 in Openmined/PySyft

Fixes #1266 

##

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Implemented sections in Openmined/notebooks/tests/Test Tensor Function Implementation.ipynb that run the unfold function for IntTensor (see other PR in this issue)
- [x] Implemented the unit test in PySyft/tests/test_inttensor.py which can be run using `python -m pytest`

**Test Configuration**:
* CPU: Intel Code i7 (4th Gen), Jupyter Notebook, Python 3.6
* GPU: n/a
* PySyft Version: 0.1.0
* Unity Version: 2017.2.0f3 Personal
* OpenMined Unity App Version: latest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
