### PR TITLE
LogTensor and decentralized handling of commands

### DIFF
--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -1,6 +1,18 @@
 """Specific Pysyft exceptions."""
 
 
+class PureTorchTensorFoundError(BaseException):
+    """Exception raised for errors in the input.
+
+        Attributes:
+            expression -- input expression in which the error occurred
+            message -- explanation of the error
+        """
+
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+
 class RemoteTensorFoundError(BaseException):
     """Exception raised for errors in the input.
 

--- a/syft/frameworks/torch/__init__.py
+++ b/syft/frameworks/torch/__init__.py
@@ -1,3 +1,4 @@
+from . import hook_args
 from . import tensors
 from . import mpc
 from .hook import TorchHook

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -112,8 +112,6 @@ class TorchHook:
 
         self._hook_native_tensor(torch.Tensor, TorchTensor)
 
-        self._hook_pointer_tensor(torch.Tensor)
-
         self._hook_torch_module()
 
         # Add the local_worker to syft so that it can be found if the hook is
@@ -175,23 +173,6 @@ class TorchHook:
                 setattr(tensor_type, f"native_{attr}", native_method)
                 new_method = self.get_hooked_method(native_method)
                 setattr(tensor_type, attr, new_method)
-
-    def _hook_pointer_tensor(self, tensor_type: type):
-        """
-        Add hooked version of all methods of the tensor_type to the
-        Pointer tensor: instead of performing the native tensor
-        method, it will be sent remotely to the location the pointer
-        is pointing at.
-        :param tensor_type: the tensor_type which holds the methods
-        """
-
-        # Use a pre-defined list to select the methods to overload
-        for attr in self.to_auto_overload[tensor_type]:
-            # if we haven't already overloaded this function
-            if f"native_{attr}" not in dir(tensor_type):
-                native_method = getattr(tensor_type, attr)
-                setattr(PointerTensor, f"native_{attr}", native_method)
-                setattr(PointerTensor, attr, self.get_pointer_method(attr))
 
     @staticmethod
     def get_pointer_method(attr):

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -174,27 +174,6 @@ class TorchHook:
                 new_method = self.get_hooked_method(native_method)
                 setattr(tensor_type, attr, new_method)
 
-    @staticmethod
-    def get_pointer_method(attr):
-        """
-        Return a overloaded method which doesn't perform the initial method
-        but send it to the appropriate worker, using the self attribute
-        which is a pointer with a location
-        :param attr: the method to overload
-        :return: the overloaded method
-        """
-
-        def overloaded_attr(self, *args, **kwargs):
-            owner = self.owner
-            # Identify the location using self which is a pointer
-            location = self.location
-            # Build the message to send
-            message = (attr, self, args, kwargs)
-            response = owner.send_command(location, message)
-            return response
-
-        return overloaded_attr
-
     def _hook_torch_module(self):
         """Overloads functions in the main torch modules.
         The way this is accomplished is by first moving all existing module
@@ -249,7 +228,7 @@ class TorchHook:
             """
             Operate the hooking
             """
-            command = (attr.__name__, _self, args)
+            command = (attr.__name__, _self, args)  # TODO add kwargs
             response = TorchTensor.handle_method_command(command)
             return response
 

--- a/syft/frameworks/torch/hook_args.py
+++ b/syft/frameworks/torch/hook_args.py
@@ -1,13 +1,19 @@
 import torch
 from syft.exceptions import RemoteTensorFoundError
 from .tensors import PointerTensor
+from .tensors import LogTensor
+from .tensors import TorchTensor
+
+hook_method_args_functions = {}
+hook_method_response_functions = {}
 
 one = lambda _args: 1
-# dict to specify the action depending of the type found
 
+# dict to specify the action depending of the type found
 type_rule = {
     list: lambda _args: [build_rule(a) for a in _args],
     tuple: lambda _args: tuple([build_rule(a) for a in _args]),
+    LogTensor: one,
     PointerTensor: one,
     torch.Tensor: one,
 }
@@ -16,8 +22,57 @@ type_rule = {
 forward_func = {
     PointerTensor: lambda p: (_ for _ in ()).throw(RemoteTensorFoundError(p)),
     torch.Tensor: lambda i: i.child if hasattr(i, "child") else i,
+    LogTensor: lambda i: i.child,
     "my_syft_tensor_type": lambda i: i.child,
 }
+
+# Dict to return the proper lambda function for the right torch or syft tensor type
+backward_func = {
+    TorchTensor: lambda i: i.wrap(),
+    torch.Tensor: lambda i: i.wrap(),
+    PointerTensor: lambda i: i,
+    LogTensor: lambda i: LogTensor().on(i),
+    "my_syft_tensor_type": lambda i: "my_syft_tensor_type().on(i)",
+}
+
+
+def hook_method_args(attr, method_self, args):
+    """Method arguments are sometimes simple types (such as strings or ints) but
+    sometimes they are custom Syft tensors such as wrappers (torch.Tensor) or LogTensor
+    or some other tensor type. Complex types (which have a .child attribute) need to
+    have arguments converted from the arg to arg.child so that the types match as the
+    method is being called down the chain. To make this efficient, we cache which args
+    need to be replaced with their children in a dictionary called
+    hook_method_args_functions. However, sometimes a method (an attr) has multiple
+    different argument signatures, such that sometimes arguments have .child objects
+    and other times they don't (such as x.div(), which can accept either a tensor or a
+    float as an argument). This invalidates the cache, so we need to have a try/except
+    which refreshes the cache if the signature triggers an error.
+
+    Args:
+        attr (str): the name of the method being called
+        method_self: the tensor on which the method is being called
+        args (list): the arguments being passed to the tensor
+    """
+    # Specify an id to distinguish methods from different classes
+    # TODO: analyse exactly the role of adding the type of self in the id
+    # TODO: and the need to recalculate also the rule (should be the same)
+    attr_id = type(method_self).__name__ + "." + attr
+
+    try:
+        # Load the utility function to transform the args
+        hook_args = hook_method_args_functions[attr_id]
+        # Try running it
+        new_self, new_args = hook_args((method_self, args))
+
+    except (IndexError, KeyError):  # Update the function in case of an error
+        args_hook_function = build_hook_args_function((method_self, args))
+        # Store this utility function in the registry
+        hook_method_args_functions[attr_id] = args_hook_function
+        # Run it
+        new_self, new_args = args_hook_function((method_self, args))
+
+    return (new_self, new_args)
 
 
 def build_hook_args_function(args):
@@ -29,6 +84,63 @@ def build_hook_args_function(args):
     # (but not pointer) with their child in the args objects
     args_hook_function = build_args_hook(args, rule)
     return args_hook_function
+
+
+def hook_method_response(attr, response, wrap_type):
+    """
+    When executing a command, arguments are inspected and all tensors are replaced
+    with their child attribute until a pointer or a torch tensor is found (for
+    example an argument could be a torch wrapper with a child being a LogTensor, with
+    a child being a torch tensor). When the result of the command is calculated,
+    we need to rebuild this chain in the reverse order (in our example put back
+    a LogTensor on top of the result and then a torch wrapper).
+    To make this efficient, we cache which elements of the response (which can be more
+    complicated with nested tuples for example) need to be wrapped in a dictionary called
+    hook_method_response_functions. However, sometimes a method (an attr) has multiple
+    different response signatures. This invalidates the cache, so we need to have a
+    try/except which refreshes the cache if the signature triggers an error.
+
+    Args:
+        attr (str): the name of the method being called
+        response (list): the arguments being passed to the tensor
+        wrap_type (type): the type of wrapper we'd like to have
+    """
+    # TODO: Why do we need to cast it in a tuple? this is a (small) time waste
+    response_is_tuple = isinstance(response, tuple)
+
+    # Add an artificial tuple
+    if not response_is_tuple:
+        response = (response, 1)
+
+    try:
+        # Load the utility function to transform the args
+        response_hook_function = hook_method_response_functions[attr]
+        # Try running it
+        new_response = response_hook_function(response)
+
+    except (IndexError, KeyError):  # Update the function in cas of an error
+        response_hook_function = build_hook_response_function(response, wrap_type)
+        # Store this utility function in the registry
+        hook_method_args_functions[attr] = response_hook_function
+        # Run it
+        new_response = response_hook_function(response)
+
+    # Remove the artificial tuple
+    if not response_is_tuple:
+        new_response, _ = new_response
+
+    return new_response
+
+
+def build_hook_response_function(response, wrap_type):
+    # Inspect the call to find tensor arguments and return a rule whose
+    # structure is the same as the response object, with 1 where there was
+    # (torch or syft) tensors and 0 when not (ex: number, str, ...)
+    rule = build_rule(response)
+    # Build a function with this rule to efficiently replace syft tensors
+    # (but not pointer) with their child in the args objects
+    response_hook_function = build_response_hook(response, rule, wrap_type)
+    return response_hook_function
 
 
 def build_rule(args):
@@ -53,14 +165,15 @@ def build_rule(args):
 def build_args_hook(args, rules, return_tuple=False):
     """
     Build a function given some rules to efficiently replace in the args object
-    syft tensors (but not pointer) with their child, and do nothing for other
-    type of object including torch tensors, str, numbers, bool, etc
-    Pointers trigger an error which is catched to get the location for forwarding
-    the call
+    syft tensors with their child (but not pointer as they don't have .child),
+    and do nothing for other type of object including torch tensors, str,
+    numbers, bool, etc.
+    Pointers trigger an error which can be caught to get the location for
+    forwarding the call.
     :param args:
     :param rules:
     :param return_tuple: force to return a tuple even with a single element
-    :return:
+    :return: a function that replace syft arg in args with arg.child
     """
 
     # get the transformation lambda for each args
@@ -72,6 +185,37 @@ def build_args_hook(args, rules, return_tuple=False):
         # Last if not, rule is probably == 1 so use type to return the right transformation.
         else lambda i: forward_func[type(i)](i)
         for a, r in zip(args, rules)  # And do this for all the args / rules provided
+    ]
+
+    # Instead of iterating which is slow, we use trick to efficiently
+    # apply each lambda to each arg
+    folds = {0: zero_fold, 1: one_fold(return_tuple), 2: two_fold, 3: three_fold, 4: four_fold}
+    f = folds[len(lambdas)]
+    return lambda x: f(lambdas, x)
+
+
+def build_response_hook(response, rules, wrap_type, return_tuple=False):
+    """
+    Build a function given some rules to efficiently replace in the response object
+    syft or torch tensors with a wrapper, and do nothing for other types of object
+    including , str, numbers, bool, etc.
+    :param response:
+    :param rules:
+    :param return_tuple: force to return a tuple even with a single element
+    :return:
+    """
+
+    # get the transformation lambda for each args
+    lambdas = [
+        (lambda i: i)  # return the same object
+        if not r  # if the rule is a number == 0.
+        else build_response_hook(
+            a, r, wrap_type, True
+        )  # If not, call recursively build_response_hook
+        if isinstance(r, (list, tuple))  # if the rule is a list or tuple.
+        # Last if not, rule is probably == 1 so use type to return the right transformation.
+        else lambda i: backward_func[wrap_type](i)
+        for a, r in zip(response, rules)  # And do this for all the responses / rules provided
     ]
 
     # Instead of iterating which is slow, we use trick to efficiently

--- a/syft/frameworks/torch/hook_args.py
+++ b/syft/frameworks/torch/hook_args.py
@@ -31,7 +31,7 @@ backward_func = {
     TorchTensor: lambda i: i.wrap(),
     torch.Tensor: lambda i: i.wrap(),
     PointerTensor: lambda i: i,
-    LogTensor: lambda i: LogTensor().on(i),
+    LogTensor: lambda i: LogTensor().on(i, wrap=False),
     "my_syft_tensor_type": lambda i: "my_syft_tensor_type().on(i)",
 }
 

--- a/syft/frameworks/torch/tensors/__init__.py
+++ b/syft/frameworks/torch/tensors/__init__.py
@@ -1,3 +1,4 @@
+from .log import LogTensor  # noqa: F401
 from .pointer import PointerTensor  # noqa: F401
 from .abstract import AbstractTensor  # noqa: F401
 from .native import TorchTensor  # noqa: F401

--- a/syft/frameworks/torch/tensors/abstract.py
+++ b/syft/frameworks/torch/tensors/abstract.py
@@ -9,6 +9,38 @@ class AbstractTensor(ABC):
     This is the tensor abstraction.
     """
 
+    def __str__(self) -> str:
+        if hasattr(self, "child"):
+            return type(self).__name__ + ">" + self.child.__str__()
+        else:
+            return type(self).__name__
+
+    def __repr__(self) -> str:
+        if hasattr(self, "child"):
+            return type(self).__name__ + ">" + self.child.__repr__()
+        else:
+            return type(self).__name__
+
+    def on(self, tensor, wrap=True):
+        """
+        Add a syft(log) tensor on top of the tensor.
+        :param tensor: the tensor to extend
+        :param wrap: if true, add the syft tensor between the wrapper
+        and the rest of the chain. If false, just add it at the top
+        :return: a syft/torch tensor
+        """
+        if not wrap:
+            self.child = tensor
+            return self
+        else:
+            # if tensor is a wrapper
+            if not hasattr(tensor, "child"):
+                tensor = tensor.wrap()
+
+            self.child = tensor.child
+            tensor.child = self
+            return tensor
+
     def wrap(self):
         """Wraps the class inside torch tensor.
 

--- a/syft/frameworks/torch/tensors/log.py
+++ b/syft/frameworks/torch/tensors/log.py
@@ -23,22 +23,6 @@ class LogTensor(AbstractTensor):
         self.id = id
         self.child = None
 
-    def __str__(self) -> str:
-        if hasattr(self, "child"):
-            return type(self).__name__ + ">" + self.child.__str__()
-        else:
-            return type(self).__name__
-
-    def __repr__(self) -> str:
-        if hasattr(self, "child"):
-            return type(self).__name__ + ">" + self.child.__repr__()
-        else:
-            return type(self).__name__
-
-    def on(self, tensor):
-        self.child = tensor
-        return self
-
     @classmethod
     def handle_method_command(cls, command):
         """

--- a/syft/frameworks/torch/tensors/log.py
+++ b/syft/frameworks/torch/tensors/log.py
@@ -59,3 +59,40 @@ class LogTensor(AbstractTensor):
         )
 
         return response
+
+    @classmethod
+    def handle_func_command(cls, command):
+        """
+        Receive an instruction for a function to be applied on a LogTensor,
+        Perform some specific action (like logging) which depends of the
+        instruction content, replace in the args all the LogTensors with
+        their child attribute, forward the command instruction to the
+        handle_function_command of the type of the child attributes, get the
+        response and replace a LogTensor on top of all tensors found in
+        the response.
+        :param command: instruction of a function command: (command name,
+        <no self>, arguments[, kwargs])
+        :return: the response of the function command
+        """
+        # TODO: add kwargs in command
+        cmd, _, args = command
+
+        # Do what you have to
+        print("Logtensor logging function", cmd)
+
+        # TODO: I can't manage the import issue, can you?
+        # Replace all LogTensor with their child attribute
+        new_args, new_type = syft.frameworks.torch.hook_args.hook_function_args(cmd, args)
+
+        # build the new command
+        new_command = (cmd, None, new_args)
+
+        # Send it to the appropriate class and get the response
+        response = new_type.handle_func_command(new_command)
+
+        # Put back LogTensor on the tensors found in the response
+        response = syft.frameworks.torch.hook_args.hook_method_response(
+            cmd, response, wrap_type=cls
+        )
+
+        return response

--- a/syft/frameworks/torch/tensors/log.py
+++ b/syft/frameworks/torch/tensors/log.py
@@ -1,0 +1,77 @@
+import syft
+from syft.frameworks.torch.tensors.abstract import AbstractTensor
+
+
+class LogTensor(AbstractTensor):
+    def __init__(self, parent: AbstractTensor = None, owner=None, id=None):
+        """Initializes a LogTensor, whose behaviour is to log all operations
+        applied on it.
+
+        Args:
+            parent: An optional AbstractTensor wrapper around the LogTensor
+                which makes it so that you can pass this LogTensor to all
+                the other methods/functions that PyTorch likes to use, although
+                it can also be other tensors which extend AbstractTensor, such
+                as custom tensors for Secure Multi-Party Computation or
+                Federated Learning.
+            owner: An optional BaseWorker object to specify the worker on which
+                the tensor is located.
+            id: An optional string or integer id of the LogTensor.
+        """
+        self.parent = parent
+        self.owner = owner
+        self.id = id
+        self.child = None
+
+    def __str__(self) -> str:
+        if hasattr(self, "child"):
+            return type(self).__name__ + ">" + self.child.__str__()
+        else:
+            return type(self).__name__
+
+    def __repr__(self) -> str:
+        if hasattr(self, "child"):
+            return type(self).__name__ + ">" + self.child.__repr__()
+        else:
+            return type(self).__name__
+
+    def on(self, tensor):
+        self.child = tensor
+        return self
+
+    @classmethod
+    def handle_method_command(cls, command):
+        """
+        Receive an instruction for a method to be applied on a LogTensor,
+        Perform some specific action (like logging) which depends of the
+        instruction content, replace in the args all the LogTensors with
+        their child attribute, forward the command instruction to the
+        handle_method_command of the type of the child attributes, get the
+        response and replace a LogTensor on top of all tensors found in
+        the response.
+        :param command: instruction of a method command: (command name,
+        self of the method, arguments[, kwargs])
+        :return: the response of the method command
+        """
+        # TODO: add kwargs in command
+        cmd, self, args = command
+
+        # Do what you have to
+        print("Logtensor logging method", cmd)
+
+        # TODO: I can't manage the import issue, can you?
+        # Replace all LogTensor with their child attribute
+        new_self, new_args = syft.frameworks.torch.hook_args.hook_method_args(cmd, self, args)
+
+        # build the new command
+        new_command = (cmd, new_self, new_args)
+
+        # Send it to the appropriate class and get the response
+        response = type(new_self).handle_method_command(new_command)
+
+        # Put back LogTensor on the tensors found in the response
+        response = syft.frameworks.torch.hook_args.hook_method_response(
+            cmd, response, wrap_type=cls
+        )
+
+        return response

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -1,3 +1,4 @@
+import syft
 from syft.frameworks.torch.tensors.abstract import AbstractTensor
 from syft.codes import MSGTYPE
 
@@ -72,6 +73,28 @@ class PointerTensor(AbstractTensor):
         self.owner = owner
         self.id = id
         self.garbage_collect_data = garbage_collect_data
+
+    @classmethod
+    def handle_method_command(cls, command):
+        """
+        Receive an instruction for a method to be applied on a Pointer,
+        Get the remote location to send the command, send it and get a
+        pointer to the response, return.
+        :param command: instruction of a method command: (command name,
+        self of the method, arguments[, kwargs])
+        :return: the response of the method command
+        """
+        cmd, self, args = command  # TODO: add kwargs
+
+        pointer = self
+        # Get info on who needs to send where the command
+        owner = pointer.owner
+        location = pointer.location
+
+        # Send the command
+        response = owner.send_command(location, command)
+
+        return response
 
     def __str__(self):
         """Returns a string version of this pointer.

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -43,6 +43,7 @@ import zstd
 import syft
 
 from syft.workers import AbstractWorker
+from syft.frameworks.torch.tensors import LogTensor
 from syft.frameworks.torch.tensors import PointerTensor
 
 from syft.frameworks.torch.tensors.abstract import initialize_tensor
@@ -666,6 +667,37 @@ def _detail_pointer_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> Point
     # return PointerTensor(**new_data)
 
 
+def _simplify_log_tensor(tensor: LogTensor) -> tuple:
+    """
+    This function takes the attributes of a LogTensor and saves them in a tuple
+    Args:
+        tensor (LogTensor): a LogTensor
+    Returns:
+        tuple: a tuple holding the unique attributes of the log tensor
+    Examples:
+        data = _simplify_log_tensor(tensor)
+    """
+
+    return (tensor.id,)
+
+
+def _detail_log_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> LogTensor:
+    """
+    This function reconstructs a LogTensor given it's attributes in form of a tuple.
+    Args:
+        worker: the worker doing the deserialization
+        tensor_tuple: a tuple holding the attributes of the LogTensor
+    Returns:
+        LogTensor: a LogTensor
+    Examples:
+        ptr = _detail_pointer_tensor(data)
+    """
+    # TODO: fix comment for this and simplifier
+    obj_id = tensor_tuple[0]
+
+    return LogTensor(owner=worker, id=obj_id)
+
+
 # High Level Simplification Router
 
 
@@ -720,6 +752,7 @@ simplifiers = {
     slice: [7, _simplify_slice],
     type(Ellipsis): [8, _simplify_ellipsis],
     PointerTensor: [9, _simplify_pointer_tensor],
+    LogTensor: [10, _simplify_log_tensor],
 }
 
 
@@ -758,4 +791,5 @@ detailers = [
     _detail_slice,
     _detail_ellipsis,
     _detail_pointer_tensor,
+    _detail_log_tensor,
 ]

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -678,7 +678,10 @@ def _simplify_log_tensor(tensor: LogTensor) -> tuple:
         data = _simplify_log_tensor(tensor)
     """
 
-    return (tensor.id,)
+    chain = None
+    if hasattr(tensor, "child"):
+        chain = _simplify(tensor.child)
+    return (tensor.id, chain)
 
 
 def _detail_log_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> LogTensor:
@@ -690,12 +693,17 @@ def _detail_log_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> LogTensor
     Returns:
         LogTensor: a LogTensor
     Examples:
-        ptr = _detail_pointer_tensor(data)
+        logtensor = _detail_log_tensor(data)
     """
-    # TODO: fix comment for this and simplifier
-    obj_id = tensor_tuple[0]
+    obj_id, chain = tensor_tuple
 
-    return LogTensor(owner=worker, id=obj_id)
+    tensor = LogTensor(owner=worker, id=obj_id)
+
+    if chain is not None:
+        chain = _detail(worker, chain)
+        tensor.child = chain
+
+    return tensor
 
 
 # High Level Simplification Router

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -249,7 +249,9 @@ class BaseWorker(AbstractWorker):
         :param message: the message specifying the command and the args
         :return: a pointer to the result
         """
-        command, _self, args, kwargs = message
+        command, _self, args = message
+        # TODO add kwargs
+        kwargs = {}
         command = command.decode("utf-8")
         # Handle methods
         if _self is not None:

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -51,6 +51,7 @@ class BaseWorker(AbstractWorker):
     def __init__(self, hook=None, id=0, known_workers={}, is_client_worker=False, log_msgs=False):
         """Initializes a BaseWorker."""
         self.hook = hook
+        self.torch = None if hook is None else hook.torch
         self.id = id
         self.is_client_worker = is_client_worker
         self.log_msgs = log_msgs
@@ -259,15 +260,14 @@ class BaseWorker(AbstractWorker):
         # Handle functions
         else:
             sy.torch.command_guard(command, "torch_modules")
-            command = sy.torch.eval_torch_modules_functions[command]
+            command = eval("self." + command)
             tensor = command(*args, **kwargs)
 
         # FIXME: should be added automatically
         tensor.owner = self
         # tensor.id ??
 
-        # TODO: Handle when the reponse is not simply a tensor
-
+        # TODO: Handle when the response is not simply a tensor
         self.register_obj(tensor)
 
         pointer = tensor.create_pointer(

--- a/test/torch/tensors/test_log.py
+++ b/test/torch/tensors/test_log.py
@@ -49,3 +49,28 @@ class TestLogTensor(object):
         x = LogTensor().on(x_tensor)
         y = x.add(x)
         assert (y.child.child == x_tensor.add(x_tensor)).all()
+
+    def test_send_get_log_chain(self):
+        """
+        Test sending and getting back a chain including a logtensor
+        """
+        self.setUp()
+        # build a long chain tensor Wrapper>LogTensor>TorchTensor
+        x_tensor = torch.Tensor([1, 2, 3])
+        x = LogTensor().on(x_tensor)
+        x_ptr = x.send(self.bob)
+        x_back = x_ptr.get()
+        assert (x_back.child.child == x_tensor).all()
+
+    def test_remote_method_on_log_chain(self):
+        """
+        Test remote method call on a chain including a log tensor
+        """
+        self.setUp()
+        # build a long chain tensor Wrapper>LogTensor>TorchTensor
+        x_tensor = torch.Tensor([1, 2, 3])
+        x = LogTensor().on(x_tensor)
+        x_ptr = x.send(self.bob)
+        y_ptr = x_ptr.add(x_ptr)
+        y = y_ptr.get()
+        assert (y.child.child == x_tensor.add(x_tensor)).all()

--- a/test/torch/tensors/test_log.py
+++ b/test/torch/tensors/test_log.py
@@ -1,0 +1,51 @@
+import random
+
+import torch
+import syft
+
+from syft.frameworks.torch.tensors import LogTensor
+
+
+class TestLogTensor(object):
+    def setUp(self):
+        hook = syft.TorchHook(torch, verbose=True)
+
+        self.me = hook.local_worker
+        self.me.is_client_worker = True
+
+        instance_id = str(int(10e10 * random.random()))
+        bob = syft.VirtualWorker(id=f"bob{instance_id}", hook=hook, is_client_worker=False)
+        alice = syft.VirtualWorker(id=f"alice{instance_id}", hook=hook, is_client_worker=False)
+        james = syft.VirtualWorker(id=f"james{instance_id}", hook=hook, is_client_worker=False)
+
+        bob.add_workers([alice, james])
+        alice.add_workers([bob, james])
+        james.add_workers([bob, alice])
+
+        self.hook = hook
+
+        self.bob = bob
+        self.alice = alice
+        self.james = james
+
+    def test_wrap(self):
+        """
+        Test the .on() wrap functionality for LogTensor
+        """
+        self.setUp()
+        x_tensor = torch.Tensor([1, 2, 3])
+        x = LogTensor().on(x_tensor)
+        assert isinstance(x, torch.Tensor)
+        assert isinstance(x.child, LogTensor)
+        assert isinstance(x.child.child, torch.Tensor)
+
+    def test_method_on_log_chain(self):
+        """
+        Test method call on a chain including a log tensor
+        """
+        self.setUp()
+        # build a long chain tensor Wrapper>LogTensor>TorchTensor
+        x_tensor = torch.Tensor([1, 2, 3])
+        x = LogTensor().on(x_tensor)
+        y = x.add(x)
+        assert (y.child.child == x_tensor.add(x_tensor)).all()

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -113,16 +113,16 @@ class TestHook(object):
         res = res_ptr.get().get()
         assert (res == expected).all()
 
-    @pytest.mark.parametrize("attr", ["relu", "celu", "elu"])
-    def test_hook_module_functional(self, attr):
-        self.setUp()
-        attr = getattr(F, attr)
-        x = torch.Tensor([1, -1, 3, 4])
-        expected = attr(x)
-        x_ptr = x.send(self.bob)
-        res_ptr = attr(x_ptr)
-        res = res_ptr.get()
-        assert (res == expected).all()
+    # @pytest.mark.parametrize("attr", ["relu", "celu", "elu"])
+    # def test_hook_module_functional(self, attr):
+    #     self.setUp()
+    #     attr = getattr(F, attr)
+    #     x = torch.Tensor([1, -1, 3, 4])
+    #     expected = attr(x)
+    #     x_ptr = x.send(self.bob)
+    #     res_ptr = attr(x_ptr)
+    #     res = res_ptr.get()
+    #     assert (res == expected).all()
 
     def test_properties(self):
         self.setUp()

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -65,6 +65,18 @@ class TestHook(object):
             assert isinstance(err_pointer, PointerTensor)
             assert err_pointer.id == ptr_id
 
+    def test_build_get_child_type(self):
+        from syft.frameworks.torch.hook_args import build_rule, build_get_tensor_type
+
+        x = torch.Tensor([1, 2, 3])
+        args = (x, [[1, x]])
+        rule = build_rule(args)
+
+        get_child_type_function = build_get_tensor_type(rule)
+
+        tensor_type = get_child_type_function(args)
+        assert tensor_type == torch.Tensor
+
     @pytest.mark.parametrize("attr", ["abs"])
     def test_get_pointer_unary_method(self, attr):
         self.setUp()
@@ -113,16 +125,16 @@ class TestHook(object):
         res = res_ptr.get().get()
         assert (res == expected).all()
 
-    # @pytest.mark.parametrize("attr", ["relu", "celu", "elu"])
-    # def test_hook_module_functional(self, attr):
-    #     self.setUp()
-    #     attr = getattr(F, attr)
-    #     x = torch.Tensor([1, -1, 3, 4])
-    #     expected = attr(x)
-    #     x_ptr = x.send(self.bob)
-    #     res_ptr = attr(x_ptr)
-    #     res = res_ptr.get()
-    #     assert (res == expected).all()
+    @pytest.mark.parametrize("attr", ["relu", "celu", "elu"])
+    def test_hook_module_functional(self, attr):
+        self.setUp()
+        attr = getattr(F, attr)
+        x = torch.Tensor([1, -1, 3, 4])
+        expected = attr(x)
+        x_ptr = x.send(self.bob)
+        res_ptr = attr(x_ptr)
+        res = res_ptr.get()
+        assert (res == expected).all()
 
     def test_properties(self):
         self.setUp()


### PR DESCRIPTION
Add a LogTensor and change the way commands are handled:

Add a handle_command method in syft/torch tensor classes for methods:
Move the call handling from the hook to each tensor class to allow for specific behaviour depending of the class.
Add a symmetric architecture to rebuild the chain on top of the response once the chain has been completely un-wrapped (like a forward and backward logic)


Add a LogTensor

```
# build a long chain tensor
wrapper = torch.Tensor()
wrapper.child = LogTensor().on(torch.Tensor([1, 2, 3]))
x = wrapper
print(x)
# operate on it
y = x.add(x)
print(y)
```

TODO:
 - resolve some todos on imports