### PR TITLE
Issue #1666

### DIFF
--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -1,21 +1,24 @@
-from syft.serde import _simplify
+from syft.serde import _simplify, serialize, deserialize
 from unittest import TestCase
+from torch import tensor
+import numpy
+import msgpack
 
 
 class TupleSerde(TestCase):
     def test_tuple_simplify(self):
         input = ("hello", "world")
-        target = (1, ("hello", "world"))
+        target = [1, ("hello", "world")]
         assert _simplify(input) == target
 
     def test_list_simplify(self):
         input = ["hello", "world"]
-        target = (2, ["hello", "world"])
+        target = [2, ["hello", "world"]]
         assert _simplify(input) == target
 
     def test_set_simplify(self):
         input = set(["hello", "world"])
-        target = (3, set(["hello", "world"]))
+        target = [3, set(["hello", "world"])]
         assert _simplify(input) == target
 
     def test_float_simplify(self):
@@ -35,5 +38,17 @@ class TupleSerde(TestCase):
 
     def test_dict_simplify(self):
         input = {"hello": "world"}
-        target = (4, {"hello": "world"})
+        target = [4, {"hello": "world"}]
         assert _simplify(input) == target
+
+    def test_torch_tensor_serde(self):
+        t = tensor(numpy.random.random((100, 100)))
+        t_serialized = serialize(t, compress=False)
+        t_serialized_deserialized = deserialize(t_serialized, compressed=False)
+        assert (t == t_serialized_deserialized).all()
+
+    def test_tuple_serde(self):
+        tuple = (1,2)
+        tuple_serialized = serialize(tuple,compress=False)
+        tuple_deserialized = deserialize(tuple_serialized, compressed=False)
+        assert tuple == tuple_deserialized

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -1,4 +1,6 @@
-from syft.serde import _simplify, serialize, deserialize
+from syft.serde import _simplify
+from syft.serde import serialize
+from syft.serde import deserialize
 from unittest import TestCase
 from torch import tensor
 import numpy
@@ -47,8 +49,3 @@ class TupleSerde(TestCase):
         t_serialized_deserialized = deserialize(t_serialized, compressed=False)
         assert (t == t_serialized_deserialized).all()
 
-    def test_tuple_serde(self):
-        tuple = (1,2)
-        tuple_serialized = serialize(tuple,compress=False)
-        tuple_deserialized = deserialize(tuple_serialized, compressed=False)
-        assert tuple == tuple_deserialized


### PR DESCRIPTION
Added serialization and deserialization of torch.Tensor objects. 

Changed the _simplifier to return a list instead of a tuple, as it looks like the `msgpack` is encoding a tuple as a list. This is throwing errors in the `_details` method. 

Renamed the methods `compress`  and `decompress` to `_compress` and `_decompress` as these are private methods. 