### PR TITLE
[pointers_are_tensors] Continue handling tensors and variables

### DIFF
--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -608,33 +608,25 @@ class TestTorchTensor(TestCase):
 
 #         assert final_loss == 0.18085284531116486
 
-#     def test_torch_function_on_remote_var(self):
-#         hook = TorchHook(verbose=False)
-#         me = hook.local_worker
-#         remote = VirtualWorker(id=2,hook=hook)
-#         me.add_worker(remote)
+    def test_torch_function_on_remote_var(self):
 
-#         x = Var(torch.FloatTensor([[1, 2], [3, 4]]))
-#         y = Var(torch.FloatTensor([[1, 2], [1, 2]]))
-#         x.send(remote)
-#         y.send(remote)
-#         z = torch.matmul(x, y)
-#         z.get()
-#         assert torch.equal(z, Var(torch.FloatTensor([[3, 6], [7, 14]])))
+        x = sy.Variable(torch.FloatTensor([[1, 2], [3, 4]]))
+        y = sy.Variable(torch.FloatTensor([[1, 2], [1, 2]]))
+        x.send(bob)
+        y.send(bob)
+        z = torch.matmul(x, y)
+        z.get()
+        assert torch.equal(z, sy.Variable(torch.FloatTensor([[3, 6], [7, 14]])))
 
-#     def test_torch_function_with_multiple_input_on_remote_var(self):
-#         hook = TorchHook(verbose=False)
-#         me = hook.local_worker
-#         remote = VirtualWorker(id=2,hook=hook)
-#         me.add_worker(remote)
+    #def test_torch_function_with_multiple_input_on_remote_var(self):
 
-#         x = Var(torch.FloatTensor([1,2]))
-#         y = Var(torch.FloatTensor([3,4]))
-#         x.send(remote)
-#         y.send(remote)
-#         z = torch.stack([x,y])
-#         z.get()
-#         assert torch.equal(z, Var(torch.FloatTensor([[1, 2], [3, 4]])))
+    #    x = sy.Variable(torch.FloatTensor([1,2]))
+    #    y = sy.Variable(torch.FloatTensor([3,4]))
+    #    x.send(bob)
+    #    y.send(bob)
+    #    z = torch.stack([x, y])
+    #    z.get()
+    #    assert torch.equal(z, sy.Variable(torch.FloatTensor([[1, 2], [3, 4]])))
 
 #     def test_torch_function_with_multiple_output_on_remote_var(self):
 #         hook = TorchHook(verbose=False)


### PR DESCRIPTION
# Description
Add support of function and method on remote tensors EXCEPT weird output/input
Add support of send / get Variable BUT some registrations remain uncontrolled
Add support of SOME function and method on singly remote Variables (=One single send)
TODO: dispatch the parts of JSON Encode/Decode to the appropriate ser and deser

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Unittests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
