### PR TITLE
Parameter attributes handling and remote usage

### DIFF
--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -6,11 +6,15 @@ import torch
 
 class PureTorchTensorFoundError(BaseException):
     """Exception raised for errors in the input.
+    This error is used in a recursive analysis of the args provided as an
+    input of a function, to break the recursion if a TorchTensor is found
+    as it means that _probably_ all the tensors are pure torch tensor and
+    the function can be applied natively on this input.
 
-        Attributes:
-            expression -- input expression in which the error occurred
-            message -- explanation of the error
-        """
+    Attributes:
+        expression -- input expression in which the error occurred
+        message -- explanation of the error
+    """
 
     def __init__(self, tensor):
         self.tensor = tensor
@@ -18,6 +22,10 @@ class PureTorchTensorFoundError(BaseException):
 
 class RemoteTensorFoundError(BaseException):
     """Exception raised for errors in the input.
+    This error is used in a context similar to PureTorchTensorFoundError but
+    to indicate that a Pointer to a remote tensor was found  in the input
+    and thus that the command should be send elsewhere. The pointer retrieved
+    by the error gives the location where the command should be sent.
 
     Attributes:
         expression -- input expression in which the error occurred

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -792,8 +792,10 @@ class TorchHook:
             if module_is_missing_grad(nn_self):
                 create_grad_objects(nn_self)
 
-            for p in nn_self.parameters():
-                p.send(dest)
+            for name, param in nn_self._parameters.items():
+                if param is not None:
+                    param_ptr = param.send(dest)
+                    nn_self.register_parameter(name, param_ptr)
 
             return nn_self
 
@@ -826,8 +828,10 @@ class TorchHook:
 
         def module_get_(nn_self):
             """overloads torch.nn instances with get method so that parameters could be sent back to owner"""
-            for p in nn_self.parameters():
-                p.get()
+            for name, param_ptr in nn_self._parameters.items():
+                if param_ptr is not None:
+                    param = param_ptr.get()
+                    nn_self.register_parameter(name, param)
 
             return nn_self
 

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -296,7 +296,7 @@ class TorchHook:
 
         def hooked__repr__(self):
             if hasattr(self, "child"):
-                return "&Parameter containing:\n" + self.child.__repr__()
+                return "Parameter containing:\n" + self.child.__repr__()
             else:
                 return self.native_param___repr__()
 

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -279,7 +279,10 @@ class TorchHook:
             # specific place otherwise it will get deleted
             if not isinstance(data, torch.Tensor) or hasattr(data, "child"):
                 p = torch.Tensor._make_subclass(cls, torch.Tensor(), requires_grad)
-                p.child = data
+                if isinstance(data, torch.Tensor):  # so it's a wrapper: remove it
+                    p.child = data.child
+                else:
+                    p.child = data
             else:
                 p = torch.Tensor._make_subclass(cls, data, requires_grad)
 
@@ -293,11 +296,11 @@ class TorchHook:
 
         def hooked__repr__(self):
             if hasattr(self, "child"):
-                return "Parameter containing:\n" + self.child.__repr__()
+                return "&Parameter containing:\n" + self.child.__repr__()
             else:
                 return self.native_param___repr__()
 
-        torch.nn.Parameter.__repr__ = hooked__repr__
+        # torch.nn.Parameter.__repr__ = hooked__repr__
 
         # Hook .data to handle chain assignment when needed
 

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -792,10 +792,8 @@ class TorchHook:
             if module_is_missing_grad(nn_self):
                 create_grad_objects(nn_self)
 
-            for name, param in nn_self._parameters.items():
-                if param is not None:
-                    param_ptr = param.send(dest)
-                    nn_self.register_parameter(name, param_ptr)
+            for p in nn_self.parameters():
+                p.send_(dest)
 
             return nn_self
 
@@ -828,10 +826,8 @@ class TorchHook:
 
         def module_get_(nn_self):
             """overloads torch.nn instances with get method so that parameters could be sent back to owner"""
-            for name, param_ptr in nn_self._parameters.items():
-                if param_ptr is not None:
-                    param = param_ptr.get()
-                    nn_self.register_parameter(name, param)
+            for p in nn_self.parameters():
+                p.get_()
 
             return nn_self
 

--- a/syft/frameworks/torch/hook_args.py
+++ b/syft/frameworks/torch/hook_args.py
@@ -85,7 +85,7 @@ def hook_method_args(attr, method_self, args):
         # Try running it
         new_self, new_args = hook_args((method_self, args))
 
-    except (IndexError, KeyError):  # Update the function in case of an error
+    except (IndexError, KeyError, AssertionError):  # Update the function in case of an error
         args_hook_function, _ = build_hook_args_function((method_self, args))
         # Store this utility function in the registry
         hook_method_args_functions[attr_id] = args_hook_function
@@ -111,7 +111,7 @@ def hook_function_args(attr, args):
         new_args = hook_args(args)
         new_type = get_tensor_type(new_args)
 
-    except (IndexError, KeyError):  # Update the function in case of an error
+    except (IndexError, KeyError, AssertionError):  # Update the function in case of an error
         args_hook_function, get_tensor_type_function = build_hook_args_function(
             args, return_tuple=True
         )
@@ -181,7 +181,7 @@ def hook_response(attr, response, wrap_type, new_self=None):
         # Try running it
         new_response = response_hook_function(response)
 
-    except (IndexError, KeyError):  # Update the function in cas of an error
+    except (IndexError, KeyError, AssertionError):  # Update the function in cas of an error
         response_hook_function = build_hook_response_function(response, wrap_type)
         # Store this utility function in the registry
         hook_method_response_functions[attr_id] = response_hook_function
@@ -241,7 +241,7 @@ def build_args_hook(args, rules, return_tuple=False):
 
     # get the transformation lambda for each args
     lambdas = [
-        (lambda i: i)  # return the same object
+        typed_identity(a)  # return the same obj with an identity fct with a type check if needed
         if not r  # if the rule is a number == 0.
         else build_args_hook(a, r, True)  # If not, call recursively build_args_hook
         if isinstance(r, (list, tuple))  # if the rule is a list or tuple.
@@ -477,3 +477,20 @@ def eight_fold(lambdas, args):
 
 def many_fold(lambdas, args):
     return tuple([lambdas[i](args[i]) for i in range(len(lambdas))])
+
+
+# Add the possibility to make a type check in the identity function applied
+# On some arg which could be None are of another type.
+# Could add more checks but not sure it is needed so far.
+
+
+def typed_identity(a):
+    if a is None:
+
+        def none_identity(i):
+            assert i is None
+            return i
+
+        return none_identity
+    else:
+        return lambda i: i

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -239,10 +239,6 @@ class TorchTensor(AbstractTensor):
             self.ptr = weakref.ref(ptr)
 
             if isinstance(self, syft.hook.torch.nn.Parameter):
-                # self.data.set_()
-                # self.data = ptr
-                # output = self
-
                 wrapper = torch.Tensor()
                 param_wrapper = torch.nn.Parameter(wrapper)
                 param_wrapper.data.set_()
@@ -410,7 +406,6 @@ class TorchTensor(AbstractTensor):
         if isinstance(self, torch.nn.Parameter):
             if isinstance(tensor, torch.nn.Parameter):
                 return tensor
-            # print('#', tensor)
             self.data = tensor.data
             self.grad = tensor.grad
             return self

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -436,7 +436,13 @@ class TorchTensor(AbstractTensor):
             else:
                 return tensor
 
-        return tensor
+        if inplace:
+            self.set_(tensor)
+            if hasattr(tensor, "child"):
+                self.child = tensor.child
+            return self
+        else:
+            return tensor
 
     def get_(self, *args, **kwargs):
         """

--- a/syft/frameworks/torch/tensors/interpreters/pointer.py
+++ b/syft/frameworks/torch/tensors/interpreters/pointer.py
@@ -237,12 +237,15 @@ class PointerTensor(AbstractTensor):
         # this next line because self no longer has .owner. Thus, we need to check
         # first here and not try to call self.owner.anything if self doesn't have
         # .owner anymore.
+        # print(self.id, '@', self.owner.id, 'ptr del', self.id_at_location, '@', self.location.id)
 
         if hasattr(self, "owner") and self.garbage_collect_data:
 
             # attribute pointers are not in charge of GC
             if self.point_to_attr is None:
-                self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)
+                pass
+                # print('SENT')
+                # self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)
 
     @property
     def grad(self):

--- a/syft/frameworks/torch/tensors/interpreters/pointer.py
+++ b/syft/frameworks/torch/tensors/interpreters/pointer.py
@@ -237,15 +237,11 @@ class PointerTensor(AbstractTensor):
         # this next line because self no longer has .owner. Thus, we need to check
         # first here and not try to call self.owner.anything if self doesn't have
         # .owner anymore.
-        # print(self.id, '@', self.owner.id, 'ptr del', self.id_at_location, '@', self.location.id)
-
         if hasattr(self, "owner") and self.garbage_collect_data:
 
             # attribute pointers are not in charge of GC
             if self.point_to_attr is None:
-                pass
-                # print('SENT')
-                # self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)
+                self.owner.send_msg(MSGTYPE.OBJ_DEL, self.id_at_location, self.location)
 
     @property
     def grad(self):

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -331,7 +331,7 @@ def _simplify_torch_parameter(param: torch.nn.Parameter) -> bin:
 
     grad = param.grad
 
-    if grad is not None:
+    if grad is not None and not isinstance(grad.child, sy.PointerTensor):
         grad_ser = _simplify_torch_tensor(grad)
     else:
         grad_ser = None
@@ -351,13 +351,15 @@ def _detail_torch_parameter(worker: AbstractWorker, param_tuple: tuple) -> torch
     Returns:
         torch.Parameter: a torch Parameter that was serialized
     """
-
     param_id, tensor_ser, requires_grad, grad_ser = param_tuple
 
     tensor = _detail_torch_tensor(worker, tensor_ser)
 
     if grad_ser is not None:
         grad = _detail_torch_tensor(worker, grad_ser)
+        grad.garbage_collect_data = False
+    elif hasattr(tensor, "child") and isinstance(tensor.child, sy.PointerTensor):
+        grad = tensor.attr("grad")
     else:
         grad = None
 

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -331,7 +331,9 @@ def _simplify_torch_parameter(param: torch.nn.Parameter) -> bin:
 
     grad = param.grad
 
-    if grad is not None and not isinstance(grad.child, sy.PointerTensor):
+    if grad is not None and not (
+        hasattr(grad, "child") and isinstance(grad.child, sy.PointerTensor)
+    ):
         grad_ser = _simplify_torch_tensor(grad)
     else:
         grad_ser = None

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -324,6 +324,7 @@ class BaseWorker(AbstractWorker):
         Args:
             obj: A torch or syft tensor with an id
         """
+        # print(self.id, obj)
         self._objects[obj.id] = obj
 
     def get_obj(self, obj_id):
@@ -379,6 +380,8 @@ class BaseWorker(AbstractWorker):
         """
 
         obj = self.get_obj(obj_id)
+        # print(self.id, obj)
+        # print('###', obj)
         self.de_register_obj(obj)
         return obj
 
@@ -453,6 +456,7 @@ class BaseWorker(AbstractWorker):
             A torch Tensor or Variable object.
         """
         obj = self.send_msg(MSGTYPE.OBJ_REQ, obj_id, location)
+        # print('##', obj)
         return obj
 
     # SECTION: Manage the workers network

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -324,7 +324,6 @@ class BaseWorker(AbstractWorker):
         Args:
             obj: A torch or syft tensor with an id
         """
-        # print(self.id, obj)
         self._objects[obj.id] = obj
 
     def get_obj(self, obj_id):
@@ -380,8 +379,6 @@ class BaseWorker(AbstractWorker):
         """
 
         obj = self.get_obj(obj_id)
-        # print(self.id, obj)
-        # print('###', obj)
         self.de_register_obj(obj)
         return obj
 
@@ -456,7 +453,6 @@ class BaseWorker(AbstractWorker):
             A torch Tensor or Variable object.
         """
         obj = self.send_msg(MSGTYPE.OBJ_REQ, obj_id, location)
-        # print('##', obj)
         return obj
 
     # SECTION: Manage the workers network

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -42,3 +42,13 @@ def test_tensors_not_collated_exception(workers):
         assert False
     except sy.exceptions.TensorsNotCollocatedException as e:
         assert True
+
+    x = th.tensor([1, 2, 3, 4, 5])
+    y = th.tensor([1, 2, 3, 4, 5]).send(alice)
+
+    try:
+
+        b = x + y
+        assert False
+    except sy.exceptions.TensorsNotCollocatedException as e:
+        assert True

--- a/test/torch/tensors/test_logging.py
+++ b/test/torch/tensors/test_logging.py
@@ -93,6 +93,20 @@ def test_send_get_log_chain(workers):
     assert (x_back.child.child == x_tensor).all()
 
 
+def test_inplace_send_get_log_chain(workers):
+    """
+    Test sending and getting back a chain including a logtensor
+    """
+
+    # Build a long chain tensor Wrapper>LoggingTensor>TorchTensor
+    x_tensor = torch.Tensor([1, 2, 3])
+    x = LoggingTensor().on(x_tensor)
+    x_ptr = x.send_(workers["bob"])
+    x_back = x_ptr.get_()
+
+    assert (x_back.child.child == x_tensor).all()
+
+
 def test_remote_method_on_log_chain(workers):
     """
     Test remote method call on a chain including a log tensor

--- a/test/torch/tensors/test_parameter.py
+++ b/test/torch/tensors/test_parameter.py
@@ -47,3 +47,10 @@ def test_remote_param_in_nn_module_linear(workers):
     tensor_ptr = tensor.send(workers["bob"])
     res_ptr = model_ptr(tensor_ptr)
     res = res_ptr.get()
+
+    model = nn.Linear(2, 1)
+    tensor = torch.tensor([1.0, -1.0])
+    model_ptr = model.send(workers["bob"])
+    tensor_ptr = tensor.send(workers["bob"])
+    res_ptr = model_ptr(tensor_ptr)
+    res = res_ptr.get()

--- a/test/torch/tensors/test_parameter.py
+++ b/test/torch/tensors/test_parameter.py
@@ -23,6 +23,16 @@ def test_param_send_get(workers):
     assert (param_back.data == tensor).all()
 
 
+def test_param_double_send_get(workers):
+    tensor = torch.tensor([[1.0, 1]])
+    param = Parameter(tensor)
+
+    param = param.send(workers["bob"]).send(workers["alice"])
+    param = param.get().get()
+
+    assert (param.data == tensor).all()
+
+
 def test_param_remote_binary_method(workers):
     tensor = torch.tensor([1.0, -1.0, 3.0, 4.0])
     param = Parameter(data=tensor.clone())

--- a/test/torch/tensors/test_parameter.py
+++ b/test/torch/tensors/test_parameter.py
@@ -23,6 +23,24 @@ def test_param_send_get(workers):
     assert (param_back.data == tensor).all()
 
 
+def test_param_inplace_send_get(workers):
+    tensor = torch.tensor([1.0, -1.0, 3.0, 4.0])
+    param = Parameter(data=tensor.clone())
+    param_ptr = param.send_(workers["bob"])
+
+    assert param_ptr.id == param.id
+    assert id(param_ptr) == id(param)
+
+    param_back = param_ptr.get_()
+
+    assert param_back.id == param_ptr.id
+    assert param_back.id == param.id
+    assert id(param_back) == id(param_ptr)
+    assert id(param_back) == id(param)
+
+    assert (param_back.data == tensor).all()
+
+
 def test_param_double_send_get(workers):
     tensor = torch.tensor([[1.0, 1]])
     param = Parameter(tensor)

--- a/test/torch/tensors/test_pointer.py
+++ b/test/torch/tensors/test_pointer.py
@@ -58,6 +58,23 @@ def test_send_get(workers):
     assert (torch.Tensor([1, 2]) == x_back).all()
 
 
+def test_inplace_send_get(workers):
+    tensor = torch.tensor([1.0, -1.0, 3.0, 4.0])
+    tensor_ptr = tensor.send_(workers["bob"])
+
+    assert tensor_ptr.id == tensor.id
+    assert id(tensor_ptr) == id(tensor)
+
+    tensor_back = tensor_ptr.get_()
+
+    assert tensor_back.id == tensor_ptr.id
+    assert tensor_back.id == tensor.id
+    assert id(tensor_back) == id(tensor)
+    assert id(tensor_back) == id(tensor)
+
+    assert (tensor_back == tensor).all()
+
+
 def test_repeated_send(workers):
     """Tests that repeated calls to .send(bob) works gracefully.
     Previously garbage collection deleted the remote object

--- a/test/torch/test_federated_learning.py
+++ b/test/torch/test_federated_learning.py
@@ -57,8 +57,8 @@ class TestFederatedLearning(object):
 
         self.setUp()
 
-        # Iniitalize A Toy Model
-        model = nn.Linear(2, 1, bias=False)
+        # Initialize A Toy Model
+        model = nn.Linear(2, 1)
 
         # Training Logic
         opt = optim.SGD(params=model.parameters(), lr=0.1)


### PR DESCRIPTION
This PR tries to get this working:
```
import torch as th
import syft as sy
# sy.create_sandbox(globals(), verbose=False)

hook = sy.TorchHook(th)
bob = sy.VirtualWorker(hook, "bob")
alice = sy.VirtualWorker(hook, "alice")

sy.local_worker.add_worker(bob)

data = th.nn.Parameter(th.tensor([[1.,1],[0,1],[1,0],[0,0]]))

data = data.send(bob).send(alice)
data = data.get().get()
```
Now this works (Garbage collection and wrapping issues fixed)
And additional fix on:
nn.model parameter send / get which must be inplace
Etc.