### PR TITLE
Update MNIST Example.ipynb

### DIFF
--- a/examples/other/experimental/MNIST Example.ipynb
+++ b/examples/other/experimental/MNIST Example.ipynb
@@ -110,7 +110,7 @@
     }
    ],
    "source": [
-    "from syft.core.hooks import TorchHook\n",
+    "from syft.core.frameworks.torch import TorchHook\n",
     "from syft.core.workers import VirtualWorker\n",
     "import torch\n",
     "import torch.nn as nn\n",


### PR DESCRIPTION
fix an import problem caused by TorchHook which has been moved into frameworks.torch