### PR TITLE
Add serde logic for bytearray #1672

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
     # stop the build if there are Python syntax errors or undefined
     # names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    - black --check --verbose --exclude=/.eggs/,/build/ .
+    - black --check --verbose --exclude=.eggs/,build/ .
     # exit-zero treats all errors as warnings.
     # diverting from the standard 79 character line length in
     # accordance with this:

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -284,6 +284,7 @@ def _simplify_range(my_range: range) -> Tuple[int, int, int]:
 
     return [my_range.start, my_range.stop, my_range.step]
 
+
 def _detail_range(my_range_params: Tuple[int, int, int]) -> range:
     """This function extracts the start, stop and step from a tuple.
 

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -80,13 +80,16 @@ class TestSerde(TestCase):
         assert (tuple_serialized_deserialized[1] == tensor_two).all()
 
     def test_bytearray(self):
-        bytearr = bytearray("This is a teststring", 'utf-8')
+        bytearr = bytearray("This is a teststring", "utf-8")
         bytearr_serialized = serialize(bytearr, compress=False)
-        bytearr_serialized_desirialized = deserialize(bytearr_serialized, compressed=False)
+        bytearr_serialized_desirialized = deserialize(
+            bytearr_serialized, compressed=False
+        )
         assert bytearr == bytearr_serialized_desirialized
 
         bytearr = bytearray(numpy.random.random((100, 100)))
         bytearr_serialized = serialize(bytearr, compress=False)
-        bytearr_serialized_desirialized = deserialize(bytearr_serialized, compressed=False)
+        bytearr_serialized_desirialized = deserialize(
+            bytearr_serialized, compressed=False
+        )
         assert bytearr == bytearr_serialized_desirialized
-

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -55,18 +55,20 @@ class TestSimplify(TestCase):
 
 
 class TestSerde(TestCase):
-    def test_torch_tensor_serde(self):
+    def test_torch_tensor(self):
         t = tensor(numpy.random.random((100, 100)))
         t_serialized = serialize(t, compress=False)
         t_serialized_deserialized = deserialize(t_serialized, compressed=False)
         assert (t == t_serialized_deserialized).all()
 
-    def test_tuple_serde(self):
+    def test_tuple(self):
+        # Test with a simple datatype
         tuple = (1, 2)
         tuple_serialized = serialize(tuple, compress=False)
         tuple_serialized_deserialized = deserialize(tuple_serialized, compressed=False)
         assert tuple == tuple_serialized_deserialized
 
+        # Test with a complex data structure
         tensor_one = tensor(numpy.random.random((100, 100)))
         tensor_two = tensor(numpy.random.random((100, 100)))
         tuple = (tensor_one, tensor_two)
@@ -76,3 +78,15 @@ class TestSerde(TestCase):
         assert type(tuple_serialized_deserialized) == type(tuple)
         assert (tuple_serialized_deserialized[0] == tensor_one).all()
         assert (tuple_serialized_deserialized[1] == tensor_two).all()
+
+    def test_bytearray(self):
+        bytearr = bytearray("This is a teststring", 'utf-8')
+        bytearr_serialized = serialize(bytearr, compress=False)
+        bytearr_serialized_desirialized = deserialize(bytearr_serialized, compressed=False)
+        assert bytearr == bytearr_serialized_desirialized
+
+        bytearr = bytearray(numpy.random.random((100, 100)))
+        bytearr_serialized = serialize(bytearr, compress=False)
+        bytearr_serialized_desirialized = deserialize(bytearr_serialized, compressed=False)
+        assert bytearr == bytearr_serialized_desirialized
+


### PR DESCRIPTION
Added a test case for serialization and deserialization of a `bytearray`.  It seems to me that we don't need to add any additional logic, as `msgpack` can handle `bytearrays` quite well. 