### PR TITLE
Provide unique ids by checking against already generated ids

### DIFF
--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -135,6 +135,12 @@ class GetNotPermittedError(Exception):
     pass
 
 
+class IdNotUniqueError(Exception):
+    """Raised by the ID Provider when setting ids that have already been generated"""
+
+    pass
+
+
 def route_method_exception(exception, self, args, kwargs):
     try:
         if self.is_wrapper:

--- a/syft/generic/id_provider.py
+++ b/syft/generic/id_provider.py
@@ -1,5 +1,6 @@
 import random
 from typing import List
+from syft import exceptions
 
 
 def create_random_id():
@@ -13,7 +14,7 @@ class IdProvider:
     Can take a pre set list in input and will complete
     when it's empty.
 
-    An instance of IdProvider is accessbile via sy.ID_PROVIDER.
+    An instance of IdProvider is accessible via sy.ID_PROVIDER.
     """
 
     def __init__(self, given_ids=None):
@@ -43,26 +44,32 @@ class IdProvider:
 
         return random_id
 
-    def set_next_ids(self, given_ids: List):
+    def set_next_ids(self, given_ids: List, check_ids: bool = True):
         """Sets the next ids returned by the id provider
 
-        Note that the ids are returned in reverse order of the list, as a pop() operation is applied
+        Note that the ids are returned in reverse order of the list, as a pop() operation is applied.
 
         Args:
             given_ids: List, next ids returned by the id provider
+            check_ids: bool, check whether these ids conflict with already generated ids
 
         """
-        # TODO: should we check whether these ids conflict with the content of self.generated?
+        if check_ids:
+            intersect = self.generated.intersection(set(given_ids))
+            if len(intersect) > 0:
+                message = "Provided IDs {} are contained in already generated IDs".format(intersect)
+                raise exceptions.IdNotUniqueError(message)
+
         self.given_ids += given_ids
 
     def start_recording_ids(self):
-        """Starts the recording in form of a list of the generated ids
+        """Starts the recording in form of a list of the generated ids.
         """
         self.record_ids = True
         self.recorded_ids = list()
 
     def get_recorded_ids(self, continue_recording=False):
-        """Returns the generated ids since the last call to start_recording_ids
+        """Returns the generated ids since the last call to start_recording_ids.
 
         Args:
             continue_recording: if False, the recording is stopped and the list of recorded ids is reset

--- a/syft/generic/id_provider.py
+++ b/syft/generic/id_provider.py
@@ -1,4 +1,5 @@
 import random
+from typing import List
 
 
 def create_random_id():
@@ -15,11 +16,11 @@ class IdProvider:
     An instance of IdProvider is accessbile via sy.ID_PROVIDER.
     """
 
-    def __init__(self, given_ids=list()):
-        self.given_ids = given_ids
-        self.generated = (
-            []
-        )  # TODO: use sorted container to quickly check whether a value is contained
+    def __init__(self, given_ids=None):
+        self.given_ids = given_ids if given_ids is not None else list()
+        self.generated = set()
+        self.record_ids = False
+        self.recorded_ids = []
 
     def pop(self, *args) -> int:
         """Provides random ids and store them.
@@ -36,5 +37,41 @@ class IdProvider:
             random_id = create_random_id()
             while random_id in self.generated:
                 random_id = create_random_id()
-        self.generated.append(random_id)
+        self.generated.add(random_id)
+        if self.record_ids:
+            self.recorded_ids.append(random_id)
+
         return random_id
+
+    def set_next_ids(self, given_ids: List):
+        """Sets the next ids returned by the id provider
+
+        Note that the ids are returned in reverse order of the list, as a pop() operation is applied
+
+        Args:
+            given_ids: List, next ids returned by the id provider
+
+        """
+        # TODO: should we check whether these ids conflict with the content of self.generated?
+        self.given_ids += given_ids
+
+    def start_recording_ids(self):
+        """Starts the recording in form of a list of the generated ids
+        """
+        self.record_ids = True
+        self.recorded_ids = list()
+
+    def get_recorded_ids(self, continue_recording=False):
+        """Returns the generated ids since the last call to start_recording_ids
+
+        Args:
+            continue_recording: if False, the recording is stopped and the list of recorded ids is reset
+
+        Returns:
+            list of recorded ids
+        """
+        ret_val = self.recorded_ids
+        if not continue_recording:
+            self.record_ids = False
+            self.recorded_ids = list()
+        return ret_val

--- a/syft/generic/id_provider.py
+++ b/syft/generic/id_provider.py
@@ -1,6 +1,10 @@
 import random
 
 
+def create_random_id():
+    return int(10e10 * random.random())
+
+
 class IdProvider:
     """Provides Id to all syft objects.
 
@@ -13,7 +17,9 @@ class IdProvider:
 
     def __init__(self, given_ids=list()):
         self.given_ids = given_ids
-        self.generated = []
+        self.generated = (
+            []
+        )  # TODO: use sorted container to quickly check whether a value is contained
 
     def pop(self, *args) -> int:
         """Provides random ids and store them.
@@ -27,6 +33,8 @@ class IdProvider:
         if len(self.given_ids):
             random_id = self.given_ids.pop(-1)
         else:
-            random_id = int(10e10 * random.random())
+            random_id = create_random_id()
+            while random_id in self.generated:
+                random_id = create_random_id()
         self.generated.append(random_id)
         return random_id

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -366,11 +366,14 @@ class BaseWorker(AbstractWorker, ObjectStorage):
                 )
                 return response
             except ResponseSignatureError:
-                return_ids = IdProvider(return_ids)
+                return_id_provider = sy.ID_PROVIDER
+                return_id_provider.set_next_ids(return_ids)
+                return_id_provider.start_recording_ids()
                 response = sy.frameworks.torch.hook_args.register_response(
-                    command_name, response, return_ids, self
+                    command_name, response, return_id_provider, self
                 )
-                raise ResponseSignatureError(return_ids.generated)
+                new_ids = return_id_provider.get_recorded_ids()
+                raise ResponseSignatureError(new_ids)
 
     def send_command(
         self, recipient: "BaseWorker", message: str, return_ids: str = None

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -367,7 +367,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
                 return response
             except ResponseSignatureError:
                 return_id_provider = sy.ID_PROVIDER
-                return_id_provider.set_next_ids(return_ids)
+                return_id_provider.set_next_ids(return_ids, check_ids=False)
                 return_id_provider.start_recording_ids()
                 response = sy.frameworks.torch.hook_args.register_response(
                     command_name, response, return_id_provider, self

--- a/test/generic/test_id_provider.py
+++ b/test/generic/test_id_provider.py
@@ -1,0 +1,78 @@
+import unittest.mock as mock
+
+from syft.generic import id_provider
+
+
+def test_pop_no_given_ids(hook):
+    provider = id_provider.IdProvider()
+    values = [10, 4, 15, 4, 2, 0]
+
+    orig_func = id_provider.create_random_id
+    mocked_random_numbers = mock.Mock()
+    mocked_random_numbers.side_effect = values
+    id_provider.create_random_id = mocked_random_numbers
+
+    val = provider.pop()
+    assert val == values[0]
+
+    val = provider.pop()
+    assert val == values[1]
+
+    val = provider.pop()
+    assert val == values[2]
+
+    # values[3] is skipped, as value already used.
+
+    val = provider.pop()
+    assert val == values[4]
+
+    val = provider.pop()
+    assert val == values[5]
+
+    id_provider.create_random_id = orig_func
+
+
+def test_pop_with_given_ids(hook):
+    given_ids = [4, 15, 2]
+    provider = id_provider.IdProvider(given_ids=given_ids.copy())
+    values = [10, 4, 15, 4, 2, 0]
+
+    orig_func = id_provider.create_random_id
+    mocked_random_numbers = mock.Mock()
+    mocked_random_numbers.side_effect = values
+    id_provider.create_random_id = mocked_random_numbers
+
+    val = provider.pop()
+    assert val == given_ids[-1]
+
+    val = provider.pop()
+    assert val == given_ids[-2]
+
+    val = provider.pop()
+    assert val == given_ids[-3]
+
+    val = provider.pop()
+    assert val == values[0]
+
+    # values[1, 2, 3, 4] are skipped, as value already used.
+
+    val = provider.pop()
+    assert val == values[5]
+
+    id_provider.create_random_id = orig_func
+
+
+def test_given_ids_side_effect(hook):
+    given_ids = [4, 15, 2]
+    provider = id_provider.IdProvider(given_ids=given_ids)
+
+    assert len(given_ids) == 3
+    provider.pop()
+
+    assert len(given_ids) == 2
+
+    provider.pop()
+    assert len(given_ids) == 1
+
+    provider.pop()
+    assert len(given_ids) == 0

--- a/test/generic/test_id_provider.py
+++ b/test/generic/test_id_provider.py
@@ -76,3 +76,52 @@ def test_given_ids_side_effect(hook):
 
     provider.pop()
     assert len(given_ids) == 0
+
+
+def test_set_next_ids(hook):
+    initial_given_ids = [2, 3]
+    provider = id_provider.IdProvider(given_ids=initial_given_ids.copy())
+
+    next_ids = [4, 5]
+    provider.set_next_ids(next_ids.copy())
+
+    val = provider.pop()
+    assert val == next_ids[-1]
+    val = provider.pop()
+    assert val == next_ids[-2]
+
+    val = provider.pop()
+    assert val == initial_given_ids[-1]
+    val = provider.pop()
+    assert val == initial_given_ids[-2]
+
+
+def test_start_recording_ids():
+    initial_given_ids = [2, 3]
+    provider = id_provider.IdProvider(given_ids=initial_given_ids.copy())
+    provider.pop()
+    provider.start_recording_ids()
+    provider.pop()
+
+    ids = provider.get_recorded_ids()
+    assert len(ids) == 1
+    assert ids[0] == initial_given_ids[-2]
+
+
+def test_get_recorded_ids():
+    initial_given_ids = [2, 3, 4]
+    provider = id_provider.IdProvider(given_ids=initial_given_ids.copy())
+    provider.pop()
+    provider.start_recording_ids()
+    provider.pop()
+
+    ids = provider.get_recorded_ids(continue_recording=True)
+    assert len(ids) == 1
+    assert ids[0] == initial_given_ids[-2]
+
+    provider.pop()
+
+    ids = provider.get_recorded_ids()
+    assert len(ids) == 2
+    assert ids[0] == initial_given_ids[-2]
+    assert ids[1] == initial_given_ids[-3]

--- a/test/generic/test_id_provider.py
+++ b/test/generic/test_id_provider.py
@@ -1,5 +1,7 @@
 import unittest.mock as mock
+import pytest
 
+from syft import exceptions
 from syft.generic import id_provider
 
 
@@ -94,6 +96,25 @@ def test_set_next_ids(hook):
     assert val == initial_given_ids[-1]
     val = provider.pop()
     assert val == initial_given_ids[-2]
+
+
+def test_set_next_ids_with_id_checking(hook):
+    initial_given_ids = [2, 3]
+    provider = id_provider.IdProvider()
+    provider.set_next_ids(initial_given_ids.copy(), check_ids=False)
+
+    # generated the initial 3 ids
+    provider.pop()
+    provider.pop()
+    provider.pop()
+
+    next_ids = [1, 2, 5]
+    with pytest.raises(exceptions.IdNotUniqueError, match=r"\{2\}"):
+        provider.set_next_ids(next_ids.copy(), check_ids=True)
+
+    next_ids = [2, 3, 5]
+    with pytest.raises(exceptions.IdNotUniqueError, match=r"\{2, 3\}"):
+        provider.set_next_ids(next_ids.copy(), check_ids=True)
 
 
 def test_start_recording_ids():


### PR DESCRIPTION
IdProvider was not guaranteed to provide an id only once. Added tests.