### PR TITLE
Adding binder support for repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PySyft 
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/kmader/PySyft/master)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/OpenMined/PySyft/master)
 
-A Library for Private, Secure Deep Learning - [Documentation](https://openmined.github.io/PySyft/) - [Tutorial](https://colab.research.google.com/drive/1vsgH0ydHyel5VRAxO2yhRQfXYUuIYkp5)
+A Library for Private, Secure Deep Learning - [Documentation](https://openmined.github.io/PySyft/) - [Tutorial](https://colab.research.google.com/drive/1vsgH0ydHyel5VRAxO2yhRQfXYUuIYkp5) - [Tutorial on Binder](https://mybinder.org/v2/gh/OpenMined/PySyft/master?filepath=examples%2FFederated%20Learning%20Example.ipynb)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# PySyft
+# PySyft 
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/kmader/PySyft/master)
+
 A Library for Private, Secure Deep Learning - [Documentation](https://openmined.github.io/PySyft/) - [Tutorial](https://colab.research.google.com/drive/1vsgH0ydHyel5VRAxO2yhRQfXYUuIYkp5)
 
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,11 @@
+name: pysyft
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.6
+  - pytorch=0.3.1
+  - scipy
+  - pip:
+    - git+https://github.com/OpenMined/PySyft
+    - sphinx_rtd_theme


### PR DESCRIPTION
# Description

Add the links and code to make Binder (http://repo2docker.readthedocs.io) work with the repo. Basically, it has the dependencies in a conda standard environment. It makes running and testing the code as easy as clicking on a link (https://mybinder.org/v2/gh/kmader/PySyft/patch-2?filepath=examples%2FFederated%20Learning%20Example.ipynb) to run and start the Federated Learning Example

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
