### PR TITLE
Create fetch_plan in base

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -717,7 +717,7 @@ class BaseWorker(AbstractWorker):
         shape = self.send_msg(MSGTYPE.GET_SHAPE, pointer, location=pointer.location)
         return sy.hook.torch.Size(shape)
 
-    def fetch_plan(self, plan_id: Union[str, int]) -> "Plan":
+    def fetch_plan(self, plan_id: Union[str, int]) -> "Plan":  # noqa: F821
         """Fetchs a copy of a the plan with the given `plan_id` from the worker registry.
 
         Args:

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -167,7 +167,6 @@ class BaseWorker(AbstractWorker):
                 tensor.owner = self
 
     def send_msg(self, msg_type: int, message: str, location: "BaseWorker") -> object:
-
         """Implements the logic to send messages.
 
         The message is serialized and sent to the specified location. The
@@ -381,7 +380,6 @@ class BaseWorker(AbstractWorker):
         return responses
 
     def set_obj(self, obj: Union[torch.Tensor, AbstractTensor]) -> None:
-
         """Adds an object to the registry of objects.
 
         Args:
@@ -719,7 +717,7 @@ class BaseWorker(AbstractWorker):
         shape = self.send_msg(MSGTYPE.GET_SHAPE, pointer, location=pointer.location)
         return sy.hook.torch.Size(shape)
 
-    def fetch_plan(self, plan_id: str) -> object:
+    def fetch_plan(self, plan_id: Union[str, int]) -> "Plan":
         """Fetchs a copy of a the plan with the given `plan_id` from the worker registry.
 
         Args:

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -719,21 +719,23 @@ class BaseWorker(AbstractWorker):
         shape = self.send_msg(MSGTYPE.GET_SHAPE, pointer, location=pointer.location)
         return sy.hook.torch.Size(shape)
 
-    def fetch_plan(self, plan_id):
+    def fetch_plan(self, plan_id: str) -> object:
         """Fetchs a copy of a the plan with the given `plan_id` from the worker registry.
 
         Args:
             plan_id: A string indicating the plan id.
 
         Returns:
-            A plan if a plan with the given `plan_id` exists. Otherwhise returns None.
+            A plan if a plan with the given `plan_id` exists. Returns None otherwise.
         """
-        if plan_id in self._objects:
-            candidate = self._objects[plan_id]
-            if isinstance(candidate, sy.Plan):
-                plan = candidate.copy()
-                plan.owner = sy.local_worker
-                return plan
+        if plan_id not in self._objects:
+            return None
+
+        candidate = self._objects[plan_id]
+        if isinstance(candidate, sy.Plan):
+            plan = candidate.copy()
+            plan.owner = sy.local_worker
+            return plan
 
         return None
 

--- a/syft/workers/plan.py
+++ b/syft/workers/plan.py
@@ -157,6 +157,11 @@ class Plan(BaseWorker):
         # Store owner that built the plan
         self.owner_when_built = self.owner
 
+    def copy(self):
+        plan = Plan(self.hook, self.owner, self.name, id=int(10e10 * random.random()))
+        plan.plan_blueprint = self.plan_blueprint
+        return plan
+
     def replace_ids(self, from_ids, to_ids):
         """
         Replace pairs of tensor ids in the plan stored


### PR DESCRIPTION
* Plans are no longer searchable :cry: . This is mainly due to the different behavior when "searching" for plans and searching for tensors.
* Now is possible to fetch a plan based on its id :smile: . This will get a plan from a worker's registry, create a copy of the plan and change the owner to whoever is fetching the plan.

This is the result of a [~~pair~~ triple programming section](https://github.com/OpenMined/PySyft/commit/66f5cc9688f5c74140772766420ba5d034d24c01) with @robert-wagner and @jlebensold.


