### PR TITLE
[pointers_are_tensors] Fix send/get in chain Tensors and partial fix of torch func

### DIFF
--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -63,13 +63,13 @@ class _SyftTensor(object):
     def parent(self, value):
         self._parent = value
 
-    def create_pointer(self, parent, register=False):
+    def create_pointer(self, owner, parent=None, register=False):
         ptr = _PointerTensor(child=None,
                              parent=parent,
                              torch_type="syft."+type(self.find_torch_object_in_family_tree(parent)).__name__,
                              location=self.owner.id,
                              id_at_location=self.id,
-                             owner=self.owner,
+                             owner=owner,
                              skip_register=(not register))
 
         if(not register):
@@ -191,18 +191,6 @@ class _LocalTensor(_SyftTensor):
     def get(self, parent):
         raise Exception("Cannot call .get() on a tensor you already have.")
 
-    def footprint(self):
-        """
-        Return useful info (excluding data) from a LocalTensor to create pointers
-        """
-        # TODO: 'type' is compulsory to pass the guard, but is not very appropriate
-        footprint = {
-            'type': 'syft.core.frameworks.torch.tensor._PointerTensor',
-            'location': self.owner.id,
-            'id_at_location': self.id,
-            'torch_type': self.torch_type
-        }
-        return footprint
 
 class _PointerTensor(_SyftTensor):
 
@@ -349,9 +337,6 @@ class _TorchObject(object):
 
     def create_pointer(self, register=False):
         return self.child.create_pointer(parent=self, register=register)
-
-    def footprint(self):
-        return self.child.footprint()
 
     def get(self):
         new_child_obj = self.child.get(parent=self)

--- a/syft/core/utils.py
+++ b/syft/core/utils.py
@@ -147,9 +147,14 @@ class PythonJSONDecoder(json.JSONDecoder):
                     #   if its a pointer because the call will be forwarded to
                     #   another worker, just change the flag to Local.
                     #
-                    # If local, we render the object
+                    # If local, we render the object or syft object
                     if obj['location'] == self.worker.id:
-                        return self.worker.get_obj(obj['id']).child
+                        syft_obj = self.worker.get_obj(obj['id'])
+                        # If the object is a LocalTensor then we render the torch object
+                        if syft_obj.__class__.__name__ == '_LocalTensor':
+                            return self.worker.get_obj(obj['id']).child
+                        else:
+                            return self.worker.get_obj(obj['id'])
                     else:
                         return {key: obj}
                 # Case of a iter type non json serializable

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -652,8 +652,6 @@ class BaseWorker(ABC):
         if obj.owner in self._known_workers.keys():
             obj.owner = self._known_workers[obj.owner]
 
-        if(obj.owner.id == 'bob'):
-            print("I am",self,"Registering ", obj.id, obj.owner)
         # traceback.print_stack()
 
         self.set_obj(obj.id, obj, force=force_attach_to_worker, tmp=temporary)
@@ -723,6 +721,7 @@ class BaseWorker(ABC):
 
         if isinstance(result.child, sy._PointerTensor):
             pointer = result.child
+            # we make a pointer to this pointer to chain like the args
             response = pointer.ser(include_data=False)
         else:
             # We don't want to create a pointer just to transfer information-> use footprint instead
@@ -730,7 +729,8 @@ class BaseWorker(ABC):
             #response = pointer.ser(include_data=False)
 
             # Probably a LocalTensor (TODO and if not ? or if list ?)
-            response = result.footprint()
+            assert result.child.__class__.__name__ in map(lambda x: x.__name__, sy._SyftTensor.__subclasses__())
+            response = result.child.ser()
 
         #response = pointer.ser(include_data=False)
         return response
@@ -800,7 +800,7 @@ class BaseWorker(ABC):
 
         if(isinstance(message, str)):
             message = json.loads(message)
-        print(message)
+        
         obj = sy.deser(message, owner=self)
         return obj
 


### PR DESCRIPTION
# Description

Fix send/get in chain Tensors and partial fix of torch func
- All functionalities claimed have unit tests
- torch func with args=FloatTensor and output=FloatTensor work remotely
- So, output=IntTensors or output=float fails so far

This can be merged directly (if to be reused direcly), or wait for additional bug fix (with unit tests!)

A code review on my `_execute_call()` (hook.py l.387) might be useful.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
