### PR TITLE
Handling more sophisticated args and kwargs when calling torch func

### DIFF
--- a/syft/core/utils.py
+++ b/syft/core/utils.py
@@ -1,10 +1,11 @@
 """Framework agnostic static utility functions."""
-import functools
-
 import json
 import re
-import torch
 import types
+import functools
+import logging
+
+import torch
 
 class PythonEncoder():
     """
@@ -67,12 +68,11 @@ class PythonEncoder():
             }
         # Generator (transformed to list)
         elif isinstance(obj, types.GeneratorType):
-            print('Generator args can\'t be transmitted')
+            logging.warning("Generator args can't be transmitted")
             return []
         # Else log the error
         else:
-            print('Unknown type', type(obj))
-            return None
+            raise ValueError('Unhandled type', type(obj))
 
 class PythonJSONDecoder(json.JSONDecoder):
     """

--- a/syft/core/utils.py
+++ b/syft/core/utils.py
@@ -1,6 +1,97 @@
 """Framework agnostic static utility functions."""
 import functools
 
+import json
+import re
+import torch
+
+class PythonEncoder():
+    """
+        Encode python and torch objects to be JSON-able
+        Torch objects are replaced by an id.
+        Note that a python object is returned, not JSON.
+    """
+    def __init__(self, retrieve_tensorvar=False):
+        self.retrieve_tensorvar = retrieve_tensorvar
+        self.found_tensorvar = []
+        self.tensorvar_types = tuple([torch.autograd.Variable,
+                                     torch.nn.Parameter,
+                                     torch.FloatTensor,
+                                     torch.DoubleTensor,
+                                     torch.HalfTensor,
+                                     torch.ByteTensor,
+                                     torch.CharTensor,
+                                     torch.ShortTensor,
+                                     torch.IntTensor,
+                                     torch.LongTensor])
+
+    def encode(self, obj, retrieve_tensorvar=None):
+        if retrieve_tensorvar is not None:
+            self.retrieve_tensorvar = retrieve_tensorvar
+        if self.retrieve_tensorvar:
+            return (self.python_encode(obj), self.found_tensorvar)
+        else:
+            return self.python_encode(obj)
+
+    def python_encode(self, obj):
+        if isinstance(obj, (int, float, str)) or obj is None:
+            return obj
+        elif isinstance(obj, self.tensorvar_types):
+            if self.retrieve_tensorvar:
+                self.found_tensorvar.append(obj)
+            key = '__'+type(obj).__name__+'__'
+            return { key: '_fl.{}'.format(obj.id) }
+        elif isinstance(obj, (tuple, set, bytearray)):
+            key = '__'+type(obj).__name__+'__'
+            return {key:[self.python_encode(i) for i in obj]}
+        elif isinstance(obj, list):
+            return [self.python_encode(i) for i in obj]
+        elif isinstance(obj, dict):
+            return {
+                k: self.python_encode(v)
+                for k, v in obj.items()
+            }
+        else:
+            try:
+                return { '__eval__': str(obj) }
+            except:
+                print('Unknown type', type(obj))
+            return None
+
+class PythonJSONDecoder(json.JSONDecoder):
+    """
+        Decode JSON and replace python types when need
+        Retrieve Torch objects replaced by their id
+    """
+    def __init__(self, worker, *args, **kwargs):
+        super(PythonJSONDecoder, self).__init__(*args,
+            object_hook=self.custom_obj_hook, **kwargs)
+        self.worker = worker
+        self.tensorvar_types = tuple([torch.autograd.Variable,
+                                     torch.nn.Parameter,
+                                     torch.FloatTensor,
+                                     torch.DoubleTensor,
+                                     torch.HalfTensor,
+                                     torch.ByteTensor,
+                                     torch.CharTensor,
+                                     torch.ShortTensor,
+                                     torch.IntTensor,
+                                     torch.LongTensor])
+
+    def custom_obj_hook(self, dct):
+        pat = re.compile('__(.+)__')
+        for key, obj in dct.items():
+            try:
+                obj_type = pat.search(key).group(1)
+                if obj_type in map(lambda x: x.__name__, self.tensorvar_types):
+                    pattern_var = re.compile('_fl.(.*)')
+                    id = int(pattern_var.search(obj).group(1))
+                    return self.worker.get_obj(id)
+                elif obj_type in ('tuple', 'set', 'bytearray', 'eval'):
+                    return eval(obj_type)(obj)
+            except AttributeError:
+                pass
+        return dct
 
 def map_tuple(hook, args, func):
     if hook:

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -142,6 +142,8 @@ class TestTorchTensor(TestCase):
         x = torch.FloatTensor([1, 2, 3])
         y = torch.FloatTensor([1, 2, 3])
         z = torch.dot(x, y)
+        # There is an issue with some Macs getting 0.0 instead
+        # Solved here: https://github.com/pytorch/pytorch/issues/5609
         assert torch.equal(torch.FloatTensor([z]), torch.FloatTensor([14]))
 
         z = torch.eq(x, y)
@@ -451,14 +453,14 @@ class TestTorchVariable(TestCase):
         loss.backward()
 
         # ensure that model and all (grand)children are owned by the local worker
-        assert model.owners[0] == local.id
-        assert model.data.owners[0] == local.id
+        assert model.owners[0].id == local.id
+        assert model.data.owners[0].id == local.id
 
         # if you get a failure here saying that model.grad.owners does not exist
         # check in hooks.py - _hook_new_grad(). self.grad_backup has probably either
         # been deleted or is being run at the wrong time (see comments there)
-        assert model.grad.owners[0] == local.id
-        assert model.grad.data.owners[0] == local.id
+        assert model.grad.owners[0].id == local.id
+        assert model.grad.data.owners[0].id == local.id
 
         # ensure that objects are not yet pointers (haven't sent it yet)
         assert not model.is_pointer

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -547,6 +547,32 @@ class TestTorchVariable(TestCase):
         z.get()
         assert torch.equal(z, Var(torch.FloatTensor([[3, 6], [7, 14]])))
 
+    def test_torch_function_with_multiple_input_on_remote_var(self):
+        hook = TorchHook(verbose=False)
+        me = hook.local_worker
+        remote = VirtualWorker(id=2,hook=hook)
+        me.add_worker(remote)
+
+        x = Var(torch.FloatTensor([1,2]))
+        y = Var(torch.FloatTensor([3,4]))
+        x.send(remote)
+        y.send(remote)
+        z = torch.stack([x,y])
+        z.get()
+        assert torch.equal(z, Var(torch.FloatTensor([[1, 2], [3, 4]])))
+
+    def test_torch_function_with_multiple_output_on_remote_var(self):
+        hook = TorchHook(verbose=False)
+        me = hook.local_worker
+        remote = VirtualWorker(id=2,hook=hook)
+        me.add_worker(remote)
+
+        x = Var(torch.FloatTensor([[1,2],[4,3],[5,6]]))
+        x.send(remote)
+        y, z = torch.max(x, 1)
+        y.get()
+        assert torch.equal(y, Var(torch.FloatTensor([2, 4, 6])))
+
     def test_torch_F_relu_on_remote_var(self):
         hook = TorchHook(verbose=False)
         me = hook.local_worker

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -160,7 +160,7 @@ class TestTorchTensor(TestCase):
 
         hook = TorchHook(verbose=False)
         local = hook.local_worker
-        remote = VirtualWorker(hook, 0)
+        remote = VirtualWorker(id=2,hook=hook)
         local.add_worker(remote)
 
         x = torch.FloatTensor([1, 2, -3, 4, 5]).send(remote)
@@ -451,14 +451,14 @@ class TestTorchVariable(TestCase):
         loss.backward()
 
         # ensure that model and all (grand)children are owned by the local worker
-        assert model.owners[0].id == local.id
-        assert model.data.owners[0].id == local.id
+        assert model.owners[0] == local.id
+        assert model.data.owners[0] == local.id
 
         # if you get a failure here saying that model.grad.owners does not exist
         # check in hooks.py - _hook_new_grad(). self.grad_backup has probably either
         # been deleted or is being run at the wrong time (see comments there)
-        assert model.grad.owners[0].id == local.id
-        assert model.grad.data.owners[0].id == local.id
+        assert model.grad.owners[0] == local.id
+        assert model.grad.data.owners[0] == local.id
 
         # ensure that objects are not yet pointers (haven't sent it yet)
         assert not model.is_pointer
@@ -515,7 +515,7 @@ class TestTorchVariable(TestCase):
 
         datasets = [(data_bob, target_bob), (data_alice, target_alice)]
 
-        for iter in range(3):
+        for iter in range(6):
 
             for data, target in datasets:
                 model.send(data.owners[0])
@@ -643,7 +643,7 @@ class TestTorchVariable(TestCase):
     def test_remote_var_unary_methods(self):
         ''' Unit tests for methods mentioned on issue 1385
             https://github.com/OpenMined/PySyft/issues/1385'''
-        hook = TorchHook()
+        hook = TorchHook(verbose=False)
         local = hook.local_worker
         remote = VirtualWorker(id=2,hook=hook)
         local.add_worker(remote)


### PR DESCRIPTION
# Description

The goal is to provide a fully working demo of federated learning on MNIST.
As for now, it is not possible to handle convolution (`F.conv2d`, `nn.conv2d`), because the args and kwargs required get lost during the hook.
Hence, we provide a stronger handling of arks and kwargs in the transmission process of commands to workers, with a special focus on the conservation of the types not natively supported in JSON.

See the **working example on MNIST** : https://colab.research.google.com/drive/1DxjiUjLUenFaVBrz3QMuJ665Z2HsfmgA

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Unit tests added on convolution

**Test Configuration**:
Colab config

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
