### PR TITLE
Add interface and unittest for IntTensor inline unfold function

### DIFF
--- a/syft/tensor/int_tensor.py
+++ b/syft/tensor/int_tensor.py
@@ -460,3 +460,15 @@ class IntTensor(BaseTensor):
         """
         return self.params_func("unfold", [dim, size, step], return_response=True)
 
+    def unfold_(self, dim, size, step):
+        """
+        Computes all slices of size `size` from `self` tensor in the dimension `dim`. Inplace version of Unfold.
+        
+        Parameters:
+            dim (int) – dimension in which unfolding happens
+            size (int) – the size of each slice that is unfolded
+            step (int) – the step between each slice
+            Output Tensor
+        """
+        return self.params_func("unfold_", [dim, size, step], return_response=True)
+

--- a/tests/test_inttensor.py
+++ b/tests/test_inttensor.py
@@ -69,3 +69,23 @@ def test_unfold():
     actual_a = a.unfold(1, 2, 2)
     assert(actual_a.equal(expected_a))
 
+def test_unfold_():
+    # Test1
+    a = IntTensor(np.array([[-1, 2, 3, 5], [0, 4, 6, 7], [10, 3, 2, -5]], dtype=np.int32))
+    expected_a = IntTensor(np.array([[[-1, 2, 3, 5], [0, 4, 6, 7]], [[0, 4, 6, 7], [10, 3, 2, -5]]], dtype=np.int32))
+    a.unfold_(0, 2, 1)
+    assert(a.equal(expected_a))
+
+    # Test2
+    a = IntTensor(np.array([[-1, 2, 3, 5], [0, 4, 6, 7], [10, 3, 2, -5]], dtype=np.int32))
+    expected_a = IntTensor(np.array([[[-1, 2, 3], [0, 4, 6], [10, 3, 2]],
+        [[2, 3, 5], [4, 6, 7], [3, 2, -5]]], dtype=np.int32))
+    a.unfold_(1, 3, 1)
+    assert(a.equal(expected_a))
+
+    # Test3
+    a = IntTensor(np.array([[-1, 2, 3, 5], [0, 4, 6, 7], [10, 3, 2, -5]], dtype=np.int32))
+    expected_a = IntTensor(np.array([[[-1, 2], [0, 4], [10, 3]], [[3, 5], [6, 7], [2, -5]]], dtype=np.int32))
+    a.unfold_(1, 2, 2)
+    assert(a.equal(expected_a))
+


### PR DESCRIPTION
# Description

This PR solves issue #1267 in Openmined/PySyft

Fixes #1267 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Implemented sections in Openmined/notebooks/tests/Test Tensor Function Implementation.ipynb that run the unfold function for IntTensor (see other PR in this issue)
- [x] Implemented the unit test in PySyft/tests/test_inttensor.py which can be run using `python -m pytest`

**Test Configuration**:
* CPU: Intel Code i7 (4th Gen), Jupyter Notebook, Python 3.6
* GPU: n/a
* PySyft Version: 0.1.0
* Unity Version: 2017.2.0f3 Personal
* OpenMined Unity App Version: latest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
