### PR TITLE
Added AbstractTensor.serlialize() convenience function w/ tests; added inline documentation

### DIFF
--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -1,4 +1,3 @@
-import random
 import inspect
 import re
 import logging

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -6,7 +6,7 @@ import syft as sy
 
 class AbstractTensor(ABC):
     """
-    This is the tensor abstraction
+    This is the tensor abstraction.
     """
 
     def wrap(self):
@@ -17,7 +17,30 @@ class AbstractTensor(ABC):
 
     def serialize(self,
                   compress=True,
-                  compress_scheme=sy.serde.LZ4):
+                  compress_scheme=0):
+        """This convenience method serializes the tensor on which it's called.
+
+            This is the high level convenience function for serializing torch tensors.
+            It includes three steps, Simplify, Serialize, and Compress as described
+            in serde.py
+
+            Args:
+                self (AbstractTensor): the tensor to be serialized
+
+                compress (bool): whether or not to compress the object
+
+                compress_scheme (int): the integer code specifying which compression
+                    scheme to use (see serde.py for scheme codes) if compress == True.
+                    The compression scheme is set to LZ4 by default (code 0).
+
+            Returns:
+                binary: the serialized form of the tensor.
+
+            Examples:
+
+                x = torch.Tensor([1,2,3,4,5])
+                x.serialize() # returns a serialized object
+        """
 
         return sy.serde.serialize(self,
                                   compress=compress,

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -15,8 +15,9 @@ class AbstractTensor(ABC):
         wrapper.is_wrapper = True
         return wrapper
 
-    def serialize(
-        self, compress=True, compress_scheme=0
+    def serialize(self,
+                  compress=True,
+                  compress_scheme=0
     ):  # Code 0 is LZ4 - check serde.py to see others
         """This convenience method serializes the tensor on which it's called.
 
@@ -43,8 +44,13 @@ class AbstractTensor(ABC):
         return sy.serde.serialize(self, compress=compress, compress_scheme=compress_scheme)
 
 
-def initialize_tensor(
-    hook_self, cls, torch_tensor: bool = False, owner=None, id=None, *init_args, **init_kwargs
+def initialize_tensor(hook_self,
+                      cls,
+                      torch_tensor: bool = False,
+                      owner=None,
+                      id=None,
+                      *init_args,
+                      **init_kwargs
 ):
 
     cls.is_wrapper = False

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -17,7 +17,7 @@ class AbstractTensor(ABC):
 
     def serialize(self,
                   compress=True,
-                  compress_scheme="lz4"):
+                  compress_scheme=sy.serde.LZ4):
 
         return sy.serde.serialize(self,
                                   compress=compress,

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -15,9 +15,9 @@ class AbstractTensor(ABC):
         wrapper.is_wrapper = True
         return wrapper
 
-    def serialize(self,
-                  compress=True,
-                  compress_scheme=0): # Code 0 is LZ4 - check serde.py to see others
+    def serialize(
+        self, compress=True, compress_scheme=0
+    ):  # Code 0 is LZ4 - check serde.py to see others
         """This convenience method serializes the tensor on which it's called.
 
             This is the high level convenience function for serializing torch tensors.
@@ -42,10 +42,7 @@ class AbstractTensor(ABC):
                 x.serialize() # returns a serialized object
         """
 
-        return sy.serde.serialize(self,
-                                  compress=compress,
-                                  compress_scheme=compress_scheme)
-
+        return sy.serde.serialize(self, compress=compress, compress_scheme=compress_scheme)
 
 
 def initialize_tensor(

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -15,9 +15,8 @@ class AbstractTensor(ABC):
         wrapper.is_wrapper = True
         return wrapper
 
-    def serialize(self,
-                  compress=True,
-                  compress_scheme=0
+    def serialize(
+        self, compress=True, compress_scheme=0
     ):  # Code 0 is LZ4 - check serde.py to see others
         """This convenience method serializes the tensor on which it's called.
 
@@ -44,13 +43,8 @@ class AbstractTensor(ABC):
         return sy.serde.serialize(self, compress=compress, compress_scheme=compress_scheme)
 
 
-def initialize_tensor(hook_self,
-                      cls,
-                      torch_tensor: bool = False,
-                      owner=None,
-                      id=None,
-                      *init_args,
-                      **init_kwargs
+def initialize_tensor(
+    hook_self, cls, torch_tensor: bool = False, owner=None, id=None, *init_args, **init_kwargs
 ):
 
     cls.is_wrapper = False

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import torch
 import random
+import syft as sy
 
 
 class AbstractTensor(ABC):
@@ -13,6 +14,15 @@ class AbstractTensor(ABC):
         wrapper.child = self
         wrapper.is_wrapper = True
         return wrapper
+
+    def serialize(self,
+                  compress=True,
+                  compress_scheme="lz4"):
+
+        return sy.serde.serialize(self,
+                                  compress=compress,
+                                  compress_scheme=compress_scheme)
+
 
 
 def initialize_tensor(

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 import torch
 import random
 import syft as sy

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -17,7 +17,7 @@ class AbstractTensor(ABC):
 
     def serialize(self,
                   compress=True,
-                  compress_scheme=0):
+                  compress_scheme=0): # Code 0 is LZ4 - check serde.py to see others
         """This convenience method serializes the tensor on which it's called.
 
             This is the high level convenience function for serializing torch tensors.

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -22,13 +22,11 @@ class AbstractTensor(ABC):
 
             This is the high level convenience function for serializing torch tensors.
             It includes three steps, Simplify, Serialize, and Compress as described
-            in serde.py
+            in serde.py.
 
             Args:
                 self (AbstractTensor): the tensor to be serialized
-
                 compress (bool): whether or not to compress the object
-
                 compress_scheme (int): the integer code specifying which compression
                     scheme to use (see serde.py for scheme codes) if compress == True.
                     The compression scheme is set to LZ4 by default (code 0).

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -1,8 +1,8 @@
 import random
 
-from . import AbstractTensor
-from . import PointerTensor
-from ....workers import BaseWorker
+from syft.frameworks.torch.tensors import AbstractTensor
+from syft.frameworks.torch.tensors import PointerTensor
+from syft.workers import BaseWorker
 
 
 class TorchTensor(AbstractTensor):

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -1,6 +1,7 @@
 import random
 
-from . import AbstractTensor, PointerTensor
+from . import AbstractTensor
+from . import PointerTensor
 from ....workers import BaseWorker
 
 

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -4,7 +4,6 @@ from . import AbstractTensor, PointerTensor
 from ....workers import BaseWorker
 
 
-
 class TorchTensor(AbstractTensor):
     """ Add methods to this tensor to have them added to every torch.Tensor obj
 

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -1,7 +1,9 @@
 import random
+import syft as sy
 
 from . import AbstractTensor, PointerTensor
 from ....workers import BaseWorker
+
 
 
 class TorchTensor(AbstractTensor):
@@ -58,7 +60,7 @@ class TorchTensor(AbstractTensor):
 
     def serialize(self,
                   compress=True,
-                  compress_scheme="lz4"):
+                  compress_scheme=sy.serde.LZ4):
 
         return self.child.serialize(compress=compress,
                                     compress_sheme=compress_scheme)

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -1,5 +1,4 @@
 import random
-import syft as sy
 
 from . import AbstractTensor, PointerTensor
 from ....workers import BaseWorker
@@ -14,6 +13,11 @@ class TorchTensor(AbstractTensor):
     all Torch tensor types. When you add a function to this tensor, it will
     be added to EVERY native torch tensor type (i.e. torch.Torch) automatically
     by the TorchHook (which is in frameworks/torch/hook.py)
+
+    Note: all methods from AbstractTensor will also be included because this
+    tensor extends AbstractTensor. So, if you're looking for a method on
+    the native torch tensor API but it's not listed here, you might try
+    checking AbstractTensor.
     """
 
     def get(self):
@@ -57,13 +61,6 @@ class TorchTensor(AbstractTensor):
         """
 
         return self.owner.send(self, location)
-
-    def serialize(self,
-                  compress=True,
-                  compress_scheme=sy.serde.LZ4):
-
-        return self.child.serialize(compress=compress,
-                                    compress_sheme=compress_scheme)
 
     def create_pointer(
         self,

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -56,6 +56,13 @@ class TorchTensor(AbstractTensor):
 
         return self.owner.send(self, location)
 
+    def serialize(self,
+                  compress=True,
+                  compress_scheme="lz4"):
+
+        return self.child.serialize(compress=compress,
+                                    compress_sheme=compress_scheme)
+
     def create_pointer(
         self,
         location: BaseWorker = None,

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -1,9 +1,6 @@
 from typing import Union
 from typing import Callable
 from typing import Any
-
-
-# @trask - my IDE can't find this - does anyone else's see it
 from types import ModuleType
 
 

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -1,6 +1,9 @@
 from typing import Union
 from typing import Callable
 from typing import Any
+
+
+# @trask - my IDE can't find this - does anyone else's see it
 from types import ModuleType
 
 

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -47,7 +47,7 @@ from syft.frameworks.torch.tensors import PointerTensor
 from .frameworks.torch.tensors.abstract import initialize_tensor
 
 
-# COMPRESSION SCHEMES
+# COMPRESSION SCHEME INT CODES
 LZ4 = 0
 ZSTD = 1
 
@@ -67,7 +67,12 @@ def serialize(obj: object, compress=True, compress_scheme=LZ4) -> bin:
 
         compress (bool): whether or not to compress the object
 
-        compress_scheme (str):
+        compress_scheme (int): the integer code specifying which compression
+            scheme to use (see above this method for scheme codes) if
+            compress == True.
+
+    Returns:
+        binary: the serialized form of the object.
 
     """
 
@@ -99,10 +104,26 @@ def serialize(obj: object, compress=True, compress_scheme=LZ4) -> bin:
 
 
 def deserialize(binary: bin, compressed=True, compress_scheme=LZ4) -> object:
+    """ This method can deserialize any object PySyft needs to send or store.
+
+    This is the high level function for deserializing any object or collection
+    of objects which PySyft has sent over the wire or stored. It includes three
+    steps, Decompress, Deserialize, and Detail as described inline below.
+
+    Args:
+        bin (binary): the serialized object to be deserialized
+
+        compressed (bool): whether or not the serialized object is compressed
+            (and thus whether or not it needs to be decompressed)
+
+        compress_scheme (int): the integer code specifying which compression
+            scheme was used if decompression is needed (see above this method
+            for scheme codes)
+
+    Returns:
+        binary: the serialized form of the object.
     """
-    This is the high level function for deserializing any object
-    or dictionary/collection of objects.
-    """
+    
     # check the 1-byte header to see if input stream was compressed or not
     if binary[0] == 48:
         compressed = False

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -45,7 +45,7 @@ import syft
 from syft.frameworks.torch.tensors import PointerTensor
 
 from .frameworks.torch.tensors.abstract import initialize_tensor
-
+from .util import CompressionNotFoundException
 
 # COMPRESSION SCHEME INT CODES
 LZ4 = 0
@@ -168,7 +168,9 @@ def _compress(decompressed_input_bin: bin, compress_scheme=LZ4) -> bin:
     elif compress_scheme == ZSTD:
         return zstd.compress(decompressed_input_bin)
     else:
-        NotImplementedError("compression scheme note found!")
+        CompressionNotFoundException(
+            "compression scheme note found for" " compression code:" + str(compress_scheme)
+        )
 
 
 def _decompress(compressed_input_bin: bin, compress_scheme=LZ4) -> bin:
@@ -187,7 +189,9 @@ def _decompress(compressed_input_bin: bin, compress_scheme=LZ4) -> bin:
     elif compress_scheme == ZSTD:
         return zstd.decompress(compressed_input_bin)
     else:
-        NotImplementedError("compression scheme not found")
+        CompressionNotFoundException(
+            "compression scheme note found for" " compression code:" + str(compress_scheme)
+        )
 
 
 # Simplify/Detail Torch Tensors

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -44,8 +44,8 @@ import syft
 
 from syft.frameworks.torch.tensors import PointerTensor
 
-from .frameworks.torch.tensors.abstract import initialize_tensor
-from .util import CompressionNotFoundException
+from syft.frameworks.torch.tensors.abstract import initialize_tensor
+from syft.util import CompressionNotFoundException
 
 # COMPRESSION SCHEME INT CODES
 LZ4 = 0

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -123,7 +123,7 @@ def deserialize(binary: bin, compressed=True, compress_scheme=LZ4) -> object:
     Returns:
         binary: the serialized form of the object.
     """
-    
+
     # check the 1-byte header to see if input stream was compressed or not
     if binary[0] == 48:
         compressed = False

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -111,14 +111,12 @@ def deserialize(binary: bin, compressed=True, compress_scheme=LZ4) -> object:
     steps, Decompress, Deserialize, and Detail as described inline below.
 
     Args:
-        bin (binary): the serialized object to be deserialized
-
+        bin (binary): the serialized object to be deserialized.
         compressed (bool): whether or not the serialized object is compressed
-            (and thus whether or not it needs to be decompressed)
-
+            (and thus whether or not it needs to be decompressed).
         compress_scheme (int): the integer code specifying which compression
             scheme was used if decompression is needed (see above this method
-            for scheme codes)
+            for scheme codes).
 
     Returns:
         binary: the serialized form of the object.

--- a/syft/util.py
+++ b/syft/util.py
@@ -1,2 +1,6 @@
 class WorkerNotFoundException(Exception):
     pass
+
+
+class CompressionNotFoundException(Exception):
+    pass

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -189,11 +189,19 @@ class TestSimplify(object):
 class TestSerde(object):
     @pytest.mark.parametrize("compress", [True, False])
     def test_torch_Tensor(self, compress):
-
         hook = TorchHook(torch)
 
         t = Tensor(numpy.random.random((100, 100)))
         t_serialized = serialize(t, compress=compress)
+        t_serialized_deserialized = deserialize(t_serialized, compressed=compress)
+        assert (t == t_serialized_deserialized).all()
+
+    @pytest.mark.parametrize("compress", [True, False])
+    def test_torch_Tensor_convenience(self, compress):
+        hook = TorchHook(torch)
+
+        t = Tensor(numpy.random.random((100, 100)))
+        t_serialized = t.serialize(compress=compress)
         t_serialized_deserialized = deserialize(t_serialized, compressed=compress)
         assert (t == t_serialized_deserialized).all()
 

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -3,6 +3,8 @@ from syft.serde import serialize
 from syft.serde import deserialize
 from syft.serde import _compress
 from syft.serde import _decompress
+from syft.serde import LZ4
+from syft.serde import ZSTD
 
 from syft import TorchHook
 from syft.frameworks.torch.tensors import PointerTensor
@@ -239,21 +241,21 @@ class TestSerde(object):
 
         assert numpy.array_equal(arr, arr_serialized_deserialized)
 
-    @pytest.mark.parametrize("compressScheme", ["lz4", "zstd"])
-    def test_compress_decompress(self, compressScheme):
+    @pytest.mark.parametrize("compress_scheme", [LZ4, ZSTD])
+    def test_compress_decompress(self, compress_scheme):
         original = msgpack.dumps([1, 2, 3])
-        compressed = _compress(original, compressScheme=compressScheme)
-        decompressed = _decompress(compressed, compressScheme=compressScheme)
+        compressed = _compress(original, compress_scheme=compress_scheme)
+        decompressed = _decompress(compressed, compress_scheme=compress_scheme)
         assert type(compressed) == bytes
         assert original == decompressed
 
-    @pytest.mark.parametrize("compressScheme", ["lz4", "zstd"])
-    def test_compressed_serde(self, compressScheme):
+    @pytest.mark.parametrize("compress_scheme", [LZ4, ZSTD])
+    def test_compressed_serde(self, compress_scheme):
         arr = numpy.random.random((100, 100))
-        arr_serialized = serialize(arr, compress=True, compressScheme=compressScheme)
+        arr_serialized = serialize(arr, compress=True, compress_scheme=compress_scheme)
 
         arr_serialized_deserialized = deserialize(
-            arr_serialized, compressed=True, compressScheme=compressScheme
+            arr_serialized, compressed=True, compress_scheme=compress_scheme
         )
         assert numpy.array_equal(arr, arr_serialized_deserialized)
 
@@ -422,15 +424,18 @@ class TestHooked(object):
         self.james = james
 
     @pytest.mark.parametrize(
-        "compress, compressScheme", [(True, "lz4"), (False, "lz4"), (True, "zstd"), (False, "zstd")]
+        "compress, compress_scheme", [(True, LZ4),
+                                     (False, LZ4),
+                                     (True, ZSTD),
+                                     (False, ZSTD)]
     )
-    def test_hooked_tensor(self, compress, compressScheme):
+    def test_hooked_tensor(self, compress, compress_scheme):
         TorchHook(torch)
 
         t = Tensor(numpy.random.random((100, 100)))
-        t_serialized = serialize(t, compress=compress, compressScheme=compressScheme)
+        t_serialized = serialize(t, compress=compress, compress_scheme=compress_scheme)
         t_serialized_deserialized = deserialize(
-            t_serialized, compressed=compress, compressScheme=compressScheme
+            t_serialized, compressed=compress, compress_scheme=compress_scheme
         )
         assert (t == t_serialized_deserialized).all()
 

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -198,6 +198,13 @@ class TestSerde(object):
 
     @pytest.mark.parametrize("compress", [True, False])
     def test_torch_Tensor_convenience(self, compress):
+        """This test evaluates torch.Tensor.serialize()
+
+        As opposed to using syft.serde.serialize(), torch objects
+        have a convenience function which lets you call .serialize()
+        directly on the tensor itself. This tests to makes sure it
+        works correctly."""
+
         hook = TorchHook(torch)
 
         t = Tensor(numpy.random.random((100, 100)))

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -432,10 +432,7 @@ class TestHooked(object):
         self.james = james
 
     @pytest.mark.parametrize(
-        "compress, compress_scheme", [(True, LZ4),
-                                     (False, LZ4),
-                                     (True, ZSTD),
-                                     (False, ZSTD)]
+        "compress, compress_scheme", [(True, LZ4), (False, LZ4), (True, ZSTD), (False, ZSTD)]
     )
     def test_hooked_tensor(self, compress, compress_scheme):
         TorchHook(torch)


### PR DESCRIPTION
Fixes https://github.com/OpenMined/PySyft/issues/1694

This PR does a few things.

1) it adds a new .serialize() convenience function to all tensors (by adding it to AbstractTensor). I added 2 unit tests for this function.
2) it removed the STRING based configuration of compression - opting instead for an integer based one (a general design decision we're optimizing for in Torch 1.0 to make things faster and more compressed). I modified previous unit tests to adjust (also fixed a style issue where compress_scheme was camel-caps for some reason)
3) it added a bit of inline documentation as I was going.
4) a few minor style fixes (removed unused imports)
5) added a new error class CompressionNotFoundException if you try to use a compression
code that doesn't exist (previously if you didn't specify one or you specified one that didn't
exist, it would just pick one at random).
