### PR TITLE
Clear hook and workers before each pytest function

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -160,6 +160,18 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         """
         raise NotImplementedError  # pragma: no cover
 
+    def remove_worker_from_registry(self, worker_id):
+        """Removes a worker from the dictionary of known workers.
+        Args:
+            worker_id: id to be removed
+        """
+        del self._known_workers[worker_id]
+
+    def remove_worker_from_local_worker_registry(self):
+        """Removes itself from the registry of hook.local_worker.
+        """
+        self.hook.local_worker.remove_worker_from_registry(worker_id=self.id)
+
     def load_data(self, data: List[Union[torch.Tensor, AbstractTensor]]) -> None:
         """Allows workers to be initialized with data when created
 
@@ -528,7 +540,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             else:
                 if fail_hard:
                     raise WorkerNotFoundException
-                logging.warning("Worker", self.id, "couldn't recognize worker", id_or_worker)
+                logging.warning("Worker %s couldn't recognize worker %s", self.id, id_or_worker)
                 return id_or_worker
         else:
             if id_or_worker.id not in self._known_workers:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,17 +28,27 @@ def hook():
     return hook
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def workers(hook):
     # To run a plan locally the local worker can't be a client worker,
     # since it needs to register objects
     hook.local_worker.is_client_worker = False
+
+    # reset the hook and the local worker
+    syft.local_worker.clear_objects()
+    syft.frameworks.torch.hook.hook_args.hook_method_args_functions = {}
+    syft.frameworks.torch.hook.hook_args.hook_method_response_functions = {}
+    syft.frameworks.torch.hook.hook_args.get_tensor_type_functions = {}
 
     # Define 3 virtual workers
     alice = syft.VirtualWorker(id="alice", hook=hook, is_client_worker=False)
     bob = syft.VirtualWorker(id="bob", hook=hook, is_client_worker=False)
     james = syft.VirtualWorker(id="james", hook=hook, is_client_worker=False)
 
-    output = {"me": hook.local_worker, "alice": alice, "bob": bob, "james": james}
+    workers = {"me": hook.local_worker, "alice": alice, "bob": bob, "james": james}
 
-    return output
+    yield workers
+
+    alice.remove_worker_from_local_worker_registry()
+    bob.remove_worker_from_local_worker_registry()
+    james.remove_worker_from_local_worker_registry()


### PR DESCRIPTION
The workers and hook were only initialized once for all unit tests. Therefore data accumulated and created unexpected behavior in the tests. 