### PR TITLE
Update README.md for Windows Pytorch Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Furthermore the container is deleted when it is stopped, in a way to facilitate 
 
 > PySyft supports Python >= 3.6 and PyTorch 0.3.1
 
-Pick the proper PyTorch version according to your machine: [CPU](http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl) | [CUDA9.1](http://download.pytorch.org/whl/cu91/torch-0.3.1-cp36-cp36m-linux_x86_64.whl) | [CUDA9.0](http://download.pytorch.org/whl/cu90/torch-0.3.1-cp36-cp36m-linux_x86_64.whl) | [CUDA8.0](http://download.pytorch.org/whl/cu80/torch-0.3.1-cp36-cp36m-linux_x86_64.whl)
+Pick the proper PyTorch version according to your machine: [CPU](http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl) | [CUDA9.1](http://download.pytorch.org/whl/cu91/torch-0.3.1-cp36-cp36m-linux_x86_64.whl) | [CUDA9.0](http://download.pytorch.org/whl/cu90/torch-0.3.1-cp36-cp36m-linux_x86_64.whl) | [CUDA8.0](http://download.pytorch.org/whl/cu80/torch-0.3.1-cp36-cp36m-linux_x86_64.whl) | [Windows-CPU](https://anaconda.org/peterjc123/pytorch-cpu)
 
 ```bash
 conda install pytorch=0.3.1 -c soumith


### PR DESCRIPTION
For Windows, Pytorch version 0.3.1 for CPU can be installed using conda as below- 
conda install -c peterjc123 pytorch-cpu

# Description
Since PySyftOn requires Pytorch version 0.3.1, hence on Windows the CPU version can be installed using conda as mentioned in the embedded URL

Fixes # (issue)
Pytorch 0.3.1 for CPU can be installed on Windows
 
## Type of change
This change requires a documentation update in README.md

# How Has This Been Tested?
By running "setup.py test" on Windows after installing pytorch 0.3.1
 
**Test Configuration**:
* CPU: Yes
* GPU: None
* PySyft Version: 0.3.1
* Unity Version:
* OpenMined Unity App Version:
* Operating System: Windows 10

# Checklist:
