### PR TITLE
Removing **kwargs from FederatedDataLoader func

### DIFF
--- a/examples/tutorials/Part 8 - Federated Learning on MNIST using a CNN.ipynb
+++ b/examples/tutorials/Part 8 - Federated Learning on MNIST using a CNN.ipynb
@@ -126,7 +126,7 @@
     "                       transforms.Normalize((0.1307,), (0.3081,))\n",
     "                   ]))\n",
     "    .federate((bob, alice)), # <-- NEW: we distribute the dataset across all the workers, it's now a FederatedDataset\n",
-    "    batch_size=args.batch_size, shuffle=True, **kwargs)\n",
+    "    batch_size=args.batch_size, shuffle=True)\n",
     "\n",
     "test_loader = torch.utils.data.DataLoader(\n",
     "    datasets.MNIST('../data', train=False, transform=transforms.Compose([\n",


### PR DESCRIPTION
In the FederatedDataLoader function, `**kwargs` is passed as a parameter. 
> kwargs = {'num_workers': 1, 'pin_memory': True}

However, the DataLoader function implementation in Pysyft doesn't take `num_workers` and `pin_memory` as arguments as in pytorch. 

> **Hence when I tried running this below snippet **

> `federated_train_loader = sy.FederatedDataLoader( 
    datasets.MNIST('../data', train=True, download=True,
                   transform=transforms.Compose([
                       transforms.ToTensor(),
                       transforms.Normalize((0.1307,), (0.3081,))
                   ]))
    .federate((bob, alice)), 
    batch_size=args.batch_size, shuffle=True, **kwargs)`

> **I got the following error:**


`>---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-29-f419dd3295b1> in <module>()
      5                        transforms.Normalize((0.1307,), (0.3081,))
      6                    ]))
----> 7     .federate((bob, alice)), batch_size=args.batch_size, shuffle=True, **kwargs)
      8 
      9 test_loader = torch.utils.data.DataLoader(
      TypeError: __init__() got an unexpected keyword argument 'num_workers'  `

Shouldn't `**kwargs` be removed from this function?