### PR TITLE
Type annotation

### DIFF
--- a/syft/serde.py
+++ b/syft/serde.py
@@ -127,7 +127,7 @@ def deserialize(
             for scheme codes).
 
     Returns:
-        binary: the serialized form of the object.
+        object: the deserialized form of the binary input.
     """
     if worker is None:
         worker = syft.torch.hook.local_worker

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -11,6 +11,7 @@ from syft.exceptions import WorkerNotFoundException
 from syft.workers import AbstractWorker
 from syft.codes import MSGTYPE
 from typing import Union, List
+import torch
 
 
 class BaseWorker(AbstractWorker):

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -9,6 +9,7 @@ from syft.frameworks.torch.tensors.interpreters import PointerTensor
 from syft.exceptions import WorkerNotFoundException
 from syft.workers import AbstractWorker
 from syft.codes import MSGTYPE
+from typing import Union, List
 
 
 class BaseWorker(AbstractWorker):
@@ -88,7 +89,7 @@ class BaseWorker(AbstractWorker):
 
     # SECTION: Methods which MUST be overridden by subclasses
     @abstractmethod
-    def _send_msg(self, message, location):
+    def _send_msg(self, message: bin, location: BaseWorker) -> bin:
         """Sends message from one worker to another.
 
         As BaseWorker implies, you should never instantiate this class by
@@ -98,8 +99,8 @@ class BaseWorker(AbstractWorker):
         example to study is VirtualWorker.
 
         Args:
-            message: A string representing the message being sent from one
-                worker to another.
+            message: A binary message to be sent from one worker
+                to another.
             location: A BaseWorker instance that lets you provide the
                 destination to send the message.
 
@@ -110,7 +111,7 @@ class BaseWorker(AbstractWorker):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def _recv_msg(self, message):
+    def _recv_msg(self, message: bin) -> bin:
         """Receives the message.
 
         As BaseWorker implies, you should never instantiate this class by
@@ -120,7 +121,7 @@ class BaseWorker(AbstractWorker):
         example to study is VirtualWorker.
 
         Args:
-            message: A string representing the message being received.
+            message: The binary message being received.
 
         Raises:
             NotImplementedError: Method not implemented error.
@@ -128,16 +129,16 @@ class BaseWorker(AbstractWorker):
         """
         raise NotImplementedError  # pragma: no cover
 
-    def load_data(self, data):
-        """Allows workers to be initialized with data when created 
-        
+    def load_data(self, data: List[Union[torch.Tensor, Tensor]]) -> None:
+        """Allows workers to be initialized with data when created
+
            The method registers the tensor individual tensor objects.
-        
+
         Args:
-            
+
             data: A list of tensors
 
-            
+
         """
 
         for tensor in data:
@@ -145,7 +146,8 @@ class BaseWorker(AbstractWorker):
             self.register_obj(tensor)
             tensor.owner = self
 
-    def send_msg(self, msg_type, message, location):
+    def send_msg(self, msg_type: int, message: str, location: BaseWorker) -> object:
+
         """Implements the logic to send messages.
 
         The message is serialized and sent to the specified location. The
@@ -180,7 +182,7 @@ class BaseWorker(AbstractWorker):
 
         return response
 
-    def recv_msg(self, bin_message):
+    def recv_msg(self, bin_message: bin) -> bin:
         """Implements the logic to receive messages.
 
         The binary message is deserialized and routed to the appropriate
@@ -213,7 +215,12 @@ class BaseWorker(AbstractWorker):
         # SECTION:recv_msg() uses self._message_router to route to these methods
         # Each method corresponds to a MsgType enum.
 
-    def send(self, tensor, workers, ptr_id=None):
+    def send(
+        self,
+        tensor: Union[torch.Tensor, Tensor],
+        workers: BaseWorker,
+        ptr_id: Union[str, int] = None,
+    ) -> PointerTensor:
         """Sends tensor to the worker(s).
 
         Send a syft or torch tensor and his child, sub-child, etc (all the
@@ -341,7 +348,8 @@ class BaseWorker(AbstractWorker):
 
         return response
 
-    def set_obj(self, obj):
+    def set_obj(self, obj: Union[torch.Tensor, Tensor]) -> None:
+
         """Adds an object to the registry of objects.
 
         Args:
@@ -349,7 +357,7 @@ class BaseWorker(AbstractWorker):
         """
         self._objects[obj.id] = obj
 
-    def get_obj(self, obj_id):
+    def get_obj(self, obj_id: Union[str, int]) -> object:
         """Returns the object from registry.
 
         Look up an object from the registry using its ID.

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -206,14 +206,7 @@ class BaseWorker(AbstractWorker):
         # Step 1: route message to appropriate function
         response = self._message_router[msg_type](contents)
 
-        # # Step 2: If response in none, set default
-        # TODO: not sure if someone needed this - if this comment
-        # is still here after Feb 15, 2018, please delete these
-        # two lines of (commented out) code.
-        # if response is None:
-        #     response = None
-
-        # Step 3: Serialize the message to simple python objects
+        # Step 2: Serialize the message to simple python objects
         bin_response = serde.serialize(response)
         return bin_response
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -10,7 +10,8 @@ from syft.frameworks.torch.tensors.interpreters import AbstractTensor
 from syft.exceptions import WorkerNotFoundException
 from syft.workers import AbstractWorker
 from syft.codes import MSGTYPE
-from typing import Union, List
+from typing import Union
+from typing import List
 import torch
 
 
@@ -86,7 +87,7 @@ class BaseWorker(AbstractWorker):
 
     # SECTION: Methods which MUST be overridden by subclasses
     @abstractmethod
-    def _send_msg(self, message: bin, location: "BaseWorker") -> bin:
+    def _send_msg(self, message: bin, location: "BaseWorker"):
         """Sends message from one worker to another.
 
         As BaseWorker implies, you should never instantiate this class by
@@ -108,7 +109,7 @@ class BaseWorker(AbstractWorker):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def _recv_msg(self, message: bin) -> bin:
+    def _recv_msg(self, message: bin):
         """Receives the message.
 
         As BaseWorker implies, you should never instantiate this class by

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 import syft as sy
 from syft import serde
 from syft.frameworks.torch.tensors.interpreters import PointerTensor
+from syft.frameworks.torch.tensors.interpreters import AbstractTensor
 from syft.exceptions import WorkerNotFoundException
 from syft.workers import AbstractWorker
 from syft.codes import MSGTYPE
@@ -89,7 +90,7 @@ class BaseWorker(AbstractWorker):
 
     # SECTION: Methods which MUST be overridden by subclasses
     @abstractmethod
-    def _send_msg(self, message: bin, location: BaseWorker) -> bin:
+    def _send_msg(self, message: bin, location: "BaseWorker") -> bin:
         """Sends message from one worker to another.
 
         As BaseWorker implies, you should never instantiate this class by
@@ -129,7 +130,8 @@ class BaseWorker(AbstractWorker):
         """
         raise NotImplementedError  # pragma: no cover
 
-    def load_data(self, data: List[Union[torch.Tensor, Tensor]]) -> None:
+    def load_data(self, data: List[Union[torch.Tensor, AbstractTensor]]) -> None:
+
         """Allows workers to be initialized with data when created
 
            The method registers the tensor individual tensor objects.
@@ -146,7 +148,7 @@ class BaseWorker(AbstractWorker):
             self.register_obj(tensor)
             tensor.owner = self
 
-    def send_msg(self, msg_type: int, message: str, location: BaseWorker) -> object:
+    def send_msg(self, msg_type: int, message: str, location: "BaseWorker") -> object:
 
         """Implements the logic to send messages.
 
@@ -217,8 +219,8 @@ class BaseWorker(AbstractWorker):
 
     def send(
         self,
-        tensor: Union[torch.Tensor, Tensor],
-        workers: BaseWorker,
+        tensor: Union[torch.Tensor, AbstractTensor],
+        workers: "BaseWorker",
         ptr_id: Union[str, int] = None,
     ) -> PointerTensor:
         """Sends tensor to the worker(s).
@@ -348,7 +350,7 @@ class BaseWorker(AbstractWorker):
 
         return response
 
-    def set_obj(self, obj: Union[torch.Tensor, Tensor]) -> None:
+    def set_obj(self, obj: Union[torch.Tensor, AbstractTensor]) -> None:
 
         """Adds an object to the registry of objects.
 

--- a/syft/workers/virtual.py
+++ b/syft/workers/virtual.py
@@ -5,5 +5,5 @@ class VirtualWorker(BaseWorker):
     def _send_msg(self, message: bin, location: BaseWorker) -> bin:
         return location._recv_msg(message)
 
-    def _recv_msg(self, message: bin):
+    def _recv_msg(self, message: bin) -> bin:
         return self.recv_msg(message)

--- a/syft/workers/virtual.py
+++ b/syft/workers/virtual.py
@@ -2,8 +2,8 @@ from .base import BaseWorker
 
 
 class VirtualWorker(BaseWorker):
-    def _send_msg(self, message, location):
+    def _send_msg(self, message: bin, location: BaseWorker) -> bin:
         return location._recv_msg(message)
 
-    def _recv_msg(self, message):
+    def _recv_msg(self, message: bin):
         return self.recv_msg(message)


### PR DESCRIPTION
Here are some more type annotations. I was not very sure how to annotation Syft Tensors that are not PointerTensors. I ended up using `AbstractTensor`. 

For torch tensors I used `torch.Tensor`.

For annotating self type classes I used strings "BaseWorker" when annotating this type from inside the BaseWorker class. It seems to be the solution for python<=3.6. For python 3.7 and above, there is another solution by importing

`from __future__ import annotations` then self type annotation is supposed to work out of the box

Thanks for the review