### PR TITLE
use IdProvider to provide random ids

### DIFF
--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -52,6 +52,11 @@ __all__ = [
 local_worker = None
 torch = None
 
+if "ID_PROVIDER" not in globals():
+    from syft.workers.abstract import IdProvider
+
+    ID_PROVIDER = IdProvider()
+
 
 def create_sandbox(gbs, verbose=True, download_data=True):
     """There's some boilerplate stuff that most people who are

--- a/syft/frameworks/torch/hook.py
+++ b/syft/frameworks/torch/hook.py
@@ -1,6 +1,5 @@
 import inspect
 import re
-import random
 import logging
 import types
 import copy
@@ -11,6 +10,7 @@ from functools import wraps
 
 import syft
 from syft import workers
+
 from syft.workers import BaseWorker
 from .tensors.interpreters import TorchTensor
 from .tensors.interpreters import PointerTensor
@@ -773,7 +773,7 @@ class TorchHook:
         @property
         def id(self):
             if not hasattr(self, "_id"):
-                self._id = int(10e10 * random.random())
+                self._id = syft.ID_PROVIDER.pop()
             return self._id
 
         @id.setter

--- a/syft/frameworks/torch/tensors/interpreters/abstract.py
+++ b/syft/frameworks/torch/tensors/interpreters/abstract.py
@@ -1,6 +1,5 @@
 from abc import ABC
 import functools
-import random
 import torch
 from typing import List
 
@@ -37,7 +36,7 @@ class AbstractTensor(ABC):
         """
         self.owner = owner
         if id is None:
-            self.id = int(10e10 * random.random())
+            self.id = sy.ID_PROVIDER.pop()
         else:
             self.id = id
         self.tags = tags
@@ -111,7 +110,7 @@ class AbstractTensor(ABC):
         wrapper.child = self
         wrapper.is_wrapper = True
         if self.id is None:
-            self.id = int(10e10 * random.random())
+            self.id = sy.ID_PROVIDER.pop()
         return wrapper
 
     def serialize(self):  # check serde.py to see how to provide compression schemes
@@ -257,7 +256,7 @@ def _apply_args(hook_self, new_tensor, owner=None, id=None):
         owner = hook_self.local_worker
 
     if id is None:
-        id = int(10e10 * random.random())
+        id = sy.ID_PROVIDER.pop()
 
     new_tensor.id = id
     new_tensor.owner = owner

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -1,4 +1,3 @@
-import random
 import weakref
 import torch
 
@@ -136,7 +135,7 @@ class TorchTensor(AbstractTensor):
             try:
                 return self._id
             except:
-                self._id = int(10e10 * random.random())
+                self._id = sy.ID_PROVIDER.pop()
                 return self._id
 
     @id.setter
@@ -403,7 +402,7 @@ class TorchTensor(AbstractTensor):
             if location.id != self.owner.id:
                 ptr_id = self.id
             else:
-                ptr_id = int(10e10 * random.random())
+                ptr_id = sy.ID_PROVIDER.pop()
 
         if shape is None:
             shape = self.shape

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -1,6 +1,4 @@
 import logging
-import random
-import sys
 
 from abc import abstractmethod
 import syft as sy
@@ -298,7 +296,7 @@ class BaseWorker(AbstractWorker):
         worker = self.get_worker(worker)
 
         if ptr_id is None:  # Define a remote id if not specified
-            ptr_id = int(10e10 * random.random())
+            ptr_id = sy.ID_PROVIDER.pop()
 
         if isinstance(obj, torch.Tensor):
             pointer = obj.create_pointer(
@@ -379,7 +377,7 @@ class BaseWorker(AbstractWorker):
             A list of PointerTensors or a single PointerTensor if just one response is expected.
         """
         if return_ids is None:
-            return_ids = [int(10e10 * random.random())]
+            return_ids = [sy.ID_PROVIDER.pop()]
 
         message = (message, return_ids)
 
@@ -391,10 +389,7 @@ class BaseWorker(AbstractWorker):
         responses = []
         for return_id in return_ids:
             response = sy.PointerTensor(
-                location=recipient,
-                id_at_location=return_id,
-                owner=self,
-                id=int(10e10 * random.random()),
+                location=recipient, id_at_location=return_id, owner=self, id=sy.ID_PROVIDER.pop()
             )
             responses.append(response)
 

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -1,5 +1,3 @@
-import pytest
-import random
 import torch
 import torch.nn as nn
 import torch as th

--- a/test/torch/tensors/test_gc.py
+++ b/test/torch/tensors/test_gc.py
@@ -1,7 +1,5 @@
 """All the tests relative to garbage collection of all kinds of remote or local tensors"""
 
-import random
-
 import torch
 import syft
 from syft.frameworks.torch.tensors.decorators import LoggingTensor

--- a/test/torch/tensors/test_logging.py
+++ b/test/torch/tensors/test_logging.py
@@ -1,9 +1,6 @@
-import random
-
 import pytest
 import torch
 import torch.nn.functional as F
-import syft
 
 from syft.frameworks.torch.tensors.decorators import LoggingTensor
 

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -1,6 +1,4 @@
 import torch
-import syft
-import random
 
 from syft.frameworks.torch.tensors.interpreters import PointerTensor
 

--- a/test/torch/tensors/test_parameter.py
+++ b/test/torch/tensors/test_parameter.py
@@ -1,5 +1,3 @@
-import random
-
 import torch
 import torch.nn as nn
 from torch.nn import Parameter

--- a/test/torch/tensors/test_pointer.py
+++ b/test/torch/tensors/test_pointer.py
@@ -1,5 +1,3 @@
-import random
-
 import torch
 import torch as th
 import syft

--- a/test/torch/tensors/test_tensor.py
+++ b/test/torch/tensors/test_tensor.py
@@ -1,9 +1,5 @@
-import random
-
 import torch
 import syft
-
-from syft.frameworks.torch.tensors.interpreters import PointerTensor
 
 
 def test_init():

--- a/test/torch/tensors/test_variable.py
+++ b/test/torch/tensors/test_variable.py
@@ -3,11 +3,8 @@ you are working on gradients being used by other abstractions, don't
 use this class. Use the abstraction's test class instead. (I.e., if you
 are testing gradients with PointerTensor, use test_pointer.py.)"""
 
-import random
-
 import torch
 import syft as sy
-from syft.frameworks.torch.tensors.decorators import LoggingTensor
 
 
 def test_gradient_serde():

--- a/test/torch/test_federated_learning.py
+++ b/test/torch/test_federated_learning.py
@@ -6,7 +6,6 @@ import torch
 hook = sy.TorchHook(torch)
 from torch import nn
 from torch import optim
-import random
 
 
 class TestFederatedLearning(object):
@@ -16,7 +15,7 @@ class TestFederatedLearning(object):
         self.me = hook.local_worker
         self.me.is_client_worker = True
 
-        instance_id = str(int(10e10 * random.random()))
+        instance_id = str(sy.ID_PROVIDER.pop())
         bob = sy.VirtualWorker(id=f"bob{instance_id}", hook=hook, is_client_worker=False)
         alice = sy.VirtualWorker(id=f"alice{instance_id}", hook=hook, is_client_worker=False)
         james = sy.VirtualWorker(id=f"james{instance_id}", hook=hook, is_client_worker=False)

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -4,7 +4,6 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import random
 
 import syft
 from syft.exceptions import RemoteTensorFoundError
@@ -36,7 +35,7 @@ def test_worker_registration(hook, workers):
 
 
 def test_pointer_found_exception(workers):
-    ptr_id = int(10e10 * random.random())
+    ptr_id = syft.ID_PROVIDER.pop()
     pointer = PointerTensor(id=ptr_id, location=workers["alice"], owner=workers["me"])
 
     try:

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -1,4 +1,3 @@
-import random
 from time import time
 from unittest.mock import patch
 
@@ -24,7 +23,7 @@ def test_send_msg():
     me = sy.torch.hook.local_worker
 
     # create a new worker (to send the object to)
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     bob = VirtualWorker(sy.torch.hook, id=f"bob{worker_id}")
 
     # initialize the object and save it's id
@@ -46,7 +45,7 @@ def test_send_msg_using_tensor_api():
     """
 
     # create worker to send object to
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     bob = VirtualWorker(sy.torch.hook, id=f"bob{worker_id}")
 
     # create a tensor to send (default on local_worker)
@@ -73,7 +72,7 @@ def test_recv_msg():
     # TEST 1: send tensor to alice
 
     # create a worker to send data to
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     alice = VirtualWorker(sy.torch.hook, id=f"alice{worker_id}")
 
     # create object to send
@@ -121,9 +120,9 @@ def tests_worker_convenience_methods():
     """
 
     me = sy.torch.hook.local_worker
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     bob = VirtualWorker(sy.torch.hook, id=f"bob{worker_id}")
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     alice = VirtualWorker(sy.torch.hook, id=f"alice{worker_id}")
     obj = torch.Tensor([100, 100])
 
@@ -152,7 +151,7 @@ def tests_worker_convenience_methods():
 
 
 def test_search():
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     bob = VirtualWorker(sy.torch.hook, id=f"bob{worker_id}")
 
     x = (

--- a/test/workers/test_worker.py
+++ b/test/workers/test_worker.py
@@ -1,6 +1,5 @@
 import pytest
 
-import random
 import torch
 import syft as sy
 from syft.exceptions import WorkerNotFoundException
@@ -12,14 +11,14 @@ def test___init__():
 
     tensor = torch.tensor([1, 2, 3, 4])
 
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     alice_id = f"alice{worker_id}"
     alice = VirtualWorker(hook, id=alice_id)
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     bob = VirtualWorker(hook, id=f"bob{worker_id}")
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     charlie = VirtualWorker(hook, id=f"charlie{worker_id}")
-    worker_id = int(10e10 * random.random())
+    worker_id = sy.ID_PROVIDER.pop()
     dawson = VirtualWorker(hook, id=f"dawson{worker_id}", data=[tensor])
 
     # Ensure adding data on signup functionality works as expected


### PR DESCRIPTION
fixes #2063

This pull request removes the duplicated code that generates the random ids. 
It does not improve on the way the random int is generated. But switching to a much larger hash is now easily possible as only one location needs to be changed.