### PR TITLE
Fix error in tutorial 2

### DIFF
--- a/examples/tutorials/Part 2 - Intro to Federated Learning.ipynb
+++ b/examples/tutorials/Part 2 - Intro to Federated Learning.ipynb
@@ -158,7 +158,6 @@
    "source": [
     "import syft as sy\n",
     "hook = sy.TorchHook(torch)\n",
-    "from syft import optim\n"
    ]
   },
   {
@@ -235,7 +234,7 @@
     "            loss.backward()\n",
     "\n",
     "            # 5) change those weights\n",
-    "            opt.step(data.shape[0])\n",
+    "            opt.step()\n",
     "            \n",
     "            # NEW) get model (with gradients)\n",
     "            model.get()\n",


### PR DESCRIPTION
I found two places to change while running the tutorial today. Please correct me if I am wrong.

+ It seems that `syft` does not have `optim`?

+ `opt.step` would not take `data.shape[0]` as input because `opt.step` should take some closure.
Doc: https://pytorch.org/docs/stable/optim.html#torch.optim.Optimizer.step