### PR TITLE
Wrong variable reference

### DIFF
--- a/syft/core/torch_/hook.py
+++ b/syft/core/torch_/hook.py
@@ -33,8 +33,8 @@ class TorchHook(object):
                              torch.ShortTensor,
                              torch.IntTensor,
                              torch.LongTensor]
-        self.var_types = [torch.autograd.variable.Variable, torch.nn.Parameter]
-        self.tensorvar_types = self.tensor_types + [torch.autograd.variable.Variable]
+        self.var_types = [torch.autograd.Variable, torch.nn.Parameter]
+        self.tensorvar_types = self.tensor_types + [torch.autograd.Variable]
         self.tensorvar_types_strs = [x.__name__ for x in self.tensorvar_types]
         self.tensorvar_methods = list(
             set(

--- a/syft/core/torch_/utils.py
+++ b/syft/core/torch_/utils.py
@@ -94,7 +94,7 @@ map_tensor_type = {
     'torch.LongTensor': torch.LongTensor
 }
 map_var_type = {
-    'torch.autograd.variable.Variable': torch.autograd.variable.Variable,
+    'torch.autograd.Variable': torch.autograd.Variable,
     'torch.nn.parameter.Parameter': torch.nn.parameter.Parameter
 }
 map_torch_type = dict(map_tensor_type, **map_var_type)


### PR DESCRIPTION
# Description

Variable type `torch.autograd.Variable` was referenced incorrectly.

Fixes # (issue)

Ran unit test and got this error:

```
File "/home/jaison/PySyft/syft/core/torch_/utils.py", line 97, in <module>
    'torch.autograd.variable.Variable': torch.autograd.variable.Variable,
AttributeError: 'function' object has no attribute 'Variable'

```

Changed  `torch.autograd.variable.Variable` to  `torch.autograd.Variable` 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: Ran unit tests without errors after the fix.

- [x] Test B: Went through PyTorch documentation to verify the syntax [here](https://pytorch.org/docs/0.3.1/autograd.html#variable)

**Test Configuration**:
* CPU: i5
* GPU: none
* PySyft Version: current master branch
* PyTorch Version: 0.4.0
* Python Version: 3.5
* Unity Version: none
* OpenMined Unity App Version: none


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
