### PR TITLE
Fixes Issue #1382 : Call of torch functions on remote Variable (ex: torch.matmul(x,y))

### DIFF
--- a/syft/core/hooks/torch/hook.py
+++ b/syft/core/hooks/torch/hook.py
@@ -206,6 +206,9 @@ class TorchHook(BaseHook):
                 part, has_self=False)
             pointer, has_remote, multiple_owners = _res
 
+            if (has_remote and not multiple_owners):
+                return pointer
+
             if not (has_remote and not multiple_owners):
                 result = hook_self._execute_local_call(None,
                                                        part,

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -1,3 +1,4 @@
+import torch
 import json
 import numbers
 import re
@@ -675,7 +676,7 @@ class BaseWorker(object):
             command = eval('obj_self.{}'.format(command))
         else:
             command = self._command_guard(
-                command_msg['command'], self.torch_funcs)
+                command_msg['command'], self.hook.torch_funcs)
             command = eval('torch.{}'.format(command))
 
         # we need the original tensorvar owners so that we can register


### PR DESCRIPTION
# Description

Fixes Issue #1382

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Pysyft test pass.

**Test Configuration**:
(See Issue #1382)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
