### PR TITLE
fixed exception in compile_command when len(pointers)=0

### DIFF
--- a/syft/core/frameworks/torch/utils.py
+++ b/syft/core/frameworks/torch/utils.py
@@ -382,9 +382,12 @@ def compile_command(attr, args, kwargs, has_self=False, self=None):
             raise NotImplementedError("All pointers should point to the same worker")
         if len(owners) > 1:
             raise NotImplementedError("All pointers should share the same owner.")
-    else:
+    elif len(pointers) == 1:
         locations = [pointers[0].location]
         owners = [pointers[0].owner]
+    else:
+        locations = []
+        owners = []
 
     return command, locations, owners
 


### PR DESCRIPTION
While running the https://github.com/OpenMined/PySyft/blob/master/examples/numpy/Federated%20Learning.ipynb
got the following error-
File "D:\PySyft\PySyft_Project\syft\core\frameworks\numpy\ndarray.py", line 228, in method
   attr=str(attr), args=args, kwargs=kwargs, has_self=True, self=self
 File "D:\PySyft\PySyft_Project\syft\core\frameworks\torch\utils.py", line 386, in compile_command
   locations = [pointers[0].location]
IndexError: list index out of range

The error was thrown from compile_command when len(pointers)=0. Fixed the same and verified by running the above Federated%20Learning.ipynb

Tested the fix with further tests. Tests passed.
\test\tensor_serde_test.py
\test\torch_test.py
(Syft) Denver_Boston_Federated_Training.ipynb