### PR TITLE
Debugger help

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ PySyft has also been explained in video form by [Siraj Ravel](https://www.youtub
 > PySyft supports Python &gt;= 3.6 and PyTorch 1.0.0
 
 ```bash
-pip3 install -r requirements.txt
-python3 setup.py install
+pip install syft
 ```
 ## Run Local Notebook Server
 All the examples can be played with by running the command
@@ -28,13 +27,13 @@ and selecting the pysyft kernel
 
 ## Try out the Tutorials
 
-A comprehensive list of tutorials can be found [here](https://github.com/OpenMined/PySyft/tree/torch_1/tutorials/)
+A comprehensive list of tutorials can be found [here](https://github.com/OpenMined/PySyft/tree/master/tutorials/)
 
 These tutorials cover how to perform techniques such as federated learning and differential privacy using PySyft.
 
 ## Start Contributing
 
-The guide for contributors can be found [here](https://github.com/OpenMined/PySyft/tree/torch_1/CONTRIBUTING.md). It covers all that you need to know to start contributing code to PySyft in an easy way.
+The guide for contributors can be found [here](https://github.com/OpenMined/PySyft/tree/master/CONTRIBUTING.md). It covers all that you need to know to start contributing code to PySyft in an easy way.
 
 Also join the rapidly growing community of 2500+ on [Slack](http://slack.openmined.org). The slack community is very friendly and great about quickly answering questions about the use and development of PySyft!
 
@@ -43,12 +42,12 @@ Also join the rapidly growing community of 2500+ on [Slack](http://slack.openmin
 We are very grateful for contributions to PySyft from the following organizations!
 
  ![drawing](https://raw.githubusercontent.com/coMindOrg/federated-averaging-tutorials/master/images/comindorg_logo.png)  
-  
+
  [coMind Website](https://comind.org/) & [coMind Github](https://github.com/coMindOrg/federated-averaging-tutorials)
 
 ## Disclaimer
 
-Do NOT use this code to protect data (private or otherwise) - at present it is very insecure. 
+Do NOT use this code to protect data (private or otherwise) - at present it is very insecure.
 
 ## License
 

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -373,7 +373,7 @@ class TorchHook:
         """
 
         @wraps(attr)
-        def overloaded_attr(self, *args, **kwargs):
+        def overloaded_pointer_method(self, *args, **kwargs):
             """
             Operate the hooking
             """
@@ -388,7 +388,7 @@ class TorchHook:
 
             return response
 
-        return overloaded_attr
+        return overloaded_pointer_method
 
     def get_hooked_syft_method(hook_self, attr):
         """
@@ -400,7 +400,7 @@ class TorchHook:
         """
 
         @wraps(attr)
-        def overloaded_attr(self, *args, **kwargs):
+        def overloaded_syft_method(self, *args, **kwargs):
             """
             Operate the hooking
             """
@@ -418,7 +418,7 @@ class TorchHook:
 
             return response
 
-        return overloaded_attr
+        return overloaded_syft_method
 
     def get_hooked_method(hook_self, attr):
         """
@@ -432,7 +432,7 @@ class TorchHook:
         """
 
         @wraps(attr)
-        def overloaded_attr(self, *args, **kwargs):
+        def overloaded_native_method(self, *args, **kwargs):
             """
             Operate the hooking
             """
@@ -461,7 +461,7 @@ class TorchHook:
 
             return response
 
-        return overloaded_attr
+        return overloaded_native_method
 
     def get_hooked_func(hook_self, attr):
         """
@@ -480,7 +480,7 @@ class TorchHook:
             attr.__module__ = "torch"
 
         @wraps(attr)
-        def overloaded_attr(*args, **kwargs):
+        def overloaded_func(*args, **kwargs):
             """
             Operate the hooking
             """
@@ -489,7 +489,7 @@ class TorchHook:
             response = TorchTensor.handle_func_command(command)
             return response
 
-        return overloaded_attr
+        return overloaded_func
 
     def _add_registration_to___init__(hook_self, tensor_type: type, torch_tensor: bool = False):
         """Adds several attributes to the tensor.

--- a/syft/frameworks/torch/hook_args.py
+++ b/syft/frameworks/torch/hook_args.py
@@ -257,8 +257,13 @@ def build_args_hook(args, rules, return_tuple=False):
         5: five_fold,
         6: six_fold,
         7: seven_fold,
+        8: eight_fold,
     }
-    f = folds[len(lambdas)]
+    try:
+        f = folds[len(lambdas)]
+    except KeyError:
+        f = many_fold
+
     return lambda x: f(lambdas, x)
 
 
@@ -386,7 +391,11 @@ def build_response_hook(response, rules, wrap_type, return_tuple=False):
         7: seven_fold,
         8: eight_fold,
     }
-    f = folds[len(lambdas)]
+    try:
+        f = folds[len(lambdas)]
+    except KeyError:
+        f = many_fold
+
     return lambda x: f(lambdas, x)
 
 
@@ -460,3 +469,7 @@ def eight_fold(lambdas, args):
         lambdas[6](args[6]),
         lambdas[7](args[7]),
     )
+
+
+def many_fold(lambdas, args):
+    return tuple([lambdas[i](args[i]) for i in range(len(lambdas))])


### PR DESCRIPTION
As we'll dive into debug logs, let's have more explicit stack traces --> 
Change hook `overloaded_attr` to explicit names like `overloaded_pointer_method`, `overloaded_syft_method`  for stacktrace clarity