### PR TITLE
In `handle_call` for the "end_get" case need to call get() on a _SyftTensor

### DIFF
--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -1028,7 +1028,8 @@ class _PointerTensor(_SyftTensor):
         self_ = tensor_command["self"] if has_self else None
 
         if attr == "end_get":
-            response = self_.get()
+            # For end_get use the tensor in the original Syft command
+            response = syft_command["self"].get()
         else:
             command, locations, owners = torch_utils.compile_command(
                 attr, args, kwargs, has_self=has_self, self=self_


### PR DESCRIPTION
Currently it's called on a `dict` object and calling `end_get` in tutorial 3 generates an error because `dict` does not have a `get()` method with no arguments.

Adds a test that demonstrates a scenario in which the code currently fails.