### PR TITLE
Add support of product scalar x tensor when scalar is of type tensor

### DIFF
--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -2744,7 +2744,7 @@ class _TorchVariable(_TorchObject):
         new_data_id=None,
         new_grad_id=None,
         new_grad_data_id=None,
-        as_list: bool = False,
+        as_list: bool = False
     ):
         """Give the root of the chain held by self to worker self->alice->obj
         [worker] => self->worker->alice->obj Because there are Variable

--- a/syft/core/frameworks/torch/tensor.py
+++ b/syft/core/frameworks/torch/tensor.py
@@ -2744,7 +2744,7 @@ class _TorchVariable(_TorchObject):
         new_data_id=None,
         new_grad_id=None,
         new_grad_data_id=None,
-        as_list: bool = False
+        as_list: bool = False,
     ):
         """Give the root of the chain held by self to worker self->alice->obj
         [worker] => self->worker->alice->obj Because there are Variable

--- a/syft/spdz/spdz.py
+++ b/syft/spdz/spdz.py
@@ -107,6 +107,14 @@ def spdz_neg(a, mod=field):
 
 def spdz_mul(x, y, workers, mod=field):
     if x.get_shape() != y.get_shape():
+        # Accept exception when multiplying with a scalar
+        if list(x.get_shape()) == [1]:
+            y_shape = list(y.get_shape())
+            x_scaled = x.repeat(*y_shape)
+            return spdz_mul(x_scaled, y, workers, mod=field)
+        elif list(y.get_shape()) == [1]:
+            return spdz_mul(y, x, workers, mod=field)
+
         raise ValueError("Shapes must be identical in order to multiply them")
     shape = x.get_shape()
     triple = generate_mul_triple_communication(shape, workers)

--- a/test/torch_test.py
+++ b/test/torch_test.py
@@ -1157,6 +1157,17 @@ class TestSNNTensor(TestCase):
         ).all()
         assert ((data * 1.1).get().decode() == torch.FloatTensor([1.1, 2.2, 3.3])).all()
 
+    def test_mpc_pseudo_scalar_mult(self):
+        """
+        When the scalar is also a tensor
+        """
+        scalar = torch.FloatTensor([2]).fix_precision().share(alice, bob)
+        data = torch.FloatTensor([1, 2, 3]).fix_precision().share(alice, bob)
+        result = scalar * data
+        assert (result.get().decode() == torch.FloatTensor([2, 4, 6])).all()
+        result = data * scalar
+        assert (result.get().decode() == torch.FloatTensor([2, 4, 6])).all()
+
 
 class TestSPDZTensor(TestCase):
     def mpc_sum(self, n1, n2):


### PR DESCRIPTION
Usecase: when sharing a scalar with mpc, you cast your float in a 1D tensor
then `mul` sees two tensors fo different shapes:
```
[a] x [[b, b], = [[ab, ab],
       [b, b]]    [ab, ab]]
```