### PR TITLE
Move hook of methods

### DIFF
--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -7,15 +7,11 @@ from functools import wraps
 
 
 import syft
-from syft.exceptions import RemoteTensorFoundError
 from syft import workers
 from syft.workers import BaseWorker
-from .tensors import TorchTensor, PointerTensor, LogTensor
+from .tensors import TorchTensor, PointerTensor, LoggingTensor
 from .torch_attributes import TorchAttributes
 from .tensors.abstract import initialize_tensor
-from .hook_args import hook_method_args
-from .hook_args import build_rule
-from .hook_args import build_args_hook
 
 
 class TorchHook:

--- a/syft/frameworks/torch/tensors/__init__.py
+++ b/syft/frameworks/torch/tensors/__init__.py
@@ -1,4 +1,4 @@
-from .log import LogTensor  # noqa: F401
+from .log import LoggingTensor  # noqa: F401
 from .pointer import PointerTensor  # noqa: F401
 from .abstract import AbstractTensor  # noqa: F401
 from .native import TorchTensor  # noqa: F401

--- a/syft/frameworks/torch/tensors/log.py
+++ b/syft/frameworks/torch/tensors/log.py
@@ -2,21 +2,21 @@ import syft
 from syft.frameworks.torch.tensors.abstract import AbstractTensor
 
 
-class LogTensor(AbstractTensor):
+class LoggingTensor(AbstractTensor):
     def __init__(self, parent: AbstractTensor = None, owner=None, id=None):
-        """Initializes a LogTensor, whose behaviour is to log all operations
+        """Initializes a LoggingTensor, whose behaviour is to log all operations
         applied on it.
 
         Args:
-            parent: An optional AbstractTensor wrapper around the LogTensor
-                which makes it so that you can pass this LogTensor to all
+            parent: An optional AbstractTensor wrapper around the LoggingTensor
+                which makes it so that you can pass this LoggingTensor to all
                 the other methods/functions that PyTorch likes to use, although
                 it can also be other tensors which extend AbstractTensor, such
                 as custom tensors for Secure Multi-Party Computation or
                 Federated Learning.
             owner: An optional BaseWorker object to specify the worker on which
                 the tensor is located.
-            id: An optional string or integer id of the LogTensor.
+            id: An optional string or integer id of the LoggingTensor.
         """
         self.parent = parent
         self.owner = owner
@@ -26,12 +26,12 @@ class LogTensor(AbstractTensor):
     @classmethod
     def handle_method_command(cls, command):
         """
-        Receive an instruction for a method to be applied on a LogTensor,
+        Receive an instruction for a method to be applied on a LoggingTensor,
         Perform some specific action (like logging) which depends of the
         instruction content, replace in the args all the LogTensors with
         their child attribute, forward the command instruction to the
         handle_method_command of the type of the child attributes, get the
-        response and replace a LogTensor on top of all tensors found in
+        response and replace a LoggingTensor on top of all tensors found in
         the response.
         :param command: instruction of a method command: (command name,
         self of the method, arguments[, kwargs])
@@ -44,7 +44,7 @@ class LogTensor(AbstractTensor):
         print("Logtensor logging method", cmd)
 
         # TODO: I can't manage the import issue, can you?
-        # Replace all LogTensor with their child attribute
+        # Replace all LoggingTensor with their child attribute
         new_self, new_args = syft.frameworks.torch.hook_args.hook_method_args(cmd, self, args)
 
         # build the new command
@@ -53,22 +53,20 @@ class LogTensor(AbstractTensor):
         # Send it to the appropriate class and get the response
         response = type(new_self).handle_method_command(new_command)
 
-        # Put back LogTensor on the tensors found in the response
-        response = syft.frameworks.torch.hook_args.hook_method_response(
-            cmd, response, wrap_type=cls
-        )
+        # Put back LoggingTensor on the tensors found in the response
+        response = syft.frameworks.torch.hook_args.hook_response(cmd, response, wrap_type=cls)
 
         return response
 
     @classmethod
     def handle_func_command(cls, command):
         """
-        Receive an instruction for a function to be applied on a LogTensor,
+        Receive an instruction for a function to be applied on a LoggingTensor,
         Perform some specific action (like logging) which depends of the
         instruction content, replace in the args all the LogTensors with
         their child attribute, forward the command instruction to the
         handle_function_command of the type of the child attributes, get the
-        response and replace a LogTensor on top of all tensors found in
+        response and replace a LoggingTensor on top of all tensors found in
         the response.
         :param command: instruction of a function command: (command name,
         <no self>, arguments[, kwargs])
@@ -81,7 +79,7 @@ class LogTensor(AbstractTensor):
         print("Logtensor logging function", cmd)
 
         # TODO: I can't manage the import issue, can you?
-        # Replace all LogTensor with their child attribute
+        # Replace all LoggingTensor with their child attribute
         new_args, new_type = syft.frameworks.torch.hook_args.hook_function_args(cmd, args)
 
         # build the new command
@@ -90,9 +88,7 @@ class LogTensor(AbstractTensor):
         # Send it to the appropriate class and get the response
         response = new_type.handle_func_command(new_command)
 
-        # Put back LogTensor on the tensors found in the response
-        response = syft.frameworks.torch.hook_args.hook_method_response(
-            cmd, response, wrap_type=cls
-        )
+        # Put back LoggingTensor on the tensors found in the response
+        response = syft.frameworks.torch.hook_args.hook_response(cmd, response, wrap_type=cls)
 
         return response

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -181,34 +181,11 @@ class PointerTensor(AbstractTensor):
                 this method is to move the tensor from the remote machine to the
                 local one, at which time the pointer has no use.
 
-            out (class:`.abstract.AbstractTensor`): this is the tensor (or
-                chain) which this object used to point to on a remote machine.
-
-        Returns:
-            tensor:
-
-        #TODO: add param get_copy which doesn't destroy remote if true.
-
-        Since PointerTensor objects always point to a remote tensor (or chain
-        of tensors, where a chain is simply a linked-list of tensors linked via
-        their .child attributes), this method will request that the tensor or
-        chain being pointed to be serialized and returned from this function.
-        This will typically mean that the remote object will be removed or
-        destroyed. If you merely wish to bring a copy back to the local worker,
-        call .copy() before calling .get().
-        TODO: add param get_copy which doesn't destroy remote if true.
-
-        Args:
-            deregister_ptr: An optional boolean parameter (default True) that
-                determines whether to deregister this pointer from the
-                pointer's owner during this method. The default is set to True
-                because the main reason people use this method is to move the
-                tensor from the remote machine to the local one, at which time
-                the pointer has no use.
-
         Returns:
             An AbstractTensor object which is the tensor (or chain) that this
             object used to point to on a remote machine.
+
+        TODO: add param get_copy which doesn't destroy remote if true.
         """
 
         # if the pointer happens to be pointing to a local object,

--- a/syft/frameworks/torch/tensors/pointer.py
+++ b/syft/frameworks/torch/tensors/pointer.py
@@ -76,28 +76,6 @@ class PointerTensor(AbstractTensor):
         self.garbage_collect_data = garbage_collect_data
 
     @classmethod
-    def handle_method_command(cls, command):
-        """
-        Receive an instruction for a method to be applied on a Pointer,
-        Get the remote location to send the command, send it and get a
-        pointer to the response, return.
-        :param command: instruction of a method command: (command name,
-        self of the method, arguments[, kwargs])
-        :return: the response of the method command
-        """
-        cmd, self, args = command  # TODO: add kwargs
-
-        pointer = self
-        # Get info on who needs to send where the command
-        owner = pointer.owner
-        location = pointer.location
-
-        # Send the command
-        response = owner.send_command(location, command)
-
-        return response
-
-    @classmethod
     def handle_func_command(cls, command):
         """
         Receive an instruction for a function to be applied on a Pointer,

--- a/syft/frameworks/torch/tensors/utils.py
+++ b/syft/frameworks/torch/tensors/utils.py
@@ -1,0 +1,25 @@
+import syft
+
+
+def hook(attr):
+    """
+    hook args and response for methods that hold the @hook decoarator
+    """
+
+    def hook_args(self, *args, **kwargs):
+        # Replace all syft tensor with their child attribute
+        new_self, new_args = syft.frameworks.torch.hook_args.hook_method_args(
+            attr.__name__, self, args
+        )
+
+        # Send it to the appropriate class and get the response
+        response = attr(self, new_self, *new_args, **kwargs)
+
+        # Put back SyftTensor on the tensors found in the response
+        response = syft.frameworks.torch.hook_args.hook_response(
+            attr, response, wrap_type=type(self)
+        )
+
+        return response
+
+    return hook_args

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -43,7 +43,7 @@ import zstd
 import syft
 
 from syft.workers import AbstractWorker
-from syft.frameworks.torch.tensors import LogTensor
+from syft.frameworks.torch.tensors import LoggingTensor
 from syft.frameworks.torch.tensors import PointerTensor
 
 from syft.frameworks.torch.tensors.abstract import initialize_tensor
@@ -667,11 +667,11 @@ def _detail_pointer_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> Point
     # return PointerTensor(**new_data)
 
 
-def _simplify_log_tensor(tensor: LogTensor) -> tuple:
+def _simplify_log_tensor(tensor: LoggingTensor) -> tuple:
     """
     This function takes the attributes of a LogTensor and saves them in a tuple
     Args:
-        tensor (LogTensor): a LogTensor
+        tensor (LoggingTensor): a LogTensor
     Returns:
         tuple: a tuple holding the unique attributes of the log tensor
     Examples:
@@ -684,20 +684,20 @@ def _simplify_log_tensor(tensor: LogTensor) -> tuple:
     return (tensor.id, chain)
 
 
-def _detail_log_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> LogTensor:
+def _detail_log_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> LoggingTensor:
     """
     This function reconstructs a LogTensor given it's attributes in form of a tuple.
     Args:
         worker: the worker doing the deserialization
         tensor_tuple: a tuple holding the attributes of the LogTensor
     Returns:
-        LogTensor: a LogTensor
+        LoggingTensor: a LogTensor
     Examples:
         logtensor = _detail_log_tensor(data)
     """
     obj_id, chain = tensor_tuple
 
-    tensor = LogTensor(owner=worker, id=obj_id)
+    tensor = LoggingTensor(owner=worker, id=obj_id)
 
     if chain is not None:
         chain = _detail(worker, chain)
@@ -760,7 +760,7 @@ simplifiers = {
     slice: [7, _simplify_slice],
     type(Ellipsis): [8, _simplify_ellipsis],
     PointerTensor: [9, _simplify_pointer_tensor],
-    LogTensor: [10, _simplify_log_tensor],
+    LoggingTensor: [10, _simplify_log_tensor],
 }
 
 

--- a/test/torch/tensors/test_log.py
+++ b/test/torch/tensors/test_log.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn.functional as F
 import syft
 
-from syft.frameworks.torch.tensors import LogTensor
+from syft.frameworks.torch.tensors import LoggingTensor
 
 
 class TestLogTensor(object):
@@ -31,13 +31,13 @@ class TestLogTensor(object):
 
     def test_wrap(self):
         """
-        Test the .on() wrap functionality for LogTensor
+        Test the .on() wrap functionality for LoggingTensor
         """
         self.setUp()
         x_tensor = torch.Tensor([1, 2, 3])
-        x = LogTensor().on(x_tensor)
+        x = LoggingTensor().on(x_tensor)
         assert isinstance(x, torch.Tensor)
-        assert isinstance(x.child, LogTensor)
+        assert isinstance(x.child, LoggingTensor)
         assert isinstance(x.child.child, torch.Tensor)
 
     def test_method_on_log_chain(self):
@@ -45,9 +45,9 @@ class TestLogTensor(object):
         Test method call on a chain including a log tensor
         """
         self.setUp()
-        # build a long chain tensor Wrapper>LogTensor>TorchTensor
+        # build a long chain tensor Wrapper>LoggingTensor>TorchTensor
         x_tensor = torch.Tensor([1, 2, 3])
-        x = LogTensor().on(x_tensor)
+        x = LoggingTensor().on(x_tensor)
         y = x.add(x)
         assert (y.child.child == x_tensor.add(x_tensor)).all()
 
@@ -56,7 +56,7 @@ class TestLogTensor(object):
         Test torch function call on a chain including a log tensor
         """
         self.setUp()
-        x = LogTensor().on(torch.Tensor([1, -1, 3]))
+        x = LoggingTensor().on(torch.Tensor([1, -1, 3]))
         y = F.relu(x)
         assert (y.child.child == torch.Tensor([1, 0, 3])).all()
 
@@ -65,9 +65,9 @@ class TestLogTensor(object):
         Test sending and getting back a chain including a logtensor
         """
         self.setUp()
-        # build a long chain tensor Wrapper>LogTensor>TorchTensor
+        # build a long chain tensor Wrapper>LoggingTensor>TorchTensor
         x_tensor = torch.Tensor([1, 2, 3])
-        x = LogTensor().on(x_tensor)
+        x = LoggingTensor().on(x_tensor)
         x_ptr = x.send(self.bob)
         x_back = x_ptr.get()
         assert (x_back.child.child == x_tensor).all()
@@ -77,9 +77,9 @@ class TestLogTensor(object):
         Test remote method call on a chain including a log tensor
         """
         self.setUp()
-        # build a long chain tensor Wrapper>LogTensor>TorchTensor
+        # build a long chain tensor Wrapper>LoggingTensor>TorchTensor
         x_tensor = torch.Tensor([1, 2, 3])
-        x = LogTensor().on(x_tensor)
+        x = LoggingTensor().on(x_tensor)
         x_ptr = x.send(self.bob)
         y_ptr = F.relu(x_ptr)
         y = y_ptr.get()
@@ -90,9 +90,9 @@ class TestLogTensor(object):
         Test remote function call on a chain including a log tensor
         """
         self.setUp()
-        # build a long chain tensor Wrapper>LogTensor>TorchTensor
+        # build a long chain tensor Wrapper>LoggingTensor>TorchTensor
         x_tensor = torch.Tensor([1, 2, 3])
-        x = LogTensor().on(x_tensor)
+        x = LoggingTensor().on(x_tensor)
         x_ptr = x.send(self.bob)
         y_ptr = x_ptr.add(x_ptr)
         y = y_ptr.get()


### PR DESCRIPTION
Move hook method from online class routing to pre routing in the hook

Rename LogTensor -> LoggingTensor

Add a decorator to easily over-hook method for syft tensors  …
See add() exemple in LoggingTensor