### PR TITLE
adds getting workers from gpt

### DIFF
--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -747,7 +747,7 @@ class _GeneralizedPointerTensor(_SyftTensor):
         return res
 
     def workers(self):
-        return self.pointer_tensor_dict.keys() 
+        return list(self.pointer_tensor_dict.keys()) 
 
 
 class _PointerTensor(_SyftTensor):

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -746,6 +746,9 @@ class _GeneralizedPointerTensor(_SyftTensor):
                 res += share
         return res
 
+    def workers(self):
+        return self.pointer_tensor_dict.keys() 
+
 
 class _PointerTensor(_SyftTensor):
 

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -1126,10 +1126,11 @@ class TestGPCTensor(TestCase):
         y.send(alice)
 
         x_pointer_tensor_dict = {alice: y.child, bob: x.child}
-        x_gp = _GeneralizedPointerTensor(x_pointer_tensor_dict, torch_type='syft.LongTensor').wrap(True)
+        x_gp = _GeneralizedPointerTensor(x_pointer_tensor_dict)
 
         results = x_gp.workers()
-        assert(results == list(x_pointer_tensor_dict.keys()))
+    
+        assert(results == [k.id for k in x_pointer_tensor_dict.keys()])
 
 
 

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -1117,6 +1117,22 @@ class TestGPCTensor(TestCase):
         results = y.get()
 
         assert (results[0] == (x.get() * 2)).all()
+    
+    def test_gpc_workers(self):
+        x = torch.LongTensor([1, 2, 3, 4, 5])
+        y = torch.LongTensor([1, 2, 3, 4, 5])
+
+        x.send(bob)
+        y.send(alice)
+
+        x_pointer_tensor_dict = {alice: y.child, bob: x.child}
+        x_gp = _GeneralizedPointerTensor(x_pointer_tensor_dict, torch_type='syft.LongTensor').wrap(True)
+
+        results = x_gp.workers()
+        assert(results == list(x_pointer_tensor_dict.keys()))
+
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

Regarding the following issue: 
https://github.com/OpenMined/PySyft/issues/1548

Adding method to return list of workers from GeneralizedPointerTensor.

Fixes # (issue)

## Type of change
Adds method `workers` to `syft/core/frameworks/torch/tensor.py` L:749  

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Adding unittest in `test/torch_test.py` L:1121

**Test Configuration**:
* CPU: Mac
* GPU: None
* PySyft Version: master
* Unity Version: None
* OpenMined Unity App Version: None

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
