### PR TITLE
[WIP] Fix websocketworker

### DIFF
--- a/syft/core/workers/websocket.py
+++ b/syft/core/workers/websocket.py
@@ -2,7 +2,7 @@ import websockets
 import asyncio
 import json
 
-from syft.core import utils
+from syft.core.frameworks.encode import decode
 from syft.core.workers import BaseWorker
 
 
@@ -178,7 +178,7 @@ class WebSocketWorker(BaseWorker):
         msg_wrapper_str = msg_wrapper_byte.decode("utf-8")
         if self.verbose:
             print("Received Command From:", self.uri, flush=True)
-        decoder = utils.PythonJSONDecoder(self)
+        decoder = decode(message=msg_wrapper_str, worker=self)
         msg_wrapper = decoder.decode(msg_wrapper_str)
         await websocket.send(self.process_message_type(msg_wrapper))
 

--- a/syft/core/workers/websocket.py
+++ b/syft/core/workers/websocket.py
@@ -44,7 +44,7 @@ class WebSocketWorker(BaseWorker):
 
     :Example Server:
 
-    >>> from syft.core.hooks import TorchHook
+    >>> from syft import TorchHook
     >>> from syft.core.workers import WebSocketWorker
     >>> hook = TorchHook()
     Hooking into Torch...
@@ -62,7 +62,7 @@ class WebSocketWorker(BaseWorker):
     :Example Client:
 
     >>> import torch
-    >>> from syft.core.hooks import TorchHook
+    >>> from syft import TorchHook
     >>> from syft.core.workers import WebSocketWorker
     >>> hook = TorchHook(local_worker=WebSocketWorker(id=0, port=8182))
     Starting Socket Worker...
@@ -85,6 +85,8 @@ class WebSocketWorker(BaseWorker):
      14
     [torch.FloatTensor of size 5]
     """
+
+    SERVER_INITIALIZED_MSG = "Server Socket has been initialized"
 
     def __init__(
         self,
@@ -113,7 +115,7 @@ class WebSocketWorker(BaseWorker):
             queue_size=queue_size,
         )
 
-        self.is_asyncronous = True
+        self.is_asyncronous = True  # TODO: Is this used?
         self.hook = hook
         self.hostname = hostname
         self.port = port
@@ -124,25 +126,25 @@ class WebSocketWorker(BaseWorker):
 
         if self.is_pointer:
             if self.verbose:
-                print("Attaching Pointer to WebSocket Worker....")
+                print("Attaching Pointer to WebSocket Worker....", flush=True)
             self.serversocket = None
             clientsocket = websockets.client.connect(self.uri)
             self.clientsocket = clientsocket
 
         else:
             if self.verbose:
-                print("Starting a Websocket Worker....")
+                print("Starting a Websocket Worker....", flush=True)
                 if not is_client_worker or self.is_pointer:
-                    print("Ready to recieve commands....")
+                    print("Ready to recieve commands....", flush=True)
                     self.serversocket = websockets.serve(
                         self._server_socket_listener, self.hostname, self.port
                     )
-                    print("Server Socket has been initialized")
+                    print(WebSocketWorker.SERVER_INITIALIZED_MSG, flush=True)
                     asyncio.get_event_loop().run_until_complete(self.serversocket)
                     asyncio.get_event_loop().run_forever()
 
                 else:
-                    print("Ready...")
+                    print("Ready...", flush=True)
 
     async def _client_socket_connect(self, json_request):
         """Establishes a connection to the server socket and waits for a
@@ -175,7 +177,7 @@ class WebSocketWorker(BaseWorker):
         msg_wrapper_byte = await websocket.recv()
         msg_wrapper_str = msg_wrapper_byte.decode("utf-8")
         if self.verbose:
-            print("Recieved Command From:", self.uri)
+            print("Received Command From:", self.uri, flush=True)
         decoder = utils.PythonJSONDecoder(self)
         msg_wrapper = decoder.decode(msg_wrapper_str)
         await websocket.send(self.process_message_type(msg_wrapper))

--- a/test/core/workers_test.py
+++ b/test/core/workers_test.py
@@ -1,5 +1,11 @@
 from unittest import TestCase
+import os
+import sys
+import time
+from threading import Thread
+from multiprocessing import Process
 import syft as sy
+from syft.core.workers import WebSocketWorker
 
 
 class TestBaseWorker(TestCase):
@@ -20,3 +26,77 @@ class TestBaseWorker(TestCase):
 
         assert len(hook.local_worker.search("#boston_housing")) == 2
         assert len(hook.local_worker.search(["#boston_housing", "#target"])) == 1
+
+
+class TestWebSocketWorker(TestCase):
+
+    def test_sending(self):
+
+        # We redirect server's stdout and stderr to a pipe
+        # to let the client know when the server is ready.
+        server_pipe_output_fd, server_pipe_input_fd = os.pipe()
+        server_pipe_output = os.fdopen(server_pipe_output_fd, 'r')
+        server_pipe_input = os.fdopen(server_pipe_input_fd, 'w')
+
+        def __server():
+            os.close(server_pipe_output_fd)
+            sys.stdout = sys.stderr = server_pipe_input
+
+            hook = sy.TorchHook()
+            WebSocketWorker(hook=hook,
+                            id=2,
+                            port=8181,
+                            is_pointer=False,
+                            is_client_worker=False,
+                            verbose=True)
+
+        server_process = Process(target=__server, args=())
+        server_process.start()
+
+        server_status = "started"
+        #  Note:
+        #  Later server_status is modified in different threads, but it's ok:
+        #  1. Simple assignments are thread-safe.
+        #  2. With the current flow of execution the thread which makes
+        #     the second modification (server_status = "stopped") waits
+        #     for the first modification (while server_status != "initialized")
+
+        os.close(server_pipe_input_fd)
+
+        def __readln_print_server_msg_loop():
+            nonlocal server_status
+
+            while server_status != "stopped":
+                server_msg = server_pipe_output.readline().strip()
+                if server_msg:
+                    print("Server: ", server_msg)
+                if server_msg == WebSocketWorker.SERVER_INITIALIZED_MSG:
+                    server_status = "initialized"
+
+        server_output_print_thread = Thread(target=__readln_print_server_msg_loop)
+        server_output_print_thread.start()
+
+
+        print("Waiting for server initialization.")
+        while server_status != "initialized":
+            time.sleep(0.1)
+
+
+        print("Client starts...")
+        hook = sy.TorchHook(local_worker=WebSocketWorker(id=111, port=8182))
+        remote_client = WebSocketWorker(hook=hook, id=2, port=8181,
+                                        is_pointer=True)
+        hook.local_worker.add_worker(remote_client)
+        x = sy.torch.FloatTensor([1, 2, 3, 4, 5]).send(remote_client)
+        x2 = sy.torch.FloatTensor([1, 2, 3, 4, 4]).send(remote_client)
+        y = x + x2 + x
+
+        assert y.get() == (3, 6, 9, 12, 14)
+
+
+        # Cleaning
+        server_process.terminate()
+        server_process.join()
+        server_status = "stopped"
+        server_output_print_thread.join()
+        os.close(server_pipe_output_fd)


### PR DESCRIPTION
I've created this pull request to bugfix branch, because I want to easily share code with Ogofo and Nivek92 who expressed interest in issue #1642. This code is not ready for master. Can someone create a separate branch for this maybe? I will then set it in this PR.

I believe the reason why there are so few tests is because this TorchHook solution (possibly combined with the way we write/run tests) makes adding new tests much harder for people. Running tests produce lots of  `Torch was already hooked... skipping hooking process` and `Replacing old worker which could cause unexpected behavior` warnings. In my case I'm adding a correctly failing test (TestWebSocketWorker) and when I run it with `python3 setup.py test` I see different error messages than when I test the same code manually (in a repl) or with
**`python -m unittest -v test.core.workers_test.TestWebSocketWorker`**

I understand the TorchHook solution is waiting for improvement. Meanwhile I tried to find a fix/workaround for tests. I experimented with setUp/tearDown and modules reloading, but wasn't successful.

So far I've put almost all effort into the test and I don't know how hard the complete fix may be.