### PR TITLE
Reduce duplication in serde test logic #1740

### DIFF
--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -140,29 +140,24 @@ class TestSerde(TestCase):
 
         assert numpy.array_equal(arr, arr_serialized_deserialized)
 
-    def test_compress_decompress_lz4(self):
+    def test_compress_decompress(self):
         original = msgpack.dumps([1, 2, 3])
         compressed = _compress(original)
         decompressed = _decompress(compressed)
         assert type(compressed) == bytes
         assert original == decompressed
 
-    def test_compress_decompress_zstd(self):
-        original = msgpack.dumps([1, 2, 3])
         compressed = _compress(original, "zstd")
         decompressed = _decompress(compressed, "zstd")
         assert type(compressed) == bytes
         assert original == decompressed
 
-    def test_compressed_serde_lz4(self):
+    def test_compressed_serde(self):
         arr = numpy.random.random((100, 100))
         arr_serialized = serialize(arr, compress=True)
-
         arr_serialized_deserialized = deserialize(arr_serialized, compressed=True)
         assert numpy.array_equal(arr, arr_serialized_deserialized)
 
-    def test_compressed_serde_zstd(self):
-        arr = numpy.random.random((100, 100))
         arr_serialized = serialize(arr, compress=True, compressScheme="zstd")
         arr_serialized_deserialized = deserialize(
             arr_serialized, compressed=True, compressScheme="zstd"


### PR DESCRIPTION
Updated the following test cases to reduce redundancy-

Merged the following test cases into a single test case - test_compress_decompress
test_compress_decompress_lz4
test_compress_decompress_zstd

Merged the following test cases into a single test case - test_compressed_serde
test_compressed_serde_lz4
test_compressed_serde_zstd

Ran black on test folder
Ran unit tests