### PR TITLE
MPCTensor inheritance

### DIFF
--- a/examples/torch/toy/Toy MPC Example.ipynb
+++ b/examples/torch/toy/Toy MPC Example.ipynb
@@ -50,23 +50,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "handling call\n"
+     ]
+    }
+   ],
+   "source": [
+    "out = xptr[0:1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[Head of chain]\n",
-       "[syft.core.frameworks.torch.tensor.LongTensor with no dimension]"
+       "\n",
+       " 1  2  3  4  5\n",
+       "[syft.core.frameworks.torch.tensor.LongTensor of size 1x5]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "xptr"
+    "out.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[_GeneralizedPointerTensor - id:4937926577 owner:0]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out.child"
    ]
   },
   {

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -844,6 +844,20 @@ class _MPCTensor(_SyftTensor):
         response = _MPCTensor(gp_response).wrap(True)
         return response
 
+    @classmethod
+    def handle_call(cls, command, owner):
+        attr = command['command']
+        args = command['args']
+        kwargs = command['kwargs']
+        self = command['self']
+
+        result_child = getattr(self.child, attr)(*args, **kwargs)
+        return _MPCTensor(result_child).wrap(True)
+
+    # def __getitem__(self, item):
+    #
+    #     return _MPCTensor(self.child.__getitem__(item)).wrap(True)
+
     def send(self, workers):
         self.n_workers = len(workers)
         self.shares = self.share(self.var, self.n_workers)
@@ -956,6 +970,15 @@ class _TorchTensor(_TorchObject):
                 x_.native_set_(self)
                 return "[Head of chain]\n" + x_.native___repr__()
             return self.native___str__()
+
+    @classmethod
+    def handle_call(cls, command, owner):
+        print(command)
+        attr = command['command']
+        args = command['args']
+        kwargs = command['kwargs']
+        self = command['self']
+        return getattr(self, attr)(*args, **kwargs)
 
     def share(self, bob, alice):
         x_enc = spdz.encode(self)


### PR DESCRIPTION
Now if you haven't implemented something custom into MPCTensor, it will attempt to accomplish the method using the default PyTorch functionality.

Aka... you can do

slice_of_mpc_tensor = my_mpc_tensor[0]