### PR TITLE
Add support of passive kwargs hook: they are forwarded as is

### DIFF
--- a/syft/frameworks/torch/tensors/decorators/logging.py
+++ b/syft/frameworks/torch/tensors/decorators/logging.py
@@ -37,11 +37,13 @@ class LoggingTensor(AbstractTensor):
 
     def manual_add(self, *args, **kwargs):
         # Replace all syft tensor with their child attribute
-        new_self, new_args = syft.frameworks.torch.hook_args.hook_method_args("add", self, args)
+        new_self, new_args, new_kwargs = syft.frameworks.torch.hook_args.hook_method_args(
+            "add", self, args, kwargs
+        )
 
         print("Log add")
         # Send it to the appropriate class and get the response
-        response = getattr(new_self, "add")(*new_args, **kwargs)
+        response = getattr(new_self, "add")(*new_args, **new_kwargs)
 
         # Put back SyftTensor on the tensors found in the response
         response = syft.frameworks.torch.hook_args.hook_response(
@@ -63,18 +65,19 @@ class LoggingTensor(AbstractTensor):
         <no self>, arguments[, kwargs])
         :return: the response of the function command
         """
-        # TODO: add kwargs in command
-        cmd, _, args = command
+        cmd, _, args, kwargs = command
 
         # Do what you have to
         print("Logtensor logging function", cmd)
 
         # TODO: I can't manage the import issue, can you?
         # Replace all LoggingTensor with their child attribute
-        new_args, new_type = syft.frameworks.torch.hook_args.hook_function_args(cmd, args)
+        new_args, new_kwargs, new_type = syft.frameworks.torch.hook_args.hook_function_args(
+            cmd, args, kwargs
+        )
 
         # build the new command
-        new_command = (cmd, None, new_args)
+        new_command = (cmd, None, new_args, new_kwargs)
 
         # Send it to the appropriate class and get the response
         response = new_type.handle_func_command(new_command)

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -179,14 +179,13 @@ class TorchTensor(AbstractTensor):
         <no self>, arguments[, kwargs])
         :return: the response of the function command
         """
-        # TODO: add kwargs
-        cmd, _, args = command
+        cmd, _, args, kwargs = command
 
         try:  # will work if tensors are wrappers
             # Replace all torch tensor with their child attribute
             # Note that we return also args_type which helps handling case 3 in the docstring
-            new_args, new_type, args_type = syft.frameworks.torch.hook_args.hook_function_args(
-                cmd, args, return_args_type=True
+            new_args, new_kwargs, new_type, args_type = syft.frameworks.torch.hook_args.hook_function_args(
+                cmd, args, kwargs, return_args_type=True
             )
             # This handles case 3: it redirects the command to the appropriate class depending
             # of the syft type of the arguments and returns
@@ -194,7 +193,7 @@ class TorchTensor(AbstractTensor):
                 return args_type.handle_func_command(command)
 
             # build the new command
-            new_command = (cmd, None, new_args)
+            new_command = (cmd, None, new_args, new_kwargs)
             # Send it to the appropriate class and get the response
             response = new_type.handle_func_command(new_command)
             # Put back the wrappers where needed
@@ -213,9 +212,9 @@ class TorchTensor(AbstractTensor):
             # Note the the cmd should already be checked upon reception by the worker
             # in the execute_command function
             if isinstance(args, tuple):
-                response = eval(cmd)(*args)
+                response = eval(cmd)(*args, **kwargs)
             else:
-                response = eval(cmd)(args)
+                response = eval(cmd)(args, **kwargs)
 
         return response
 
@@ -438,7 +437,7 @@ class TorchTensor(AbstractTensor):
         """
 
         location = self.child.location
-        self.owner.send_command(message=("mid_get", self.child, ()), recipient=location)
+        self.owner.send_command(message=("mid_get", self.child, (), {}), recipient=location)
 
         return self
 

--- a/syft/frameworks/torch/tensors/interpreters/pointer.py
+++ b/syft/frameworks/torch/tensors/interpreters/pointer.py
@@ -116,8 +116,8 @@ class PointerTensor(AbstractTensor):
         with the raising error RemoteTensorFoundError
         """
         try:
-            cmd, _, args = command
-            _ = syft.frameworks.torch.hook_args.hook_function_args(cmd, args)
+            cmd, _, args, kwargs = command
+            _ = syft.frameworks.torch.hook_args.hook_function_args(cmd, args, kwargs)
         except RemoteTensorFoundError as err:
             pointer = err.pointer
             return pointer

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -125,10 +125,12 @@ class FixedPrecisionTensor(AbstractTensor):
         in the fixed precision setting
         """
         # Replace all syft tensor with their child attribute
-        new_self, new_args = syft.frameworks.torch.hook_args.hook_method_args("mul", self, args)
+        new_self, new_args, new_kwargs = syft.frameworks.torch.hook_args.hook_method_args(
+            "mul", self, args, kwargs
+        )
 
         # Send it to the appropriate class and get the response
-        response = getattr(new_self, "mul")(*new_args, **kwargs)
+        response = getattr(new_self, "mul")(*new_args, **new_kwargs)
 
         # Put back SyftTensor on the tensors found in the response
         response = syft.frameworks.torch.hook_args.hook_response(
@@ -151,10 +153,12 @@ class FixedPrecisionTensor(AbstractTensor):
         in the fixed precision setting
         """
         # Replace all syft tensor with their child attribute
-        new_self, new_args = syft.frameworks.torch.hook_args.hook_method_args("matmul", self, args)
+        new_self, new_args, new_kwargs = syft.frameworks.torch.hook_args.hook_method_args(
+            "matmul", self, args, kwargs
+        )
 
         # Send it to the appropriate class and get the response
-        response = getattr(new_self, "matmul")(*new_args, **kwargs)
+        response = getattr(new_self, "matmul")(*new_args, **new_kwargs)
 
         # Put back SyftTensor on the tensors found in the response
         response = syft.frameworks.torch.hook_args.hook_response(
@@ -184,7 +188,7 @@ class FixedPrecisionTensor(AbstractTensor):
         :return: the response of the function command
         """
         # TODO: add kwargs in command
-        cmd, _, args = command
+        cmd, _, args, kwargs = command
 
         # unhook
         if cmd == "torch.nn.functional.linear":
@@ -199,10 +203,12 @@ class FixedPrecisionTensor(AbstractTensor):
 
         # TODO: I can't manage the import issue, can you?
         # Replace all FixedPrecisionTensor with their child attribute
-        new_args, new_type = syft.frameworks.torch.hook_args.hook_function_args(cmd, args)
+        new_args, new_kwargs, new_type = syft.frameworks.torch.hook_args.hook_function_args(
+            cmd, args, kwargs
+        )
 
         # build the new command
-        new_command = (cmd, None, new_args)
+        new_command = (cmd, None, new_args, new_kwargs)
 
         # Send it to the appropriate class and get the response
         response = new_type.handle_func_command(new_command)

--- a/syft/frameworks/torch/tensors/interpreters/utils.py
+++ b/syft/frameworks/torch/tensors/interpreters/utils.py
@@ -8,12 +8,12 @@ def hook(attr):
 
     def hook_args(self, *args, **kwargs):
         # Replace all syft tensor with their child attribute
-        new_self, new_args = syft.frameworks.torch.hook_args.hook_method_args(
-            attr.__name__, self, args
+        new_self, new_args, new_kwargs = syft.frameworks.torch.hook_args.hook_method_args(
+            attr.__name__, self, args, kwargs
         )
 
         # Send it to the appropriate class and get the response
-        response = attr(self, new_self, *new_args, **kwargs)
+        response = attr(self, new_self, *new_args, **new_kwargs)
 
         # Put back SyftTensor on the tensors found in the response
         response = syft.frameworks.torch.hook_args.hook_response(

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -284,7 +284,7 @@ class BaseWorker(AbstractWorker):
         :return: a pointer to the result
         """
 
-        command, _self, args = message
+        command, _self, args, kwargs = message
 
         # TODO add kwargs
         kwargs = {}


### PR DESCRIPTION
Add support of passive kwargs hook: they are forwarded as is
This is sufficient for python numbers, str, tuple, etc.

removes the warning for cases like:
```
x = torch.tensor([1., 2])
F.log_softmax(x, dim=0)
```