### PR TITLE
[pointers_are_tensors] Add a hook on backward compatible with non-trivial chains

### DIFF
--- a/syft/core/workers/base.py
+++ b/syft/core/workers/base.py
@@ -204,6 +204,7 @@ class BaseWorker(ABC):
           of object types. However, the object is typically only used during testing or
           local development with :class:`VirtualWorker` workers.
         """
+
         message_wrapper = utils.decode(message_wrapper_json, worker=self)
 
         response, private = self.process_message_type(message_wrapper)
@@ -551,6 +552,8 @@ class BaseWorker(ABC):
             variable = result
             self.register(variable.child)
             self.register(variable.data.child)
+            if hasattr(variable, 'grad') and variable.grad is not None:
+                self.register(variable.grad.child)
         # Case of a iter type non json serializable
         elif isinstance(result, (list, tuple, set, bytearray, range)):
             for res in result:
@@ -737,6 +740,7 @@ class BaseWorker(ABC):
             object.data.child.id = new_data_id
             if object.grad is None:
                 object.grad = sy.Variable(sy.zeros(object.size()))
+                object.grad.native_set_()
             object.grad.child.id = new_grad_id
         object = utils.encode(object, retrieve_pointers=False, private_local=False)
 


### PR DESCRIPTION
**Add a hook on backward compatible with non-trivial chains**

- The backward hook retrieves the variables modified in the computational
  graph and retablish the grad chains after backward is called, updating
  only the gradient value
- There is an improved (but not complete) support of remote non-trivial
  chain of which backward is performed, unittest use PlusIsMinusTensor


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

unittest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
