### PR TITLE
Context manager for TorchHook is back!

### DIFF
--- a/syft/core/hooks/base.py
+++ b/syft/core/hooks/base.py
@@ -7,10 +7,10 @@ class BaseHook(object):
     def __init__(self):
         pass
 
-    # TODO: decorate with abstractmethod after TorchHook is extended
+    @abstractmethod
     def __enter__(self):
         return self
 
-    # TODO: decorate with abstractmethod after TorchHook is extended
+    @abstractmethod
     def __exit__(self):
         pass

--- a/syft/core/hooks/base.py
+++ b/syft/core/hooks/base.py
@@ -1,15 +1,16 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 
-class BaseHook(ABC):
-    r""" A abstract interface for deep learning framework hooks."""
+class BaseHook(object):
+    __metaclass__ = ABCMeta
+    """An abstract interface for deep learning framework hooks."""
     @abstractmethod
     def __init__(self):
         pass
 
     # TODO: decorate with abstractmethod after TorchHook is extended
     def __enter__(self):
-        raise NotImplementedError
+        return self
 
     # TODO: decorate with abstractmethod after TorchHook is extended
     def __exit__(self):
-        raise NotImplementedError
+        pass


### PR DESCRIPTION
Previously, the `__enter__` and `__exit__` methods were deleted from TorchHook.  They're back, and they're better than ever!  In particular, they no longer assume that torch was unhooked before the TorchHook was initialized.  In addition, I wrapped all the various hooking logic from `__init__` into it's own function, preparing for an API change where you have to imperatively establish the hooks instead of having them happen whenever you instantiate TorchHook.