### PR TITLE
Fix regexp for black exclude option in pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
     # stop the build if there are Python syntax errors or undefined
     # names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    - black --check --verbose --exclude /.eggs/build/ .
+    - black --check --verbose .
     # exit-zero treats all errors as warnings.
     # diverting from the standard 79 character line length in
     # accordance with this:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,3 @@
 [tool.black]
 py36 = true
-exclude = '''
-(
-    | \.git
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | \.eggs
-)
-'''
+exclude = '(\.git|\.mypy_cache|\.tox|\.venv|\.eggs)'


### PR DESCRIPTION
Whitespaces in regexp inside pyproject.toml shouldn't be there. Maybe now travis will build fine? 