### PR TITLE
Strings id + Unittest 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,30 @@ RUN apt-get update \
  && apt-get install -y python3.6 \
                        python3-pip \
                        build-essential \
- && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install jupyter \
+ && rm -rf /var/lib/apt/lists/* \
+ && pip3 install jupyter \
  && pip3 install http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl \
  && pip3 install torchvision \
- && rm -r /root/.cache/pip
+ && rm -r /root/.cache/pip \
+ &&  mkdir PySyft \
+ &&  mkdir PySyft/examples
 
-RUN mkdir PySyft
 COPY syft/ /PySyft/syft/
-COPY examples/ /PySyft/examples/
 COPY requirements.txt /PySyft/requirements.txt
 COPY setup.py /PySyft/setup.py
 COPY README.md /PySyft/README.md
+
 WORKDIR /PySyft
-RUN python3 setup.py install
 
-RUN jupyter notebook --generate-config
-RUN jupyter nbextension enable --py --sys-prefix widgetsnbextension && \
-python3 -m ipykernel.kernelspec
-
-RUN mkdir /notebooks
-WORKDIR /notebooks
-
-RUN  apt-get -y purge python3-pip \
+RUN python3 setup.py install \
+ && jupyter notebook --generate-config \
+ && jupyter nbextension enable --py --sys-prefix widgetsnbextension \
+ && python3 -m ipykernel.kernelspec \
+ && mkdir /notebooks \
+ && apt-get -y purge python3-pip \
                      build-essential \
  && apt-get -y clean
+
+WORKDIR /notebooks
 
 ENTRYPOINT ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--Notebook.open_browser=False", "--NotebookApp.token=''", "--allow-root"]

--- a/syft/core/utils.py
+++ b/syft/core/utils.py
@@ -120,7 +120,11 @@ class PythonJSONDecoder(json.JSONDecoder):
                 # Case of a tensor or a Variable
                 if obj_type in map(lambda x: x.__name__, self.tensorvar_types):
                     pattern_var = re.compile('_fl.(.*)')
-                    id = int(pattern_var.search(obj).group(1))
+                    id_pattern=pattern_var.search(obj).group(1)
+                    try:
+                        id = int(id_pattern)
+                    except ValueError:
+                        id = str(id_pattern)
                     return self.worker.get_obj(id)
                 # Case of a iter type non json serializable
                 elif obj_type in ('tuple', 'set', 'bytearray', 'range'):

--- a/test/core/utils_test.py
+++ b/test/core/utils_test.py
@@ -1,0 +1,69 @@
+import torch
+from unittest import TestCase
+
+from syft.core.hooks import TorchHook
+from syft.core.utils import PythonJSONDecoder
+
+
+class TestPythonJSONDecoder(TestCase):
+    def test_custom_obj_hook(self):
+        hook = TorchHook()
+        local = hook.local_worker
+        objects = [ # (object, id)
+            (torch.FloatTensor([0]), 1111),
+            (torch.FloatTensor([1]), 'this_is_a_string_id'),
+            (torch.autograd.Variable(torch.FloatTensor([2])), 2222),
+            (torch.autograd.Variable(torch.FloatTensor([3])), 'three'),
+            (torch.nn.Parameter(torch.FloatTensor([4])), 4444),
+            (torch.nn.Parameter(torch.FloatTensor([5])), 'five'),
+            (torch.DoubleTensor([6]), 6666),
+            (torch.DoubleTensor([7]), 'seven'),
+            (torch.HalfTensor([8]), 8888),
+            (torch.HalfTensor([9]), 'nine'),
+            (torch.ByteTensor([10]), 1010),
+            (torch.ByteTensor([11]), 'eleven'),
+            (torch.CharTensor([12]), 1212),
+            (torch.CharTensor([13]), 'thirteen'),
+            (torch.ShortTensor([14]), 1414),
+            (torch.ShortTensor([15]), 'fifteen'),
+            (torch.IntTensor([16]), 1616),
+            (torch.IntTensor([17]), 'seventeen'),
+            (torch.LongTensor([18]), 1818),
+            (torch.LongTensor([19]), 'nineteen'),
+        ]
+        for obj, id in objects:
+            local._objects[id]=obj
+        test_json_dumps = [ # JSON dumps of the objects
+            {'__FloatTensor__': '_fl.1111'},
+            {'__FloatTensor__': '_fl.this_is_a_string_id'},
+            {'__Variable__': '_fl.2222'},
+            {'__Variable__': '_fl.three'},
+            {'__Parameter__': '_fl.4444'},
+            {'__Parameter__': '_fl.five'},
+            {'__DoubleTensor__': '_fl.6666'},
+            {'__DoubleTensor__': '_fl.seven'},
+            {'__HalfTensor__': '_fl.8888'},
+            {'__HalfTensor__': '_fl.nine'},
+            {'__ByteTensor__': '_fl.1010'},
+            {'__ByteTensor__': '_fl.eleven'},
+            {'__CharTensor__': '_fl.1212'},
+            {'__CharTensor__': '_fl.thirteen'},
+            {'__ShortTensor__': '_fl.1414'},
+            {'__ShortTensor__': '_fl.fifteen'},
+            {'__IntTensor__': '_fl.1616'},
+            {'__IntTensor__': '_fl.seventeen'},
+            {'__LongTensor__': '_fl.1818'},
+            {'__LongTensor__': '_fl.nineteen'}
+            #{'__tuple__':}, TODO
+            #{'__set__':}, TODO
+            #{'__bytearray__':},TODO
+            #{'__range__': }, TODO
+            #{'__slice__': }  TODO
+        ]
+        json_decoder = PythonJSONDecoder(local)
+        for i in range(len(test_json_dumps)):
+            if i<= 19:
+                self.assertIs(json_decoder.custom_obj_hook(test_json_dumps[i]), objects[i][0])
+            else:
+                self.assertEqual(json_decoder.custom_obj_hook(test_json_dumps[i]), objects[i][0])
+


### PR DESCRIPTION
# Description

I modify the custom_obj_hook method of PythonJSONDecoder in order to allow string id.

Fixes #
Before my change, remote operations on objects with string was throwing exception on server side and empty responses on client side.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test FloatTensor with int id
- [x] Test FloatTensor with string id
- [x] Test Variable with int id
- [x] Test Variable with string id
- [x] Test Parameter with int id
- [x] Test Parameter with string id
- [x] Test DoubleTensor with int id
- [x] Test DoubleTensor with string id
- [x] Test HalfTensor with int id
- [x] Test HalfTensor with string id
- [x] Test ByteTensor with int id
- [x] Test ByteTensor with string id
- [x] Test CharTensor with int id
- [x] Test CharTensor with string id
- [x] Test ShortTensor with int id
- [x] Test ShortTensor with string id
- [x] Test IntTensor with int id
- [x] Test IntTensor with string id
- [x] Test LongTensor with int id
- [x] Test LongTensor with string id
- [ ] Test tuple
- [ ] Test set
- [ ] Test bytearray
- [ ] Test range
- [ ] Test slice

**Test Configuration**:
Docker container of the project

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
