### PR TITLE
Add pointer tensor tutorial for torch 1

### DIFF
--- a/examples/torch/Remote PyTorch using Virtual Worker.ipynb
+++ b/examples/torch/Remote PyTorch using Virtual Worker.ipynb
@@ -1,0 +1,551 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic Virtual Worker Tutorial\n",
+    "\n",
+    "This notebook contains a basic introduction to PySyft using VirtualWorkers, which are local workers designed to make learning and developement easy (i.e., not require an actual internet connection). All of your workers (performing Torch operations) will live in this one notebook. However, the interfaces will be identical to those that do execute commands over a network.\n",
+    "\n",
+    "This tutorial assumes you are already familiar with torch. If you need a primer on PyTorch, check out the following tutorial. (https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Initializing a Hook\n",
+    "\n",
+    "PySyft, at it's most basic level, is a set of overloaded operations on major deep learning frameworks. (it takes a framework and modifies its default behavior). The object we use to do this is called a Hook, and we must \"run a hook\" in order to get PySyft's functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import syft as sy\n",
+    "import torch\n",
+    "# this is our hook\n",
+    "hook = sy.TorchHook(torch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now all the operations necessary to use PySyft have been overloaded. You can tell that it's been hooked in the following ways."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# don't run this line... just type \"torch.na\" and then hit the <tab> key to see all the native_ functions\n",
+    "# torch.na"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See all the \"native\" functions that now appear in the package? Those are the original PyTorch functions.. simply renamed old+function-name. All of the actual functions (such as torch.abs()) are actually PySyft code which, if the conditions are right, will call the corresponding \"native\" functions (such as torch.native_abs()). In fact, the default will do this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([-2., -1.,  0.,  1.,  2.,  3.])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = torch.Tensor([-2,-1,0,1,2,3])\n",
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([2., 1., 0., 1., 2., 3.])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x.abs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may be wondering... what was the purpose of all this overloading?!?! PyTorch seems no different! Where the functionality for PySyft begins is when we start using what are called Workers. These are machines that can run PyTorch code _remotely_."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Initializing a Remote Worker\n",
+    "\n",
+    "As it turns out, you actually already have one worker created (by default) inside of TorchHook. It's called the \"local_worker\" and it represents the machine you're working on right now (your client)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<syft.workers.virtual.VirtualWorker id:me>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "local = hook.local_worker\n",
+    "local"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, you could have initialized your own local worker when you created the TorchHook, but since we didn't do that the hook automatically created one for you of type VirtualWorker. VirtualWorker is a special kind of worker which allows you to _pretend to initialize and talk to another machine_ when in fact all commands are actually running locally. It's very convenient because it allows you to do testing and development in an environment that exactly mimics working with a cluster of remote machines but all of the information is actually running locally (in this notebook!) which makes it easier to introspect (And write unit tests)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote = sy.VirtualWorker(id=\"remote\",hook=hook)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Above we created a new worker with an id of 'remote'.\n",
+    "\n",
+    "It's very important that all of your workers have different IDs. In case you were wondering, the local_worker is automatically initialized with an id of 'me'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'me'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "local.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'remote'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote.id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, before we start performing remote execution, we need to tell our local worker about our remote worker (so that the local worker... and by extension all of our local PyTorch objects... knows how to communicate with the new remote worker)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local.add_worker(remote)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And done! We are now ready to start performing remote operations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Sending and Receiving Tensors from Remote Workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = torch.Tensor([1,2,3,4,5])\n",
+    "x2 = torch.Tensor([1,1,1,1,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_ptr = x.send(remote)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x2_ptr = x2.send(remote)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our tensors now live on the remote worker!! We can check in the following way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "72163725007"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "28864723834"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x2.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{72163725007: tensor([1., 2., 3., 4., 5.]),\n",
+       " 28864723834: tensor([1., 1., 1., 1., 1.])}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "remote._objects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And there they are!!! Notice that when we print these tensors we can't actually see the data on the client (in this notebook) anymore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PointerTensor - id:16074542879 owner:me loc:remote id@loc:72163725007]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_ptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PointerTensor - id:16074542879 owner:me loc:remote id@loc:72163725007]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(x_ptr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PointerTensor - id:71053816926 owner:me loc:remote id@loc:28864723834]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x2_ptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PointerTensor - id:71053816926 owner:me loc:remote id@loc:28864723834]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(x2_ptr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And if we perform operations... we can't see the result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = x_ptr + x2_ptr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PointerTensor - id:19683840849 owner:me loc:remote id@loc:19683840849]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PointerTensor - id:19683840849 owner:me loc:remote id@loc:19683840849]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But, we can bring all of them back!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([1., 2., 3., 4., 5.])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_ptr.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([1., 1., 1., 1., 1.])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x2_ptr.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([2., 3., 4., 5., 6.])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y.get()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pysyft",
+   "language": "python",
+   "name": "pysyft"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This tutorial replicates the functionality of the pointer tensor tutorial for the torch 1 branch. It is the start of having tutorials for torch_1