### PR TITLE
Fix moving a module to cuda

### DIFF
--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -336,7 +336,7 @@ class TorchHook:
                 if hasattr(self, "child"):
                     del self.child
 
-                self.native_param_data.set_(new_data)  # .wrap()
+                self.native_param_data.set_(new_data.cpu())  # .wrap()
             return self
 
         torch.nn.Parameter.data = data


### PR DESCRIPTION
new_data and native_param_data are not different device.
moving new_data to cpu before passing to native_param_data's set method

Fixes: #1893