### PR TITLE
Fix Precision Tensor : support neg values, mul and matmul op

### DIFF
--- a/syft/core/frameworks/torch/hook.py
+++ b/syft/core/frameworks/torch/hook.py
@@ -560,6 +560,8 @@ class TorchHook(object):
             for p in self.parameters():
                 p.send(dest)
 
+            return self
+
         torch.nn.Module.send = module_send_
 
         def module_get_(self):
@@ -568,5 +570,17 @@ class TorchHook(object):
                 p.get()
 
         torch.nn.Module.get = module_get_
+
+        def module_fix_precision_(self):
+            """Overloads fix_precision for torch.nn.Module"""
+            if module_is_missing_grad(self):
+                create_grad_objects(self)
+
+            for p in self.parameters():
+                p.fix_precision_()
+
+            return self
+
+        torch.nn.Module.fix_precision = module_fix_precision_
 
 

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -1418,10 +1418,10 @@ class _SPDZTensor(_SyftTensor):
         return gp_response
 
     def __mul__(self, other):
-        if(isinstance(other, _SPDZTensor)):
+        if isinstance(other, _SPDZTensor):
             workers = list(self.shares.child.pointer_tensor_dict.keys())
             if torch_utils.is_variable(self.torch_type):
-                gp_response = self*1
+                gp_response = self * 1
                 gp_response.data = spdz.spdz_mul(self.data.shares, other.data.shares, workers)
                 #TODO: and the grad ?
             else:
@@ -1432,7 +1432,13 @@ class _SPDZTensor(_SyftTensor):
 
     def mm(self, other):
         workers = list(self.shares.child.pointer_tensor_dict.keys())
-        gp_response = spdz.spdz_matmul(self.shares, other.shares, workers)
+        if torch_utils.is_variable(self.torch_type):
+            gp_response = self * 1
+            gp_response.data = spdz.spdz_matmul(self.data.shares, other.data.shares, workers)
+            # TODO: and the grad ?
+        else:
+            gp_response = spdz.spdz_matmul(self.shares, other.shares, workers)
+
         return gp_response
 
     def __matmul__(self, other):

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -1002,14 +1002,20 @@ class _PointerTensor(_SyftTensor):
         return tensorvar
 
     def get_shape(self):
-        cmd = {}
-        cmd['command'] = "get_shape"
-        cmd['args'] = []
-        cmd['kwargs'] = {}
-        cmd['has_self'] = True
-        cmd['self'] = self
+        cmd = {
+            'command': 'get_shape',
+            'self': self,
+            'args': [],
+            'kwargs': {},
+            'has_self': True
+        }
+        shape_ptr = self.handle_call(cmd, self.owner)
 
-        return sy.Size(self.handle_call(cmd, self.owner).get().int().tolist())
+        if not isinstance(shape_ptr, tuple):
+            shape_ptr = (shape_ptr, )
+
+        shape = [shape_i.get().int().tolist()[0] for shape_i in shape_ptr]
+        return sy.Size(shape)
 
     def decode(self):
         raise NotImplementedError("It is not possible to remotely decode a tensorvar for the moment")

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -1162,7 +1162,7 @@ class _FixedPrecisionTensor(_SyftTensor):
 
         if has_self:
             self = command['self']
-            if attr in ('__add__', '__mul__') and isinstance(args[0], sy._FixedPrecisionTensor):
+            if attr in ('__add__', '__mul__', 'mm') and isinstance(args[0], sy._FixedPrecisionTensor):
                 # Compute the precision to keep
                 other = args[0]
                 assert (self.base == other.base) and (self.bits == other.bits), \
@@ -1179,6 +1179,10 @@ class _FixedPrecisionTensor(_SyftTensor):
                     torch_tensorvar = torch_tensorvar % self.field
                 elif attr == '__mul__':
                     torch_tensorvar = cls.__mul__(self, other)
+                elif attr == 'mm':
+                    torch_tensorvar = cls.mm(self, other)
+
+                if attr in ('__mul__', 'mm'):
                     # Decimal rounding to the appropriate precision
                     # FIXME:
                     # Given a field F, shares s1 ad s2, we should do the following:
@@ -1241,6 +1245,10 @@ class _FixedPrecisionTensor(_SyftTensor):
 
     def __mul__(self, other):
         response = self.child * other.child
+        return response
+
+    def mm(self, other):
+        response = self.child.mm(other.child)
         return response
 
     def __repr__(self):

--- a/syft/mpc/__init__.py
+++ b/syft/mpc/__init__.py
@@ -1,4 +1,3 @@
 from . import securenn
-from . import interface
 
-__all__ = ['securenn', 'interface']
+__all__ = ['securenn']

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -1318,6 +1318,159 @@ class TestSPDZTensor(TestCase):
         z = z.get().get().decode()
         assert torch.eq(z, sy.Variable(torch.FloatTensor([2.2, 4, 6]))).all()
 
+    def fix_precision_operation(self, l1, l2, var=False, op='plus'):
+        if var:
+            x = sy.Variable(torch.FloatTensor(l1))
+            y = sy.Variable(torch.FloatTensor(l2))
+        else:
+            x = torch.FloatTensor(l1)
+            y = torch.FloatTensor(l2)
+        x = x.fix_precision()
+        y = y.fix_precision()
+        if op == 'plus':
+            z = x + y
+            l_res = [e1 + e2 for e1, e2 in zip(l1, l2)]
+        elif op == 'mul':
+            z = x * y
+            l_res = [e1 * e2 for e1, e2 in zip(l1, l2)]
+        else:
+            raise ArithmeticError('Unknown operator')
+        z = z.decode()
+        if var:
+            assert torch.eq(z, sy.Variable(torch.FloatTensor(l_res))).all()
+        else:
+            assert torch.eq(z, torch.FloatTensor(l_res)).all()
+
+    def test_addition_fix_precision(self):
+        self.fix_precision_operation([3.3], [5.1])
+        self.fix_precision_operation([2.5, 3.2], [5.4, -1.1])
+        self.fix_precision_operation([-2.8, -3.9], [-1, -1])
+        self.fix_precision_operation([-2, 3.3], [-1.9, 1])
+        self.fix_precision_operation([-19000, 3.3], [-1.9, 17654])
+
+    def test_var_addition_fix_precision(self):
+        self.fix_precision_operation([3.3], [5.1], var=True)
+        self.fix_precision_operation([2.5, 3.2], [5.4, -1.1], var=True)
+        self.fix_precision_operation([-2.8, -3.9], [-1, -1], var=True)
+        self.fix_precision_operation([-2, 3.3], [-1.9, 1], var=True)
+        self.fix_precision_operation([-19000, 3.3], [-1.9, 17654], var=True)
+
+    def test_mult_fix_precision(self):
+        self.fix_precision_operation([3.3], [5.1], op='mul')
+        self.fix_precision_operation([2.5, 3.2], [5.4, -1.1], op='mul')
+        self.fix_precision_operation([-2.8, -3.9], [-1, -1], op='mul')
+        self.fix_precision_operation([-2, 3.3], [-1.9, 1], op='mul')
+        self.fix_precision_operation([-19000, 3.3], [-1.9, 17654], op='mul')
+
+    def test_var_mult_fix_precision(self):
+        self.fix_precision_operation([3.3], [5.1], var=True, op='mul')
+        self.fix_precision_operation([2.5, 3.2], [5.4, -1.1], var=True, op='mul')
+        self.fix_precision_operation([-2.8, -3.9], [-1, -1], var=True, op='mul')
+        self.fix_precision_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
+        self.fix_precision_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
+
+    def remote_fix_precision_operation(self, l1, l2, var=False, op='plus'):
+        if var:
+            x = sy.Variable(torch.FloatTensor(l1))
+            y = sy.Variable(torch.FloatTensor(l2))
+        else:
+            x = torch.FloatTensor(l1)
+            y = torch.FloatTensor(l2)
+        x = x.send(bob).fix_precision()
+        y = y.send(bob).fix_precision()
+        if op == 'plus':
+            z = x + y
+            l_res = [e1 + e2 for e1, e2 in zip(l1, l2)]
+        elif op == 'mul':
+            z = x * y
+            l_res = [e1 * e2 for e1, e2 in zip(l1, l2)]
+        else:
+            raise ArithmeticError('Unknown operator')
+        z = z.get().decode()
+        if var:
+            assert torch.eq(z, sy.Variable(torch.FloatTensor(l_res))).all()
+        else:
+            assert torch.eq(z, torch.FloatTensor(l_res)).all()
+
+    def test_addition_remote_fix_precision(self):
+        self.remote_fix_precision_operation([3.3], [5.1])
+        self.remote_fix_precision_operation([2.5, 3.2], [5.4, -1.1])
+        self.remote_fix_precision_operation([-2.8, -3.9], [-1, -1])
+        self.remote_fix_precision_operation([-2, 3.3], [-1.9, 1])
+        self.remote_fix_precision_operation([-19000, 3.3], [-1.9, 17654])
+
+    def test_var_addition_remote_fix_precision(self):
+        self.remote_fix_precision_operation([3.3], [5.1], var=True)
+        self.remote_fix_precision_operation([2.5, 3.2], [5.4, -1.1], var=True)
+        self.remote_fix_precision_operation([-2.8, -3.9], [-1, -1], var=True)
+        self.remote_fix_precision_operation([-2, 3.3], [-1.9, 1], var=True)
+        self.remote_fix_precision_operation([-19000, 3.3], [-1.9, 17654], var=True)
+
+    def test_mult_remote_fix_precision(self):
+        self.remote_fix_precision_operation([3.3], [5.1], op='mul')
+        self.remote_fix_precision_operation([2.5, 3.2], [5.4, -1.1], op='mul')
+        self.remote_fix_precision_operation([-2.8, -3.9], [-1, -1], op='mul')
+        self.remote_fix_precision_operation([-2, 3.3], [-1.9, 1], op='mul')
+        self.remote_fix_precision_operation([-19000, 3.3], [-1.9, 17654], op='mul')
+
+    def test_var_mult_remote_fix_precision(self):
+        self.remote_fix_precision_operation([3.3], [5.1], var=True, op='mul')
+        self.remote_fix_precision_operation([2.5, 3.2], [5.4, -1.1], var=True, op='mul')
+        self.remote_fix_precision_operation([-2.8, -3.9], [-1, -1], var=True, op='mul')
+        self.remote_fix_precision_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
+        self.remote_fix_precision_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
+
+    def remote_fix_precision_share_operation(self, l1, l2, var=False, op='plus'):
+        if var:
+            x = sy.Variable(torch.FloatTensor(l1))
+            y = sy.Variable(torch.FloatTensor(l2))
+        else:
+            x = torch.FloatTensor(l1)
+            y = torch.FloatTensor(l2)
+        x = x.send(bob).fix_precision().share(alice, bob)
+        y = y.send(bob).fix_precision().share(alice, bob)
+        if op == 'plus':
+            z = x + y
+            l_res = [e1 + e2 for e1, e2 in zip(l1, l2)]
+        elif op == 'mul':
+            z = x * y
+            l_res = [e1 * e2 for e1, e2 in zip(l1, l2)]
+        else:
+            raise ArithmeticError('Unknown operator')
+        z = z.get().get().decode()
+        if var:
+            assert torch.eq(z, sy.Variable(torch.FloatTensor(l_res))).all()
+        else:
+            assert torch.eq(z, torch.FloatTensor(l_res)).all()
+
+    def test_addition_remote_fix_precision_share(self):
+        self.remote_fix_precision_share_operation([3.3], [5.1])
+        self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1])
+        self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1])
+        self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1])
+        self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654])
+
+    def test_var_addition_remote_fix_precision_share(self):
+        self.remote_fix_precision_share_operation([3.3], [5.1], var=True)
+        self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1], var=True)
+        self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], var=True)
+        self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], var=True)
+        self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], var=True)
+
+    # def test_mult_remote_fix_precision_share(self):
+    #     self.remote_fix_precision_share_operation([3.3], [5.1], op='mul')
+    #     self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1], op='mul')
+    #     self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], op='mul')
+    #     self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], op='mul')
+    #     self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], op='mul')
+    #
+    # def test_var_mult_remote_fix_precision_share(self):
+    #     self.remote_fix_precision_share_operation([3.3], [5.1], var=True, op='mul')
+    #     self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1], var=True, op='mul')
+    #     self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], var=True, op='mul')
+    #     self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
+    #     self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
+
 
 class TestGPCTensor(TestCase):
 

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -1457,19 +1457,19 @@ class TestSPDZTensor(TestCase):
         self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], var=True)
         self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], var=True)
 
-    # def test_mult_remote_fix_precision_share(self):
-    #     self.remote_fix_precision_share_operation([3.3], [5.1], op='mul')
-    #     self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1], op='mul')
-    #     self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], op='mul')
-    #     self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], op='mul')
-    #     self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], op='mul')
-    #
-    # def test_var_mult_remote_fix_precision_share(self):
-    #     self.remote_fix_precision_share_operation([3.3], [5.1], var=True, op='mul')
-    #     self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1], var=True, op='mul')
-    #     self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], var=True, op='mul')
-    #     self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
-    #     self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
+    def test_mult_remote_fix_precision_share(self):
+        self.remote_fix_precision_share_operation([3.3], [5.1], op='mul')
+        self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1], op='mul')
+        self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], op='mul')
+        self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], op='mul')
+        #self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], op='mul')
+
+    def test_var_mult_remote_fix_precision_share(self):
+        self.remote_fix_precision_share_operation([3.3], [5.1], var=True, op='mul')
+        self.remote_fix_precision_share_operation([2.5, 3.2], [5.4, -1.1], var=True, op='mul')
+        self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], var=True, op='mul')
+        self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
+        #self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
 
 
 class TestGPCTensor(TestCase):

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 import random
 import syft as sy
+import numpy as np
 from syft.core import utils
 from syft.core.frameworks.torch import utils as torch_utils
 from syft.core.frameworks import encode
@@ -1333,6 +1334,9 @@ class TestSPDZTensor(TestCase):
         elif op == 'mul':
             z = x * y
             l_res = [e1 * e2 for e1, e2 in zip(l1, l2)]
+        elif op == 'matmul':
+            z = x.mm(y)
+            l_res = np.dot(np.array(l1), np.array(l2)).tolist()
         else:
             raise ArithmeticError('Unknown operator')
         z = z.decode()
@@ -1369,6 +1373,44 @@ class TestSPDZTensor(TestCase):
         self.fix_precision_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
         self.fix_precision_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
 
+    def test_matmul_fix_precision(self):
+        self.fix_precision_operation([[3.3, 2.1],
+                                      [1.1, 5.2]],
+                                     [[1, 2],
+                                      [3, 4]], op='matmul')
+        self.fix_precision_operation([[-3.3, -2.1],
+                                      [1.1,  5.2]],
+                                     [[1,  2],
+                                      [3, -4.8]], op='matmul')
+        self.fix_precision_operation([[1.1, -2.1],
+                                      [3.2, 8.1],
+                                      [3.0, -7]],
+                                     [[-3.3, -2.1],
+                                      [1.1, 5.2]], op='matmul')
+        self.fix_precision_operation([[-40.2, -20.1],
+                                      [100.7, 51.2]],
+                                     [[14.1, 21],
+                                      [30, -41.8]], op='matmul')
+
+    def test_var_matmul_fix_precision(self):
+        self.fix_precision_operation([[3.3, 2.1],
+                                      [1.1, 5.2]],
+                                     [[1, 2],
+                                      [3, 4]], var=True, op='matmul')
+        self.fix_precision_operation([[-3.3, -2.1],
+                                      [1.1, 5.2]],
+                                     [[1, 2],
+                                      [3, -4.8]], var=True, op='matmul')
+        self.fix_precision_operation([[1.1, -2.1],
+                                      [3.2, 8.1],
+                                      [3.0, -7]],
+                                     [[-3.3, -2.1],
+                                      [1.1, 5.2]], var=True, op='matmul')
+        self.fix_precision_operation([[-40.2, -20.1],
+                                      [100.7, 51.2]],
+                                     [[14.1, 21],
+                                      [30, -41.8]], var=True, op='matmul')
+
     def remote_fix_precision_operation(self, l1, l2, var=False, op='plus'):
         if var:
             x = sy.Variable(torch.FloatTensor(l1))
@@ -1384,6 +1426,9 @@ class TestSPDZTensor(TestCase):
         elif op == 'mul':
             z = x * y
             l_res = [e1 * e2 for e1, e2 in zip(l1, l2)]
+        elif op == 'matmul':
+            z = x.mm(y)
+            l_res = np.dot(np.array(l1), np.array(l2)).tolist()
         else:
             raise ArithmeticError('Unknown operator')
         z = z.get().decode()
@@ -1420,6 +1465,44 @@ class TestSPDZTensor(TestCase):
         self.remote_fix_precision_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
         self.remote_fix_precision_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
 
+    def test_matmul_remote_fix_precision(self):
+        self.remote_fix_precision_operation([[3.3, 2.1],
+                                             [1.1, 5.2]],
+                                            [[1, 2],
+                                             [3, 4]], op='matmul')
+        self.remote_fix_precision_operation([[-3.3, -2.1],
+                                             [1.1,  5.2]],
+                                            [[1,  2],
+                                             [3, -4.8]], op='matmul')
+        self.remote_fix_precision_operation([[1.1, -2.1],
+                                             [3.2, 8.1],
+                                             [3.0, -7]],
+                                            [[-3.3, -2.1],
+                                             [1.1, 5.2]], op='matmul')
+        self.remote_fix_precision_operation([[-40.2, -20.1],
+                                             [100.7, 51.2]],
+                                            [[14.1, 21],
+                                             [30, -41.8]], op='matmul')
+
+    def test_var_matmul_remote_fix_precision(self):
+        self.remote_fix_precision_operation([[3.3, 2.1],
+                                             [1.1, 5.2]],
+                                            [[1, 2],
+                                             [3, 4]], var=True, op='matmul')
+        self.remote_fix_precision_operation([[-3.3, -2.1],
+                                             [1.1, 5.2]],
+                                            [[1, 2],
+                                             [3, -4.8]], var=True, op='matmul')
+        self.remote_fix_precision_operation([[1.1, -2.1],
+                                             [3.2, 8.1],
+                                             [3.0, -7]],
+                                            [[-3.3, -2.1],
+                                             [1.1, 5.2]], var=True, op='matmul')
+        self.remote_fix_precision_operation([[-40.2, -20.1],
+                                             [100.7, 51.2]],
+                                            [[14.1, 21],
+                                             [30, -41.8]], var=True, op='matmul')
+
     def remote_fix_precision_share_operation(self, l1, l2, var=False, op='plus'):
         if var:
             x = sy.Variable(torch.FloatTensor(l1))
@@ -1435,6 +1518,9 @@ class TestSPDZTensor(TestCase):
         elif op == 'mul':
             z = x * y
             l_res = [e1 * e2 for e1, e2 in zip(l1, l2)]
+        elif op == 'matmul':
+            z = x.mm(y)
+            l_res = np.dot(np.array(l1), np.array(l2)).tolist()
         else:
             raise ArithmeticError('Unknown operator')
         z = z.get().get().decode()
@@ -1470,6 +1556,44 @@ class TestSPDZTensor(TestCase):
         self.remote_fix_precision_share_operation([-2.8, -3.9], [-1, -1], var=True, op='mul')
         self.remote_fix_precision_share_operation([-2, 3.3], [-1.9, 1], var=True, op='mul')
         #self.remote_fix_precision_share_operation([-19000, 3.3], [-1.9, 17654], var=True, op='mul')
+
+    def test_matmul_remote_fix_precision_share(self):
+        self.remote_fix_precision_share_operation([[3.3, 2.1],
+                                                   [1.1, 5.2]],
+                                                  [[1, 2],
+                                                   [3, 4]], op='matmul')
+        self.remote_fix_precision_share_operation([[-3.3, -2.1],
+                                                   [1.1,  5.2]],
+                                                  [[1,  2],
+                                                   [3, -4.8]], op='matmul')
+        self.remote_fix_precision_share_operation([[1.1, -2.1],
+                                                   [3.2, 8.1],
+                                                   [3.0, -7]],
+                                                  [[-3.3, -2.1],
+                                                   [1.1, 5.2]], op='matmul')
+        self.remote_fix_precision_share_operation([[-40.2, -20.1],
+                                                   [10.7, 21.2]],
+                                                  [[14.1, 21],
+                                                   [10, -11.8]], op='matmul')
+
+    # def test_var_matmul_remote_fix_precision_share(self):
+    #     self.remote_fix_precision_share_operation([[3.3, 2.1],
+    #                                                [1.1, 5.2]],
+    #                                               [[1, 2],
+    #                                                [3, 4]], var=True, op='matmul')
+    #     self.remote_fix_precision_share_operation([[-3.3, -2.1],
+    #                                                [1.1, 5.2]],
+    #                                               [[1, 2],
+    #                                                [3, -4.8]], var=True, op='matmul')
+    #     self.remote_fix_precision_share_operation([[1.1, -2.1],
+    #                                                [3.2, 8.1],
+    #                                                [3.0, -7]],
+    #                                               [[-3.3, -2.1],
+    #                                                [1.1, 5.2]], var=True, op='matmul')
+    #     self.remote_fix_precision_share_operation([[-40.2, -20.1],
+    #                                                [10.7, 21.2]],
+    #                                               [[14.1, 21],
+    #                                                [10, -11.8]], op='matmul')
 
 
 class TestGPCTensor(TestCase):

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -1168,6 +1168,15 @@ class TestSPDZTensor(TestCase):
 
         assert torch_utils.chain_print(x, display=False) == display_chain.tensor.local
 
+    def test_fix_precision_mul(self):
+        x = torch.FloatTensor([2.1, 1])
+        y = torch.FloatTensor([1.2, 1.111])
+        x = x.fix_precision()
+        y = y.fix_precision()
+        z = x + y
+        z = z.decode()
+        assert torch.eq(z, torch.FloatTensor([3.3, 2.111])).all()
+
     def test_var_fix_precision_decode(self):
         x = sy.Variable(torch.FloatTensor([0.1, 0.2, 0.1, 0.2]))
         x = x.fix_precision()

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -1576,24 +1576,24 @@ class TestSPDZTensor(TestCase):
                                                   [[14.1, 21],
                                                    [10, -11.8]], op='matmul')
 
-    # def test_var_matmul_remote_fix_precision_share(self):
-    #     self.remote_fix_precision_share_operation([[3.3, 2.1],
-    #                                                [1.1, 5.2]],
-    #                                               [[1, 2],
-    #                                                [3, 4]], var=True, op='matmul')
-    #     self.remote_fix_precision_share_operation([[-3.3, -2.1],
-    #                                                [1.1, 5.2]],
-    #                                               [[1, 2],
-    #                                                [3, -4.8]], var=True, op='matmul')
-    #     self.remote_fix_precision_share_operation([[1.1, -2.1],
-    #                                                [3.2, 8.1],
-    #                                                [3.0, -7]],
-    #                                               [[-3.3, -2.1],
-    #                                                [1.1, 5.2]], var=True, op='matmul')
-    #     self.remote_fix_precision_share_operation([[-40.2, -20.1],
-    #                                                [10.7, 21.2]],
-    #                                               [[14.1, 21],
-    #                                                [10, -11.8]], op='matmul')
+    def test_var_matmul_remote_fix_precision_share(self):
+        self.remote_fix_precision_share_operation([[3.3, 2.1],
+                                                   [1.1, 5.2]],
+                                                  [[1, 2],
+                                                   [3, 4]], var=True, op='matmul')
+        self.remote_fix_precision_share_operation([[-3.3, -2.1],
+                                                   [1.1, 5.2]],
+                                                  [[1, 2],
+                                                   [3, -4.8]], var=True, op='matmul')
+        self.remote_fix_precision_share_operation([[1.1, -2.1],
+                                                   [3.2, 8.1],
+                                                   [3.0, -7]],
+                                                  [[-3.3, -2.1],
+                                                   [1.1, 5.2]], var=True, op='matmul')
+        self.remote_fix_precision_share_operation([[-40.2, -20.1],
+                                                   [10.7, 21.2]],
+                                                  [[14.1, 21],
+                                                   [10, -11.8]], op='matmul')
 
 
 class TestGPCTensor(TestCase):


### PR DESCRIPTION
# Description
This PR does the following:
- Add the support of neg values
- Add multiplication (local and remote and compatible with spdz)
- Add matmul

What remains to be done for another PR:
- Address the issue of LongTensor being too small for "real" computations

Suggestions are welcome!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Unittests

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
