### PR TITLE
[WIP] Async operations

### DIFF
--- a/syft/async_call.py
+++ b/syft/async_call.py
@@ -6,7 +6,7 @@ from .exceptions import AsyncOperationNotFinalizedError
 from .exceptions import ThreadTimeOutError
 
 
-class AsyncCall(object):
+class AsyncCallWrapper(object):
     """Asynchronous call definition.
 
     Runs `self.fnc` asynchronously using `threading`.
@@ -53,20 +53,11 @@ class AsyncCall(object):
             self.callback(self._result)
 
 
-class AsyncCallWrapper(object):
-    def __init__(self, fnc, callback=None):
-        self.fnc = fnc
-        self.callback = callback
-
-    def __call__(self, *args, **kwargs):
-        return AsyncCall(self.fnc, self.callback)(*args, **kwargs)
-
-
 def Async(fnc=None, callback=None):
     def async_wrapper(fnc):
-        return AsyncCall(fnc, callback)
+        return AsyncCallWrapper(fnc, callback)
 
     if fnc:
-        return AsyncCall(fnc, callback)
+        return AsyncCallWrapper(fnc, callback)
     else:
         return async_wrapper

--- a/syft/async_call.py
+++ b/syft/async_call.py
@@ -1,0 +1,72 @@
+"""Asynchronous operations related classes."""
+
+import threading
+
+from .exceptions import AsyncOperationNotFinalizedError
+from .exceptions import ThreadTimeOutError
+
+
+class AsyncCall(object):
+    """Asynchronous call definition.
+
+    Runs `self.fnc` asynchronously using `threading`.
+
+    Attributes:
+        fnc: A function to be executed asynchronously.
+        callaback: A function that should be executed after the asynchronous
+            operations.
+        result: The return of `fnc` if it has finished the execution
+            otherwhise raises `AsyncOperationNotFinalizedError()`.
+    """
+
+    def __init__(self, fnc, callback=None):
+        self.fnc = fnc
+        self.callback = callback
+        self._thread, self._result = None, None
+
+    def __call__(self, *args, **kwargs):
+        """Calls `self.run` using `threading`."""
+        self._thread = threading.Thread(
+            target=self.run, name=self.fnc.__name__, args=args, kwargs=kwargs
+        )
+        self._thread.start()
+        return self
+
+    @property
+    def result(self):
+        if not self._thread or self._thread.isAlive():
+            raise AsyncOperationNotFinalizedError()
+        else:
+            return self._result
+
+    def wait(self, timeout=None):
+        self._thread.join(timeout)
+        if self._thread.isAlive():
+            raise ThreadTimeOutError()
+        else:
+            return self._result
+
+    def run(self, *args, **kwargs):
+        """Calls `self.fnc` and a callback function if available."""
+        self._result = self.fnc(*args, **kwargs)
+        if self.callback:
+            self.callback(self._result)
+
+
+class AsyncCallWrapper(object):
+    def __init__(self, fnc, callback=None):
+        self.fnc = fnc
+        self.callback = callback
+
+    def __call__(self, *args, **kwargs):
+        return AsyncCall(self.fnc, self.callback)(*args, **kwargs)
+
+
+def Async(fnc=None, callback=None):
+    def async_wrapper(fnc):
+        return AsyncCall(fnc, callback)
+
+    if fnc:
+        return AsyncCall(fnc, callback)
+    else:
+        return async_wrapper

--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -1,13 +1,25 @@
 """Specific Pysyft exceptions."""
 
 
-class WorkerNotFoundException(Exception):
-    """Raised when a non-existent worker is requested."""
+class AsyncOperationNotFinalizedError(RuntimeError):
+    """Raised when a result of a async operation is not ready to be accessed."""
 
     pass
 
 
 class CompressionNotFoundException(Exception):
     """Raised when a non existent compression/decompression scheme is requested."""
+
+    pass
+
+
+class ThreadTimeOutError(RuntimeError):
+    """Raised when an async operation times out."""
+
+    pass
+
+
+class WorkerNotFoundException(Exception):
+    """Raised when a non-existent worker is requested."""
 
     pass

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -46,18 +46,11 @@ class TorchHook:
 
     Example:
         >>> import syft as sy
-        >>> hook = sy.TorchHook()
-        Hooking into Torch...
-        Overloading Complete.
-        >>> x = sy.Tensor([-2,-1,0,1,2,3])
+        >>> import torch
+        >>> hook = sy.TorchHook(torch)
+        >>> x = torch.Tensor([-2,-1,0,1,2,3])
         >>> x
-        -2
-        -1
-        0
-        1
-        2
-        3
-        [syft.core.frameworks.torch.tensor.FloatTensor of size 6]
+        tensor([1., 2., 3.])
     """
 
     def __init__(

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -185,12 +185,13 @@ class BaseWorker(AbstractWorker):
                 the object on the remote worker(s).
 
         Example:
-            >>> import torch
             >>> import syft as sy
+            >>> import torch
             >>> hook = sy.TorchHook(torch)
             >>> bob = sy.VirtualWorker(hook)
+            >>> me = hook.local_worker
             >>> x = torch.Tensor([1, 2, 3, 4])
-            >>> x.send(bob, 1000)
+            >>> me.send(x, bob, 1000)
             Will result in bob having the tensor x with id 1000
 
         Returns:
@@ -361,7 +362,8 @@ class BaseWorker(AbstractWorker):
 
         Example:
             >>> import syft as sy
-            >>> hook = sy.TorchHook(verbose=False)
+            >>> import torch
+            >>> hook = sy.TorchHook(hook, verbose=False)
             >>> me = hook.local_worker
             >>> bob = sy.VirtualWorker(id="bob",hook=hook, is_client_worker=False)
             >>> me.add_worker([bob])
@@ -405,9 +407,9 @@ class BaseWorker(AbstractWorker):
                 pointer to a remote worker, which must have a unique id.
 
         Example:
-            >>> import torch
             >>> import syft as sy
-            >>> hook = sy.TorchHook(verbose=False)
+            >>> import torch
+            >>> hook = sy.TorchHook(torch, verbose=False)
             >>> me = hook.local_worker
             >>> bob = sy.VirtualWorker(id="bob",hook=hook, is_client_worker=False)
             >>> me.add_worker([bob])

--- a/test/test_async_call.py
+++ b/test/test_async_call.py
@@ -1,0 +1,21 @@
+"""This file tests async.py."""
+
+import time
+from syft.async_call import Async
+
+
+def test_async():
+    """Tests if operations are executed async when using `Async``decorator."""
+    array = []
+
+    @Async
+    def custom_append(obj):
+        """Sleeps for 1 second and then adds object to array."""
+        time.sleep(1)
+        array.append(obj)
+
+    custom_append(1)
+    array.append(2)
+    assert array == [2]
+    time.sleep(1)
+    assert array == [2, 1]

--- a/test/test_async_call.py
+++ b/test/test_async_call.py
@@ -10,12 +10,12 @@ def test_async():
 
     @Async
     def custom_append(obj):
-        """Sleeps for 1 second and then adds object to array."""
-        time.sleep(1)
+        """Sleeps for 0.1 seconds and then adds object to array."""
+        time.sleep(0.1)
         array.append(obj)
 
     custom_append(1)
     array.append(2)
     assert array == [2]
-    time.sleep(1)
+    time.sleep(0.3)  # waits a little longer to make sure the async operation was finalized
     assert array == [2, 1]


### PR DESCRIPTION
Fixes #1659

- [x] Add async decorator implementation
- [ ] Make send operations async (c = a + b)  - see Issue #1809 for details
- [ ] Raise error when y = a + c is executed
- [ ] Turn off async mode - #1810
- [ ] Save y = a + b in key-value (c.id, serialized_command) command queue - #1811
- [ ] If new tensor is registered into worker._objects
- [ ] Check if tensor.id is blocking some operation, and release blocked commands

