### PR TITLE
Fix broken links to Virtual Worker Tutorial notebook

### DIFF
--- a/examples/SocketWorker Client.ipynb
+++ b/examples/SocketWorker Client.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This tutorial is a 2 notebook tutorial. The partner notebook is the notebook entitled SocketWorker Server.ipynb and is in the same folder as this notebook. You should execute this notebook AFTER you have executed the other one.\n",
     "\n",
-    "In this tutorial, we'll demonstrate how to launch a SocketWorker server which will listen for PyTorch commands over a socket connection. This tutorial is a followup to the VirtualWorker tutorial (https://github.com/OpenMined/PySyft/blob/master/examples/MPC%20Using%20Virtual%20Worker.ipynb) where the only difference is that in this tutorial the two workers are connected via a socket connection on the localhost network.\n",
+    "In this tutorial, we'll demonstrate how to launch a SocketWorker server which will listen for PyTorch commands over a socket connection. This tutorial is a followup to the VirtualWorker tutorial (https://github.com/OpenMined/PySyft/blob/master/examples/Remote%20PyTorch%20using%20Virtual%20Worker.ipynb) where the only difference is that in this tutorial the two workers are connected via a socket connection on the localhost network.\n",
     "\n",
     "If you'd like to circumvent the need to install dependencies, this notebook is also available as as Colab notebook\n",
     "\n",

--- a/examples/SocketWorker Server.ipynb
+++ b/examples/SocketWorker Server.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This tutorial is a 2 notebook tutorial. The partner notebook is the notebook entitled SocketWorker Client.ipynb and is in the same folder as this notebook. You should execute this notebook BEFORE the other.\n",
     "\n",
-    "In this tutorial, we'll demonstrate how to launch a SocketWorker server which will listen for PyTorch commands over a socket connection. This tutorial is a followup to the VirtualWorker tutorial (https://github.com/OpenMined/PySyft/blob/master/examples/MPC%20Using%20Virtual%20Worker.ipynb) where the only difference is that in this tutorial the two workers are connected via a socket connection on the localhost network.\n",
+    "In this tutorial, we'll demonstrate how to launch a SocketWorker server which will listen for PyTorch commands over a socket connection. This tutorial is a followup to the VirtualWorker tutorial (https://github.com/OpenMined/PySyft/blob/master/examples/Remote%20PyTorch%20using%20Virtual%20Worker.ipynb) where the only difference is that in this tutorial the two workers are connected via a socket connection on the localhost network.\n",
     "\n",
     "If you'd like to circumvent the need to install dependencies, this notebook is also available as as Colab notebook\n",
     "\n",


### PR DESCRIPTION
# Description

"SockerWorker Server.ipynb" and "SockerWorker Client.ipynb" notebooks contains broken links to "Basic Virtual Worker Tutorial" notebook.

# Checklist:

- [x] My changes generate no new warnings
