### PR TITLE
[Pointers are tensors]  Working on chains: sanitizing the previous work

### DIFF
--- a/syft/core/frameworks/torch/__init__.py
+++ b/syft/core/frameworks/torch/__init__.py
@@ -13,6 +13,12 @@ torch.torch_funcs = dir(torch)
 # this is a list of all module functions in torch.nn.functional
 torch.torch_functional_funcs = dir(torch.nn.functional)
 
+# Gathers all the functions from above
+torch.torch_modules = {
+            'torch': torch.torch_funcs,
+            'torch.nn.functional': torch.torch_functional_funcs
+        }
+
 # this is the list of torch tensor types that we will override for remote execution
 torch.tensor_types = [torch.FloatTensor,
                      torch.DoubleTensor,
@@ -39,4 +45,5 @@ torch.tensorvar_methods = list(
     )
 )
 
+# Torch functions we don't want to override
 torch.torch_exclude = ['save', 'load', 'typename', 'is_tensor']

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -160,25 +160,6 @@ class _LocalTensor(_SyftTensor):
         else:
             return json.dumps({'___LocalTensor__': data}) + "\n"
 
-    def ser_old(self, include_data=True, *args, **kwargs):
-
-        tensor_msg = {}
-
-        tensor_msg['type'] = str(self.__class__).split("'")[1]
-        tensor_msg['torch_type'] = "syft."+type(self.parent).__name__
-
-        if hasattr(self, 'child') and self.child is not None:
-            tensor_msg['child'] = self.child.ser(include_data=include_data,
-                                                 stop_recurse_at_torch_type=True)
-        tensor_msg['id'] = self.id
-        owner_type = type(self.owner)
-        if (owner_type is int or owner_type is str):
-            tensor_msg['owner'] = self.owner
-        else:
-            tensor_msg['owner'] = self.owner.id
-
-        return tensor_msg
-
     def __add__(self, other):
         """
         An example of how to overload a specific function given that
@@ -216,55 +197,6 @@ class _LocalTensor(_SyftTensor):
                                          id=None,
                                          skip_register=True)
         return syft_obj
-
-    @staticmethod
-    def deser_old(msg_obj, register=True):
-
-        if('child' not in msg_obj):
-
-            # create empty object as a backup if no child is provided
-            if('torch_type' in msg_obj):
-                child_type = guard[msg_obj['torch_type']]
-                child = child_type()
-            else:
-                raise Exception("Object must either have a child object or at least"+\
-                                "a decided Torch type in which data will be stored")
-        else:
-            # get the type of the child to call the correct deser function
-            child_type = guard[msg_obj['child']['type']]
-
-            if(child_type not in torch.tensor_types):
-                raise Exception("LocalTensor child object must be a Torch tensor")
-
-            # create child object - don't deregister it yet because we need to get a
-            # reference to the local worker
-            child = child_type.deser(msg_obj['child'], register=True, suppress_warning=True)
-
-        # get reference to child owner (to have access to the local_worker object)
-        child_worker_reference = child.owner
-
-        # ok... now we can deregister it. This is a little bit of a hack but it works
-        # TODO: perhaps there's a better strategy for getting access to the local_worker
-        # object?
-        child.owner.de_register_object(child)
-
-        owner = child_worker_reference.get_worker(msg_obj['owner'])
-
-        if(register):
-            if msg_obj['id'] in owner._objects:
-                msg = "Cannot deserialize and register a tensor that already exists.\n"
-                msg += "Either set register=False, remove the current tensor, or initialize\n"
-                msg += "this tensor with a different id."
-                raise Exception(msg)
-
-        result = _LocalTensor(child=child,
-                             owner=owner,
-                             torch_type=msg_obj['torch_type'],
-                             id=msg_obj['id'],
-                             parent=child,
-                             skip_register=not register)
-
-        return result
 
     def get(self, parent, deregister_ptr=None):
         raise TypeError("Cannot call .get() on a tensor you already have.")
@@ -329,20 +261,6 @@ class _PointerTensor(_SyftTensor):
                                              id=None,
                                              skip_register=True)
         return syft_obj
-    @staticmethod
-    def deser_old(msg_obj, child, owner):
-
-        if 'id' not in msg_obj.keys():
-            msg_obj['id'] = random.randint(0,9999999999)
-        obj = _PointerTensor(child=child,
-                             parent=None,
-                             owner=owner,
-                             id=msg_obj['id'],
-                             location=msg_obj['location'],
-                             id_at_location=msg_obj['id_at_location'],
-                             torch_type = msg_obj['torch_type']
-                             )
-        return obj
 
     def wrap(self): # TODO do it in a smart (and dual?) way
         wrapper = guard[self.torch_type]()
@@ -370,7 +288,6 @@ class _PointerTensor(_SyftTensor):
         syft_tensor = tensorvar.child
         syft_tensor.id = self.id
         if self.torch_type == 'syft.Variable':
-            raise Exception('Get the real variable head')
             tensorvar.data.child.id = self.parent.data.child.id
 
         # Register the result
@@ -515,27 +432,6 @@ class _TorchTensor(_TorchObject):
             return json.dumps({key: tensor_msg}) + "\n"
 
 
-    def ser_old(self, include_data=True, stop_recurse_at_torch_type=False, as_dict=True):
-        """Serializes a {} object to JSON.""".format(type(self))
-        if(not stop_recurse_at_torch_type):
-            serializations = self.child.ser(include_data=include_data, as_dict=True)
-            serializations['torch_type'] = "syft."+type(self).__name__
-            if(as_dict):
-                return serializations
-            else:
-                return json.dumps(serializations) + "\n"
-        else:
-            tensor_msg = {}
-            tensor_msg['type'] = str(self.__class__).split("'")[1]
-            tensor_msg['torch_type'] = "syft."+type(self).__name__
-            if include_data:
-                tensor_msg['data'] = self.tolist()
-
-            if(as_dict):
-                return tensor_msg
-            else:
-                return json.dumps(tensor_msg) + "\n"
-
     @staticmethod
     def deser(msg_obj, worker, acquire):
         obj_type, msg_obj = utils.extract_type_and_obj(msg_obj)
@@ -551,29 +447,6 @@ class _TorchTensor(_TorchObject):
         tensorvar.child = syft_obj
         syft_obj.parent = tensorvar
         return tensorvar
-
-    @staticmethod
-    def deser_old(msg_obj, register=True, suppress_warning=False):
-
-        if('data' in msg_obj):
-            if register and not suppress_warning:
-                msg = "Registering a data holding tensor is not advised.\n"
-                msg += "our system is designed for data tensors to only be \n"
-                msg += "called by LocalTensor pointers which are themselves registered.\n"
-                msg += "The system will attempt to handle this gracefully but this could\n"
-                msg += "result in undefined behavior. Are you sure you want to do this?"
-                msg += "If so, set suppress_warning=True to not display this message."
-                logging.warn(msg)
-            torch_type = guard[msg_obj['torch_type']]
-            result = torch_type(msg_obj['data'])
-
-            if(not register):
-                result.owner.de_register_object(result)
-        else:
-            child_type = guard[msg_obj['type']]
-            result = child_type.deser(msg_obj=msg_obj, register=register).wrap()
-
-        return result
 
     def send(self, worker, ptr_id=None):
         """
@@ -649,20 +522,7 @@ class _TorchVariable(_TorchObject):
         obj_id = self.child.id
         obj_data_id = self.data.child.id
 
-        # creates a pointer to LocalTensor without a Torch object wrapping it because
-        # we're going to set self.child to be this pointer.
-        # we set register=True because we want it to be registered locally
-
-
-
-
-        #if isinstance(self.child, sy._PointerTensor):
-        #    prindffft('BLouclage')
-        #    self.child.child = self
-        #else:
-        #    self.child.parent.data = self.data
-
-        p = self.owner.send_obj(self.child,
+        self.owner.send_obj(self,
                             new_id,
                             worker,
                             new_data_id=new_data_id)
@@ -677,38 +537,44 @@ class _TorchVariable(_TorchObject):
         self.child.id = obj_id
         var_ptr = self.child.create_pointer(location=worker, id_at_location=new_id, register=True)
         self.child = var_ptr
-        self.parent = var_ptr
-        var_ptr.child = self
         var_ptr.parent = self
+        self.parent = None
 
         # same for data
         self.data.child.id = obj_data_id
         var_data_ptr = self.data.child.create_pointer(location=worker, id_at_location=new_data_id, register=True)
         self.data.child = var_data_ptr
-        self.data.parent = var_data_ptr
-        var_data_ptr.child = self.data
         var_data_ptr.parent = self.data
+        self.data.parent = None
 
-        #self.child.parent.data = self.data
         return self
 
     def get(self, deregister_ptr=True, update_ptr_wrapper=True):
 
-        # returns a SyftTensor object (Local or Pointer) without a parent wrapper
-        syft_tensor = self.child.get(parent=self, deregister_ptr=deregister_ptr)
-
-        # this will change the pointer variable (wrapper) to instead wrap the
+        # returns a Variable object wrapping a SyftTensor
+        variable = self.child.get(deregister_ptr=deregister_ptr)
+        utils.assert_has_only_torch_tensorvars(variable)
+        # this will change the wrapper variable to instead wrap the
         # SyftTensor object that was returned so that any variable that may
         # still exist referencing this pointer will simply call local data instead
         # of sending messages elsewhere, or a closer pointer
         if update_ptr_wrapper:
-            self.child = syft_tensor
-            # In case we have a final get() (ie returning a Variable)
-            if not isinstance(syft_tensor, sy._PointerTensor) \
-              and syft_tensor.child is not None \
-              and syft_tensor.child.dim() > 0:
-                self.set_(syft_tensor.child)
-                self.data = syft_tensor.child.data
+            self.child = variable.child
+            self.data.child = variable.data.child
+
+            # In case we have a final get() (ie returning a FloatTensor), we have e.g.
+            # x = Float(...)
+            # x.send(...)
+            # x2 = x.get()
+            # We  have x2: [no dim]->[_Local]->[Float()]
+            # Whereas we expect x2: [Float()]
+            # So we use the .set_() method, to change the storage of [no dim]
+            if not isinstance(variable.child, sy._PointerTensor) \
+              and variable.data is not None \
+              and variable.data.dim() > 0:
+                self.set_(variable)
+            utils.fix_chain_ends(self)
+            utils.assert_is_chain_well_formed(self)
 
         return self
 
@@ -728,23 +594,23 @@ class _TorchVariable(_TorchObject):
 
     @staticmethod
     def deser(msg_obj, worker, acquire):
-        raise NotImplementedError('not implemented')
-        data = utils.decode(msg_obj['data'])
+        obj_type, msg_obj = utils.extract_type_and_obj(msg_obj)
+        var_syft_obj = sy._SyftTensor.deser(msg_obj['child'], worker, acquire)
+        # Deser the var.data
+        var_data_type, var_data_tensor = utils.extract_type_and_obj(msg_obj['data'])
+        if utils.is_tensor(var_data_type):
+            var_data =  eval('sy.' + var_data_type).deser(msg_obj['data'], worker, acquire)
+            worker.hook.local_worker.de_register(var_data)
         # TODO: Find a smart way to skip register and not leaking the info to the local worker
         # This would imply overload differently the __init__ to provide an owner for the child attr.
-        variable = sy.Variable(data)
-        self.worker.hook.local_worker.de_register(data)
-        self.worker.hook.local_worker.de_register(variable)
-        syft_obj = utils.python_decode(obj['child'])
-        # This is a special case where we want to get rid of the empty wrapper
-        if syft_obj.child is not None and len(data) == 0:
-            return syft_obj.child
-        tensorvar.child = syft_obj
-        syft_obj.parent = tensorvar
-        return tensorvar
+        variable = sy.Variable(var_data)
+        worker.hook.local_worker.de_register(variable)
 
-    def ser(self):
-        pass
+        variable.child = var_syft_obj
+        var_syft_obj.parent = variable
+
+        return variable
+
 
 guard = {
     'syft.core.frameworks.torch.tensor.Variable': torch.autograd.Variable,

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -193,8 +193,11 @@ class _LocalTensor(_SyftTensor):
 
     @staticmethod
     def deser(msg_obj, worker, acquire):
+        if not 'owner' in msg_obj:
+            raise TypeError("sy._LocalTensor can't deserialize a non-valid sy._LocalTensor. "
+                            "Do you wan to call sy.FloatTensor.deser() instead?")
         if msg_obj['owner'] == worker.id:
-            raise Exception('_LocalTensor sent to itself')
+            logging.warning('_LocalTensor sent to itself')
         if acquire:  # We need to register the info given
             syft_obj = sy._LocalTensor(child=None,
                                        parent=None,

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -258,7 +258,6 @@ class BaseWorker(ABC):
         elif message_wrapper['type'] == 'torch_cmd':
             response = self.process_command(message)
             if response.child.torch_type == 'syft.Variable':
-                #response.data.child.owner = self
                 self.register(response.data.child)
             self.register(response.child)
             return response, True  # Result is private
@@ -652,6 +651,11 @@ class BaseWorker(ABC):
             self.hook.local_worker.de_register(result.child)
             result.child.owner = self
             self.register(result.child)
+            if isinstance(result, sy.Variable):
+                self.hook.local_worker.de_register(result.data.child)
+                result.data.child.owner = self
+                self.register(result.data.child)
+            # end of to do
 
             utils.assert_has_only_torch_tensorvars(result)
 

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -206,7 +206,7 @@ class BaseWorker(ABC):
 
         response, private = self.process_message_type(message_wrapper)
 
-        response = utils.encode(response, retrieve_tensorvar=False, retrieve_pointers=False, private_local=private)
+        response = utils.encode(response, retrieve_pointers=False, private_local=private)
         response = json.dumps(response).encode()
 
 
@@ -685,7 +685,7 @@ class BaseWorker(ABC):
             if new_data_id is None:
                 raise AttributeError('Please provide a new_data_id arg, to be able to point to Var.data')
             object.data.child.id = new_data_id
-        object = utils.encode(object, retrieve_tensorvar=False, retrieve_pointers=False, private_local=False)
+        object = utils.encode(object, retrieve_pointers=False, private_local=False)
 
         # We don't need any response to proceed to registration
         self.send_msg(message=object,

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -608,25 +608,25 @@ class TestTorchTensor(TestCase):
 
 #         assert final_loss == 0.18085284531116486
 
-    # def test_torch_function_on_remote_var(self):
-    #
-    #     x = sy.Variable(torch.FloatTensor([[1, 2], [3, 4]]))
-    #     y = sy.Variable(torch.FloatTensor([[1, 2], [1, 2]]))
-    #     x.send(bob)
-    #     y.send(bob)
-    #     z = torch.matmul(x, y)
-    #     z.get()
-    #     assert torch.equal(z, sy.Variable(torch.FloatTensor([[3, 6], [7, 14]])))
+    def test_torch_function_on_remote_var(self):
 
-    #def test_torch_function_with_multiple_input_on_remote_var(self):
+        x = sy.Variable(torch.FloatTensor([[1, 2], [3, 4]]))
+        y = sy.Variable(torch.FloatTensor([[1, 2], [1, 2]]))
+        x.send(bob)
+        y.send(bob)
+        z = torch.matmul(x, y)
+        z.get()
+        assert torch.equal(z, sy.Variable(torch.FloatTensor([[3, 6], [7, 14]])))
 
-    #    x = sy.Variable(torch.FloatTensor([1,2]))
-    #    y = sy.Variable(torch.FloatTensor([3,4]))
-    #    x.send(bob)
-    #    y.send(bob)
-    #    z = torch.stack([x, y])
-    #    z.get()
-    #    assert torch.equal(z, sy.Variable(torch.FloatTensor([[1, 2], [3, 4]])))
+    def test_torch_function_with_multiple_input_on_remote_var(self):
+
+       x = sy.Variable(torch.FloatTensor([1,2]))
+       y = sy.Variable(torch.FloatTensor([3,4]))
+       x.send(bob)
+       y.send(bob)
+       z = torch.stack([x, y])
+       z.get()
+       assert torch.equal(z, sy.Variable(torch.FloatTensor([[1, 2], [3, 4]])))
 
 #     def test_torch_function_with_multiple_output_on_remote_var(self):
 #         hook = TorchHook(verbose=False)
@@ -669,137 +669,119 @@ class TestTorchTensor(TestCase):
 #         expected_conv = Var(torch.FloatTensor([[[[3, -2], [-2, -3]]]]))
 #         assert torch.equal(conv, expected_conv)
 
-#     def test_torch_nn_conv2d_on_remote_var(self):
-#         hook = TorchHook(verbose=False)
-#         me = hook.local_worker
-#         remote = VirtualWorker(id=2,hook=hook)
-#         me.add_worker(remote)
+    # def test_torch_nn_conv2d_on_remote_var(self):
+    #
+    #     x = sy.Variable(torch.FloatTensor([[[[1, -1, 2], [-1, 0, 1], [1, 0, -2]]]]))
+    #     x.send(bob)
+    #     convolute = torch.nn.Conv2d(1, 1, 2, stride=1, padding=0)
+    #     convolute.weight = torch.nn.Parameter(torch.FloatTensor([[[[1, -1], [-1, 1]]]]))
+    #     convolute.bias = torch.nn.Parameter(torch.FloatTensor([0]))
+    #     convolute.send(bob)
+    #     conv = convolute(x)
+    #     conv.get()
+    #     expected_conv = sy.Variable(torch.FloatTensor([[[[3, -2], [-2, -3]]]]))
+    #     assert torch.equal(conv, expected_conv)
 
-#         x = Var(torch.FloatTensor([[[[1, -1, 2], [-1, 0, 1], [1, 0, -2]]]]))
-#         x.send(remote)
-#         convolute = nn.Conv2d(1, 1, 2, stride=1, padding=0)
-#         convolute.weight = torch.nn.Parameter(torch.FloatTensor([[[[1, -1], [-1, 1]]]]))
-#         convolute.bias = torch.nn.Parameter(torch.FloatTensor([0]))
-#         convolute.send(remote)
-#         conv = convolute(x)
-#         conv.get()
-#         expected_conv = Var(torch.FloatTensor([[[[3, -2], [-2, -3]]]]))
-#         assert torch.equal(conv, expected_conv)
-
-#     def test_local_var_unary_methods(self):
-#         ''' Unit tests for methods mentioned on issue 1385
-#             https://github.com/OpenMined/PySyft/issues/1385'''
-
-#         x = Var(torch.FloatTensor([1, 2, -3, 4, 5]))
-#         assert torch.equal(x.abs(), Var(torch.FloatTensor([1, 2, 3, 4, 5])))
-#         assert torch.equal(x.abs_(), Var(torch.FloatTensor([1, 2, 3, 4, 5])))
-#         x = Var(torch.FloatTensor([1, 2, -3, 4, 5]))
-#         assert torch.equal(x.cos().int(), Var(torch.IntTensor(
-#             [0, 0, 0, 0, 0])))
-#         x = Var(torch.FloatTensor([1, 2, -3, 4, 5]))
-#         assert torch.equal(x.cos_().int(), Var(torch.IntTensor(
-#             [0, 0, 0, 0, 0])))
-#         x = Var(torch.FloatTensor([1, 2, -3, 4, 5]))
-#         assert torch.equal(x.ceil(), x)
-#         assert torch.equal(x.ceil_(), x)
-#         assert torch.equal(x.cpu(), x)
+    # def test_local_var_unary_methods(self):
+    #     ''' Unit tests for methods mentioned on issue 1385
+    #         https://github.com/OpenMined/PySyft/issues/1385'''
+    #
+    #     x = sy.Variable(torch.FloatTensor([1, 2, -3, 4, 5]))
+    #     assert torch.equal(x.abs(), sy.Variable(torch.FloatTensor([1, 2, 3, 4, 5])))
+    #     assert torch.equal(x.abs_(), sy.Variable(torch.FloatTensor([1, 2, 3, 4, 5])))
+    #     x = sy.Variable(torch.FloatTensor([1, 2, -3, 4, 5]))
+    #     assert torch.equal(x.cos().int(), sy.Variable(torch.IntTensor(
+    #         [0, 0, 0, 0, 0])))
+    #     x = sy.Variable(torch.FloatTensor([1, 2, -3, 4, 5]))
+    #     assert torch.equal(x.cos_().int(), sy.Variable(torch.IntTensor(
+    #         [0, 0, 0, 0, 0])))
+    #     x = sy.Variable(torch.FloatTensor([1, 2, -3, 4, 5]))
+    #     assert torch.equal(x.ceil(), x)
+    #     assert torch.equal(x.ceil_(), x)
+    #     assert torch.equal(x.cpu(), x)
 
 
-#     def test_local_var_binary_methods(self):
-#         ''' Unit tests for methods mentioned on issue 1385
-#             https://github.com/OpenMined/PySyft/issues/1385'''
-#         x = torch.FloatTensor([1, 2, 3, 4])
-#         y = torch.FloatTensor([[1, 2, 3, 4]])
-#         z = torch.matmul(x, y.t())
-#         assert (torch.equal(z, torch.FloatTensor([30])))
-#         z = torch.add(x, y)
-#         assert (torch.equal(z, torch.FloatTensor([[2, 4, 6, 8]])))
-#         x = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
-#         y = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
-#         z = torch.cross(x, y, dim=1)
-#         assert (torch.equal(z, torch.FloatTensor([[0, 0, 0], [0, 0, 0], [0, 0, 0]])))
-#         x = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
-#         y = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
-#         z = torch.dist(x, y)
-#         t = torch.FloatTensor([z])
-#         assert (torch.equal(t, torch.FloatTensor([0.])))
-#         x = torch.FloatTensor([1, 2, 3])
-#         y = torch.FloatTensor([1, 2, 3])
-#         z = torch.dot(x, y)
-#         t = torch.FloatTensor([z])
-#         assert torch.equal(t, torch.FloatTensor([14]))
-#         z = torch.eq(x, y)
-#         assert (torch.equal(z, torch.ByteTensor([1, 1, 1])))
-#         z = torch.ge(x, y)
-#         assert (torch.equal(z, torch.ByteTensor([1, 1, 1])))
+    def test_local_var_binary_methods(self):
+        ''' Unit tests for methods mentioned on issue 1385
+            https://github.com/OpenMined/PySyft/issues/1385'''
+        x = torch.FloatTensor([1, 2, 3, 4])
+        y = torch.FloatTensor([[1, 2, 3, 4]])
+        z = torch.matmul(x, y.t())
+        assert (torch.equal(z, torch.FloatTensor([30])))
+        z = torch.add(x, y)
+        assert (torch.equal(z, torch.FloatTensor([[2, 4, 6, 8]])))
+        x = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
+        y = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
+        z = torch.cross(x, y, dim=1)
+        assert (torch.equal(z, torch.FloatTensor([[0, 0, 0], [0, 0, 0], [0, 0, 0]])))
+        x = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
+        y = torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])
+        z = torch.dist(x, y)
+        t = torch.FloatTensor([z])
+        assert (torch.equal(t, torch.FloatTensor([0.])))
+        x = torch.FloatTensor([1, 2, 3])
+        y = torch.FloatTensor([1, 2, 3])
+        z = torch.dot(x, y)
+        t = torch.FloatTensor([z])
+        assert torch.equal(t, torch.FloatTensor([14]))
+        z = torch.eq(x, y)
+        assert (torch.equal(z, torch.ByteTensor([1, 1, 1])))
+        z = torch.ge(x, y)
+        assert (torch.equal(z, torch.ByteTensor([1, 1, 1])))
 
 #     def test_remote_var_unary_methods(self):
 #         ''' Unit tests for methods mentioned on issue 1385
 #             https://github.com/OpenMined/PySyft/issues/1385'''
-#         hook = TorchHook(verbose=False)
-#         local = hook.local_worker
-#         remote = VirtualWorker(id=2,hook=hook)
-#         local.add_worker(remote)
 
-#         x = Var(torch.FloatTensor([1, 2, -3, 4, 5])).send(remote)
+#         x = sy.Variable(torch.FloatTensor([1, 2, -3, 4, 5])).send(bob)
 #         assert torch.equal(x.abs().get(), Var(torch.FloatTensor([1, 2, 3, 4, 5])))
 #         assert torch.equal(x.abs_().get(), Var(torch.FloatTensor([1, 2, 3, 4, 5])))
 #         assert torch.equal(x.cos().int().get(), Var(torch.IntTensor(
 #             [0, 0, 0, 0, 0])))
 #         assert torch.equal(x.cos_().int().get(), Var(torch.IntTensor(
 #             [0, 0, 0, 0, 0])))
-#         x = Var(torch.FloatTensor([1, 2, -3, 4, 5])).send(remote)
+#         x = sy.Variable(torch.FloatTensor([1, 2, -3, 4, 5])).send(bob)
 #         assert torch.equal(x.ceil().get(), Var(torch.FloatTensor([1, 2, -3, 4, 5])))
 #         assert torch.equal(x.ceil_().get(), Var(torch.FloatTensor([1, 2, -3, 4, 5])))
 #         assert torch.equal(x.cpu().get(), Var(torch.FloatTensor([1, 2, -3, 4, 5])))
 
-#     def test_local_var_binary_methods(self):
+    def test_local_var_binary_methods(self):
         
-#         x = Var(torch.FloatTensor([1, 2, 3, 4, 5]))
-#         y = Var(torch.FloatTensor([1, 2, 3, 4, 5]))
-#         assert  torch.equal(x.add_(y), Var(torch.FloatTensor([2,4,6,8,10])))
+        x = sy.Variable(torch.FloatTensor([1, 2, 3, 4, 5]))
+        y = sy.Variable(torch.FloatTensor([1, 2, 3, 4, 5]))
+        assert  torch.equal(x.add_(y), sy.Variable(torch.FloatTensor([2,4,6,8,10])))
 
-#     def test_remote_var_binary_methods(self):
+    def test_remote_var_binary_methods(self):
+        x = sy.Variable(torch.FloatTensor([1, 2, 3, 4, 5])).send(bob)
+        y = sy.Variable(torch.FloatTensor([1, 2, 3, 4, 5])).send(bob)
+        assert torch.equal(x.add_(y).get(),  sy.Variable(torch.FloatTensor([2,4,6,8,10])))
 
-#         hook = TorchHook()
-#         local = hook.local_worker
-#         remote = VirtualWorker(hook, 0)
-#         local.add_worker(remote)
+    def test_remote_var_binary_methods(self):
+        ''' Unit tests for methods mentioned on issue 1385
+            https://github.com/OpenMined/PySyft/issues/1385'''
 
-#         x = Var(torch.FloatTensor([1, 2, 3, 4, 5])).send(remote)
-#         y = Var(torch.FloatTensor([1, 2, 3, 4, 5])).send(remote)
-#         assert torch.equal(x.add_(y).get(),  Var(torch.FloatTensor([2,4,6,8,10])))
-
-#     def test_remote_var_binary_methods(self):
-#         ''' Unit tests for methods mentioned on issue 1385
-#             https://github.com/OpenMined/PySyft/issues/1385'''
-#         hook = TorchHook(verbose=False)
-#         local = hook.local_worker
-#         remote = VirtualWorker(hook, 1)
-#         local.add_worker(remote)
-
-#         x = Var(torch.FloatTensor([1, 2, 3, 4])).send(remote)
-#         y = Var(torch.FloatTensor([[1, 2, 3, 4]])).send(remote)
-#         z = torch.matmul(x, y.t())
-#         assert (torch.equal(z.get(), Var(torch.FloatTensor([30]))))
-#         z = torch.add(x, y)
-#         assert (torch.equal(z.get(), Var(torch.FloatTensor([[2, 4, 6, 8]]))))
-#         x = Var(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(remote)
-#         y = Var(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(remote)
-#         z = torch.cross(x, y, dim=1)
-#         assert (torch.equal(z.get(), Var(torch.FloatTensor([[0, 0, 0], [0, 0, 0], [0, 0, 0]]))))
-#         x = Var(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(remote)
-#         y = Var(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(remote)
-#         z = torch.dist(x, y)
-#         assert (torch.equal(z.get(), Var(torch.FloatTensor([0.]))))
-#         x = Var(torch.FloatTensor([1, 2, 3])).send(remote)
-#         y = Var(torch.FloatTensor([1, 2, 3])).send(remote)
-#         z = torch.dot(x, y)
-#         print(torch.equal(z.get(), Var(torch.FloatTensor([14]))))
-#         z = torch.eq(x, y)
-#         assert (torch.equal(z.get(), Var(torch.ByteTensor([1, 1, 1]))))
-#         z = torch.ge(x, y)
-#         assert (torch.equal(z.get(), Var(torch.ByteTensor([1, 1, 1]))))
+        x = sy.Variable(torch.FloatTensor([1, 2, 3, 4])).send(bob)
+        y = sy.Variable(torch.FloatTensor([[1, 2, 3, 4]])).send(bob)
+        z = torch.matmul(x, y.t())
+        assert (torch.equal(z.get(), sy.Variable(torch.FloatTensor([30]))))
+        z = torch.add(x, y)
+        assert (torch.equal(z.get(), sy.Variable(torch.FloatTensor([[2, 4, 6, 8]]))))
+        x = sy.Variable(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(bob)
+        y = sy.Variable(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(bob)
+        z = torch.cross(x, y, dim=1)
+        assert (torch.equal(z.get(), sy.Variable(torch.FloatTensor([[0, 0, 0], [0, 0, 0], [0, 0, 0]]))))
+        x = sy.Variable(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(bob)
+        y = sy.Variable(torch.FloatTensor([[1, 2, 3], [3, 4, 5], [5, 6, 7]])).send(bob)
+        z = torch.dist(x, y)
+        assert (torch.equal(z.get(), sy.Variable(torch.FloatTensor([0.]))))
+        x = sy.Variable(torch.FloatTensor([1, 2, 3])).send(bob)
+        y = sy.Variable(torch.FloatTensor([1, 2, 3])).send(bob)
+        z = torch.dot(x, y)
+        print(torch.equal(z.get(), sy.Variable(torch.FloatTensor([14]))))
+        z = torch.eq(x, y)
+        assert (torch.equal(z.get(), sy.Variable(torch.ByteTensor([1, 1, 1]))))
+        z = torch.ge(x, y)
+        assert (torch.equal(z.get(), sy.Variable(torch.ByteTensor([1, 1, 1]))))
 
 
 if __name__ == '__main__':

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import TestCase
 import syft as sy
 import torch
+import torch.nn.functional as F
 
 
 hook = sy.TorchHook(verbose=True)
@@ -640,34 +641,24 @@ class TestTorchTensor(TestCase):
 #         y.get()
 #         assert torch.equal(y, Var(torch.FloatTensor([2, 4, 6])))
 
-#     def test_torch_F_relu_on_remote_var(self):
-#         hook = TorchHook(verbose=False)
-#         me = hook.local_worker
-#         remote = VirtualWorker(id=2,hook=hook)
-#         me.add_worker(remote)
+    def test_torch_F_relu_on_remote_var(self):
+        x = sy.Variable(torch.FloatTensor([[1, -1], [-1, 1]]))
+        x.send(bob)
+        x = F.relu(x)
+        x.get()
+        assert torch.equal(x, sy.Variable(torch.FloatTensor([[1, 0], [0, 1]])))
 
-#         x = Var(torch.FloatTensor([[1, -1], [-1, 1]]))
-#         x.send(remote)
-#         x = F.relu(x)
-#         x.get()
-#         assert torch.equal(x, Var(torch.FloatTensor([[1, 0], [0, 1]])))
-
-#     def test_torch_F_conv2d_on_remote_var(self):
-#         hook = TorchHook(verbose=False)
-#         me = hook.local_worker
-#         remote = VirtualWorker(id=2,hook=hook)
-#         me.add_worker(remote)
-
-#         x = Var(torch.FloatTensor([[[[1, -1, 2], [-1, 0, 1], [1, 0, -2]]]]))
-#         x.send(remote)
-#         weight = torch.nn.Parameter(torch.FloatTensor([[[[1, -1], [-1, 1]]]]))
-#         bias = torch.nn.Parameter(torch.FloatTensor([0]))
-#         weight.send(remote)
-#         bias.send(remote)
-#         conv = F.conv2d(x, weight, bias, stride=(1,1))
-#         conv.get()
-#         expected_conv = Var(torch.FloatTensor([[[[3, -2], [-2, -3]]]]))
-#         assert torch.equal(conv, expected_conv)
+    def test_torch_F_conv2d_on_remote_var(self):
+        x = sy.Variable(torch.FloatTensor([[[[1, -1, 2], [-1, 0, 1], [1, 0, -2]]]]))
+        x.send(bob)
+        weight = torch.nn.Parameter(torch.FloatTensor([[[[1, -1], [-1, 1]]]]))
+        bias = torch.nn.Parameter(torch.FloatTensor([0]))
+        weight.send(bob)
+        bias.send(bob)
+        conv = F.conv2d(x, weight, bias, stride=(1,1))
+        conv.get()
+        expected_conv = sy.Variable(torch.FloatTensor([[[[3, -2], [-2, -3]]]]))
+        assert torch.equal(conv, expected_conv)
 
     # def test_torch_nn_conv2d_on_remote_var(self):
     #

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -608,15 +608,15 @@ class TestTorchTensor(TestCase):
 
 #         assert final_loss == 0.18085284531116486
 
-    def test_torch_function_on_remote_var(self):
-
-        x = sy.Variable(torch.FloatTensor([[1, 2], [3, 4]]))
-        y = sy.Variable(torch.FloatTensor([[1, 2], [1, 2]]))
-        x.send(bob)
-        y.send(bob)
-        z = torch.matmul(x, y)
-        z.get()
-        assert torch.equal(z, sy.Variable(torch.FloatTensor([[3, 6], [7, 14]])))
+    # def test_torch_function_on_remote_var(self):
+    #
+    #     x = sy.Variable(torch.FloatTensor([[1, 2], [3, 4]]))
+    #     y = sy.Variable(torch.FloatTensor([[1, 2], [1, 2]]))
+    #     x.send(bob)
+    #     y.send(bob)
+    #     z = torch.matmul(x, y)
+    #     z.get()
+    #     assert torch.equal(z, sy.Variable(torch.FloatTensor([[3, 6], [7, 14]])))
 
     #def test_torch_function_with_multiple_input_on_remote_var(self):
 


### PR DESCRIPTION
# Description

Working on chains: enable send/get tensors

Changing paradigm: Always send a chain with head=tensorvar and tail=_Local or _Pointer.
- When tail is _Local, head and tail loop with child and parent
- When tail is _Pointer, the loop is broken


Working on chains: enable send/get, func and methods on remote tensors

- The Python/JSON Encode/Decoder has been modified to include a 'mode'
  parameter for decoding, to disambiguate the behaviors
- There is still an issue with converting tensors (run x.int() to see)
- Todo: decompose the parts of the Python/JSON Encode/Decoder in the
  tensors methods

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
