### PR TITLE
Parameter hooking

### DIFF
--- a/examples/experimental/GC Experiment.ipynb
+++ b/examples/experimental/GC Experiment.ipynb
@@ -4,13 +4,61 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'nn' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-d1cb18fbf924>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mcollections\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mOrderedDict\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0mhook\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTorchHook\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtorch\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtorch\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      7\u001b[0m \u001b[0mbob\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVirtualWorker\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"bob\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/atrask/anaconda/lib/python3.6/site-packages/syft-0.1.0-py3.6.egg/syft/frameworks/torch/hook.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, torch, local_worker, is_client, verbose)\u001b[0m\n\u001b[1;32m    119\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_hook_tensor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    120\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 121\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_hook_parameters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    122\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    123\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_hook_torch_module\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/atrask/anaconda/lib/python3.6/site-packages/syft-0.1.0-py3.6.egg/syft/frameworks/torch/hook.py\u001b[0m in \u001b[0;36m_hook_parameters\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    259\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mparams\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    260\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 261\u001b[0;31m         \u001b[0mnn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparameters\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_params\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    262\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    263\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_hook_torch_module\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'nn' is not defined"
+     ]
+    }
+   ],
    "source": [
     "import syft as sy\n",
     "import torch\n",
+    "import torch.nn as nn\n",
+    "from collections import OrderedDict\n",
     "\n",
     "hook = sy.TorchHook(torch=torch)\n",
     "bob = sy.VirtualWorker(id=\"bob\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Parameter containing:\n",
+       " tensor([5.])]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "class MyLayer(nn.Module):\n",
+    "    \n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.some_params = nn.Parameter(torch.tensor([5.]))\n",
+    "        \n",
+    "\n",
+    "\n",
+    "m = MyLayer()\n",
+    "out = list(m.parameters())\n",
+    "out"
    ]
   },
   {
@@ -22,6 +70,49 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PointerTensor - id:44800487555 owner:me loc:bob id@loc:9357626166]\n",
+      "[PointerTensor - id:44800487555 owner:me loc:bob id@loc:9357626166]\n"
+     ]
+    }
+   ],
+   "source": [
+    "ptr = torch.Tensor([1.0, -1.0, 3.0, 4.0]).send(bob)\n",
+    "print(ptr.child)\n",
+    "p = nn.Parameter(ptr)\n",
+    "p.data = ptr\n",
+    "p.data.child = ptr.child\n",
+    "print(p.data.child) # --> trigger attribute error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PointerTensor - id:26881423769 owner:me loc:bob id@loc:74911762772]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p.data.child"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -29,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -54,7 +145,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-4-31f7f2294fad>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgrad\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"adsf\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-12-31f7f2294fad>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgrad\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"adsf\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;31mRuntimeError\u001b[0m: expected Variable or None (got str)"
      ]
     }

--- a/examples/experimental/GC Experiment.ipynb
+++ b/examples/experimental/GC Experiment.ipynb
@@ -4,21 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'nn' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-1-d1cb18fbf924>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mcollections\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mOrderedDict\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0mhook\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTorchHook\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtorch\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtorch\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      7\u001b[0m \u001b[0mbob\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVirtualWorker\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mid\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"bob\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/atrask/anaconda/lib/python3.6/site-packages/syft-0.1.0-py3.6.egg/syft/frameworks/torch/hook.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, torch, local_worker, is_client, verbose)\u001b[0m\n\u001b[1;32m    119\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_hook_tensor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    120\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 121\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_hook_parameters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    122\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    123\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_hook_torch_module\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/atrask/anaconda/lib/python3.6/site-packages/syft-0.1.0-py3.6.egg/syft/frameworks/torch/hook.py\u001b[0m in \u001b[0;36m_hook_parameters\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    259\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mparams\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    260\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 261\u001b[0;31m         \u001b[0mnn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparameters\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_params\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    262\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    263\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_hook_torch_module\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'nn' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import syft as sy\n",
     "import torch\n",
@@ -31,34 +17,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Parameter containing:\n",
-       " tensor([5.])]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "\n",
     "class MyLayer(nn.Module):\n",
     "    \n",
     "    def __init__(self):\n",
     "        super().__init__()\n",
     "        self.some_params = nn.Parameter(torch.tensor([5.]))\n",
-    "        \n",
     "\n",
     "\n",
     "m = MyLayer()\n",
     "out = list(m.parameters())\n",
-    "out"
+    "assert len(out) == 1\n",
+    "assert out[0] == m.some_params"
    ]
   },
   {

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -476,8 +476,7 @@ class TorchHook:
 
         hook_self.torch.tensor = new_tensor
 
-    @staticmethod
-    def _hook_properties(tensor_type: type):
+    def _hook_properties(hook_self, tensor_type: type):
         """Overloads tensor_type properties.
 
         This method gets called only on torch.Tensor. If you're not sure how
@@ -513,6 +512,19 @@ class TorchHook:
             return self
 
         tensor_type.id = id
+
+        @property
+        def owner(self):
+            if not hasattr(self, "_owner"):
+                self._owner = hook_self.local_worker
+            return self._owner
+
+        @owner.setter
+        def owner(self, new_owner):
+            self._owner = new_owner
+            return self
+
+        tensor_type.owner = owner
 
         @property
         def is_wrapper(self):

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -215,8 +215,14 @@ class TorchHook:
                 setattr(PointerTensor, attr, new_method)
 
     def _hook_parameters(self):
+        """
+        This method overrides the torch Parameter class such that
+        it works correctly with our overridden tensor types. The
+        native torch Parameter class kept deleting all of our
+        attributes on our custom tensors, so we wrote our own.
+        """
 
-        class Parameter():
+        class Parameter:
             r"""A kind of Tensor that is to be considered a module parameter.
 
             Parameters are :class:`~torch.Tensor` subclasses, that have a
@@ -238,8 +244,10 @@ class TorchHook:
                 self.data = data
 
             def __repr__(self):
-                return 'Parameter containing:\n' + self.data.__repr__()
+                return "Parameter containing:\n" + self.data.__repr__()
 
+        # this was in the original torch.nn.Parameter code and we might need it later
+        # thought we'd just leave it here for now.
         #     def __deepcopy__(self, memo):
         #         if id(self) in memo:
         #             return memo[id(self)]

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -376,8 +376,8 @@ class BaseWorker(AbstractWorker):
 
         if hasattr(obj, "id"):
             self.rm_obj(obj.id)
-        if hasattr(obj, "owner"):
-            del obj.owner
+        if hasattr(obj, "_owner"):
+            del obj._owner
 
     def rm_obj(self, remote_key):
         """Removes an object.

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -167,3 +167,17 @@ class TestHook(object):
         z = x.div(y)
 
         assert True
+
+    def test_parameter_hooking(self):
+
+        self.setUp()
+
+        class MyLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.some_params = torch.nn.Parameter(torch.tensor([5.0]))
+
+        m = MyLayer()
+        out = list(m.parameters())
+        assert len(out) == 1
+        assert out[0] == m.some_params

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -142,6 +142,8 @@ class TestHook(object):
         self.setUp()
         x = torch.tensor([1.0, -1.0, 3.0, 4.0], requires_grad=True)
         x.send(self.bob)
+        x = torch.tensor([1.0, -1.0, 3.0, 4.0], requires_grad=True)[0:2]
+        x.send(self.bob)
 
     def test_properties(self):
         self.setUp()


### PR DESCRIPTION
ptr = torch.Tensor([1.0, -1.0, 3.0, 4.0]).send(bob)
print(ptr.child)
p = nn.Parameter(ptr)
p.data = ptr
print(p.data.child) # --> trigger attribute error


This used to fail but now it does not