### PR TITLE
small fix so that the tutorial works with torch 1.1.0

### DIFF
--- a/examples/tutorials/Part 4 - Federated Learning via Trusted Aggregator.ipynb
+++ b/examples/tutorials/Part 4 - Federated Learning via Trusted Aggregator.ipynb
@@ -221,8 +221,9 @@
     }
    ],
    "source": [
-    "model.weight.data.set_(((alices_model.weight.data + bobs_model.weight.data) / 2).get())\n",
-    "model.bias.data.set_(((alices_model.bias.data + bobs_model.bias.data) / 2).get())\n",
+    "with torch.no_grad():\n",
+    "    model.weight.set_(((alices_model.weight.data + bobs_model.weight.data) / 2).get())\n",
+    "    model.bias.set_(((alices_model.bias.data + bobs_model.bias.data) / 2).get())\n",
     "\"\""
    ]
   },
@@ -291,9 +292,9 @@
     "    \n",
     "    alices_model.move(secure_worker)\n",
     "    bobs_model.move(secure_worker)\n",
-    "    \n",
-    "    model.weight.data.set_(((alices_model.weight.data + bobs_model.weight.data) / 2).get())\n",
-    "    model.bias.data.set_(((alices_model.bias.data + bobs_model.bias.data) / 2).get())\n",
+    "    with torch.no_grad():\n",
+    "        model.weight.set_(((alices_model.weight.data + bobs_model.weight.data) / 2).get())\n",
+    "        model.bias.set_(((alices_model.bias.data + bobs_model.bias.data) / 2).get())\n",
     "    \n",
     "    print(\"Bob:\" + str(bobs_loss) + \" Alice:\" + str(alices_loss))"
    ]
@@ -400,9 +401,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (Pysyft)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "pysyft"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -414,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This fixes the exception:
`RuntimeError: set_storage is not allowed on Tensor created from .data or .detach()`
that occurs when running tutorial 4 with `torch 1.1.0`.

Following the fix from [here](https://discuss.pytorch.org/t/api-change-for-tensor-data-set-in-torch-nightly/33310/2), we:

1. just remove the reference to `.data`,
2. wrap the code with `with torch.no_grad()`