### PR TITLE
Replace hard-coded compression by strategy

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/abstract.py
+++ b/syft/frameworks/torch/tensors/interpreters/abstract.py
@@ -90,21 +90,13 @@ class AbstractTensor(ABC):
         # wrapper.child.parent = weakref.ref(wrapper)
         return wrapper
 
-    def serialize(
-        self, compress=True, compress_scheme=0
-    ):  # Code 0 is LZ4 - check serde.py to see others
+    def serialize(self):  # check serde.py to see how to provide compression schemes
         """Serializes the tensor on which it's called.
 
         This is the high level convenience function for serializing torch
         tensors. It includes three steps, Simplify, Serialize, and Compress as
         described in serde.py.
-
-        Args:
-            compress: A boolean indicating whether to compress the object or
-                not.
-            compress_scheme: An integer code specifying the compression scheme
-                to use (see serde.py for scheme codes) if compress is True. The
-                compression scheme is set to LZ4 by default (code 0).
+        By default serde is compressing using LZ4
 
         Returns:
             The serialized form of the tensor.
@@ -112,7 +104,7 @@ class AbstractTensor(ABC):
                 x = torch.Tensor([1,2,3,4,5])
                 x.serialize() # returns a serialized object
         """
-        return sy.serde.serialize(self, compress=compress, compress_scheme=compress_scheme)
+        return sy.serde.serialize(self)
 
     def ser(self, *args, **kwargs):
         return self.serialize(*args, **kwargs)

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -25,7 +25,11 @@ are the types and values are the simplification logic. For example,
 simplifiers[tuple] will return the function which knows how to simplify the
 tuple type. The same is true for all other simplifier/detailer functions.
 
+By default, the simplification/detail operations expect Torch tensors. If the setup requires other
+serialization process, it can override the functions _serialize_tensor and _deserialize_tensor
+
 By default, we serialize using msgpack and compress using lz4.
+If different compressions are required, the worker can override the function _apply_compress_scheme
 """
 from tempfile import TemporaryFile
 from typing import Collection
@@ -55,16 +59,15 @@ from syft.frameworks.torch.tensors.decorators import LoggingTensor
 from syft.frameworks.torch.tensors.interpreters import PointerTensor
 from syft.frameworks.torch.tensors.interpreters.abstract import initialize_tensor
 
-# COMPRESSION SCHEME INT CODES
-LZ4 = 0
-ZSTD = 1
 
-# Indicator on binary header that compression was not used.
-UNUSED_COMPRESSION_INDICATOR = 48
+# COMPRESSION SCHEME INT CODES
+NO_COMPRESSION = 40
+LZ4 = 41
+ZSTD = 42
 
 
 # High Level Public Functions (these are the ones you use)
-def serialize(obj: object, compress=True, compress_scheme=LZ4, simplified=False) -> bin:
+def serialize(obj: object, simplified=False) -> bin:
     """This method can serialize any object PySyft needs to send or store.
 
     This is the high level function for serializing any object or collection
@@ -73,10 +76,6 @@ def serialize(obj: object, compress=True, compress_scheme=LZ4, simplified=False)
 
     Args:
         obj (object): the object to be serialized
-        compress (bool): whether or not to compress the object
-        compress_scheme (int): the integer code specifying which compression
-            scheme to use (see above this method for scheme codes) if
-            compress == True.
         simplified (bool): in some cases we want to pass in data which has
             already been simplified - in which case we must skip double
             simplification - which would be bad.... so bad... so... so bad
@@ -107,12 +106,10 @@ def serialize(obj: object, compress=True, compress_scheme=LZ4, simplified=False)
     # otherwise we output the compressed stream with header set to '1'
     # even if compressed flag is set to false by the caller we
     # output the input stream as it is with header set to '0'
-    return _compress(binary, compress_scheme, compress)
+    return _compress(binary)
 
 
-def deserialize(
-    binary: bin, worker: AbstractWorker = None, compressed=True, compress_scheme=LZ4, detail=True
-) -> object:
+def deserialize(binary: bin, worker: AbstractWorker = None, detail=True) -> object:
     """ This method can deserialize any object PySyft needs to send or store.
 
     This is the high level function for deserializing any object or collection
@@ -124,11 +121,6 @@ def deserialize(
         worker (AbstractWorker): the worker which is acquiring the message content,
             for example used to specify the owner of a tensor received(not obvious
             for virtual workers)
-        compressed (bool): whether or not the serialized object is compressed
-            (and thus whether or not it needs to be decompressed).
-        compress_scheme (int): the integer code specifying which compression
-            scheme was used if decompression is needed (see above this method
-            for scheme codes).
         detail (bool): there are some cases where we need to perform the decompression
             and deserialization part, but we don't need to detail all the message.
             This is the case for Plan workers for instance
@@ -140,7 +132,7 @@ def deserialize(
         worker = syft.torch.hook.local_worker
 
     # 1) Decompress the binary if needed
-    binary = _decompress(binary, compress_scheme)
+    binary = _decompress(binary)
 
     # 2) Deserialize
     # This function converts the binary into the appropriate python
@@ -232,74 +224,101 @@ def torch_tensor_deserializer(tensor_bin) -> torch.Tensor:
 # Chosen Compression Algorithm
 
 
-def _compress(decompressed_input_bin: bin, compress_scheme=LZ4, compress=True) -> bin:
+def _apply_compress_scheme(decompressed_input_bin) -> tuple:
     """
-    This function compresses a binary using LZ4
+    Apply the selected compression scheme.
+    By default is used LZ4
+
+    Args:
+        decompressed_input_bin: the binary to be compressed
+    """
+    return apply_lz4_compression(decompressed_input_bin)
+
+
+def apply_lz4_compression(decompressed_input_bin) -> tuple:
+    """
+    Apply LZ4 compression to the input
+
+    Args:
+        :param decompressed_input_bin: the binary to be compressed
+        :return: a tuple (compressed_result, LZ4)
+    """
+    return lz4.frame.compress(decompressed_input_bin), LZ4
+
+
+def apply_zstd_compression(decompressed_input_bin) -> tuple:
+    """
+    Apply ZSTD compression to the input
+
+    Args:
+        :param decompressed_input_bin: the binary to be compressed
+        :return: a tuple (compressed_result, ZSTD)
+    """
+
+    return zstd.compress(decompressed_input_bin), ZSTD
+
+
+def apply_no_compression(decompressed_input_bin) -> tuple:
+    """
+    No compression is applied to the input
+
+    Args:
+        :param decompressed_input_bin: the binary
+        :return: a tuple (the binary, LZ4)
+    """
+
+    return decompressed_input_bin, NO_COMPRESSION
+
+
+def _compress(decompressed_input_bin: bin) -> bin:
+    """
+    This function compresses a binary using the function _apply_compress_scheme
+    if the input has been already compressed in some step, it will return it as it is
 
     Args:
         decompressed_input_bin (bin): binary to be compressed
-        compress_scheme: the compression method to use
-        compress (bool): if the data is already compressed, there is no
-            need to re-compress the input.
 
     Returns:
         bin: a compressed binary
 
     """
 
-    if compress:
+    compress_stream, compress_scheme = _apply_compress_scheme(decompressed_input_bin)
 
-        if compress_scheme == LZ4:
-            compress_stream = lz4.frame.compress(decompressed_input_bin)
-        elif compress_scheme == ZSTD:
-            compress_stream = zstd.compress(decompressed_input_bin)
-        else:
-            raise CompressionNotFoundException(
-                "compression scheme note found for" " compression code:" + str(compress_scheme)
-            )
-
-        if len(compress_stream) < len(decompressed_input_bin):
-            return b"\x31" + compress_stream
-
-    return b"\x30" + decompressed_input_bin
+    if len(compress_stream) < len(decompressed_input_bin):
+        return compress_scheme.to_bytes(1, byteorder="big") + compress_stream
+    else:
+        return NO_COMPRESSION.to_bytes(1, byteorder="big") + decompressed_input_bin
 
 
-def _decompress(binary: bin, compress_scheme=LZ4) -> bin:
+def _decompress(binary: bin) -> bin:
     """
-    This function decompresses a binary using LZ4
+    This function decompresses a binary using the scheme defined in the first byte of the input
 
     Args:
-        compressed_input_bin (bin): a compressed binary
-        compress_scheme: the compression method to use
+        binary (bin): a compressed binary
 
     Returns:
         bin: decompressed binary
 
     """
 
-    # check the 1-byte header to see if input stream was compressed or not
-    if binary[0] == UNUSED_COMPRESSION_INDICATOR:
-        compressed = False
-    else:
-        compressed = True
+    # check the 1-byte header to check the compression scheme used
+    compress_scheme = binary[0]
 
     # remove the 1-byte header from the input stream
     binary = binary[1:]
-
-    # 1)  Decompress
-    # If enabled, this functionality decompresses the binary
-    if compressed:
-
-        if compress_scheme == LZ4:
-            return lz4.frame.decompress(binary)
-        elif compress_scheme == ZSTD:
-            return zstd.decompress(binary)
-        else:
-            raise CompressionNotFoundException(
-                "compression scheme note found for" " compression code:" + str(compress_scheme)
-            )
-
-    return binary
+    # 1)  Decompress or return the original stream
+    if compress_scheme == LZ4:
+        return lz4.frame.decompress(binary)
+    elif compress_scheme == ZSTD:
+        return zstd.decompress(binary)
+    elif compress_scheme == NO_COMPRESSION:
+        return binary
+    else:
+        raise CompressionNotFoundException(
+            "compression scheme not found for" " compression code:" + str(compress_scheme)
+        )
 
 
 # Simplify/Detail Torch Tensors

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -3,7 +3,14 @@ This file tests the ability for serde.py to convert complex types into
 simple python types which are serializable by standard serialization tools.
 For more on how/why this works, see serde.py directly.
 """
-from syft.serde import _simplify
+import warnings
+
+from syft.serde import (
+    _simplify,
+    apply_lz4_compression,
+    apply_no_compression,
+    apply_zstd_compression,
+)
 from syft.serde import serialize
 from syft.serde import deserialize
 from syft.serde import _compress
@@ -205,9 +212,14 @@ def test_pointer_tensor_simplify():
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_torch_Tensor(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     t = Tensor(numpy.random.random((100, 100)))
-    t_serialized = serialize(t, compress=compress)
-    t_serialized_deserialized = deserialize(t_serialized, compressed=compress)
+    t_serialized = serialize(t)
+    t_serialized_deserialized = deserialize(t_serialized)
     assert (t == t_serialized_deserialized).all()
 
 
@@ -219,27 +231,36 @@ def test_torch_Tensor_convenience(compress):
     have a convenience function which lets you call .serialize()
     directly on the tensor itself. This tests to makes sure it
     works correctly."""
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
 
     t = Tensor(numpy.random.random((100, 100)))
-    t_serialized = t.serialize(compress=compress)
-    t_serialized_deserialized = deserialize(t_serialized, compressed=compress)
+    t_serialized = t.serialize()
+    t_serialized_deserialized = deserialize(t_serialized)
     assert (t == t_serialized_deserialized).all()
 
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_tuple(compress):
     # Test with a simple datatype
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     tuple = (1, 2)
-    tuple_serialized = serialize(tuple, compress=compress)
-    tuple_serialized_deserialized = deserialize(tuple_serialized, compressed=compress)
+    tuple_serialized = serialize(tuple)
+    tuple_serialized_deserialized = deserialize(tuple_serialized)
     assert tuple == tuple_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     tuple = (tensor_one, tensor_two)
-    tuple_serialized = serialize(tuple, compress=compress)
-    tuple_serialized_deserialized = deserialize(tuple_serialized, compressed=compress)
+    tuple_serialized = serialize(tuple)
+    tuple_serialized_deserialized = deserialize(tuple_serialized)
     # `assert tuple_serialized_deserialized == tuple` does not work, therefore it's split
     # into 3 assertions
     assert type(tuple_serialized_deserialized) == type(tuple)
@@ -249,83 +270,107 @@ def test_tuple(compress):
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_bytearray(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     bytearr = bytearray("This is a teststring", "utf-8")
-    bytearr_serialized = serialize(bytearr, compress=compress)
-    bytearr_serialized_desirialized = deserialize(bytearr_serialized, compressed=compress)
+    bytearr_serialized = serialize(bytearr)
+    bytearr_serialized_desirialized = deserialize(bytearr_serialized)
     assert bytearr == bytearr_serialized_desirialized
 
     bytearr = bytearray(numpy.random.random((100, 100)))
-    bytearr_serialized = serialize(bytearr, compress=False)
-    bytearr_serialized_desirialized = deserialize(bytearr_serialized, compressed=False)
+    bytearr_serialized = serialize(bytearr)
+    bytearr_serialized_desirialized = deserialize(bytearr_serialized)
     assert bytearr == bytearr_serialized_desirialized
 
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_ndarray_serde(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
     arr = numpy.random.random((100, 100))
-    arr_serialized = serialize(arr, compress=compress)
+    arr_serialized = serialize(arr)
 
-    arr_serialized_deserialized = deserialize(arr_serialized, compressed=compress)
+    arr_serialized_deserialized = deserialize(arr_serialized)
 
     assert numpy.array_equal(arr, arr_serialized_deserialized)
 
 
 @pytest.mark.parametrize("compress_scheme", [LZ4, ZSTD])
 def test_compress_decompress(compress_scheme):
+    if compress_scheme == LZ4:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    elif compress_scheme == ZSTD:
+        syft.serde._apply_compress_scheme = apply_zstd_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     original = msgpack.dumps([1, 2, 3])
-    compressed = _compress(original, compress_scheme=compress_scheme)
-    decompressed = _decompress(compressed, compress_scheme=compress_scheme)
+    compressed = _compress(original)
+    decompressed = _decompress(compressed)
     assert type(compressed) == bytes
     assert original == decompressed
 
 
 @pytest.mark.parametrize("compress_scheme", [LZ4, ZSTD])
 def test_compressed_serde(compress_scheme):
-    arr = numpy.random.random((100, 100))
-    arr_serialized = serialize(arr, compress=True, compress_scheme=compress_scheme)
+    if compress_scheme == LZ4:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    elif compress_scheme == ZSTD:
+        syft.serde._apply_compress_scheme = apply_zstd_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
 
-    arr_serialized_deserialized = deserialize(
-        arr_serialized, compressed=True, compress_scheme=compress_scheme
-    )
+    arr = numpy.random.random((100, 100))
+    arr_serialized = serialize(arr)
+
+    arr_serialized_deserialized = deserialize(arr_serialized)
     assert numpy.array_equal(arr, arr_serialized_deserialized)
 
 
-@pytest.mark.parametrize("compress_scheme", [-1, 2, 3, 1000])
-def test_invalid_compression_scheme(compress_scheme):
-    arr = numpy.random.random((100, 100))
-    with pytest.raises(CompressionNotFoundException):
-        _ = serialize(arr, compress=True, compress_scheme=compress_scheme)
-
-
-@pytest.mark.parametrize("compress_scheme", [-1, 2, 3, 1000])
+@pytest.mark.parametrize("compress_scheme", [1, 2, 3, 100])
 def test_invalid_decompression_scheme(compress_scheme):
     # using numpy.ones because numpy.random.random is not compressed.
     arr = numpy.ones((100, 100))
-    arr_serialized = serialize(arr, compress=True, compress_scheme=LZ4)
+
+    def some_other_compression_scheme(decompressed_input):
+        # Simulate compression by removing some values
+        return decompressed_input[:10], compress_scheme
+
+    syft.serde._apply_compress_scheme = some_other_compression_scheme
+    arr_serialized = serialize(arr)
     with pytest.raises(CompressionNotFoundException):
-        _ = deserialize(arr_serialized, compressed=True, compress_scheme=compress_scheme)
+        _ = deserialize(arr_serialized)
 
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_dict(compress):
     # Test with integers
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
     _dict = {1: 1, 2: 2, 3: 3}
-    dict_serialized = serialize(_dict, compress=compress)
-    dict_serialized_deserialized = deserialize(dict_serialized, compressed=compress)
+    dict_serialized = serialize(_dict)
+    dict_serialized_deserialized = deserialize(dict_serialized)
     assert _dict == dict_serialized_deserialized
 
     # Test with strings
     _dict = {"one": 1, "two": 2, "three": 3}
-    dict_serialized = serialize(_dict, compress=compress)
-    dict_serialized_deserialized = deserialize(dict_serialized, compressed=compress)
+    dict_serialized = serialize(_dict)
+    dict_serialized_deserialized = deserialize(dict_serialized)
     assert _dict == dict_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     _dict = {0: tensor_one, 1: tensor_two}
-    dict_serialized = serialize(_dict, compress=compress)
-    dict_serialized_deserialized = deserialize(dict_serialized, compressed=compress)
+    dict_serialized = serialize(_dict)
+    dict_serialized_deserialized = deserialize(dict_serialized)
     # `assert dict_serialized_deserialized == _dict` does not work, therefore it's split
     # into 3 assertions
     assert type(dict_serialized_deserialized) == type(_dict)
@@ -335,35 +380,45 @@ def test_dict(compress):
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_range_serde(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     _range = range(1, 2, 3)
 
-    range_serialized = serialize(_range, compress=compress)
+    range_serialized = serialize(_range)
 
-    range_serialized_deserialized = deserialize(range_serialized, compressed=compress)
+    range_serialized_deserialized = deserialize(range_serialized)
 
     assert _range == range_serialized_deserialized
 
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_list(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     # Test with integers
     _list = [1, 2]
-    list_serialized = serialize(_list, compress=compress)
-    list_serialized_deserialized = deserialize(list_serialized, compressed=compress)
+    list_serialized = serialize(_list)
+    list_serialized_deserialized = deserialize(list_serialized)
     assert _list == list_serialized_deserialized
 
     # Test with strings
     _list = ["hello", "world"]
-    list_serialized = serialize(_list, compress=compress)
-    list_serialized_deserialized = deserialize(list_serialized, compressed=compress)
+    list_serialized = serialize(_list)
+    list_serialized_deserialized = deserialize(list_serialized)
     assert _list == list_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     _list = (tensor_one, tensor_two)
-    list_serialized = serialize(_list, compress=compress)
-    list_serialized_deserialized = deserialize(list_serialized, compressed=compress)
+    list_serialized = serialize(_list)
+    list_serialized_deserialized = deserialize(list_serialized)
     # `assert list_serialized_deserialized == _list` does not work, therefore it's split
     # into 3 assertions
     assert type(list_serialized_deserialized) == type(_list)
@@ -373,24 +428,29 @@ def test_list(compress):
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_set(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     # Test with integers
     _set = set([1, 2])
-    set_serialized = serialize(_set, compress=compress)
-    set_serialized_deserialized = deserialize(set_serialized, compressed=compress)
+    set_serialized = serialize(_set)
+    set_serialized_deserialized = deserialize(set_serialized)
     assert _set == set_serialized_deserialized
 
     # Test with strings
     _set = set(["hello", "world"])
-    set_serialized = serialize(_set, compress=compress)
-    set_serialized_deserialized = deserialize(set_serialized, compressed=compress)
+    set_serialized = serialize(_set)
+    set_serialized_deserialized = deserialize(set_serialized)
     assert _set == set_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     _set = (tensor_one, tensor_two)
-    set_serialized = serialize(_set, compress=compress)
-    set_serialized_deserialized = deserialize(set_serialized, compressed=compress)
+    set_serialized = serialize(_set)
+    set_serialized_deserialized = deserialize(set_serialized)
     # `assert set_serialized_deserialized == _set` does not work, therefore it's split
     # into 3 assertions
     assert type(set_serialized_deserialized) == type(_set)
@@ -400,18 +460,23 @@ def test_set(compress):
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_slice(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     s = slice(0, 100, 2)
     x = numpy.random.rand(100)
-    s_serialized = serialize(s, compress=compress)
-    s_serialized_deserialized = deserialize(s_serialized, compressed=compress)
+    s_serialized = serialize(s)
+    s_serialized_deserialized = deserialize(s_serialized)
 
     assert type(s) == type(s_serialized_deserialized)
     assert (x[s] == x[s_serialized_deserialized]).all()
 
     s = slice(40, 50)
     x = numpy.random.rand(100)
-    s_serialized = serialize(s, compress=False)
-    s_serialized_deserialized = deserialize(s_serialized, compressed=False)
+    s_serialized = serialize(s)
+    s_serialized_deserialized = deserialize(s_serialized)
 
     assert type(s) == type(s_serialized_deserialized)
     assert (x[s] == x[s_serialized_deserialized]).all()
@@ -419,14 +484,19 @@ def test_slice(compress):
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_float(compress):
+    if compress:
+        syft.serde._apply_compress_scheme = apply_lz4_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     x = 0.5
     y = 1.5
 
-    x_serialized = serialize(x, compress=compress)
-    x_serialized_deserialized = deserialize(x_serialized, compressed=compress)
+    x_serialized = serialize(x)
+    x_serialized_deserialized = deserialize(x_serialized)
 
-    y_serialized = serialize(y, compress=compress)
-    y_serialized_deserialized = deserialize(y_serialized, compressed=compress)
+    y_serialized = serialize(y)
+    y_serialized_deserialized = deserialize(y_serialized)
 
     assert x_serialized_deserialized == x
     assert y_serialized_deserialized == y
@@ -436,11 +506,11 @@ def test_compressed_float():
     x = 0.5
     y = 1.5
 
-    x_serialized = serialize(x, compress=True)
-    x_serialized_deserialized = deserialize(x_serialized, compressed=True)
+    x_serialized = serialize(x)
+    x_serialized_deserialized = deserialize(x_serialized)
 
-    y_serialized = serialize(y, compress=True)
-    y_serialized_deserialized = deserialize(y_serialized, compressed=True)
+    y_serialized = serialize(y)
+    y_serialized_deserialized = deserialize(y_serialized)
 
     assert x_serialized_deserialized == x
     assert y_serialized_deserialized == y
@@ -450,20 +520,29 @@ def test_compressed_float():
     "compress, compress_scheme", [(True, LZ4), (False, LZ4), (True, ZSTD), (False, ZSTD)]
 )
 def test_hooked_tensor(compress, compress_scheme):
+    if compress:
+        if compress_scheme == LZ4:
+            syft.serde._apply_compress_scheme = apply_lz4_compression
+        elif compress_scheme == ZSTD:
+            syft.serde._apply_compress_scheme = apply_zstd_compression
+        else:
+            syft.serde._apply_compress_scheme = apply_no_compression
+    else:
+        syft.serde._apply_compress_scheme = apply_no_compression
+
     t = Tensor(numpy.random.random((100, 100)))
-    t_serialized = serialize(t, compress=compress, compress_scheme=compress_scheme)
-    t_serialized_deserialized = deserialize(
-        t_serialized, compressed=compress, compress_scheme=compress_scheme
-    )
+    t_serialized = serialize(t)
+    t_serialized_deserialized = deserialize(t_serialized)
     assert (t == t_serialized_deserialized).all()
 
 
 def test_PointerTensor(hook, workers):
+    syft.serde._apply_compress_scheme = apply_no_compression
     t = PointerTensor(
         id=1000, location=workers["alice"], owner=workers["alice"], id_at_location=12345
     )
-    t_serialized = serialize(t, compress=False)
-    t_serialized_deserialized = deserialize(t_serialized, compressed=False)
+    t_serialized = serialize(t)
+    t_serialized_deserialized = deserialize(t_serialized)
     print(f"t.location - {t.location}")
     print(f"t_serialized_deserialized.location - {t_serialized_deserialized.location}")
     assert t.id == t_serialized_deserialized.id


### PR DESCRIPTION
This PR will help to open the compression/decompression process to workers that do not have access to the configuration used during seder

The way of choosing a compression with this PR is by overriding the function `_apply_compress_scheme`
The function will default to `LZ4` compression.
If no compression is required then use `_apply_compress_scheme = apply_no_compression`
Other compression schemes, as SZTD, can be applied similarly: 
`_apply_compress_scheme = apply_zstd_compression`

## Changes:
* Replace flag determining compression by flag indicating possible compression schemes (including NO_COMPRESSION)
* Added hooks that can be overridden to set the compression scheme (or none)