### PR TITLE
Clean SPDZ mul and AdditiveSharingTensor methods

### DIFF
--- a/syft/frameworks/torch/crypto/securenn.py
+++ b/syft/frameworks/torch/crypto/securenn.py
@@ -5,7 +5,7 @@ https://eprint.iacr.org/2018/442.pdf
 
 import torch
 
-import syft
+import syft as sy
 
 # Q field
 Q_BITS = 31
@@ -162,15 +162,15 @@ def msb(a_sh, alice, bob):
     r_0 = decompose(r)[..., -1].send(bob, alice).child
     r = r.send(bob, alice).child
 
-    assert isinstance(r, syft.frameworks.torch.tensors.interpreters.MultiPointerTensor)
+    assert isinstance(r, sy.MultiPointerTensor)
 
     j0 = torch.zeros(x_bit_sh.shape).long().send(bob)
     j1 = torch.ones(x_bit_sh.shape).long().send(alice)
-    j = syft.MultiPointerTensor(children=[j0, j1])
+    j = sy.MultiPointerTensor(children=[j0, j1])
     j_0 = j[..., -1]
 
-    assert isinstance(j, syft.frameworks.torch.tensors.interpreters.MultiPointerTensor)
-    assert isinstance(j_0, syft.frameworks.torch.tensors.interpreters.MultiPointerTensor)
+    assert isinstance(j, sy.MultiPointerTensor)
+    assert isinstance(j_0, sy.MultiPointerTensor)
 
     # 4)
     BETA = (torch.rand(a_sh.shape) > 0.5).long().send(bob, alice).child
@@ -203,9 +203,9 @@ def msb(a_sh, alice, bob):
 
 
 def relu_deriv(a_sh):
-    assert isinstance(a_sh, syft.frameworks.torch.tensors.interpreters.AdditiveSharingTensor)
+    assert isinstance(a_sh, sy.AdditiveSharingTensor)
 
-    workers = [syft.hook.local_worker.get_worker(w_name) for w_name in list(a_sh.child.keys())]
+    workers = [sy.hook.local_worker.get_worker(w_name) for w_name in list(a_sh.child.keys())]
     return msb(a_sh, *workers)
 
 

--- a/syft/frameworks/torch/crypto/spdz.py
+++ b/syft/frameworks/torch/crypto/spdz.py
@@ -1,55 +1,47 @@
 import torch
 from typing import Callable
+import syft as sy
 from syft.workers.abstract import AbstractWorker
 
 
-def spdz_mul(
-    cmd: Callable, shares: dict, other_shares, crypto_provider: AbstractWorker, field: int, **kwargs
-):
-    """Abstractly Multiplies two tensors
+def spdz_mul(cmd: Callable, x_sh, y_sh, crypto_provider: AbstractWorker, field: int):
+    """Abstractly multiplies two tensors (mul or matmul)
 
     Args:
-        cmd: a callable of the equation to be commuted
-        shares: a dictionary <location_id -> PointerTensor) of shares corresponding to
-            self. Equivalent to calling self.child.
-        other_shares: a dictionary <location_id -> PointerTensor) of shares corresponding
-            to the tensor being multiplied by self.
-        crypto_provider: an AbstractWorker which is used to generate triples
-        field: an interger denoting the size of the field
-        """
-    locations = list(shares.keys())
-    shares_shape = shares[locations[0]].shape
-    other_shape = other_shares[locations[0]].shape
-    triple = crypto_provider.generate_triple(cmd, field, shares_shape, other_shape, locations)
-    a, b, c = triple
-    a, b, c = a.child, b.child, c.child
-    d = {}
-    e = {}
-    for location in locations:
-        d[location] = shares[location] - a[location]
-        e[location] = other_shares[location] - b[location]
-    delta = torch.zeros(shares_shape, dtype=torch.long)
-    epsilon = torch.zeros(other_shape, dtype=torch.long)
+        cmd: a callable of the equation to be computed (mul or matmul)
+        x_sh (AdditiveSharingTensor): the left part of the operation
+        y_sh (AdditiveSharingTensor): the right part of the operation
+        crypto_provider (AbstractWorker): an AbstractWorker which is used to generate triples
+        field (int): an integer denoting the size of the field
 
-    for location in locations:
-        d_temp = d[location].get()
-        e_temp = e[location].get()
-        delta = delta + d_temp
-        epsilon = epsilon + e_temp
+    Return:
+        an AdditiveSharingTensor
+    """
+    assert isinstance(x_sh, sy.AdditiveSharingTensor)
+    assert isinstance(y_sh, sy.AdditiveSharingTensor)
+
+    locations = x_sh.locations
+
+    # Get triples
+    a, b, a_mul_b = crypto_provider.generate_triple(cmd, field, x_sh.shape, y_sh.shape, locations)
+
+    delta = x_sh - a
+    epsilon = y_sh - b
+    # Reconstruct and send to all workers
+    delta = delta.get().send(*locations).child
+    epsilon = epsilon.get().send(*locations).child
 
     delta_epsilon = cmd(delta, epsilon)
 
-    delta_ptrs = {}
-    epsilon_ptrs = {}
-    a_epsilon = {}
-    delta_b = {}
-    z = {}
-    for location in locations:
-        delta_ptrs[location] = delta.send(location)
-        epsilon_ptrs[location] = epsilon.send(location)
-        a_epsilon[location] = cmd(a[location], epsilon_ptrs[location])
-        delta_b[location] = cmd(delta_ptrs[location], b[location])
-        z[location] = a_epsilon[location] + delta_b[location] + c[location]
-    delta_epsilon_pointer = delta_epsilon.send(locations[0])
-    z[locations[0]] = z[locations[0]] + delta_epsilon_pointer
-    return z
+    # Trick to keep only one child in the MultiPointerTensor (like in SNN)
+    j1 = torch.ones(delta_epsilon.shape).long().send(locations[0])
+    j0 = torch.zeros(delta_epsilon.shape).long().send(*locations[1:])
+    if len(locations) == 2:
+        j = sy.MultiPointerTensor(children=[j1, j0])
+    else:
+        j = sy.MultiPointerTensor(children=[j1] + list(j0.child.child.values()))
+
+    delta_b = cmd(delta, b)
+    a_epsilon = cmd(a, epsilon)
+
+    return delta_epsilon * j + delta_b + a_epsilon + a_mul_b

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -27,17 +27,21 @@ class AdditiveSharingTensor(AbstractTensor):
         functions.
 
         Args:
-            parent: An optional AbstractTensor wrapper around the LoggingTensor
-                which makes it so that you can pass this LoggingTensor to all
-                the other methods/functions that PyTorch likes to use, although
-                it can also be other tensors which extend AbstractTensor, such
-                as custom tensors for Secure Multi-Party Computation or
-                Federated Learning.
+            shares: Optional dictionary with the shares already split
+            parent: An optional AbstractTensor wrapper around the AdditiveSharingTensor
+                which makes it so that you can pass this AdditiveSharingTensor to all
+                the other methods/functions that PyTorch likes to use
             owner: An optional BaseWorker object to specify the worker on which
                 the tensor is located.
             id: An optional string or integer id of the LoggingTensor.
-            Q_BITS: the amount of memory for each number  (the exponent)
-            BASE: the amount of memory for each number (the base)
+            field: size of the arithmetic field in which the shares live
+            n_bits: linked to the field with the relation (2 ** nbits) == field
+            crypto_provider: an optional BaseWorker providing crypto elements
+                such as Beaver triples
+            tags: an optional set of hashtags corresponding to this tensor
+                which this tensor should be searchable for
+            description: an optional string describing the purpose of the
+                tensor
         """
         super().__init__(id=id, owner=owner, tags=tags, description=description, parent=parent)
 
@@ -61,9 +65,9 @@ class AdditiveSharingTensor(AbstractTensor):
         return out
 
     @property
-    def location(self):
-        """Provide a location attribute"""
-        return [s.owner for s in self.child.values()]
+    def locations(self):
+        """Provide a locations attribute"""
+        return [s.location for s in self.child.values()]
 
     @property
     def shape(self):
@@ -92,7 +96,8 @@ class AdditiveSharingTensor(AbstractTensor):
         return sum(shares)
 
     def virtual_get(self):
-        """Get the value of the tensor without calling get - Only for VirtualWorkers"""
+        """Get the value of the tensor without calling get
+         - Useful for debugging, only for VirtualWorkers"""
 
         shares = list()
 
@@ -121,20 +126,6 @@ class AdditiveSharingTensor(AbstractTensor):
             shares_dict[shares[i].location.id] = shares[i]
 
         self.child = shares_dict
-        return self
-
-    def set_shares(self, shares):
-        """A setter for the shares value. This is used primarily at the end of function calls.
-        (see add()  below for an example).
-
-        Args:
-            shares: a dict of shares. Each key is the id of a worker on which the share exists. Each value
-                is the PointerTensor corresponding to a share.
-            """
-        assert isinstance(
-            shares, dict
-        ), "Share should be provided as a dict {'worker.id': pointer, ...}"
-        self.child = shares
         return self
 
     @staticmethod
@@ -171,9 +162,19 @@ class AdditiveSharingTensor(AbstractTensor):
         return shares
 
     @overloaded.overload_method
-    def _getitem_multipointer(self, _self_shares, indices_shares):
+    def _getitem_multipointer(self, self_shares, indices_shares):
+        """
+        Support x[i] where x is an AdditiveSharingTensor and i a MultiPointerTensor
+        
+        Args:
+            self_shares (dict): the dict of shares of x
+            indices_shares (dict): the dict of shares of i
+        
+        Returns:
+            an AdditiveSharingTensor
+        """
         selected_shares = {}
-        for worker, share in _self_shares.items():
+        for worker, share in self_shares.items():
             indices = []
             for index in indices_shares:
                 if isinstance(index, slice):
@@ -202,7 +203,7 @@ class AdditiveSharingTensor(AbstractTensor):
     ## SECTION SPDZ
 
     @overloaded.method
-    def add(self, shares: dict, other_shares, *args, **kwargs):
+    def add(self, shares: dict, other_shares):
         """Adds two tensors together
 
         Args:
@@ -232,7 +233,7 @@ class AdditiveSharingTensor(AbstractTensor):
         return self.add(other, **kwargs)
 
     @overloaded.method
-    def sub(self, shares: dict, other_shares, **kwargs):
+    def sub(self, shares: dict, other_shares):
         """Subtracts an other tensor from self.
 
         Args:
@@ -260,76 +261,88 @@ class AdditiveSharingTensor(AbstractTensor):
         """Subtracts two tensors. Forwards command to sub. See .sub() for details."""
         return self.sub(*args, **kwargs)
 
-    def _abstract_mul(self, equation: str, shares: dict, other_shares, **kwargs):
+    def _private_mul(self, other, equation: str):
         """Abstractly Multiplies two tensors
 
         Args:
-            equation: a string reprsentation of the equation to be computed in einstein
+            self: an AdditiveSharingTensor
+            other: another AdditiveSharingTensor
+            equation: a string representation of the equation to be computed in einstein
                 summation form
-            shares: a dictionary <location_id -> PointerTensor) of shares corresponding to
-                self. Equivalent to calling self.child.
-            other_shares: a dictionary <location_id -> PointerTensor) of shares corresponding
-                to the tensor being multiplied by self.
         """
         # check to see that operation is either mul or matmul
         assert equation == "mul" or equation == "matmul"
         cmd = getattr(torch, equation)
 
-        # if someone passes in a constant... (i.e., x + 3)
-        # TODO: Handle public mul more efficiently
-        if not isinstance(other_shares, dict):
-            other_shares = torch.Tensor([other_shares]).share(*self.child.keys()).child.child
+        assert isinstance(other, AdditiveSharingTensor)
 
-        assert len(shares) == len(other_shares)
+        assert len(self.child) == len(other.child)
 
         if self.crypto_provider is None:
-            raise AttributeError("For multiplication a crytoprovider must be passed.")
+            raise AttributeError("For multiplication a cryto_provider must be passed.")
 
-        shares = spdz.spdz_mul(cmd, shares, other_shares, self.crypto_provider, self.field)
+        shares = spdz.spdz_mul(cmd, self, other, self.crypto_provider, self.field)
 
         return shares
 
     @overloaded.method
-    def mul(self, shares: dict, other_shares, *args, **kwargs):
-        """Multiplies two tensors together
-        For details see abstract_mul
+    def _public_mul(self, shares, other, equation):
+        """Multiplies an AdditiveSharingTensor with a non-private value
+        (int, MultiPointerTensor, etc.)
 
         Args:
-            shares: a dictionary <location_id -> PointerTensor) of shares corresponding to
+            shares (dict): a dictionary <location_id -> PointerTensor) of shares corresponding to
                 self. Equivalent to calling self.child.
-            other_shares: a dictionary <location_id -> PointerTensor) of shares corresponding
-                to the tensor being multiplied by self.
+            other (dict of int): a dictionary <location_id -> PointerTensor) of shares corresponding
+                to the tensor being multiplied with self or an integer
+            equation: a string representation of the equation to be computed in einstein
+                summation form
         """
+        assert equation == "mul" or equation == "matmul"
+        cmd = getattr(torch, equation)
 
-        return self._abstract_mul("mul", shares, other_shares, **kwargs)
+        if isinstance(other, dict):
+            return {worker: cmd(share, other[worker]) for worker, share in shares.items()}
+        else:
+            return {worker: cmd(share, other) for worker, share in shares.items()}
+
+    def mul(self, other):
+        """Multiplies two tensors together
+
+        Args:
+            self (AdditiveSharingTensor): an AdditiveSharingTensor
+            other: another AdditiveSharingTensor, or a MultiPointerTensor, or an integer
+        """
+        if not isinstance(other, sy.AdditiveSharingTensor):
+            return self._public_mul(other, "mul")
+
+        return self._private_mul(other, "mul")
 
     def __mul__(self, other, **kwargs):
         """Multiplies two number for details see mul
         """
-        if isinstance(other, sy.MultiPointerTensor):
-            return self.mul(other, **kwargs) / len(other.child.keys())
         return self.mul(other, **kwargs)
 
-    @overloaded.method
-    def matmul(self, shares: dict, other_shares, **kwargs):
-        """Multiplies two tensors together
-        For details see abstract_mul
+    def matmul(self, other):
+        """Multiplies two tensors matrices together
 
         Args:
-            shares: a dictionary <location_id -> PointerTensor) of shares corresponding to
-                self. Equivalent to calling self.child.
-            other_shares: a dictionary <location_id -> PointerTensor) of shares corresponding
-                to the tensor being multiplied by self.
+            self: an AdditiveSharingTensor
+            other: another AdditiveSharingTensor or a MultiPointerTensor
         """
-        return self._abstract_mul("matmul", shares, other_shares, **kwargs)
+        # If the multiplication can be public
+        if not isinstance(other, sy.AdditiveSharingTensor):
+            return self._public_mul(other, "matmul")
+
+        return self._private_mul(other, "matmul")
 
     def mm(self, *args, **kwargs):
-        """Multiplies two number for details see mul
+        """Multiplies two tensors matrices together
         """
         return self.matmul(*args, **kwargs)
 
     def __matmul__(self, *args, **kwargs):
-        """Multiplies two number for details see mul
+        """Multiplies two tensors matrices together
         """
         return self.matmul(*args, **kwargs)
 
@@ -360,6 +373,21 @@ class AdditiveSharingTensor(AbstractTensor):
 
     def __mod__(self, *args, **kwargs):
         return self.mod(*args, **kwargs)
+
+    @staticmethod
+    @overloaded.module
+    def torch(module):
+        def mul(self, other):
+            """Overload torch.mul(x, y) to redirect to x.mul(y)"""
+            return self.mul(other)
+
+        module.mul = mul
+
+        def matmul(self, other):
+            """Overload torch.matmul(x, y) to redirect to x.matmul(y)"""
+            return self.matmul(other)
+
+        module.matmul = matmul
 
     ## SECTION SNN
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -781,19 +781,19 @@ class BaseWorker(AbstractWorker):
         """Generates a multiplication triple and sends it to all locations
 
         Args:
-            equation: string representation of the equation in einsum notation
+            cmd: equation in einsum notation
             field: integer representing the field size
             a_size: tuple which is the size that a should be
             b_size: tuple which is the size that b should be
             locations: a list of workers where the triple should be shared between
 
         return:
-            a triple of AdditiveSharedTensor
+            a triple of AdditiveSharedTensors such that c_shared = cmd(a_shared, b_shared)
         """
         a = self.torch.randint(field, a_size)
         b = self.torch.randint(field, b_size)
         c = cmd(a, b)
-        a_shared = a.share(*locations, field=field).child
-        b_shared = b.share(*locations, field=field).child
-        c_shared = c.share(*locations, field=field).child
-        return (a_shared, b_shared, c_shared)
+        a_shared = a.share(*locations, field=field, crypto_provider=self).child
+        b_shared = b.share(*locations, field=field, crypto_provider=self).child
+        c_shared = c.share(*locations, field=field, crypto_provider=self).child
+        return a_shared, b_shared, c_shared


### PR DESCRIPTION
All is in the title :)

I aligned the spdz protocol syntax on the secure nn one: the objects used are AdditiveSharedTensors and MultiPointerTensors

Regarding the section in spdz_mul 
```
# Trick to keep only one child in the MultiPointerTensor (like in SNN)
    j1 = torch.ones(delta_epsilon.shape).long().send(locations[0])
    j0 = torch.zeros(delta_epsilon.shape).long().send(*locations[1:])
    if len(locations) == 2:
        j = sy.MultiPointerTensor(children=[j1, j0])
    else:
        j = sy.MultiPointerTensor(children=[j1] + list(j0.child.child.values()))
```
It could be a method of the MultiPointerTensor (used in several cases including spdz and snn), if someone finds a fancy name, I'll add it as a native method for this tensor!