### PR TITLE
Serialization strategies

### DIFF
--- a/syft/serde.py
+++ b/syft/serde.py
@@ -183,11 +183,15 @@ def deserialize_tensor(tensor_bin) -> torch.Tensor:
 
 
 def numpy_tensor_serializer(tensor: torch.Tensor) -> bin:
-    """Strategy to serialize a tensor using numpy npy format"""
-    assert not tensor.requires_grad, (
-        "Torch to Numpy serializer can only be used with tensors that do not require"
-        "grad. This is a current limitation of Torch"
-    )
+    """Strategy to serialize a tensor using numpy npy format.
+    If tensor requires to calculate gradients, it will detached.
+    """
+    if tensor.requires_grad:
+        print(
+            "Torch to Numpy serializer can only be used with tensors that do not require"
+            "grad. Detaching tensor to continue"
+        )
+        tensor = tensor.detach()
 
     np_tensor = tensor.numpy()
     outfile = TemporaryFile()

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -27,34 +27,32 @@ tuple type. The same is true for all other simplifier/detailer functions.
 
 By default, we serialize using msgpack and compress using lz4.
 """
-
+import io
+import zstd
+from tempfile import TemporaryFile
 from typing import Collection
 from typing import Dict
 from typing import Tuple
-import torch
-import msgpack
+
 import lz4
+import msgpack
+import numpy
+import torch
 from lz4 import (  # noqa: F401
     frame,
 )  # needed as otherwise we will get: module 'lz4' has no attribute 'frame'
-import io
-import numpy
-import zstd
+
 import syft
 import syft as sy
-
-from syft.workers import AbstractWorker
+from syft.exceptions import CompressionNotFoundException
 from syft.frameworks.torch.tensors.decorators import LoggingTensor
 from syft.frameworks.torch.tensors.interpreters import PointerTensor
-
 from syft.frameworks.torch.tensors.interpreters.abstract import initialize_tensor
-from syft.exceptions import CompressionNotFoundException
-
+from syft.workers import AbstractWorker
 
 # COMPRESSION SCHEME INT CODES
 LZ4 = 0
 ZSTD = 1
-
 
 # Indicator on binary header that compression was not used.
 UNUSED_COMPRESSION_INDICATOR = 48
@@ -157,6 +155,70 @@ def deserialize(
     return _detail(worker, simple_objects)
 
 
+def serialize_tensor(tensor) -> bin:
+    """Serialize the tensor using as default Torch serialization strategy
+    This function can be overridden to provide different tensor serialization strategies
+
+    Args
+        (torch.Tensor): an input tensor to be serialized
+
+    Returns
+        A serialized version of the input tensor
+
+    """
+    return torch_tensor_serializer(tensor)
+
+
+def deserialize_tensor(tensor_bin) -> torch.Tensor:
+    """Deserialize the input tensor passed as parameter into a Torch tensor.
+    This function can be overridden to provide different deserialization strategies
+
+    Args
+        tensor_bin: A binary representation of a tensor
+
+    Returns
+        a Torch tensor
+    """
+    return torch_tensor_deserializer(tensor_bin)
+
+
+def numpy_tensor_serializer(tensor: torch.Tensor) -> bin:
+    """Strategy to serialize a tensor using numpy npy format"""
+    assert not tensor.requires_grad, (
+        "Torch to Numpy serializer can only be used with tensors that do not require"
+        "grad. This is a current limitation of Torch"
+    )
+
+    np_tensor = tensor.numpy()
+    outfile = TemporaryFile()
+    numpy.save(outfile, np_tensor)
+    # Simulate close and open by calling seek
+    outfile.seek(0)
+    return outfile.read()
+
+
+def numpy_tensor_deserializer(tensor_bin) -> torch.Tensor:
+    """"Strategy to deserialize a binary input in npy format into a Torch tensor"""
+    input_file = TemporaryFile()
+    input_file.write(tensor_bin)
+    # read data from file
+    input_file.seek(0)
+    return torch.from_numpy(numpy.load(input_file))
+
+
+def torch_tensor_serializer(tensor) -> bin:
+    """Strategy to serialize a tensor using Torch saver"""
+    binary_stream = io.BytesIO()
+    torch.save(tensor, binary_stream)
+    return binary_stream.getvalue()
+
+
+def torch_tensor_deserializer(tensor_bin) -> torch.Tensor:
+    """"Strategy to deserialize a binary input using Torch load"""
+    bin_tensor_stream = io.BytesIO(tensor_bin)
+    return torch.load(bin_tensor_stream)
+
+
 # Chosen Compression Algorithm
 
 
@@ -223,9 +285,7 @@ def _simplify_torch_tensor(tensor: torch.Tensor) -> bin:
         (optinally) is the chain of graident tensors (nested tuple)
     """
 
-    binary_stream = io.BytesIO()
-    torch.save(tensor, binary_stream)
-    tensor_bin = binary_stream.getvalue()
+    tensor_bin = serialize_tensor(tensor)
 
     # note we need to do this expicitly because torch.save does not
     # seem to be including .grad by default
@@ -275,8 +335,7 @@ def _detail_torch_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> torch.T
 
     tensor_id, tensor_bin, chain, grad_chain, tags, description = tensor_tuple
 
-    bin_tensor_stream = io.BytesIO(tensor_bin)
-    tensor = torch.load(bin_tensor_stream)
+    tensor = deserialize_tensor(tensor_bin)
 
     # note we need to do this explicitly because torch.load does not
     # include .grad informatino
@@ -777,7 +836,6 @@ def _detail_pointer_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> Point
             if tensor is not None:
 
                 if not tensor.is_wrapper and not isinstance(tensor, torch.Tensor):
-
                     # if the tensor is a wrapper then it doesn't need to be wrapped
                     # i the tensor isn't a wrapper, BUT it's just a plain torch tensor,
                     # then it doesn't need to be wrapped.

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -482,8 +482,8 @@ def test_pointer_tensor_detail(id):
 
 
 def test_numpy_tensor_serde():
-    syft.serde.serialize_tensor = syft.serde.numpy_tensor_serializer
-    syft.serde.deserialize_tensor = syft.serde.numpy_tensor_deserializer
+    syft.serde._serialize_tensor = syft.serde.numpy_tensor_serializer
+    syft.serde._deserialize_tensor = syft.serde.numpy_tensor_deserializer
 
     tensor = torch.tensor(numpy.random.random((10, 10)), requires_grad=False)
 
@@ -491,7 +491,7 @@ def test_numpy_tensor_serde():
     tensor_deserialized = deserialize(tensor_serialized)
 
     # Back to Pytorch serializer
-    syft.serde.serialize_tensor = syft.serde.torch_tensor_serializer
-    syft.serde.deserialize_tensor = syft.serde.torch_tensor_deserializer
+    syft.serde._serialize_tensor = syft.serde.torch_tensor_serializer
+    syft.serde._deserialize_tensor = syft.serde.torch_tensor_deserializer
 
     assert torch.eq(tensor_deserialized, tensor).all()

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -479,3 +479,19 @@ def test_pointer_tensor_detail(id):
     x_ptr = 2 * x_ptr
     x_back = x_ptr.get()
     assert (x_back == 2 * x).all()
+
+
+def test_numpy_tensor_serde():
+    syft.serde.serialize_tensor = syft.serde.numpy_tensor_serializer
+    syft.serde.deserialize_tensor = syft.serde.numpy_tensor_deserializer
+
+    tensor = torch.tensor(numpy.random.random((10, 10)), requires_grad=False)
+
+    tensor_serialized = serialize(tensor)
+    tensor_deserialized = deserialize(tensor_serialized)
+
+    # Back to Pytorch serializer
+    syft.serde.serialize_tensor = syft.serde.torch_tensor_serializer
+    syft.serde.deserialize_tensor = syft.serde.torch_tensor_deserializer
+
+    assert torch.eq(tensor_deserialized, tensor).all()


### PR DESCRIPTION
This PR enables different strategies to serialise/deserialise tensors.
Right now the serialisation of the tensors is delegated to Torch but the serialised objects are not compatible with other platforms

This PR includes a strategy to seder the tensors using npy format