### PR TITLE
[Pointers are tensors] Playing with PlusIsMinus Tensor : full support on Torch Tensors

### DIFF
--- a/syft/core/frameworks/torch/hook.py
+++ b/syft/core/frameworks/torch/hook.py
@@ -400,7 +400,7 @@ class TorchHook(object):
 
     def _execute_call(hook_self, attr, self, *args, **kwargs):
         """
-        Forwar the call to the local_worker
+        Forward the call to the local_worker
         """
         return hook_self.local_worker._execute_call(attr, self, *args, **kwargs)
 

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -661,8 +661,6 @@ class BaseWorker(ABC):
         }
         if has_self:
             raw_command['self'] = self_
-
-
         if is_torch_command:
             # Unwrap the torch wrapper
             syft_command, child_type = utils.prepare_child_command(raw_command, replace_tensorvar_with_child=True)

--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -201,12 +201,12 @@ class BaseWorker(ABC):
           of object types. However, the object is typically only used during testing or
           local development with :class:`VirtualWorker` workers.
         """
-
         message_wrapper = utils.decode(message_wrapper_json, worker=self)
 
         response, private = self.process_message_type(message_wrapper)
 
         response = utils.encode(response, retrieve_pointers=False, private_local=private)
+
         response = json.dumps(response).encode()
 
 
@@ -621,6 +621,8 @@ class BaseWorker(ABC):
           the owners of the tensors involved.
         """
 
+        utils.assert_has_only_torch_tensorvars(command_msg)
+
         attr = command_msg['command']
         has_self = command_msg['has_self']
         args = command_msg['args']
@@ -634,7 +636,16 @@ class BaseWorker(ABC):
         Transmit the call to the appropriate TensorType for handling
         """
 
-        utils.assert_has_only_torch_tensorvars((args, kwargs))
+        # Distinguish between a command with torch tensors (like when called by the client,
+        # or received from another worker), and a command with syft tensor, which can occur
+        # when a function is overloaded by a SyftTensor (for instance _PlusIsMinusTensor
+        # overloads add and replace it by sub)
+        try:
+            utils.assert_has_only_torch_tensorvars((args, kwargs))
+            is_torch_command = True
+        except AssertionError:
+            is_torch_command = False
+
         has_self = self_ is not None
 
         if has_self:
@@ -650,29 +661,57 @@ class BaseWorker(ABC):
         }
         if has_self:
             raw_command['self'] = self_
-            next_child_type = type(self_.child)
+
+
+        if is_torch_command:
+            # Unwrap the torch wrapper
+            syft_command, child_type = utils.prepare_child_command(raw_command, replace_tensorvar_with_child=True)
         else:
-            next_child_type, _ = utils.prepare_child_command(raw_command, replace_tensorvar_with_child=False)
+            # Get the next syft class (the actual syft class is the one which redirected (see the  _PlusIsMinus ex.)
+            syft_command, child_type = utils.prepare_child_command(raw_command, replace_tensorvar_with_child=True)
+
+        utils.assert_has_only_syft_tensors(syft_command)
 
         # Note: because we have pb of registration of tensors with the right worker, and because having
         # Virtual workers creates even more ambiguity, we specify the worker performing the operation
-        result = next_child_type.handle_call(raw_command, owner=self)
+        result = child_type.handle_call(syft_command, owner=self)
 
         if isinstance(result, (int, float, bool)) and self.id != self.hook.local_worker.id:
-            result = sy.FloatTensor([result])
+            # result = sy.FloatTensor([result])
+            pass
+        if isinstance(result, (int, float, bool)) or result is None:
+            return result
 
         results = result if isinstance(result, tuple) else (result,)
         for res in results:
             # occasionally results are None, like when calling .backward()
             if res is not None and hasattr(res, 'child') and self.id != self.hook.local_worker.id:
                 # Re assign the worker (just in case, especially useful with Virtualworkers)
-                self.hook.local_worker.de_register(res.child)
-                res.child.owner = self
+                self.hook.local_worker.de_register(res)
+                res.owner = self
                 if utils.is_variable(res):
-                    self.hook.local_worker.de_register(res.data.child)
-                    res.data.child.owner = self
+                    self.hook.local_worker.de_register(res.parent.data.child)
+                    res.parent.data.child.owner = self
 
-        return result
+        if is_torch_command:
+            # Wrap the result
+            if has_self and utils.is_in_place_method(attr):
+                raw_command['self'].child = result
+                result.parent = raw_command['self']
+                return raw_command['self']
+            else:
+                _tail = utils.find_tail_of_chain(result)
+                if isinstance(_tail, sy._LocalTensor):
+                    wrapper = _tail.child
+                    wrapper.child = result
+                    result.parent = wrapper
+                else:
+                    wrapper = utils.wrap_command(result)
+                return wrapper
+        else:
+            # We don't need to wrap
+            return result
+
 
     def send_obj(self, object, new_id, recipient, new_data_id=None):
         """send_obj(self, obj, new_id, recipient, new_data_id=None) -> obj

--- a/test/tensor_serde_test.py
+++ b/test/tensor_serde_test.py
@@ -15,8 +15,8 @@ bob.add_workers([me, alice])
 alice.add_workers([me, bob])
 me.add_workers([bob, alice])
 
-torch.manual_seed(1)
-random.seed(1)
+#torch.manual_seed(1)
+#random.seed(1)
 
 class TestTensorPointerSerde(TestCase):
 
@@ -91,7 +91,6 @@ class TestTensorPointerSerde(TestCase):
         assert x.id not in me._objects
 
     def test_floattensor2json2floattensor(self):
-
         xs = {
             '__FloatTensor__': {
                 'type': 'syft.core.frameworks.torch.tensor.FloatTensor',
@@ -118,8 +117,17 @@ class TestTensorPointerSerde(TestCase):
         assert x2.owner.id == 0
 
         # make sure it works (can do operations)
-        y = x2 + x2
+        y = x2.add(x2)
 
+        assert (x2 == sy.FloatTensor([1, 2, 3, 4, 5])).all()
+        assert (y == sy.FloatTensor([2, 4, 6, 8, 10])).all()
+
+        y = torch.add(x2, x2)
+
+        assert (x2 == sy.FloatTensor([1, 2, 3, 4, 5])).all()
+        assert (y == sy.FloatTensor([2, 4, 6, 8, 10])).all()
+
+        y = x2 + x2
         assert (x2 == sy.FloatTensor([1, 2, 3, 4, 5])).all()
         assert (y == sy.FloatTensor([2, 4, 6, 8, 10])).all()
 


### PR DESCRIPTION
# Description
Enable support on functions and methods on local and remote tensor non-trivial chains (ie including a PlusIsMinusTensor) 

The process chain is a bit changed:
The idea that we should always send a wrapper on even a partial chain is relativised: we still do this when sending commands / objects to another worker, because it is useful for a worker receiving an object for instance to have directly the wrapper available (just as it is convenient wor the local_worker, i.e. us); but within a local chain (ie Float > _PlusIsMinus > _Pointer), the intermediate nodes don't need the wrapper to execute correctly, and this enable to more easily overload methods as well, for the head element (of e.g. command['self']) is of the same type than the class in which handle_call is performed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unittest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
