### PR TITLE
[pointers_are_tensors] Handling of nested args/kwargs (incl. _SyftTensor) on methods

### DIFF
--- a/syft/core/frameworks/torch/hook.py
+++ b/syft/core/frameworks/torch/hook.py
@@ -263,8 +263,7 @@ class TorchHook(object):
     def _forward_call_to_remote(hook_self, attr):
 
         def _execute_remote_call(self, *args, **kwargs):
-
-            command = self.compile_command(attr,
+            command, tensorvars = self.compile_command(attr,
                           args,
                           kwargs,
                           True)

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -256,25 +256,19 @@ class _PointerTensor(_SyftTensor):
         tensor_msg['torch_type'] = self.torch_type
         return tensor_msg
 
-    def compile_command(self, attr, args, kwargs, has_self):
-    
+    def compile_command(self, attr, args, kwargs, has_self): #self, attr, args, kwargs, has_self):
         command = {}
-
         command['has_self'] = has_self
-
-
-        command['self'] = self.id_at_location
-
+        if has_self:
+            command['self'] = self # TODO .id_at_location
+            #args = args[1:] # TODO compare to master
         command['command'] = attr
-        command['args'] = utils.map_tuple(None, args, self._tensors_to_str_ids)
-        command['kwargs'] = utils.map_dict(None, kwargs, self._tensors_to_str_ids)
-        command['arg_types'] = [type(x).__name__ for x in args]
-        command['kwarg_types'] = [type(kwargs[x]).__name__ for x in kwargs]
+        command['args'] = args
+        command['kwargs'] = kwargs
 
-        kwarg_types = command['arg_types']
-        arg_types = command['arg_types']
-
-        return command
+        encoder = utils.PythonEncoder()
+        command, tensorvars = encoder.encode(command, retrieve_tensorvar=True)
+        return command, tensorvars
 
     @staticmethod
     def _tensors_to_str_ids(tensor):

--- a/syft/core/utils.py
+++ b/syft/core/utils.py
@@ -1,6 +1,162 @@
 """Framework agnostic static utility functions."""
+import json
+import re
+import types
 import functools
+import logging
 
+import torch
+import syft as sy
+
+class PythonEncoder():
+    """
+        Encode python and torch objects to be JSON-able
+        In particular, (hooked) Torch objects are replaced by their id.
+        Note that a python object is returned, not JSON.
+    """
+    def __init__(self, retrieve_tensorvar=False):
+        self.retrieve_tensorvar = retrieve_tensorvar
+        self.found_tensorvar = []
+        self.tensorvar_types = tuple([torch.autograd.Variable,
+                                     torch.nn.Parameter,
+                                     torch.FloatTensor,
+                                     torch.DoubleTensor,
+                                     torch.HalfTensor,
+                                     torch.ByteTensor,
+                                     torch.CharTensor,
+                                     torch.ShortTensor,
+                                     torch.IntTensor,
+                                     torch.LongTensor])
+
+    def encode(self, obj, retrieve_tensorvar=None):
+        """
+            Performs encoding, and retrieves if requested all the tensors and
+            Variables found
+        """
+        if retrieve_tensorvar is not None:
+            self.retrieve_tensorvar = retrieve_tensorvar
+        if self.retrieve_tensorvar:
+            return (self.python_encode(obj), self.found_tensorvar)
+        else:
+            return self.python_encode(obj)
+
+    def python_encode(self, obj):
+        # Case of basic types
+        if isinstance(obj, (int, float, str)) or obj is None:
+            return obj
+        # Tensors and Variable encoded with their id
+        #elif obj.__name__ in map(lambda x: x.__name__, self.tensorvar_types):
+        elif isinstance(obj, self.tensorvar_types):
+            if not is_tensor_empty(obj):
+                if self.retrieve_tensorvar:
+                    self.found_tensorvar.append(obj)
+                key = '__'+type(obj).__name__+'__'
+                return { key: '_fl.{}'.format(obj.id) }
+            else: # we have a _PointerTensor
+                return self.python_encode(obj.child)
+        # sy._SyftTensor (Pointer, Local)
+        elif issubclass(obj.__class__, sy._SyftTensor):
+            key = '__'+type(obj).__name__+'__'
+            # loc: obj.location.id,
+            try: # _PointerTensor
+                location = obj.location.id
+                id = obj.id_at_location
+            except AttributeError: # _LocalTensor
+                location = obj.owner.id
+                id = obj.id
+            return { key: {
+                        'location': location,
+                        'id': id
+                    }}
+        # Lists
+        elif isinstance(obj, list):
+            return [self.python_encode(i) for i in obj]
+        # Iterables non json-serializable
+        elif isinstance(obj, (tuple, set, bytearray, range)):
+            key = '__'+type(obj).__name__+'__'
+            return {key:[self.python_encode(i) for i in obj]}
+        # Slice
+        elif isinstance(obj, slice):
+            key = '__'+type(obj).__name__+'__'
+            return { key: { 'args': [obj.start, obj.stop, obj.step]}}
+        # Dict
+        elif isinstance(obj, dict):
+            return {
+                k: self.python_encode(v)
+                for k, v in obj.items()
+            }
+        # Generator (transformed to list)
+        elif isinstance(obj, types.GeneratorType):
+            logging.warning("Generator args can't be transmitted")
+            return []
+        # Else log the error
+        else:
+            raise ValueError('Unhandled type', type(obj))
+
+class PythonJSONDecoder(json.JSONDecoder):
+    """
+        Decode JSON and reinsert python types when needed
+        Retrieve Torch objects replaced by their id
+    """
+    def __init__(self, worker, *args, **kwargs):
+        super(PythonJSONDecoder, self).__init__(*args,
+            object_hook=self.custom_obj_hook, **kwargs)
+        self.worker = worker
+        self.tensorvar_types = tuple([torch.autograd.Variable,
+                                     torch.nn.Parameter,
+                                     torch.FloatTensor,
+                                     torch.DoubleTensor,
+                                     torch.HalfTensor,
+                                     torch.ByteTensor,
+                                     torch.CharTensor,
+                                     torch.ShortTensor,
+                                     torch.IntTensor,
+                                     torch.LongTensor])
+
+    def custom_obj_hook(self, dct):
+        """
+            Is called on every dict found. We check if some keys correspond
+            to special keywords referring to a type we need to re-cast
+            (e.g. tuple, or torch Variable).
+            Note that in the case we have such a keyword, we will have created
+            at encoding a dict with a single key value pair, so the return if
+            the for loop is valid. TODO: fix this.
+        """
+        pat = re.compile('__(.+)__')
+        for key, obj in dct.items():
+            try:
+                obj_type = pat.search(key).group(1)
+                # Case of a tensor or a Variable
+                if obj_type in map(lambda x: x.__name__, self.tensorvar_types):
+                    pattern_var = re.compile('_fl.(.*)')
+                    id = int(pattern_var.search(obj).group(1))
+                    return self.worker.get_obj(id)
+                # Syft tensor
+                elif obj_type in map(lambda x: x.__name__, sy._SyftTensor.__subclasses__()):
+                    #   TODO: if there are more pointers, we shoudn't give back the obj
+                    #   if its a pointer because the call will be forwarded to
+                    #   another worker, just change the flag to Local.
+                    #
+                    # If local, we render the object
+                    if obj['location'] == self.worker.id:
+                        return self.worker.get_obj(obj['id']).child
+                    else:
+                        return {key: obj}
+                # Case of a iter type non json serializable
+                elif obj_type in ('tuple', 'set', 'bytearray', 'range'):
+                    return eval(obj_type)(obj)
+                # Case of a slice
+                elif obj_type == 'slice':
+                    return slice(*obj['args'])
+                else:
+                    return obj
+            except AttributeError:
+                pass
+        return dct
+
+def is_tensor_empty(obj):
+    # TODO Will break with PyTorch >= 0.4
+    return obj.dim() == 0
 
 def map_tuple(hook, args, func):
     if hook:


### PR DESCRIPTION
# Description

Add handling of nested args/kwargs (incl. _SyftTensor) on methods only

This allows to call methods on Tensors (eg `x.add(y)`), with the following limitations:
- with single output
- chains of pointers in args must be identical

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Not tested except on notebooks

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
