### PR TITLE
Allow socket connection to remote machines

### DIFF
--- a/syft/core/workers/socket.py
+++ b/syft/core/workers/socket.py
@@ -102,7 +102,7 @@ class SocketWorker(BaseWorker):
             self.serversocket = None
 
             clientsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            clientsocket.connect(('localhost', self.port))
+            clientsocket.connect((self.hostname, self.port))
             self.clientsocket = clientsocket
 
         else:


### PR DESCRIPTION
# Description

This pull request just replace the hardcoded 'localhost' host in socket connections with the object's attribute.
It allows to connect to remote computers (not only localhost)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test with localhost (basically run this notebook: https://github.com/OpenMined/PySyft/blob/master/examples/SocketWorker%20Client.ipynb
- [x] Test with 2 computers on a local network and initalize SocketWorkers with real IP address

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
