### PR TITLE
Solution for #1685

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
     # stop the build if there are Python syntax errors or undefined
     # names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    - black --check --verbose --exclude=/.eggs/,/build/ .
+    - black --check --verbose --exclude=".eggs/|build/" .
     # exit-zero treats all errors as warnings.
     # diverting from the standard 79 character line length in
     # accordance with this:

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -284,6 +284,7 @@ def _simplify_range(my_range: range) -> Tuple[int, int, int]:
 
     return [my_range.start, my_range.stop, my_range.step]
 
+
 def _detail_range(my_range_params: Tuple[int, int, int]) -> range:
     """This function extracts the start, stop and step from a tuple.
 


### PR DESCRIPTION
Fixed travis.yml to correctly ignore `.egg/` and `build/` directory while checking code style using `black`.