### PR TITLE
Type annotation

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -206,14 +206,7 @@ class BaseWorker(AbstractWorker):
         # Step 1: route message to appropriate function
         response = self._message_router[msg_type](contents)
 
-        # # Step 2: If response in none, set default
-        # TODO: not sure if someone needed this - if this comment
-        # is still here after Feb 15, 2018, please delete these
-        # two lines of (commented out) code.
-        # if response is None:
-        #     response = None
-
-        # Step 3: Serialize the message to simple python objects
+        # Step 2: Serialize the message to simple python objects
         bin_response = serde.serialize(response)
         return bin_response
 

--- a/syft/workers/virtual.py
+++ b/syft/workers/virtual.py
@@ -5,5 +5,5 @@ class VirtualWorker(BaseWorker):
     def _send_msg(self, message: bin, location: BaseWorker) -> bin:
         return location._recv_msg(message)
 
-    def _recv_msg(self, message: bin):
+    def _recv_msg(self, message: bin) -> bin:
         return self.recv_msg(message)

--- a/syft/workers/virtual.py
+++ b/syft/workers/virtual.py
@@ -2,8 +2,8 @@ from .base import BaseWorker
 
 
 class VirtualWorker(BaseWorker):
-    def _send_msg(self, message, location):
+    def _send_msg(self, message: bin, location: BaseWorker) -> bin:
         return location._recv_msg(message)
 
-    def _recv_msg(self, message):
+    def _recv_msg(self, message: bin):
         return self.recv_msg(message)


### PR DESCRIPTION
This is my first contribution attempt ever to OpenMined's PySyft. So, I made it so concise with the issue #1456 

I annotated the 'message' type in _recv_msg and _send_msg (in virtual.py) as binary although they are marked as strings in the doc strings in base.py. I thought this might be a typo  since `send_msg` and `recv_msg` use binary message types. So please let me know if I am missing something here.