### PR TITLE
Guarantee Lz4 Compressed binary is shorter than original #1704

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ coverage
 ipykernel
 msgpack
 lz4
+zstd
 pre-commit
 sphinx_rtd_theme
 websockets

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -44,7 +44,7 @@ import zstd
 # High Level Public Functions (these are the ones you use)
 
 
-def serialize(obj: object, compress=True, compressScheme='lz4') -> bin:
+def serialize(obj: object, compress=True, compressScheme="lz4") -> bin:
     """This is the high level function for serializing any object or
     dictionary/collection of objects."""
 
@@ -65,25 +65,26 @@ def serialize(obj: object, compress=True, compressScheme='lz4') -> bin:
     # if compressed stream length is greater than input stream
     # we output the input stream as it is with header set to '0'
     # otherwise we output the compressed stream with header set to '1'
-    # even if compressed flag is set to false by the caller we 
-    # output the input stream as it is with header set to '0' 
+    # even if compressed flag is set to false by the caller we
+    # output the input stream as it is with header set to '0'
     if compress:
         compress_stream = _compress(binary, compressScheme)
         if len(compress_stream) < len(binary):
-           return b'\x31' + compress_stream
+            return b"\x31" + compress_stream
 
-    return b'\x30' + binary
+    return b"\x30" + binary
 
-def deserialize(binary: bin, compressed=True, compressScheme='lz4') -> object:
+
+def deserialize(binary: bin, compressed=True, compressScheme="lz4") -> object:
     """
     This is the high level function for deserializing any object
     or dictionary/collection of objects.
     """
-    #check the 1-byte header to see if input stream was compressed or not
+    # check the 1-byte header to see if input stream was compressed or not
     if binary[0] == 48:
-       compressed = False
-    
-    #remove the 1-byte header from the input stream
+        compressed = False
+
+    # remove the 1-byte header from the input stream
     binary = binary[1:]
     # 1)  Decompress
     # If enabled, this functionality decompresses the binary
@@ -107,7 +108,7 @@ def deserialize(binary: bin, compressed=True, compressScheme='lz4') -> object:
 # Chosen Compression Algorithm
 
 
-def _compress(decompressed_input_bin: bin, compressScheme='lz4') -> bin:
+def _compress(decompressed_input_bin: bin, compressScheme="lz4") -> bin:
     """
     This function compresses a binary using LZ4
 
@@ -118,13 +119,13 @@ def _compress(decompressed_input_bin: bin, compressScheme='lz4') -> bin:
         bin: a compressed binary
 
     """
-    if compressScheme == 'lz4':
-       return lz4.frame.compress(decompressed_input_bin)
+    if compressScheme == "lz4":
+        return lz4.frame.compress(decompressed_input_bin)
     else:
-       return zstd.compress(decompressed_input_bin)
+        return zstd.compress(decompressed_input_bin)
 
 
-def _decompress(compressed_input_bin: bin, compressScheme='lz4') -> bin:
+def _decompress(compressed_input_bin: bin, compressScheme="lz4") -> bin:
     """
     This function decompresses a binary using LZ4
 
@@ -135,10 +136,10 @@ def _decompress(compressed_input_bin: bin, compressScheme='lz4') -> bin:
         bin: decompressed binary
 
     """
-    if compressScheme == 'lz4':
-       return lz4.frame.decompress(compressed_input_bin)
+    if compressScheme == "lz4":
+        return lz4.frame.decompress(compressed_input_bin)
     else:
-       return zstd.decompress(compressed_input_bin)
+        return zstd.decompress(compressed_input_bin)
 
 
 # Simplify/Detail Torch Tensors

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -110,19 +110,31 @@ class TestSerde(TestCase):
 
         assert numpy.array_equal(arr, arr_serialized_deserialized)
 
-    def test_compress_decompress(self):
+    def test_compress_decompress_lz4(self):
         original = msgpack.dumps([1, 2, 3])
         compressed = _compress(original)
         decompressed = _decompress(compressed)
         assert type(compressed) == bytes
         assert original == decompressed
 
-    def test_compressed_serde(self):
+    def test_compress_decompress_zstd(self):
+        original = msgpack.dumps([1, 2, 3])
+        compressed = _compress(original, 'zstd')
+        decompressed = _decompress(compressed, 'zstd')
+        assert type(compressed) == bytes
+        assert original == decompressed
+
+    def test_compressed_serde_lz4(self):
         arr = numpy.random.random((100, 100))
         arr_serialized = serialize(arr, compress=True)
 
         arr_serialized_deserialized = deserialize(arr_serialized, compressed=True)
+        assert numpy.array_equal(arr, arr_serialized_deserialized)
 
+    def test_compressed_serde_zstd(self):
+        arr = numpy.random.random((100, 100))
+        arr_serialized = serialize(arr, compress=True, compressScheme='zstd')
+        arr_serialized_deserialized = deserialize(arr_serialized, compressed=True, compressScheme='zstd')
         assert numpy.array_equal(arr, arr_serialized_deserialized)
 
     def test_dict(self):

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -149,8 +149,8 @@ class TestSerde(TestCase):
 
     def test_compress_decompress_zstd(self):
         original = msgpack.dumps([1, 2, 3])
-        compressed = _compress(original, 'zstd')
-        decompressed = _decompress(compressed, 'zstd')
+        compressed = _compress(original, "zstd")
+        decompressed = _decompress(compressed, "zstd")
         assert type(compressed) == bytes
         assert original == decompressed
 
@@ -163,8 +163,10 @@ class TestSerde(TestCase):
 
     def test_compressed_serde_zstd(self):
         arr = numpy.random.random((100, 100))
-        arr_serialized = serialize(arr, compress=True, compressScheme='zstd')
-        arr_serialized_deserialized = deserialize(arr_serialized, compressed=True, compressScheme='zstd')
+        arr_serialized = serialize(arr, compress=True, compressScheme="zstd")
+        arr_serialized_deserialized = deserialize(
+            arr_serialized, compressed=True, compressScheme="zstd"
+        )
         assert numpy.array_equal(arr, arr_serialized_deserialized)
 
     def test_dict(self):


### PR DESCRIPTION
Change details-
1. Added support for 'zstd' compression algorithm in the library. Now both 'lz4' and 'zstd' algorithms can be used.
2. Handled the scenario when compression algorithm output is greater than the input stream in serialize\deserialize apis. Added a 1-byte header to the serialized output to indicate output is compressed or not.
3. Added 2 unit test cases for zstd algorithm for testing compression\decompression apis and serialize\deserialize apis.
4. Added zstd dependency in requirements.txt
5. Executed unit test cases using "python setup.py test". All tests passed including the newly added unit tests. 