### PR TITLE
Torch 1 and (not) headless tensor chains - send/get - GC - ptr.method() - etc.

### DIFF
--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -2,11 +2,12 @@
 from . import frameworks
 from . import workers
 from . import serde
+from . import codes
 
 from syft.frameworks.torch import TorchHook
 from syft.workers import VirtualWorker
 
-__all__ = ["frameworks", "workers", "serde", "TorchHook", "VirtualWorker"]
+__all__ = ["frameworks", "workers", "serde", "TorchHook", "VirtualWorker", "codes"]
 
 local_worker = None
 torch = None

--- a/syft/codes.py
+++ b/syft/codes.py
@@ -1,0 +1,6 @@
+class MSGTYPE(object):
+    CMD = 1
+    OBJ = 2
+    OBJ_REQ = 3
+    OBJ_DEL = 4
+    EXCEPTION = 5

--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -1,6 +1,18 @@
 """Specific Pysyft exceptions."""
 
 
+class PointerFoundError(BaseException):
+    """Exception raised for errors in the input.
+
+    Attributes:
+        expression -- input expression in which the error occurred
+        message -- explanation of the error
+    """
+
+    def __init__(self, pointer):
+        self.pointer = pointer
+
+
 class WorkerNotFoundException(Exception):
     """Raised when a non-existent worker is requested."""
 

--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -1,7 +1,7 @@
 """Specific Pysyft exceptions."""
 
 
-class PointerFoundError(BaseException):
+class RemoteTensorFoundError(BaseException):
     """Exception raised for errors in the input.
 
     Attributes:

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -252,8 +252,8 @@ class TorchHook:
                 # structure is the same as the args object, with 1 where there was
                 # (torch or syft) tensors and 0 when not (ex: number, str, ...)
                 rule = build_rule(args)
-                # Build a function with this rule to efficiently replace syft tensors (but not pointer)
-                # with their child in the args objects
+                # Build a function with this rule to efficiently replace syft tensors
+                # (but not pointer) with their child in the args objects
                 args_hook_function = build_args_hook(args, rule)
                 # Store this utility function in the registry
                 hook_self.args_hook_for_overloaded_attr[attr] = args_hook_function
@@ -463,17 +463,18 @@ class TorchHook:
                 added to it, typically just torch.Tensor.
         """
 
-        @property
-        def location(self):
-            return self.child.location
-
-        tensor_type.location = location
-
-        @property
-        def id_at_location(self):
-            return self.child.id_at_location
-
-        tensor_type.id_at_location = id_at_location
+        # Not needed in the headless setting
+        # @property
+        # def location(self):
+        #     return self.child.location
+        #
+        # tensor_type.location = location
+        #
+        # @property
+        # def id_at_location(self):
+        #     return self.child.id_at_location
+        #
+        # tensor_type.id_at_location = id_at_location
 
         @property
         def id(self):
@@ -541,22 +542,23 @@ class TorchHook:
 
         return to_overload
 
-    def _rename_native_functions(self, tensor_type: type):
-        """Renames functions that are not auto overloaded as native functions.
-
-        Args:
-            tensor_type: The type of tensor whose native methods are getting
-                renamed. Typically just torch.Tensor.
-        """
-        for attr in self.to_auto_overload[tensor_type]:
-
-            lit = getattr(tensor_type, attr)
-
-            # if we haven't already overloaded this function
-            if f"native_{attr}" not in dir(tensor_type):
-                setattr(tensor_type, f"native_{attr}", lit)
-
-            setattr(tensor_type, attr, None)
+    # Not needed at the moment
+    # def _rename_native_functions(self, tensor_type: type):
+    #     """Renames functions that are not auto overloaded as native functions.
+    #
+    #     Args:
+    #         tensor_type: The type of tensor whose native methods are getting
+    #             renamed. Typically just torch.Tensor.
+    #     """
+    #     for attr in self.to_auto_overload[tensor_type]:
+    #
+    #         lit = getattr(tensor_type, attr)
+    #
+    #         # if we haven't already overloaded this function
+    #         if f"native_{attr}" not in dir(tensor_type):
+    #             setattr(tensor_type, f"native_{attr}", lit)
+    #
+    #         setattr(tensor_type, attr, None)
 
     @staticmethod
     def _add_methods_from__torch_tensor(tensor_type: type, syft_type: type):

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -6,7 +6,7 @@ import syft
 from ... import workers
 
 from ...workers import BaseWorker
-from .tensors import TorchTensor
+from .tensors import TorchTensor, PointerTensor
 from .torch_attributes import TorchAttributes
 from .tensors.abstract import initialize_tensor
 
@@ -102,6 +102,9 @@ class TorchHook:
         self.to_auto_overload = {}
 
         self._hook_native_tensor(torch.Tensor, TorchTensor)
+
+        # Overload auto overloaded with Torch methods
+        self._add_methods_from__torch_tensor(PointerTensor, TorchTensor)
 
         # Add the local_worker to syft so that it can be found if the hook is
         # called several times

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -400,6 +400,18 @@ class TorchHook:
         """
 
         @property
+        def location(self):
+            return self.child.location
+
+        tensor_type.location = location
+
+        @property
+        def id_at_location(self):
+            return self.child.id_at_location
+
+        tensor_type.id_at_location = id_at_location
+
+        @property
         def id(self):
             if not hasattr(self, "_id"):
                 self._id = int(10e10 * random.random())

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -159,8 +159,6 @@ class TorchHook:
         is pointing at.
         :param tensor_type: the tensor_type which holds the methods
         """
-        # Add methods defined in the TorchTensor class to the Pointer class
-        self._add_methods_from__torch_tensor(PointerTensor, TorchTensor)
 
         # Use a pre-defined list to select the methods to overload
         for attr in self.to_auto_overload[tensor_type]:
@@ -498,8 +496,6 @@ class TorchHook:
             "__sizeof__",
             "__subclasshook__",
             "_get_type",
-            "__str__",
-            "__repr__",
             "__eq__",
             "__gt__",
             "__ge__",
@@ -509,5 +505,7 @@ class TorchHook:
         # For all methods defined in TorchTensor which are not internal methods (like __class__etc)
         for attr in dir(syft_type):
             if attr not in exclude:
+                if hasattr(tensor_type, attr):
+                    setattr(tensor_type, f"native_{attr}", getattr(tensor_type, attr))
                 # Add to the native tensor this method
                 setattr(tensor_type, attr, getattr(TorchTensor, attr))

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -13,6 +13,7 @@ from syft.workers import BaseWorker
 from .tensors import TorchTensor, PointerTensor
 from .torch_attributes import TorchAttributes
 from .tensors.abstract import initialize_tensor
+from .hook_args import *
 
 
 class TorchHook:
@@ -292,10 +293,8 @@ class TorchHook:
                         return attr(new_self, *new_args)
                     except TypeError:
                         return overloaded_attr(new_self, *new_args)
-                    # return getattr(new_self, attr.__name__)(*new_args)
                 else:
                     return attr(new_self, new_args)
-                    # return getattr(new_self, attr.__name__)(new_args)
             except RemoteTensorFoundError as err:  # if a pointer as been detected
                 # Extract the pointer with the error
                 pointer = err.pointer
@@ -310,108 +309,6 @@ class TorchHook:
                 tensor = hook_self.torch.Tensor()
                 tensor.child = response
                 return tensor
-
-        def build_hook_args_function(args):
-            # Inspect the call to find tensor arguments and return a rule whose
-            # structure is the same as the args object, with 1 where there was
-            # (torch or syft) tensors and 0 when not (ex: number, str, ...)
-            rule = build_rule(args)
-            # Build a function with this rule to efficiently replace syft tensors
-            # (but not pointer) with their child in the args objects
-            args_hook_function = build_args_hook(args, rule)
-            return args_hook_function
-
-        def build_rule(args):
-            """
-            Inspect the args object to find torch or syft tensor arguments and
-            return a rule whose structure is the same as the args object,
-            with 1 where there was (torch or syft) tensors and 0 when
-            not (ex: number, str, ...)
-
-            Example:
-                in: ([tensor(1, 2), Pointer@bob], 42)
-                out: ([1, 1], 0)
-            """
-            one = lambda _args: 1
-            # dict to specify the action depending of the type found
-            type_rule = {
-                list: lambda _args: [build_rule(a) for a in _args],
-                tuple: lambda _args: tuple([build_rule(a) for a in _args]),
-                PointerTensor: one,
-                hook_self.torch.Tensor: one,
-            }
-            type_args = type(args)
-            if type_args in type_rule:
-                return type_rule[type_args](args)
-            else:
-                return 0
-
-        def build_args_hook(args, rules, return_tuple=False):
-            """
-            Build a function given some rules to efficiently replace in the args object
-            syft tensors (but not pointer) with their child, and do nothing for other
-            type of object including torch tensors, str, numbers, bool, etc
-            Pointers trigger an error which is catched to get the location for forwarding
-            the call
-            :param args:
-            :param rules:
-            :param return_tuple: force to return a tuple even with a single element
-            :return:
-            """
-            # Dict to return the proper lambda function for the right torch or syft tensor type
-            forward_func = {
-                PointerTensor: lambda p: (_ for _ in ()).throw(RemoteTensorFoundError(p)),
-                hook_self.torch.Tensor: lambda i: i.child if hasattr(i, "child") else i,
-                "my_syft_tensor_type": lambda i: i.child,
-            }
-            # get the transformation lambda for each args
-            lambdas = [
-                (lambda i: i)  # return the same object
-                if not r  # if the rule is a number == 0.
-                else build_args_hook(a, r, True)  # If not, call recursively build_args_hook
-                if isinstance(r, (list, tuple))  # if the rule is a list or tuple.
-                # Last if not, rule is probably == 1 so use type to return the right transformation.
-                else lambda i: forward_func[type(i)](i)
-                for a, r in zip(args, rules)  # And do this for all the args / rules provided
-            ]
-
-            # Instead of iterating which is slow, we use trick to efficiently
-            # apply each lambda to each arg
-            folds = {
-                0: zero_fold,
-                1: one_fold(return_tuple),
-                2: two_fold,
-                3: three_fold,
-                4: four_fold,
-            }
-            f = folds[len(lambdas)]
-            return lambda x: f(lambdas, x)
-
-        def zero_fold(*a):
-            return tuple()
-
-        def one_fold(return_tuple):
-            def _one_fold(lambdas, args):
-                return lambdas[0](args[0])
-
-            def tuple_one_fold(lambdas, args):
-                return (lambdas[0](args[0]),)
-
-            return {False: _one_fold, True: tuple_one_fold}[return_tuple]
-
-        def two_fold(lambdas, args):
-            return lambdas[0](args[0]), lambdas[1](args[1])
-
-        def three_fold(lambdas, args):
-            return lambdas[0](args[0]), lambdas[1](args[1]), lambdas[2](args[2])
-
-        def four_fold(lambdas, args):
-            return (
-                lambdas[0](args[0]),
-                lambdas[1](args[1]),
-                lambdas[2](args[2]),
-                lambdas[3](args[3]),
-            )
 
         return overloaded_attr
 
@@ -453,9 +350,15 @@ class TorchHook:
                 new_args = hook_args(args)
                 # Run the native function with the new args
                 if isinstance(new_args, tuple):
-                    return attr(*new_args)
+                    try:
+                        return attr(*new_args)
+                    except TypeError:
+                        return overloaded_attr(*new_args)
                 else:
-                    return attr(new_args)
+                    try:
+                        return attr(new_args)
+                    except TypeError:
+                        return overloaded_attr(new_args)
             except RemoteTensorFoundError as err:  # if a pointer as been detected
                 # Extract the pointer with the error
                 pointer = err.pointer
@@ -468,77 +371,6 @@ class TorchHook:
                 # Send the command
                 response = owner.send_command(location, message)
                 return response
-
-        def build_rule(args):
-            """
-            Inspect the args object to find torch or syft tensor arguments and
-            return a rule whose structure is the same as the args object,
-            with 1 where there was (torch or syft) tensors and 0 when
-            not (ex: number, str, ...)
-
-            Example:
-                in: ([tensor(1, 2), Pointer@bob], 42)
-                out: ([1, 1], 0)
-            """
-            one = lambda _args: 1
-            # dict to specify the action depending of the type found
-            type_rule = {
-                list: lambda _args: [build_rule(a) for a in _args],
-                tuple: lambda _args: tuple([build_rule(a) for a in _args]),
-                PointerTensor: one,
-                hook_self.torch.Tensor: one,
-            }
-            type_args = type(args)
-            if type_args in type_rule:
-                return type_rule[type_args](args)
-            else:
-                return 0
-
-        def build_args_hook(args, rules):
-            """
-            Build a function given some rules to efficiently replace in the args object
-            syft tensors (but not pointer) with their child, and do nothing for other
-            type of object including torch tensors, str, numbers, bool, etc
-            Pointers trigger an error which is catched to get the location for forwarding
-            the call
-            :param args:
-            :param rules:
-            :return:
-            """
-            # Dict to return the proper lambda function for the right torch or syft tensor type
-            forward_func = {
-                PointerTensor: lambda p: (_ for _ in ()).throw(RemoteTensorFoundError(p)),
-                hook_self.torch.Tensor: lambda i: i.child if hasattr(i, "child") else i,
-                "my_syft_tensor_type": lambda i: i.child,
-            }
-            # get the transformation lambda for each args
-            lambdas = [
-                (lambda i: i)  # return the same object
-                if not r  # if the rule is a number == 0.
-                else build_args_hook(a, r)  # If not, call recursively build_args_hook
-                if isinstance(r, (list, tuple))  # if the rule is a list or tuple.
-                # Last if not, rule is probably == 1 so use type to return the right transformation.
-                else lambda i: forward_func[type(i)](i)
-                for a, r in zip(args, rules)  # And do this for all the args / rules provided
-            ]
-
-            # Instead of iterating which is slow, we use trick to efficiently
-            # apply each lambda to each arg
-            folds = {0: zero_fold, 1: one_fold, 2: two_fold, 3: three_fold}
-            f = folds[len(lambdas)]
-            return lambda x: f(lambdas, x)
-
-        def zero_fold(*a):
-            return tuple()
-
-        def one_fold(lambdas, args):
-            return lambdas[0](args[0])
-
-        def two_fold(lambdas, args):
-            return lambdas[0](args[0]), lambdas[1](args[1])
-
-        def three_fold(lambdas, args):
-            return lambdas[0](args[0]), lambdas[1](args[1]), lambdas[2](args[2])
 
         return overloaded_attr
 

--- a/syft/frameworks/torch/hook_args.py
+++ b/syft/frameworks/torch/hook_args.py
@@ -1,0 +1,102 @@
+import torch
+from syft.exceptions import RemoteTensorFoundError
+from .tensors import PointerTensor
+
+
+def build_hook_args_function(args):
+    # Inspect the call to find tensor arguments and return a rule whose
+    # structure is the same as the args object, with 1 where there was
+    # (torch or syft) tensors and 0 when not (ex: number, str, ...)
+    rule = build_rule(args)
+    # Build a function with this rule to efficiently replace syft tensors
+    # (but not pointer) with their child in the args objects
+    args_hook_function = build_args_hook(args, rule)
+    return args_hook_function
+
+
+def build_rule(args):
+    """
+    Inspect the args object to find torch or syft tensor arguments and
+    return a rule whose structure is the same as the args object,
+    with 1 where there was (torch or syft) tensors and 0 when
+    not (ex: number, str, ...)
+
+    Example:
+        in: ([tensor(1, 2), Pointer@bob], 42)
+        out: ([1, 1], 0)
+    """
+    one = lambda _args: 1
+    # dict to specify the action depending of the type found
+    type_rule = {
+        list: lambda _args: [build_rule(a) for a in _args],
+        tuple: lambda _args: tuple([build_rule(a) for a in _args]),
+        PointerTensor: one,
+        torch.Tensor: one,
+    }
+    type_args = type(args)
+    if type_args in type_rule:
+        return type_rule[type_args](args)
+    else:
+        return 0
+
+
+def build_args_hook(args, rules, return_tuple=False):
+    """
+    Build a function given some rules to efficiently replace in the args object
+    syft tensors (but not pointer) with their child, and do nothing for other
+    type of object including torch tensors, str, numbers, bool, etc
+    Pointers trigger an error which is catched to get the location for forwarding
+    the call
+    :param args:
+    :param rules:
+    :param return_tuple: force to return a tuple even with a single element
+    :return:
+    """
+    # Dict to return the proper lambda function for the right torch or syft tensor type
+    forward_func = {
+        PointerTensor: lambda p: (_ for _ in ()).throw(RemoteTensorFoundError(p)),
+        torch.Tensor: lambda i: i.child if hasattr(i, "child") else i,
+        "my_syft_tensor_type": lambda i: i.child,
+    }
+    # get the transformation lambda for each args
+    lambdas = [
+        (lambda i: i)  # return the same object
+        if not r  # if the rule is a number == 0.
+        else build_args_hook(a, r, True)  # If not, call recursively build_args_hook
+        if isinstance(r, (list, tuple))  # if the rule is a list or tuple.
+        # Last if not, rule is probably == 1 so use type to return the right transformation.
+        else lambda i: forward_func[type(i)](i)
+        for a, r in zip(args, rules)  # And do this for all the args / rules provided
+    ]
+
+    # Instead of iterating which is slow, we use trick to efficiently
+    # apply each lambda to each arg
+    folds = {0: zero_fold, 1: one_fold(return_tuple), 2: two_fold, 3: three_fold, 4: four_fold}
+    f = folds[len(lambdas)]
+    return lambda x: f(lambdas, x)
+
+
+def zero_fold(*a):
+    return tuple()
+
+
+def one_fold(return_tuple):
+    def _one_fold(lambdas, args):
+        return lambdas[0](args[0])
+
+    def tuple_one_fold(lambdas, args):
+        return (lambdas[0](args[0]),)
+
+    return {False: _one_fold, True: tuple_one_fold}[return_tuple]
+
+
+def two_fold(lambdas, args):
+    return lambdas[0](args[0]), lambdas[1](args[1])
+
+
+def three_fold(lambdas, args):
+    return lambdas[0](args[0]), lambdas[1](args[1]), lambdas[2](args[2])
+
+
+def four_fold(lambdas, args):
+    return (lambdas[0](args[0]), lambdas[1](args[1]), lambdas[2](args[2]), lambdas[3](args[3]))

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -37,6 +37,7 @@ class TorchTensor(AbstractTensor):
             A torch.Tensor[PointerTensor] pointer to self. Note that this
             object will likely be wrapped by a torch.Tensor wrapper.
         """
+
         # If you send a pointer p1, you want the pointer to pointer p2 to control
         # the garbage collection and not the remaining old p1 (here self). Because if
         # p2 is not GCed, GCing p1 shouldn't delete the remote tensor, but if you
@@ -46,6 +47,10 @@ class TorchTensor(AbstractTensor):
             self.garbage_collect_data = False
 
         ptr = self.owner.send(self, location)
+
+        # The last pointer should control remote GC, not the previous self.ptr
+        if hasattr(self, "ptr"):
+            self.ptr().garbage_collect_data = False
 
         # we need to cache this weak reference to the pointer so that
         # if this method gets called multiple times we can simply re-use

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -123,13 +123,3 @@ class TorchTensor(AbstractTensor):
             )
 
         return ptr
-
-    def reshape(self, *args, **kwargs):
-        """Reshapes a tensor to have new dimensions.
-
-        This method is the same functionality as the default reshape function
-        which ships with PyTorch. See the PyTorch documentation for the correct
-        args and kwargs.
-        https://pytorch.org/docs/stable/torch.html#torch.reshape
-        """
-        return getattr(self, "native_reshape")(*args, **kwargs)

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -1,4 +1,5 @@
 import random
+import weakref
 
 from syft.frameworks.torch.tensors import AbstractTensor
 from syft.frameworks.torch.tensors import PointerTensor
@@ -36,7 +37,13 @@ class TorchTensor(AbstractTensor):
             A torch.Tensor[PointerTensor] pointer to self. Note that this
             object will likely be wrapped by a torch.Tensor wrapper.
         """
-        return self.owner.send(self, location)
+        ptr = self.owner.send(self, location)
+
+        # we need to cache this weak reference to the pointer so that
+        # if this method gets called multiple times we can simply re-use
+        # the same pointer which was previously created
+        self.ptr = weakref.ref(ptr)
+        return ptr
 
     def create_pointer(
         self,

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -56,7 +56,7 @@ class TorchTensor(AbstractTensor):
         # want to do so, as p2 is not GCed, you can still do `del p2`.
         # This allows to chain multiple .send().send() calls.
         if hasattr(self, "child") and isinstance(self.child, PointerTensor):
-            self.garbage_collect_data = False
+            self.child.garbage_collect_data = False
 
         ptr = self.owner.send(self, location)
 

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -69,9 +69,7 @@ class TorchTensor(AbstractTensor):
         # the same pointer which was previously created
         self.ptr = weakref.ref(ptr)
 
-        self.set_()
-        self.child = ptr
-        return self
+        return ptr.wrap()
 
     def create_pointer(
         self,
@@ -166,12 +164,10 @@ class TorchTensor(AbstractTensor):
     def get(self, deregister_ptr: bool = True):
         """Requests the tensor/chain being pointed to, be serialized and return
         """
+        # Transfer the get() to the child attribute which is a pointer
         tensor = self.child.get()
 
-        if hasattr(tensor, "child"):
-            self.child = tensor.child
-        else:
-            delattr(self, "child")
+        # Clean the wrapper
+        delattr(self, "child")
 
-        self.native_set_(tensor)
-        return self
+        return tensor

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -52,6 +52,7 @@ class TorchTensor(AbstractTensor):
         register: bool = False,
         owner: BaseWorker = None,
         ptr_id: (str or int) = None,
+        garbage_location: bool = True,
     ) -> PointerTensor:
         """Creates a pointer to the "self" torch.Tensor object.
 
@@ -93,6 +94,8 @@ class TorchTensor(AbstractTensor):
             ptr_id: A string or integer parameter to specify the id of the pointer
                 in case you wish to set it manually for any special reason.
                 Otherwise, it will be set randomly.
+            garbage_location: If true (default), delete the remote tensor when the
+                pointer is deleted.
 
         Returns:
             A torch.Tensor[PointerTensor] pointer to self. Note that this
@@ -127,6 +130,7 @@ class TorchTensor(AbstractTensor):
                 register=register,
                 owner=owner,
                 id=ptr_id,
+                garbage_location=garbage_location,
             )
 
         return ptr

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -19,26 +19,6 @@ class TorchTensor(AbstractTensor):
     checking AbstractTensor.
     """
 
-    def get(self):
-        """Gets remote data from remote places to the client.
-
-        Many tensor types point to data which exists at another location,
-        including PointerTensor and various Secure Multi-Party Computation
-        tensors. All of these tensor types have a .get() method which requests
-        that the data on the remote machine be set back to the client
-        (to the machine upon which .get() is called).
-
-        Returns:
-            An AbstractTensor, typically this method will return a single
-            tensor, although that tensor might be a combination of several
-            remote tensors which exist on several different machines. If the
-            method you're trying to call/implement needs to return multiple
-            tensors or has some very special way in which those tensors should
-            be combined, consider creating a special method specifically for
-            that functionality.
-        """
-        return self.child.get()
-
     def send(self, location):
         """Gets the pointer to a new remote object.
 
@@ -103,7 +83,7 @@ class TorchTensor(AbstractTensor):
             owner: A BaseWorker parameter to specify the worker on which the
                 pointer is located. It is also where the pointer is registered
                 if register is set to True.
-            id: A string or integer parameter to specify the id of the pointer
+            ptr_id: A string or integer parameter to specify the id of the pointer
                 in case you wish to set it manually for any special reason.
                 Otherwise, it will be set randomly.
 
@@ -142,7 +122,7 @@ class TorchTensor(AbstractTensor):
                 id=ptr_id,
             )
 
-        return ptr.wrap()
+        return ptr
 
     def reshape(self, *args, **kwargs):
         """Reshapes a tensor to have new dimensions.

--- a/syft/frameworks/torch/tensors/native.py
+++ b/syft/frameworks/torch/tensors/native.py
@@ -52,7 +52,7 @@ class TorchTensor(AbstractTensor):
         register: bool = False,
         owner: BaseWorker = None,
         ptr_id: (str or int) = None,
-        garbage_location: bool = True,
+        garbage_collect_data: bool = True,
     ) -> PointerTensor:
         """Creates a pointer to the "self" torch.Tensor object.
 
@@ -94,7 +94,7 @@ class TorchTensor(AbstractTensor):
             ptr_id: A string or integer parameter to specify the id of the pointer
                 in case you wish to set it manually for any special reason.
                 Otherwise, it will be set randomly.
-            garbage_location: If true (default), delete the remote tensor when the
+            garbage_collect_data: If true (default), delete the remote tensor when the
                 pointer is deleted.
 
         Returns:
@@ -130,7 +130,7 @@ class TorchTensor(AbstractTensor):
                 register=register,
                 owner=owner,
                 id=ptr_id,
-                garbage_location=garbage_location,
+                garbage_collect_data=garbage_collect_data,
             )
 
         return ptr

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -175,17 +175,17 @@ class PointerTensor(AbstractTensor):
     def set_(self):
         return self
 
-    def __del__(self):
-        """This method garbage collects the object this pointer is pointing to.
-        By default, PySyft assumes that every object only has one pointer to it.
-        Thus, if the pointer gets garbage collected, we want to automatically
-        garbage collect the object being pointed to.
-        """
-
-        # if .get() gets called on the pointer before this method is called, then
-        # the remote object has already been removed. This results in an error on
-        # this next line because self no longer has .owner. Thus, we need to check
-        # first here and not try to call self.owner.anything if self doesn't have
-        # .owner anymore.
-        if hasattr(self, "owner") and self.garbage_collect_data:
-            self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)
+    # def __del__(self):
+    #     """This method garbage collects the object this pointer is pointing to.
+    #     By default, PySyft assumes that every object only has one pointer to it.
+    #     Thus, if the pointer gets garbage collected, we want to automatically
+    #     garbage collect the object being pointed to.
+    #     """
+    #
+    #     # if .get() gets called on the pointer before this method is called, then
+    #     # the remote object has already been removed. This results in an error on
+    #     # this next line because self no longer has .owner. Thus, we need to check
+    #     # first here and not try to call self.owner.anything if self doesn't have
+    #     # .owner anymore.
+    #     if hasattr(self, "owner") and self.garbage_collect_data:
+    #         self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -40,7 +40,7 @@ class PointerTensor(AbstractTensor):
         register=False,
         owner=None,
         id=None,
-        garbage_location=True,
+        garbage_collect_data=True,
     ):
         """Initializes a PointerTensor.
 
@@ -63,7 +63,7 @@ class PointerTensor(AbstractTensor):
                 different from the location parameter that specifies where the
                 pointer points to.
             id: An optional string or integer id of the PointerTensor.
-            garbage_location: If true (default), delete the remote tensor when the
+            garbage_collect_data: If true (default), delete the remote tensor when the
                 pointer is deleted.
         """
 
@@ -71,7 +71,7 @@ class PointerTensor(AbstractTensor):
         self.id_at_location = id_at_location
         self.owner = owner
         self.id = id
-        self.garbage_location = garbage_location
+        self.garbage_collect_data = garbage_collect_data
 
     def __str__(self):
         """Returns a string version of this pointer.
@@ -184,5 +184,5 @@ class PointerTensor(AbstractTensor):
         # this next line because self no longer has .owner. Thus, we need to check
         # first here and not try to call self.owner.anything if self doesn't have
         # .owner anymore.
-        if hasattr(self, "owner") and self.garbage_location:
+        if hasattr(self, "owner") and self.garbage_collect_data:
             self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -175,17 +175,17 @@ class PointerTensor(AbstractTensor):
     def set_(self):
         return self
 
-    # def __del__(self):
-    #     """This method garbage collects the object this pointer is pointing to.
-    #     By default, PySyft assumes that every object only has one pointer to it.
-    #     Thus, if the pointer gets garbage collected, we want to automatically
-    #     garbage collect the object being pointed to.
-    #     """
-    #
-    #     # if .get() gets called on the pointer before this method is called, then
-    #     # the remote object has already been removed. This results in an error on
-    #     # this next line because self no longer has .owner. Thus, we need to check
-    #     # first here and not try to call self.owner.anything if self doesn't have
-    #     # .owner anymore.
-    #     if hasattr(self, "owner") and self.garbage_collect_data:
-    #         self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)
+    def __del__(self):
+        """This method garbage collects the object this pointer is pointing to.
+        By default, PySyft assumes that every object only has one pointer to it.
+        Thus, if the pointer gets garbage collected, we want to automatically
+        garbage collect the object being pointed to.
+        """
+
+        # if .get() gets called on the pointer before this method is called, then
+        # the remote object has already been removed. This results in an error on
+        # this next line because self no longer has .owner. Thus, we need to check
+        # first here and not try to call self.owner.anything if self doesn't have
+        # .owner anymore.
+        if hasattr(self, "owner") and self.garbage_collect_data:
+            self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -103,27 +103,27 @@ class PointerTensor(AbstractTensor):
         Since PointerTensor objects always point to a remote tensor (or chain
         of tensors, where a chain is simply a linked-list of tensors linked via
         their .child attributes), this method will request that the tensor/chain
-        being pointed to be serialized and returned from this function. 
+        being pointed to be serialized and returned from this function.
 
         Note:
-            This will typically mean that the remote object will be 
-            removed/destroyed. To just bring a copy back to the local worker, 
-            call .copy() before calling .get(). 
+            This will typically mean that the remote object will be
+            removed/destroyed. To just bring a copy back to the local worker,
+            call .copy() before calling .get().
 
 
         Args:
 
-            deregister_ptr (bool, optional): this determines whether to 
-                deregister this pointer from the pointer's owner during this 
-                method. This defaults to True because the main reason people use 
-                this method is to move the tensor from the remote machine to the 
+            deregister_ptr (bool, optional): this determines whether to
+                deregister this pointer from the pointer's owner during this
+                method. This defaults to True because the main reason people use
+                this method is to move the tensor from the remote machine to the
                 local one, at which time the pointer has no use.
 
-            out (class:`.abstract.AbstractTensor`): this is the tensor (or 
+            out (class:`.abstract.AbstractTensor`): this is the tensor (or
                 chain) which this object used to point to on a remote machine.
-        
+
         Returns:
-            tensor: 
+            tensor:
 
         #TODO: add param get_copy which doesn't destroy remote if true.
 

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -172,6 +172,9 @@ class PointerTensor(AbstractTensor):
 
         return tensor
 
+    def set_(self):
+        return self
+
     def __del__(self):
         """This method garbage collects the object this pointer is pointing to.
         By default, PySyft assumes that every object only has one pointer to it.

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -172,9 +172,6 @@ class PointerTensor(AbstractTensor):
 
         return tensor
 
-    def set_(self):
-        return self
-
     def __del__(self):
         """This method garbage collects the object this pointer is pointing to.
         By default, PySyft assumes that every object only has one pointer to it.

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -40,6 +40,7 @@ class PointerTensor(AbstractTensor):
         register=False,
         owner=None,
         id=None,
+        garbage_location=True,
     ):
         """Initializes a PointerTensor.
 
@@ -62,12 +63,15 @@ class PointerTensor(AbstractTensor):
                 different from the location parameter that specifies where the
                 pointer points to.
             id: An optional string or integer id of the PointerTensor.
+            garbage_location: If true (default), delete the remote tensor when the
+                pointer is deleted.
         """
 
         self.location = location
         self.id_at_location = id_at_location
         self.owner = owner
         self.id = id
+        self.garbage_location = garbage_location
 
     def __str__(self):
         """Returns a string version of this pointer.
@@ -180,5 +184,5 @@ class PointerTensor(AbstractTensor):
         # this next line because self no longer has .owner. Thus, we need to check
         # first here and not try to call self.owner.anything if self doesn't have
         # .owner anymore.
-        if hasattr(self, "owner"):
+        if hasattr(self, "owner") and self.garbage_location:
             self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -58,6 +58,7 @@ class TorchAttributes(object):
             "storage_offset",
             "size",
             "stride",
+            "set_",
         ]
 
         # SECTION: List all torch tensor methods we want to overload

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -48,7 +48,17 @@ class TorchAttributes(object):
         }
 
         # Add special functions to exclude from the hook
-        self.exclude = ["save", "load", "typename", "is_tensor", "manual_seed"]
+        self.exclude = [
+            "save",
+            "load",
+            "typename",
+            "is_tensor",
+            "manual_seed",
+            "storage",
+            "storage_offset",
+            "size",
+            "stride",
+        ]
 
         # SECTION: List all torch tensor methods we want to overload
         self.tensor_types = [torch.Tensor]

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -31,10 +31,7 @@ class TorchAttributes(object):
         self.hook = hook
 
         # List modules that we will hook
-        self.torch_modules = {
-            "torch": torch,
-            "torch.nn.functional": torch.nn.functional,
-        }  # "torch.nn": torch.nn
+        self.torch_modules = {"torch": torch, "torch.nn.functional": torch.nn.functional}
 
         # List all the function names with module as prefix in the modules to hook
         self.torch_modules_functions = {

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -31,7 +31,10 @@ class TorchAttributes(object):
         self.hook = hook
 
         # List modules that we will hook
-        self.torch_modules = {"torch": torch, "torch.nn.functional": torch.nn.functional}
+        self.torch_modules = {
+            "torch": torch,
+            "torch.nn.functional": torch.nn.functional,
+        }  # "torch.nn": torch.nn
 
         # List all the function names with module as prefix in the modules to hook
         self.torch_modules_functions = {

--- a/syft/objects.py
+++ b/syft/objects.py
@@ -1,6 +1,0 @@
-import enum
-
-
-class ObjType(enum.Enum):
-
-    Tensor = 0

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -525,7 +525,8 @@ def _detail_ndarray(
 
     Args:
         worker: the worker doing the deserialization
-        arr_representation (tuple): a tuple holding the byte representation, shape and dtype of the array
+        arr_representation (tuple): a tuple holding the byte representation, shape
+        and dtype of the array
 
     Returns:
         numpy.ndarray: a numpy array

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -628,13 +628,22 @@ def _detail_pointer_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> Point
         ptr = _detail_pointer_tensor(data)
     """
     # TODO: fix comment for this and simplifier
+    obj_id = tensor_tuple[0]
+    id_at_location = tensor_tuple[1]
+    worker_id = tensor_tuple[2].decode("utf-8")
 
-    return PointerTensor(
-        location=syft.torch.hook.local_worker.get_worker(tensor_tuple[2]),
-        id_at_location=tensor_tuple[1],
-        owner=worker,
-        id=tensor_tuple[0],
-    )
+    print(worker.id, "detailing pointer", worker_id, "at", id_at_location)
+
+    # If the pointer received is pointing at the current worker, we load the tensor instead
+    if worker_id == worker.id:
+        tensor = worker.get_obj(id_at_location)
+        return tensor
+    # Else we keep the same Pointer
+    else:
+        location = syft.torch.hook.local_worker.get_worker(worker_id)
+        return PointerTensor(
+            location=location, id_at_location=id_at_location, owner=worker, id=obj_id
+        )
 
     # a more general but slower/more verbose option
 

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -224,7 +224,7 @@ def _simplify_torch_tensor(tensor: torch.Tensor) -> bin:
     tensor_bin = binary_stream.getvalue()
 
     chain = None
-    if tensor.is_wrapper:
+    if hasattr(tensor, "child"):
         chain = _simplify(tensor.child)
     return (tensor.id, tensor_bin, chain)
 

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -632,8 +632,6 @@ def _detail_pointer_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> Point
     id_at_location = tensor_tuple[1]
     worker_id = tensor_tuple[2].decode("utf-8")
 
-    print(worker.id, "detailing pointer", worker_id, "at", id_at_location)
-
     # If the pointer received is pointing at the current worker, we load the tensor instead
     if worker_id == worker.id:
         tensor = worker.get_obj(id_at_location)

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -296,9 +296,8 @@ class BaseWorker(AbstractWorker):
         # An object called with get_obj will be "with high probability" serialized
         # and sent back, so it will be GCed but remote data is any shouldn't be
         # deleted
-        if obj.is_wrapper:
-            if isinstance(obj.child, PointerTensor):
-                obj.child.garbage_collect_data = False
+        if hasattr(obj, "child") and isinstance(obj.child, PointerTensor):
+            obj.child.garbage_collect_data = False
 
         return obj
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -6,10 +6,7 @@ from syft.exceptions import WorkerNotFoundException
 from syft import serde
 from syft.workers import AbstractWorker
 
-MSGTYPE_CMD = 1
-MSGTYPE_OBJ = 2
-MSGTYPE_OBJ_REQ = 3
-MSGTYPE_EXCEPTION = 4
+from syft.codes import MSGTYPE
 
 
 class BaseWorker(AbstractWorker):
@@ -61,9 +58,9 @@ class BaseWorker(AbstractWorker):
         self.add_worker(self)
         # For performance, we cache each
         self._message_router = {
-            MSGTYPE_CMD: self.execute_command,
-            MSGTYPE_OBJ: self.set_obj,
-            MSGTYPE_OBJ_REQ: self.respond_to_obj_req,
+            MSGTYPE.OBJ: self.set_obj,
+            MSGTYPE.OBJ_REQ: self.respond_to_obj_req,
+            MSGTYPE.OBJ_DEL: self.rm_obj,
         }
 
     # SECTION: Methods which MUST be overridden by subclasses
@@ -255,7 +252,7 @@ class BaseWorker(AbstractWorker):
         :return:
         """
 
-        response = self.send_msg(MSGTYPE_CMD, message, location=recipient)
+        response = self.send_msg(MSGTYPE.CMD, message, location=recipient)
 
         return response
 
@@ -265,7 +262,6 @@ class BaseWorker(AbstractWorker):
         Args:
             obj: A torch or syft tensor with an id
         """
-
         self._objects[obj.id] = obj
 
     def get_obj(self, obj_id):
@@ -349,7 +345,7 @@ class BaseWorker(AbstractWorker):
             location: A BaseWorker instance indicating the worker which should
                 receive the object.
         """
-        return self.send_msg(MSGTYPE_OBJ, obj, location)
+        return self.send_msg(MSGTYPE.OBJ, obj, location)
 
     def request_obj(self, obj_id, location):
         """Returns the requested object from specified location.
@@ -362,7 +358,7 @@ class BaseWorker(AbstractWorker):
         Returns:
             A torch Tensor or Variable object.
         """
-        obj = self.send_msg(MSGTYPE_OBJ_REQ, obj_id, location)
+        obj = self.send_msg(MSGTYPE.OBJ_REQ, obj_id, location)
         return obj
 
     # SECTION: Manage the workers network

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -234,8 +234,6 @@ class BaseWorker(AbstractWorker):
         command, _self, args, kwargs = message
         command = command.decode("utf-8")
         if _self is not None:
-            print(_self)
-            print(command)
             tensor = getattr(_self, command)(*args, **kwargs)
             # FIXME: should be added automatically
             tensor.owner = self

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -134,7 +134,7 @@ class BaseWorker(AbstractWorker):
         bin_response = self._send_msg(bin_message, location)
 
         # Step 3: deserialize the response
-        response = serde.deserialize(bin_response)
+        response = serde.deserialize(bin_response, worker=self)
 
         return response
 
@@ -153,7 +153,7 @@ class BaseWorker(AbstractWorker):
             A binary message response.
         """
         # Step 0: deserialize message
-        (msg_type, contents) = serde.deserialize(bin_message)
+        (msg_type, contents) = serde.deserialize(bin_message, worker=self)
 
         # Step 1: route message to appropriate function
         response = self._message_router[msg_type](contents)

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -4,6 +4,7 @@ import random
 from abc import abstractmethod
 import syft as sy
 from syft import serde
+from syft.frameworks.torch.tensors import PointerTensor
 from syft.exceptions import WorkerNotFoundException
 from syft.workers import AbstractWorker
 from syft.codes import MSGTYPE
@@ -291,6 +292,13 @@ class BaseWorker(AbstractWorker):
             obj_id: A string or integer id of an object to look up.
         """
         obj = self._objects[obj_id]
+
+        # An object called with get_obj will be "with high probability" serialized
+        # and sent back, so it will be GCed but remote data is any shouldn't be
+        # deleted
+        if obj.is_wrapper:
+            if isinstance(obj.child, PointerTensor):
+                obj.child.garbage_collect_data = False
 
         return obj
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -290,7 +290,6 @@ class BaseWorker(AbstractWorker):
         Args:
             obj_id: A string or integer id of an object to look up.
         """
-
         obj = self._objects[obj_id]
 
         return obj

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -454,7 +454,7 @@ class BaseWorker(AbstractWorker):
             5
             [syft.core.frameworks.torch.tensor.FloatTensor of size 5]
             >>> x.send(bob)
-            FloatTensor[_PointerTensor - id:9121428371 owner:0 loc:bob 
+            FloatTensor[_PointerTensor - id:9121428371 owner:0 loc:bob
                         id@loc:47416674672]
             >>> x.get()
             1

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -2,9 +2,9 @@ import logging
 import random
 
 from abc import abstractmethod
-import syft
-from syft.exceptions import WorkerNotFoundException
+import syft as sy
 from syft import serde
+from syft.exceptions import WorkerNotFoundException
 from syft.workers import AbstractWorker
 from syft.codes import MSGTYPE
 
@@ -241,8 +241,8 @@ class BaseWorker(AbstractWorker):
             tensor = getattr(_self, command)(*args, **kwargs)
         # Handle functions
         else:
-            syft.torch.command_guard(command, "torch_modules")
-            command = syft.torch.eval_torch_modules_functions[command]
+            sy.torch.command_guard(command, "torch_modules")
+            command = sy.torch.eval_torch_modules_functions[command]
             tensor = command(*args, **kwargs)
 
         # FIXME: should be added automatically
@@ -259,7 +259,7 @@ class BaseWorker(AbstractWorker):
             register=True,
             owner=self,
             ptr_id=tensor.id,
-            garbage_location=False,
+            garbage_collect_data=False,
         )
         return pointer
 
@@ -504,8 +504,8 @@ class BaseWorker(AbstractWorker):
 
         Example:
             A VirtualWorker instance with id 'bob' would return a string value of.
-            >>> import syft
-            >>> bob = syft.VirtualWorker(id="bob")
+            >>> import syft as sy
+            >>> bob = sy.VirtualWorker(id="bob")
             >>> bob
             <syft.workers.virtual.VirtualWorker id:bob>
 

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -13,14 +13,12 @@ from syft.serde import ZSTD
 
 
 import syft
-from syft import TorchHook
 from syft.exceptions import CompressionNotFoundException
 from syft.frameworks.torch.tensors import PointerTensor
 
 import msgpack
 import numpy
 import pytest
-import torch
 from torch import Tensor
 
 
@@ -284,7 +282,7 @@ def test_compressed_serde(compress_scheme):
 def test_invalid_compression_scheme(compress_scheme):
     arr = numpy.random.random((100, 100))
     try:
-        arr_serialized = serialize(arr, compress=True, compress_scheme=compress_scheme)
+        _ = serialize(arr, compress=True, compress_scheme=compress_scheme)
         assert False
     except CompressionNotFoundException:
         assert True
@@ -296,9 +294,7 @@ def test_invalid_decompression_scheme(compress_scheme):
     arr = numpy.ones((100, 100))
     arr_serialized = serialize(arr, compress=True, compress_scheme=LZ4)
     try:
-        arr_serialized_deserialized = deserialize(
-            arr_serialized, compressed=True, compress_scheme=compress_scheme
-        )
+        _ = deserialize(arr_serialized, compressed=True, compress_scheme=compress_scheme)
         assert False
     except CompressionNotFoundException:
         assert True

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -1,7 +1,6 @@
-from syft.frameworks.torch.hook import TorchHook
-from syft.workers.virtual import VirtualWorker
-from unittest import TestCase
 import torch
+
+from syft.frameworks.torch.tensors import PointerTensor
 
 
 def test_overload_reshape():
@@ -43,11 +42,14 @@ def test_create_pointer_defaults(workers):
     assert ptr.location == workers["bob"]
 
 
-# def test_get():
-#     tensor = torch.rand(5, 3)
-#     tensor.id = 1
+def test_get(workers):
+    bob = workers["bob"]
+    me = workers["me"]
+    tensor = torch.rand(5, 3)
+    tensor.owner = me
+    tensor.id = 1
 
-#     pointer = tensor.send(workers['bob'])
+    pointer = tensor.send(bob)
 
-#     assert type(pointer) == PointerTensor
-#     assert pointer.get() == tensor
+    assert type(pointer) == PointerTensor
+    assert (pointer.get() == tensor).all()

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -51,5 +51,5 @@ def test_get(workers):
 
     pointer = tensor.send(bob)
 
-    assert type(pointer) == PointerTensor
+    assert type(pointer.child) == PointerTensor
     assert (pointer.get() == tensor).all()

--- a/test/torch/tensors/test_tensor.py
+++ b/test/torch/tensors/test_tensor.py
@@ -199,29 +199,29 @@ class TestPointer(object):
         # ensure bob's object was garbage collected
         assert x_id not in self.bob._objects
 
-    # def test_repeated_send(self):
-    #     """Tests that repeated calls to .send(bob) works gracefully
-    #     Previously garbage collection deleted the remote object
-    #     when .send() was called twice. This test ensures the fix still
-    #     works."""
-    #
-    #     self.setUp()
-    #
-    #     # create tensor
-    #     x = torch.Tensor([1, 2])
-    #     print(x.id)
-    #
-    #     # send tensor to bob
-    #     x_ptr = x.send(self.bob)
-    #     print(self.bob._objects)
-    #     print(x_ptr.id_at_location)
-    #
-    #     # send tensor again
-    #     x_ptr = x.send(self.bob)
-    #     print(self.bob._objects)
-    #     print(x_ptr.id_at_location)
-    #
-    #     # ensure bob has tensor
-    #     print(self.bob._objects)
-    #     print(list(self.bob._objects.keys()))
-    #     assert x.id in self.bob._objects
+    def test_repeated_send(self):
+        """Tests that repeated calls to .send(bob) works gracefully
+        Previously garbage collection deleted the remote object
+        when .send() was called twice. This test ensures the fix still
+        works."""
+
+        self.setUp()
+
+        # create tensor
+        x = torch.Tensor([1, 2])
+        print(x.id)
+
+        # send tensor to bob
+        x_ptr = x.send(self.bob)
+        print(self.bob._objects)
+        print(x_ptr.id_at_location)
+
+        # send tensor again
+        x_ptr = x.send(self.bob)
+        print(self.bob._objects)
+        print(x_ptr.id_at_location)
+
+        # ensure bob has tensor
+        print(self.bob._objects)
+        print(list(self.bob._objects.keys()))
+        assert x.id in self.bob._objects

--- a/test/torch/tensors/test_tensor.py
+++ b/test/torch/tensors/test_tensor.py
@@ -213,15 +213,9 @@ class TestPointer(object):
 
         # send tensor to bob
         x_ptr = x.send(self.bob)
-        print(self.bob._objects)
-        print(x_ptr.id_at_location)
 
         # send tensor again
         x_ptr = x.send(self.bob)
-        print(self.bob._objects)
-        print(x_ptr.id_at_location)
 
         # ensure bob has tensor
-        print(self.bob._objects)
-        print(list(self.bob._objects.keys()))
         assert x.id in self.bob._objects

--- a/test/torch/tensors/test_tensor.py
+++ b/test/torch/tensors/test_tensor.py
@@ -4,19 +4,113 @@ import syft
 from syft.frameworks.torch.tensors import PointerTensor
 
 
-def test_init():
-    hook = syft.TorchHook(torch, verbose=True)
-    tensor_extension = torch.Tensor()
-    assert tensor_extension.id is not None
-    assert tensor_extension.owner is not None
+class TestNative(object):
+    def test_init(self):
+        hook = syft.TorchHook(torch, verbose=True)
+        tensor_extension = torch.Tensor()
+        assert tensor_extension.id is not None
+        assert tensor_extension.owner is not None
 
 
-def test_init(workers):
-    pointer = PointerTensor(id=1000, location=workers["alice"], owner=workers["me"])
-    pointer.__str__()
+class TestPointer(object):
+    def setUp(self):
+        hook = syft.TorchHook(torch, verbose=True)
 
+        self.me = hook.local_worker
+        self.me.is_client_worker = True
 
-def test_create_pointer(workers):
-    x = torch.Tensor([1, 2])
-    x.create_pointer()
-    x.create_pointer(location=workers["james"])
+        bob = syft.VirtualWorker(id="bob", hook=hook, is_client_worker=False)
+        alice = syft.VirtualWorker(id="alice", hook=hook, is_client_worker=False)
+        james = syft.VirtualWorker(id="james", hook=hook, is_client_worker=False)
+
+        bob.add_workers([alice, james])
+        alice.add_workers([bob, james])
+        james.add_workers([bob, alice])
+
+        self.hook = hook
+
+        self.bob = bob
+        self.alice = alice
+        self.james = james
+
+    def test_init(self):
+        self.setUp()
+        pointer = PointerTensor(id=1000, location=self.alice, owner=self.me)
+        pointer.__str__()
+
+    def test_create_pointer(self):
+        self.setUp()
+        x = torch.Tensor([1, 2])
+        x.create_pointer()
+        x.create_pointer(location=self.james)
+
+    def test_explicit_garbage_collect_pointer(self):
+        """Tests whether deleting a PointerTensor garbage collects the remote object too"""
+
+        self.setUp()
+
+        # create tensor
+        x = torch.Tensor([1, 2])
+
+        # send tensor to bob
+        x_ptr = x.send(self.bob)
+
+        # ensure bob has tensor
+        assert x.id in self.bob._objects
+
+        # delete pointer to tensor, which should
+        # automatically garbage collect the remote
+        # object on Bob's machine
+        del x_ptr
+
+        # ensure bob's object was garbage collected
+        assert x.id not in self.bob._objects
+
+    def test_implicit_garbage_collection_pointer(self):
+        """Tests whether GCing a PointerTEnsor GCs the remote object too."""
+
+        self.setUp()
+
+        # create tensor
+        x = torch.Tensor([1, 2])
+
+        # send tensor to bob
+        x_ptr = x.send(self.bob)
+
+        # ensure bob has tensor
+        assert x.id in self.bob._objects
+
+        # delete pointer to tensor, which should
+        # automatically garbage collect the remote
+        # object on Bob's machine
+        x_ptr = "asdf"
+
+        # ensure bob's object was garbage collected
+        assert x.id not in self.bob._objects
+
+    # def test_repeated_send(self):
+    #     """Tests that repeated calls to .send(bob) works gracefully
+    #     Previously garbage collection deleted the remote object
+    #     when .send() was called twice. This test ensures the fix still
+    #     works."""
+    #
+    #     self.setUp()
+    #
+    #     # create tensor
+    #     x = torch.Tensor([1, 2])
+    #     print(x.id)
+    #
+    #     # send tensor to bob
+    #     x_ptr = x.send(self.bob)
+    #     print(self.bob._objects)
+    #     print(x_ptr.id_at_location)
+    #
+    #     # send tensor again
+    #     x_ptr = x.send(self.bob)
+    #     print(self.bob._objects)
+    #     print(x_ptr.id_at_location)
+    #
+    #     # ensure bob has tensor
+    #     print(self.bob._objects)
+    #     print(list(self.bob._objects.keys()))
+    #     assert x.id in self.bob._objects

--- a/test/torch/tensors/test_tensor.py
+++ b/test/torch/tensors/test_tensor.py
@@ -50,38 +50,40 @@ class TestPointer(object):
     def test_send_get(self):
         """Test several send get usages"""
         self.setUp()
+        bob = self.bob
+        alice = self.alice
 
         # simple send
         x = torch.Tensor([1, 2])
-        x_ptr = x.send(self.bob)
+        x_ptr = x.send(bob)
         x_back = x_ptr.get()
         assert (x == x_back).all()
 
         # send with variable overwriting
         x = torch.Tensor([1, 2])
-        x = x.send(self.bob)
+        x = x.send(bob)
         x_back = x.get()
         assert (torch.Tensor([1, 2]) == x_back).all()
 
         # double send
         x = torch.Tensor([1, 2])
-        x_ptr = x.send(self.bob)
-        x_ptr_ptr = x_ptr.send(self.alice)
+        x_ptr = x.send(bob)
+        x_ptr_ptr = x_ptr.send(alice)
         x_ptr_back = x_ptr_ptr.get()
         x_back_back = x_ptr_back.get()
         assert (x == x_back_back).all()
 
         # double send with variable overwriting
         x = torch.Tensor([1, 2])
-        x = x.send(self.bob)
-        x = x.send(self.alice)
+        x = x.send(bob)
+        x = x.send(alice)
         x = x.get()
         x_back = x.get()
         assert (torch.Tensor([1, 2]) == x_back).all()
 
         # chained double send
         x = torch.Tensor([1, 2])
-        x = x.send(self.bob).send(self.alice)
+        x = x.send(bob).send(alice)
         x_back = x.get().get()
         assert (torch.Tensor([1, 2]) == x_back).all()
 

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 import random
 
 import syft
-from syft.exceptions import PointerFoundError
+from syft.exceptions import RemoteTensorFoundError
 from syft.frameworks.torch.tensors import PointerTensor
 
 
@@ -59,8 +59,8 @@ class TestHook(object):
         ptr_id = int(10e10 * random.random())
         pointer = PointerTensor(id=ptr_id, location=self.alice, owner=self.me)
         try:
-            raise PointerFoundError(pointer)
-        except PointerFoundError as err:
+            raise RemoteTensorFoundError(pointer)
+        except RemoteTensorFoundError as err:
             err_pointer = err.pointer
             assert isinstance(err_pointer, PointerTensor)
             assert err_pointer.id == ptr_id
@@ -79,7 +79,7 @@ class TestHook(object):
     @pytest.mark.parametrize("attr", ["relu", "celu", "elu"])
     def test_hook_module_functional(self, attr):
         self.setUp()
-        attr = eval(f"F.{attr}")
+        attr = getattr(F, attr)
         x = torch.Tensor([1, -1, 3, 4])
         expected = attr(x)
         x_ptr = x.send(self.bob)

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -1,36 +1,93 @@
 import pytest
 import torch
+import torch.nn.functional as F
+import random
+
 import syft
-
-from syft.frameworks.torch import TorchHook
-from syft.workers import VirtualWorker
-
-
-def test___init__(hook):
-    assert torch.torch_hooked
-    assert hook.torch.__version__ == torch.__version__
+from syft.exceptions import PointerFoundError
+from syft.frameworks.torch.tensors import PointerTensor
 
 
-def test_torch_attributes():
-    with pytest.raises(RuntimeError):
-        syft.torch._command_guard("false_command", "torch_modules")
+class TestHook(object):
+    def setUp(self):
+        hook = syft.TorchHook(torch, verbose=True)
 
-    assert syft.torch._is_command_valid_guard("torch.add", "torch_modules")
-    assert not syft.torch._is_command_valid_guard("false_command", "torch_modules")
+        self.me = hook.local_worker
+        self.me.is_client_worker = True
 
-    syft.torch._command_guard("torch.add", "torch_modules", get_native=False)
+        instance_id = str(int(10e10 * random.random()))
+        bob = syft.VirtualWorker(id=f"bob{instance_id}", hook=hook, is_client_worker=False)
+        alice = syft.VirtualWorker(id=f"alice{instance_id}", hook=hook, is_client_worker=False)
+        james = syft.VirtualWorker(id=f"james{instance_id}", hook=hook, is_client_worker=False)
 
+        bob.add_workers([alice, james])
+        alice.add_workers([bob, james])
+        james.add_workers([bob, alice])
 
-def test_worker_registration():
-    hook = syft.TorchHook(torch, verbose=True)
+        self.hook = hook
 
-    me = hook.local_worker
-    me.is_client_worker = False
+        self.bob = bob
+        self.alice = alice
+        self.james = james
 
-    bob = syft.VirtualWorker(id="bob", hook=hook, is_client_worker=False)
+    def test___init__(self):
+        self.setUp()
+        assert torch.torch_hooked
+        assert self.hook.torch.__version__ == torch.__version__
 
-    me.add_workers([bob])
+    def test_torch_attributes(self):
+        with pytest.raises(RuntimeError):
+            syft.torch._command_guard("false_command", "torch_modules")
 
-    worker = me.get_worker(bob)
+        assert syft.torch._is_command_valid_guard("torch.add", "torch_modules")
+        assert not syft.torch._is_command_valid_guard("false_command", "torch_modules")
 
-    assert bob == worker
+        syft.torch._command_guard("torch.add", "torch_modules", get_native=False)
+
+    def test_worker_registration(self):
+        self.setUp()
+        boris = syft.VirtualWorker(id="boris", hook=self.hook, is_client_worker=False)
+
+        self.me.add_workers([boris])
+
+        worker = self.me.get_worker(boris)
+
+        assert boris == worker
+
+    def test_pointer_found_exception(self):
+        self.setUp()
+        ptr_id = int(10e10 * random.random())
+        pointer = PointerTensor(id=ptr_id, location=self.alice, owner=self.me)
+        try:
+            raise PointerFoundError(pointer)
+        except PointerFoundError as err:
+            err_pointer = err.pointer
+            assert isinstance(err_pointer, PointerTensor)
+            assert err_pointer.id == ptr_id
+
+    @pytest.mark.parametrize("attr", ["add", "mul"])
+    def test_get_pointer_method(self, attr):
+        self.setUp()
+        new_attr = self.hook.get_pointer_method(attr)
+        x = torch.Tensor([1, 2, 3])
+        expected = getattr(x, attr)(x)
+        x_ptr = x.send(self.bob)
+        res_ptr = new_attr(x_ptr, x_ptr)
+        res = res_ptr.get()
+        assert (res == expected).all()
+
+    @pytest.mark.parametrize("attr", ["relu", "celu", "elu"])
+    def test_hook_module_functional(self, attr):
+        self.setUp()
+        attr = eval(f"F.{attr}")
+        x = torch.Tensor([1, -1, 3, 4])
+        expected = attr(x)
+        x_ptr = x.send(self.bob)
+        res_ptr = attr(x_ptr)
+        res = res_ptr.get()
+        assert (res == expected).all()
+
+    def test_properties(self):
+        self.setUp()
+        x = torch.Tensor([1, -1, 3, 4])
+        assert x.is_wrapper is False

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -65,28 +65,63 @@ class TestHook(object):
             assert isinstance(err_pointer, PointerTensor)
             assert err_pointer.id == ptr_id
 
-    @pytest.mark.parametrize("attr", ["add", "mul"])
-    def test_get_pointer_method(self, attr):
+    @pytest.mark.parametrize("attr", ["abs"])
+    def test_get_pointer_unary_method(self, attr):
         self.setUp()
         x = torch.Tensor([1, 2, 3])
-        method = getattr(x, attr)
         native_method = getattr(x, f"native_{attr}")
-        expected = native_method(x)
+        expected = native_method()
         x_ptr = x.send(self.bob)
-        res_ptr = method(x_ptr)
+        method = getattr(x_ptr, attr)
+        res_ptr = method()
         res = res_ptr.get()
         assert (res == expected).all()
 
     @pytest.mark.parametrize("attr", ["add", "mul"])
-    def test_get_pointer_to_pointer_method(self, attr):
+    def test_get_pointer_binary_method(self, attr):
         self.setUp()
         x = torch.Tensor([1, 2, 3])
-        method = getattr(x, attr)
+        native_method = getattr(x, f"native_{attr}")
+        expected = native_method(x)
+        x_ptr = x.send(self.bob)
+        method = getattr(x_ptr, attr)
+        res_ptr = method(x_ptr)
+        res = res_ptr.get()
+        assert (res == expected).all()
+
+    @pytest.mark.parametrize("attr", ["abs"])
+    def test_get_pointer_to_pointer_unary_method(self, attr):
+        self.setUp()
+        x = torch.Tensor([1, 2, 3])
+        native_method = getattr(x, f"native_{attr}")
+        expected = native_method()
+        x_ptr = x.send(self.bob).send(self.alice)
+        method = getattr(x_ptr, attr)
+        res_ptr = method()
+        res = res_ptr.get().get()
+        assert (res == expected).all()
+
+    @pytest.mark.parametrize("attr", ["add", "mul"])
+    def test_get_pointer_to_pointer_binary_method(self, attr):
+        self.setUp()
+        x = torch.Tensor([1, 2, 3])
         native_method = getattr(x, f"native_{attr}")
         expected = native_method(x)
         x_ptr = x.send(self.bob).send(self.alice)
+        method = getattr(x_ptr, attr)
         res_ptr = method(x_ptr)
         res = res_ptr.get().get()
+        assert (res == expected).all()
+
+    @pytest.mark.parametrize("attr", ["relu", "celu", "elu"])
+    def test_hook_module_functional(self, attr):
+        self.setUp()
+        attr = getattr(F, attr)
+        x = torch.Tensor([1, -1, 3, 4])
+        expected = attr(x)
+        x_ptr = x.send(self.bob)
+        res_ptr = attr(x_ptr)
+        res = res_ptr.get()
         assert (res == expected).all()
 
     def test_properties(self):

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -4,7 +4,6 @@ from syft.workers.virtual import VirtualWorker
 from syft.codes import MSGTYPE
 from syft import serde
 
-import numpy
 import torch
 
 
@@ -49,7 +48,7 @@ def test_send_msg_using_tensor_api():
     obj_id = obj.id
 
     # send the object to Bob (from local_worker)
-    obj_ptr = obj.send(bob)
+    _ = obj.send(bob)
 
     # ensure tensor made it to Bob
     assert obj_id in bob._objects

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -1,8 +1,7 @@
 import syft as sy
 
 from syft.workers.virtual import VirtualWorker
-from syft.workers.base import MSGTYPE_OBJ
-from syft.workers.base import MSGTYPE_OBJ_REQ
+from syft.codes import MSGTYPE
 from syft import serde
 
 import numpy
@@ -27,7 +26,7 @@ def test_send_msg():
     obj_id = obj.id
 
     # Send data to bob
-    me.send_msg(MSGTYPE_OBJ, obj, bob)
+    me.send_msg(MSGTYPE.OBJ, obj, bob)
 
     # ensure that object is now on bob's machine
     assert obj_id in bob._objects
@@ -73,7 +72,7 @@ def test_recv_msg():
     obj = torch.Tensor([100, 100])
 
     # create/serialize message
-    msg = (MSGTYPE_OBJ, obj)
+    msg = (MSGTYPE.OBJ, obj)
     bin_msg = serde.serialize(msg)
 
     # have alice receive message
@@ -85,7 +84,7 @@ def test_recv_msg():
     # Test 2: get tensor back from alice
 
     # Create message: Get tensor from alice
-    msg = (MSGTYPE_OBJ_REQ, obj.id)
+    msg = (MSGTYPE.OBJ_REQ, obj.id)
 
     # serialize message
     bin_msg = serde.serialize(msg)


### PR DESCRIPTION
Continue addressing #1657
- Improve ownership on send / get tensors #1697 #1698
- Add GC from #1796* to solve #1701 (see also #1658)
- Add hooking for torch methods on pointers, following up on #1729

PR was first intended to explore chains without torch wrappers. This solution is simpler to write but makes PySyft less flexible for libraries using PyTorch. We're currently putting back the wrapper while keeping the features developed in the first setting.


### Typical examples
```
import syft as sy
import torch
import torch.nn.functional as F
hook = sy.TorchHook(torch)
me = hook.local_worker
alice = sy.VirtualWorker(hook, id="alice")
bob = sy.VirtualWorker(hook, id="bob")
```
**Fast remote op on pointers**
```
x = torch.Tensor([1, 2, 3, 4])
x2 = torch.Tensor([4, 3, 2, 1])
x_ptr = x.send(bob)
x2_ptr = x2.send(bob)
```
(Run it twice to see the speed-up)
```
%%time
y_ptr = x_ptr + x2_ptr
```
**torch module functional**
(Run it twice to see the speed-up)
```
%%time
F.relu(x_ptr)
```
**Garbage collection**
```
# Clean registries
bob._objects = {}
alice._objects = {}
x = torch.Tensor([1, 2, 3, 4])
x_ptr = x.send(bob)
x_ptr_ptr = x_ptr.send(alice)
print(bob._objects, alice._objects)
del x_ptr_ptr
print(bob._objects, alice._objects)
```

**Todo checklist:**
- [x] Handling duplicate send from same tensor, and chained send (`x.send(bob).send(alice)`)
- [x] Tests for the method hooking
- [x] module Functional hooking (like `torch.nn.functional.relu(ptr1)`)

**For next PRs**
 - Change function name with integer when sending messages
- module Functional hooking (like `torch.nn.Linear(2, 3)(ptr1)`)
- Functional hooking (like `torch.add(ptr1, ptr2)`)

