### PR TITLE
Add libc6-compat library to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6-alpine
 
 # installing alpine packages which is needed for building python packages "especially pillow" :)
-RUN apk add g++ python-dev tiff-dev zlib-dev freetype-dev
+RUN apk add g++ python-dev tiff-dev zlib-dev freetype-dev libc6-compat
 
 RUN pip install jupyter \
     && pip install http://download.pytorch.org/whl/cpu/torch-0.3.1-cp36-cp36m-linux_x86_64.whl \


### PR DESCRIPTION
Issue: https://github.com/OpenMined/PySyft/issues/1590

Tested with Docket on this notebook: https://github.com/OpenMined/PySyft/blob/master/examples/torch/Boston_Housing_Federated_Training.ipynb

Workaround from: https://github.com/grpc/grpc/issues/6126#issuecomment-211863937
