### PR TITLE
[pointers_are_tensors] Add move function (with pb of extra registering..)

### DIFF
--- a/examples/experimental/Forward or Move tensors.ipynb
+++ b/examples/experimental/Forward or Move tensors.ipynb
@@ -37,7 +37,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{7548717683: <_PointerTensor - id:7548717683 owner:0 loc:bob id@loc:1000>}\n",
+      "{5666873488: <_PointerTensor - id:5666873488 owner:0 loc:bob id@loc:1000>}\n",
       "{1000: <_LocalTensor - id:1000 owner:bob>}\n",
       "{}\n",
       "{}\n"
@@ -62,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{7548717683: <_PointerTensor - id:7548717683 owner:0 loc:bob id@loc:1000>, 1059756606: <_PointerTensor - id:1059756606 owner:0 loc:bob id@loc:1000>}\n",
+      "{5666873488: <_PointerTensor - id:5666873488 owner:0 loc:bob id@loc:1000>}\n",
       "{1000: <_PointerTensor - id:1000 owner:bob loc:alice id@loc:1001>}\n",
       "{1001: <_LocalTensor - id:1001 owner:alice>}\n",
       "{}\n"
@@ -80,14 +80,16 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{7548717683: <_PointerTensor - id:7548717683 owner:0 loc:bob id@loc:1000>, 1059756606: <_PointerTensor - id:1059756606 owner:0 loc:bob id@loc:1000>, 2083950893: <_PointerTensor - id:2083950893 owner:0 loc:bob id@loc:8573024416>}\n",
-      "{1000: <_PointerTensor - id:1000 owner:bob loc:alice id@loc:1001>, 8573024416: <_PointerTensor - id:8573024416 owner:bob loc:alice id@loc:1001>}\n",
+      "{5666873488: <_PointerTensor - id:5666873488 owner:0 loc:bob id@loc:1000>}\n",
+      "{1000: <_PointerTensor - id:1000 owner:bob loc:alice id@loc:1001>}\n",
       "{1001: <_PointerTensor - id:1001 owner:alice loc:james id@loc:1002>}\n",
       "{1002: <_LocalTensor - id:1002 owner:james>}\n"
      ]
@@ -103,7 +105,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{5666873488: <_PointerTensor - id:5666873488 owner:0 loc:bob id@loc:1000>}\n",
+      "{1000: <_PointerTensor - id:1000 owner:bob loc:alice id@loc:1001>, 1003: <_LocalTensor - id:1003 owner:bob>}\n",
+      "{1001: <_PointerTensor - id:1001 owner:alice loc:james id@loc:1002>}\n",
+      "{1002: <_PointerTensor - id:1002 owner:james loc:bob id@loc:1003>}\n"
+     ]
+    }
+   ],
+   "source": [
+    "x.move(bob, new_id=1003)\n",
+    "print(me._objects)\n",
+    "print(bob._objects)\n",
+    "print(alice._objects)\n",
+    "print(james._objects)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -117,13 +143,13 @@
        "[syft.FloatTensor of size 4]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "x.get().get().get()"
+    "x.get().get().get().get()"
    ]
   },
   {

--- a/examples/experimental/Forward or Move tensors.ipynb
+++ b/examples/experimental/Forward or Move tensors.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft as sy\n",
+    "hook = sy.TorchHook()\n",
+    "me = hook.local_worker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bob = sy.VirtualWorker(id=\"bob\",hook=hook, is_client_worker=False)\n",
+    "alice = sy.VirtualWorker(id=\"alice\",hook=hook, is_client_worker=False)\n",
+    "james = sy.VirtualWorker(id=\"james\",hook=hook, is_client_worker=False)\n",
+    "me.is_client_worker = False\n",
+    "bob.add_workers([me, alice, james])\n",
+    "alice.add_workers([me, bob, james])\n",
+    "james.add_workers([me, bob, alice])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{7548717683: <_PointerTensor - id:7548717683 owner:0 loc:bob id@loc:1000>}\n",
+      "{1000: <_LocalTensor - id:1000 owner:bob>}\n",
+      "{}\n",
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = sy.FloatTensor([1,2,3,4])\n",
+    "x.send(bob, new_id=1000)\n",
+    "print(me._objects)\n",
+    "print(bob._objects)\n",
+    "print(alice._objects)\n",
+    "print(james._objects)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{7548717683: <_PointerTensor - id:7548717683 owner:0 loc:bob id@loc:1000>, 1059756606: <_PointerTensor - id:1059756606 owner:0 loc:bob id@loc:1000>}\n",
+      "{1000: <_PointerTensor - id:1000 owner:bob loc:alice id@loc:1001>}\n",
+      "{1001: <_LocalTensor - id:1001 owner:alice>}\n",
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "x.move(alice, new_id=1001)\n",
+    "print(me._objects)\n",
+    "print(bob._objects)\n",
+    "print(alice._objects)\n",
+    "print(james._objects)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{7548717683: <_PointerTensor - id:7548717683 owner:0 loc:bob id@loc:1000>, 1059756606: <_PointerTensor - id:1059756606 owner:0 loc:bob id@loc:1000>, 2083950893: <_PointerTensor - id:2083950893 owner:0 loc:bob id@loc:8573024416>}\n",
+      "{1000: <_PointerTensor - id:1000 owner:bob loc:alice id@loc:1001>, 8573024416: <_PointerTensor - id:8573024416 owner:bob loc:alice id@loc:1001>}\n",
+      "{1001: <_PointerTensor - id:1001 owner:alice loc:james id@loc:1002>}\n",
+      "{1002: <_LocalTensor - id:1002 owner:james>}\n"
+     ]
+    }
+   ],
+   "source": [
+    "x.move(james, new_id=1002)\n",
+    "print(me._objects)\n",
+    "print(bob._objects)\n",
+    "print(alice._objects)\n",
+    "print(james._objects)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       " 1\n",
+       " 2\n",
+       " 3\n",
+       " 4\n",
+       "[syft.FloatTensor of size 4]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x.get().get().get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/syft/core/frameworks/torch/hook.py
+++ b/syft/core/frameworks/torch/hook.py
@@ -102,16 +102,16 @@ class TorchHook(object):
             else:
                 id = None
 
-            if('skip_register' in kwargs and kwargs['skip_register']):
-                "do nothing"
+
+            if(register_child_instead):
+                cls.native___init__()
+                _ = cls.child
             else:
-                if(register_child_instead):
-                    cls.native___init__()
-                    _ = cls.child
+                cls.native___init__(*args, **kwargs)
+                if('skip_register' in kwargs and kwargs['skip_register']):
+                    "do nothing"
                 else:
-                    cls.native___init__(*args, **kwargs)
                     owner.register_object(cls, owner=owner, id=id)
-        #                 return result
 
         tensorvar_type.__init__ = new___init__
 

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -3,10 +3,11 @@ import torch
 import random
 import syft as sy
 from ... import utils
+import logging
 
 class _SyftTensor(object):
     ""
-    
+
     def __init__(self, child, parent, torch_type, id=None, owner=None, skip_register=False):
         self.child = child
         self.parent = parent
@@ -64,13 +65,14 @@ class _SyftTensor(object):
     def create_pointer(self, parent, register=False):
         ptr = _PointerTensor(child=None,
                              parent=parent,
+                             torch_type="syft."+type(self.find_torch_object_in_family_tree(parent)).__name__,
                              location=self.owner.id,
                              id_at_location=self.id,
                              owner=self.owner,
-                             torch_type="syft."+type(self.find_torch_object_in_family_tree(parent)).__name__)
+                             skip_register=(not register))
 
-        if(not register):
-            ptr.owner.rm_obj(ptr.id)
+        #if(not register):
+        #    ptr.owner.rm_obj(ptr.id)
 
         return ptr
 
@@ -194,6 +196,8 @@ class _PointerTensor(_SyftTensor):
         self.location = self.owner.get_worker(location)
         self.id_at_location = id_at_location
         self.torch_type = torch_type
+        if self.location == self.owner:
+            logging.warning("Do you really want a pointer pointing to itself? (self.location == self.owner)")
 
     def __add__(self, *args, **kwargs):
 
@@ -351,7 +355,7 @@ class _TorchTensor(object):
 
         response = pointer.owner.send_torch_command(recipient=pointer.location,
                                                     message=command)
-        return sy.deser(response).wrap()
+        return self
 
     def send(self, worker, new_id=None):
         """

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -702,10 +702,12 @@ class BaseWorker(ABC):
                              owner=self,
                              id=result.id)
 
-        ptr = result.create_pointer(register=False)
+        if isinstance(result.child, sy._PointerTensor):
+            pointer = result.child
+        else:
+            pointer = result.create_pointer(register=True) #TODO =False ??
 
-        response = ptr.ser(include_data=False)
-
+        response = pointer.ser(include_data=False)
         return response
 
         # args = utils.map_tuple(
@@ -756,10 +758,9 @@ class BaseWorker(ABC):
         Main function that handles incoming torch commands.
         """
 
-        message = message
         # take in command message, return result of local execution
         response = self.process_command(message)
-        
+
         return response
 
     def handle_register(self, torch_object, obj_msg, force_attach_to_worker=False, temporary=False):

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -674,9 +674,18 @@ class BaseWorker(ABC):
         # Need to retrieve the tensors from self.worker.objects
 
         _self = self._objects[command_msg['self']]
-        args = [self._objects[id].parent for id in command_msg['args']]
+        args = []
+        for id in command_msg['args']:
+            try:
+                arg = self._objects[id].parent
+            except KeyError:
+                arg = id
+            args.append(arg)
 
-        result = getattr(_self, command_msg['command'])(*args)
+        if hasattr(_self, command_msg['command']):
+            result = getattr(_self, command_msg['command'])(*args)
+        else:
+            result = getattr(_self.child, command_msg['command'])(*args)
 
         # sometimes for virtual workers the owner is not correct
         # because it defaults to hook.local_worker


### PR DESCRIPTION
# Description

I added the previously discussed move() function which moves the end chain Tensor to another worker: `self->alice->obj [worker] => self->alice->worker->obj`
This functionality differs of send() which would perform: `self->alice->obj [worker] => self->worker->alice->obj`

However there is still an issue with undesired Tensors being created  (see `Forward or Move tensors.ipynb`), which is due to the ability of `self.child` to create arbitrarily tensors, I don't know how we could handle this at the moment.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No tests so far, just use `Forward or Move tensors.ipynb`