### PR TITLE
Fix bug with double decoding the input byte stream

### DIFF
--- a/syft/core/workers.py
+++ b/syft/core/workers.py
@@ -1051,7 +1051,7 @@ class SocketWorker(BaseWorker):
                     message = self._process_buffer(connection)
 
                     # process message and generate response
-                    response = self.receive_msg(message)
+                    response = self.receive_msg(message, False)
 
                     # send response back
                     connection.send(response.encode())


### PR DESCRIPTION
# Description

Fix bug with double decoding the input byte stream (in _process_buffer & receive_msg). This generates an error in Python 3 as `str.decode()` was deprecated. Resolves #1358 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on Worker notebooks

**Test Configuration**:
* CPU:
* GPU:
* PySyft Version:
* Unity Version:
* OpenMined Unity App Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
