### PR TITLE
Torch 1749 serde posthook

### DIFF
--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -131,8 +131,6 @@ class TorchHook:
         # Rename native functions
         self._rename_native_functions(tensor_type)
 
-        self._assign_methods_to_use_child(tensor_type)
-
         # Overload auto overloaded with Torch methods
         self._add_methods_from__torch_tensor(tensor_type)
 
@@ -223,15 +221,6 @@ class TorchHook:
                 setattr(tensor_type, f"native_{attr}", lit)
 
             setattr(tensor_type, attr, None)
-
-    def _assign_methods_to_use_child(self, tensor_type):
-        """Assigns methods to use as child for auto overloaded functions.
-           Parameters: tensor_type:Torch Tensor
-        """
-
-        # Iterate through auto overloaded tensor methods
-        for attr in self.to_auto_overload[tensor_type]:
-            setattr(tensor_type, attr, getattr(tensor_type, f"native_{attr}"))
 
     @staticmethod
     def _add_methods_from__torch_tensor(tensor_type):

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -3,10 +3,12 @@ from syft.serde import serialize
 from syft.serde import deserialize
 from syft.serde import _compress
 from syft.serde import _decompress
+from syft import TorchHook
 from unittest import TestCase
 from torch import Tensor
 import numpy
 import msgpack
+import torch
 
 
 class TestSimplify(TestCase):
@@ -370,3 +372,18 @@ class TestSerde(TestCase):
 
         assert type(s) == type(s_serialized_deserialized)
         assert (x[s] == x[s_serialized_deserialized]).all()
+
+
+class TestHooked(TestCase):
+    def test_hooked_tensor(self):
+        TorchHook(torch)
+
+        def test(compress):
+            t = Tensor(numpy.random.random((100, 100)))
+            t_serialized = serialize(t, compress=compress)
+            t_serialized_deserialized = deserialize(t_serialized, compressed=compress)
+            assert (t == t_serialized_deserialized).all()
+
+        arguments = [True, False]
+        for arg in arguments:
+            test(arg)

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -421,4 +421,3 @@ class TestHooked(TestCase):
 
         assert x_serialized_deserialized == x
         assert y_serialized_deserialized == y
-

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -378,12 +378,17 @@ class TestHooked(TestCase):
     def test_hooked_tensor(self):
         TorchHook(torch)
 
-        def test(compress):
+        def test(compress, compressScheme):
             t = Tensor(numpy.random.random((100, 100)))
-            t_serialized = serialize(t, compress=compress)
-            t_serialized_deserialized = deserialize(t_serialized, compressed=compress)
+            t_serialized = serialize(t, compress=compress, compressScheme=compressScheme)
+            t_serialized_deserialized = deserialize(
+                t_serialized, compressed=compress, compressScheme=compressScheme
+            )
             assert (t == t_serialized_deserialized).all()
 
-        arguments = [True, False]
-        for arg in arguments:
-            test(arg)
+        compress_vals = [True, False]
+        compressScheme_vals = ["zstd", "lz4"]
+
+        for compress in compress_vals:
+            for compressScheme in compressScheme_vals:
+                test(compress, compressScheme)


### PR DESCRIPTION
This is based on #1746. The test should be generally fine, but on current `torch_1`the test will fail as the torch functionality is broken.

Can be merged based on approval of #1746. 