### PR TITLE
Add serialization support for torch.jit.ScriptModule instances

### DIFF
--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -601,7 +601,8 @@ def test_serde_object_wrapper_int():
     assert obj_wrapper.id == obj_wrapper_received.id
 
 
-def test_serialize_and_deserialize_torch_scriptmodule():
+@pytest.mark.skip(reason="bug in pytorch version 1.1.0, jit.trace returns raw C function")
+def test_serialize_and_deserialize_torch_scriptmodule():  # pragma: no cover
     @torch.jit.script
     def foo(x):
         return x + 2
@@ -612,7 +613,8 @@ def test_serialize_and_deserialize_torch_scriptmodule():
     assert foo.code == foo_loaded.code
 
 
-def test_torch_jit_script_module_serde():
+@pytest.mark.skip(reason="bug in pytorch version 1.1.0, jit.trace returns raw C function")
+def test_torch_jit_script_module_serde():  # pragma: no cover
     @torch.jit.script
     def foo(x):
         return x + 2

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -4,19 +4,6 @@ simple python types which are serializable by standard serialization tools.
 For more on how/why this works, see serde.py directly.
 """
 from syft import serde
-from syft.serde import (
-    _simplify,
-    apply_lz4_compression,
-    apply_no_compression,
-    apply_zstd_compression,
-)
-from syft.serde import serialize
-from syft.serde import deserialize
-from syft.serde import _compress
-from syft.serde import _decompress
-from syft.serde import LZ4
-from syft.serde import NO_COMPRESSION
-from syft.serde import ZSTD
 
 
 import syft
@@ -39,7 +26,7 @@ def test_tuple_simplify():
 
     input = ("hello", "world")
     target = (2, ((18, (b"hello",)), (18, (b"world",))))
-    assert _simplify(input) == target
+    assert serde._simplify(input) == target
 
 
 def test_list_simplify():
@@ -51,7 +38,7 @@ def test_list_simplify():
 
     input = ["hello", "world"]
     target = (3, [(18, (b"hello",)), (18, (b"world",))])
-    assert _simplify(input) == target
+    assert serde._simplify(input) == target
 
 
 def test_set_simplify():
@@ -63,8 +50,8 @@ def test_set_simplify():
 
     input = set(["hello", "world"])
     target = (4, [(18, (b"hello",)), (18, (b"world",))])
-    assert _simplify(input)[0] == target[0]
-    assert set(_simplify(input)[1]) == set(target[1])
+    assert serde._simplify(input)[0] == target[0]
+    assert set(serde._simplify(input)[1]) == set(target[1])
 
 
 def test_float_simplify():
@@ -75,7 +62,7 @@ def test_float_simplify():
 
     input = 5.6
     target = 5.6
-    assert _simplify(input) == target
+    assert serde._simplify(input) == target
 
 
 def test_int_simplify():
@@ -86,7 +73,7 @@ def test_int_simplify():
 
     input = 5
     target = 5
-    assert _simplify(input) == target
+    assert serde._simplify(input) == target
 
 
 def test_string_simplify():
@@ -97,7 +84,7 @@ def test_string_simplify():
 
     input = "hello"
     target = (18, (b"hello",))
-    assert _simplify(input) == target
+    assert serde._simplify(input) == target
 
 
 def test_dict_simplify():
@@ -109,7 +96,7 @@ def test_dict_simplify():
 
     input = {"hello": "world"}
     target = (5, [((18, (b"hello",)), (18, (b"world",)))])
-    assert _simplify(input) == target
+    assert serde._simplify(input) == target
 
 
 def test_range_simplify():
@@ -121,7 +108,7 @@ def test_range_simplify():
 
     input = range(1, 3, 4)
     target = (6, (1, 3, 4))
-    assert _simplify(input) == target
+    assert serde._simplify(input) == target
 
 
 def test_torch_tensor_simplify():
@@ -137,7 +124,7 @@ def test_torch_tensor_simplify():
     input = Tensor(numpy.random.random((100, 100)))
 
     # simplify the tnesor
-    output = _simplify(input)
+    output = serde._simplify(input)
 
     # make sure outer type is correct
     assert type(output) == tuple
@@ -165,7 +152,7 @@ def test_ndarray_simplify():
     """
 
     input = numpy.random.random((100, 100))
-    output = _simplify(input)
+    output = serde._simplify(input)
 
     # make sure simplified type ID is correct
     assert output[0] == 7
@@ -180,10 +167,10 @@ def test_ellipsis_simplify():
     """Make sure ellipsis simplifies correctly."""
 
     # the id indicating an ellipsis is here
-    assert _simplify(Ellipsis)[0] == 9
+    assert serde._simplify(Ellipsis)[0] == 9
 
     # the simplified ellipsis (empty object)
-    assert _simplify(Ellipsis)[1] == b""
+    assert serde._simplify(Ellipsis)[1] == b""
 
 
 def test_torch_device_simplify():
@@ -191,10 +178,10 @@ def test_torch_device_simplify():
     device = torch.device("cpu")
 
     # the id indicating an torch.device is here
-    assert _simplify(device)[0] == 10
+    assert serde._simplify(device)[0] == 10
 
     # the simplified torch.device
-    assert _simplify(device)[1] == "cpu"
+    assert serde._simplify(device)[1] == "cpu"
 
 
 def test_pointer_tensor_simplify():
@@ -203,7 +190,7 @@ def test_pointer_tensor_simplify():
     alice = syft.VirtualWorker(syft.torch.hook, id="alice")
     input_tensor = pointers.PointerTensor(id=1000, location=alice, owner=alice)
 
-    output = _simplify(input_tensor)
+    output = serde._simplify(input_tensor)
 
     assert output[1][0] == input_tensor.id
     assert output[1][1] == input_tensor.id_at_location
@@ -213,13 +200,13 @@ def test_pointer_tensor_simplify():
 @pytest.mark.parametrize("compress", [True, False])
 def test_torch_Tensor(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     t = Tensor(numpy.random.random((100, 100)))
-    t_serialized = serialize(t)
-    t_serialized_deserialized = deserialize(t_serialized)
+    t_serialized = serde.serialize(t)
+    t_serialized_deserialized = serde.deserialize(t_serialized)
     assert (t == t_serialized_deserialized).all()
 
 
@@ -232,13 +219,13 @@ def test_torch_Tensor_convenience(compress):
     directly on the tensor itself. This tests to makes sure it
     works correctly."""
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     t = Tensor(numpy.random.random((100, 100)))
     t_serialized = t.serialize()
-    t_serialized_deserialized = deserialize(t_serialized)
+    t_serialized_deserialized = serde.deserialize(t_serialized)
     assert (t == t_serialized_deserialized).all()
 
 
@@ -246,21 +233,21 @@ def test_torch_Tensor_convenience(compress):
 def test_tuple(compress):
     # Test with a simple datatype
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     tuple = (1, 2)
-    tuple_serialized = serialize(tuple)
-    tuple_serialized_deserialized = deserialize(tuple_serialized)
+    tuple_serialized = serde.serialize(tuple)
+    tuple_serialized_deserialized = serde.deserialize(tuple_serialized)
     assert tuple == tuple_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     tuple = (tensor_one, tensor_two)
-    tuple_serialized = serialize(tuple)
-    tuple_serialized_deserialized = deserialize(tuple_serialized)
+    tuple_serialized = serde.serialize(tuple)
+    tuple_serialized_deserialized = serde.deserialize(tuple_serialized)
     # `assert tuple_serialized_deserialized == tuple` does not work, therefore it's split
     # into 3 assertions
     assert type(tuple_serialized_deserialized) == type(tuple)
@@ -271,64 +258,64 @@ def test_tuple(compress):
 @pytest.mark.parametrize("compress", [True, False])
 def test_bytearray(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     bytearr = bytearray("This is a teststring", "utf-8")
-    bytearr_serialized = serialize(bytearr)
-    bytearr_serialized_desirialized = deserialize(bytearr_serialized)
+    bytearr_serialized = serde.serialize(bytearr)
+    bytearr_serialized_desirialized = serde.deserialize(bytearr_serialized)
     assert bytearr == bytearr_serialized_desirialized
 
     bytearr = bytearray(numpy.random.random((100, 100)))
-    bytearr_serialized = serialize(bytearr)
-    bytearr_serialized_desirialized = deserialize(bytearr_serialized)
+    bytearr_serialized = serde.serialize(bytearr)
+    bytearr_serialized_desirialized = serde.deserialize(bytearr_serialized)
     assert bytearr == bytearr_serialized_desirialized
 
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_ndarray_serde(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
     arr = numpy.random.random((100, 100))
-    arr_serialized = serialize(arr)
+    arr_serialized = serde.serialize(arr)
 
-    arr_serialized_deserialized = deserialize(arr_serialized)
+    arr_serialized_deserialized = serde.deserialize(arr_serialized)
 
     assert numpy.array_equal(arr, arr_serialized_deserialized)
 
 
-@pytest.mark.parametrize("compress_scheme", [LZ4, ZSTD, NO_COMPRESSION])
+@pytest.mark.parametrize("compress_scheme", [serde.LZ4, serde.ZSTD, serde.NO_COMPRESSION])
 def test_compress_decompress(compress_scheme):
-    if compress_scheme == LZ4:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
-    elif compress_scheme == ZSTD:
-        syft.serde._apply_compress_scheme = apply_zstd_compression
+    if compress_scheme == serde.LZ4:
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
+    elif compress_scheme == serde.ZSTD:
+        syft.serde._apply_compress_scheme = serde.apply_zstd_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     original = msgpack.dumps([1, 2, 3])
-    compressed = _compress(original)
-    decompressed = _decompress(compressed)
+    compressed = serde._compress(original)
+    decompressed = serde._decompress(compressed)
     assert type(compressed) == bytes
     assert original == decompressed
 
 
-@pytest.mark.parametrize("compress_scheme", [LZ4, ZSTD, NO_COMPRESSION])
+@pytest.mark.parametrize("compress_scheme", [serde.LZ4, serde.ZSTD, serde.NO_COMPRESSION])
 def test_compressed_serde(compress_scheme):
-    if compress_scheme == LZ4:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
-    elif compress_scheme == ZSTD:
-        syft.serde._apply_compress_scheme = apply_zstd_compression
+    if compress_scheme == serde.LZ4:
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
+    elif compress_scheme == serde.ZSTD:
+        syft.serde._apply_compress_scheme = serde.apply_zstd_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     arr = numpy.random.random((100, 100))
-    arr_serialized = serialize(arr)
+    arr_serialized = serde.serialize(arr)
 
-    arr_serialized_deserialized = deserialize(arr_serialized)
+    arr_serialized_deserialized = serde.deserialize(arr_serialized)
     assert numpy.array_equal(arr, arr_serialized_deserialized)
 
 
@@ -342,35 +329,35 @@ def test_invalid_decompression_scheme(compress_scheme):
         return decompressed_input[:10], compress_scheme
 
     syft.serde._apply_compress_scheme = some_other_compression_scheme
-    arr_serialized = serialize(arr)
+    arr_serialized = serde.serialize(arr)
     with pytest.raises(CompressionNotFoundException):
-        _ = deserialize(arr_serialized)
+        _ = serde.deserialize(arr_serialized)
 
 
 @pytest.mark.parametrize("compress", [True, False])
 def test_dict(compress):
     # Test with integers
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
     _dict = {1: 1, 2: 2, 3: 3}
-    dict_serialized = serialize(_dict)
-    dict_serialized_deserialized = deserialize(dict_serialized)
+    dict_serialized = serde.serialize(_dict)
+    dict_serialized_deserialized = serde.deserialize(dict_serialized)
     assert _dict == dict_serialized_deserialized
 
     # Test with strings
     _dict = {"one": 1, "two": 2, "three": 3}
-    dict_serialized = serialize(_dict)
-    dict_serialized_deserialized = deserialize(dict_serialized)
+    dict_serialized = serde.serialize(_dict)
+    dict_serialized_deserialized = serde.deserialize(dict_serialized)
     assert _dict == dict_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     _dict = {0: tensor_one, 1: tensor_two}
-    dict_serialized = serialize(_dict)
-    dict_serialized_deserialized = deserialize(dict_serialized)
+    dict_serialized = serde.serialize(_dict)
+    dict_serialized_deserialized = serde.deserialize(dict_serialized)
     # `assert dict_serialized_deserialized == _dict` does not work, therefore it's split
     # into 3 assertions
     assert type(dict_serialized_deserialized) == type(_dict)
@@ -381,15 +368,15 @@ def test_dict(compress):
 @pytest.mark.parametrize("compress", [True, False])
 def test_range_serde(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     _range = range(1, 2, 3)
 
-    range_serialized = serialize(_range)
+    range_serialized = serde.serialize(_range)
 
-    range_serialized_deserialized = deserialize(range_serialized)
+    range_serialized_deserialized = serde.deserialize(range_serialized)
 
     assert _range == range_serialized_deserialized
 
@@ -397,28 +384,28 @@ def test_range_serde(compress):
 @pytest.mark.parametrize("compress", [True, False])
 def test_list(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     # Test with integers
     _list = [1, 2]
-    list_serialized = serialize(_list)
-    list_serialized_deserialized = deserialize(list_serialized)
+    list_serialized = serde.serialize(_list)
+    list_serialized_deserialized = serde.deserialize(list_serialized)
     assert _list == list_serialized_deserialized
 
     # Test with strings
     _list = ["hello", "world"]
-    list_serialized = serialize(_list)
-    list_serialized_deserialized = deserialize(list_serialized)
+    list_serialized = serde.serialize(_list)
+    list_serialized_deserialized = serde.deserialize(list_serialized)
     assert _list == list_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     _list = (tensor_one, tensor_two)
-    list_serialized = serialize(_list)
-    list_serialized_deserialized = deserialize(list_serialized)
+    list_serialized = serde.serialize(_list)
+    list_serialized_deserialized = serde.deserialize(list_serialized)
     # `assert list_serialized_deserialized == _list` does not work, therefore it's split
     # into 3 assertions
     assert type(list_serialized_deserialized) == type(_list)
@@ -429,28 +416,28 @@ def test_list(compress):
 @pytest.mark.parametrize("compress", [True, False])
 def test_set(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     # Test with integers
     _set = set([1, 2])
-    set_serialized = serialize(_set)
-    set_serialized_deserialized = deserialize(set_serialized)
+    set_serialized = serde.serialize(_set)
+    set_serialized_deserialized = serde.deserialize(set_serialized)
     assert _set == set_serialized_deserialized
 
     # Test with strings
     _set = set(["hello", "world"])
-    set_serialized = serialize(_set)
-    set_serialized_deserialized = deserialize(set_serialized)
+    set_serialized = serde.serialize(_set)
+    set_serialized_deserialized = serde.deserialize(set_serialized)
     assert _set == set_serialized_deserialized
 
     # Test with a complex data structure
     tensor_one = Tensor(numpy.random.random((100, 100)))
     tensor_two = Tensor(numpy.random.random((100, 100)))
     _set = (tensor_one, tensor_two)
-    set_serialized = serialize(_set)
-    set_serialized_deserialized = deserialize(set_serialized)
+    set_serialized = serde.serialize(_set)
+    set_serialized_deserialized = serde.deserialize(set_serialized)
     # `assert set_serialized_deserialized == _set` does not work, therefore it's split
     # into 3 assertions
     assert type(set_serialized_deserialized) == type(_set)
@@ -461,22 +448,22 @@ def test_set(compress):
 @pytest.mark.parametrize("compress", [True, False])
 def test_slice(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     s = slice(0, 100, 2)
     x = numpy.random.rand(100)
-    s_serialized = serialize(s)
-    s_serialized_deserialized = deserialize(s_serialized)
+    s_serialized = serde.serialize(s)
+    s_serialized_deserialized = serde.deserialize(s_serialized)
 
     assert type(s) == type(s_serialized_deserialized)
     assert (x[s] == x[s_serialized_deserialized]).all()
 
     s = slice(40, 50)
     x = numpy.random.rand(100)
-    s_serialized = serialize(s)
-    s_serialized_deserialized = deserialize(s_serialized)
+    s_serialized = serde.serialize(s)
+    s_serialized_deserialized = serde.deserialize(s_serialized)
 
     assert type(s) == type(s_serialized_deserialized)
     assert (x[s] == x[s_serialized_deserialized]).all()
@@ -485,18 +472,18 @@ def test_slice(compress):
 @pytest.mark.parametrize("compress", [True, False])
 def test_float(compress):
     if compress:
-        syft.serde._apply_compress_scheme = apply_lz4_compression
+        syft.serde._apply_compress_scheme = serde.apply_lz4_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     x = 0.5
     y = 1.5
 
-    x_serialized = serialize(x)
-    x_serialized_deserialized = deserialize(x_serialized)
+    x_serialized = serde.serialize(x)
+    x_serialized_deserialized = serde.deserialize(x_serialized)
 
-    y_serialized = serialize(y)
-    y_serialized_deserialized = deserialize(y_serialized)
+    y_serialized = serde.serialize(y)
+    y_serialized_deserialized = serde.deserialize(y_serialized)
 
     assert x_serialized_deserialized == x
     assert y_serialized_deserialized == y
@@ -506,11 +493,11 @@ def test_compressed_float():
     x = 0.5
     y = 1.5
 
-    x_serialized = serialize(x)
-    x_serialized_deserialized = deserialize(x_serialized)
+    x_serialized = serde.serialize(x)
+    x_serialized_deserialized = serde.deserialize(x_serialized)
 
-    y_serialized = serialize(y)
-    y_serialized_deserialized = deserialize(y_serialized)
+    y_serialized = serde.serialize(y)
+    y_serialized_deserialized = serde.deserialize(y_serialized)
 
     assert x_serialized_deserialized == x
     assert y_serialized_deserialized == y
@@ -519,28 +506,28 @@ def test_compressed_float():
 @pytest.mark.parametrize(
     "compress, compress_scheme",
     [
-        (True, LZ4),
-        (False, LZ4),
-        (True, ZSTD),
-        (False, ZSTD),
-        (True, NO_COMPRESSION),
-        (False, NO_COMPRESSION),
+        (True, serde.LZ4),
+        (False, serde.LZ4),
+        (True, serde.ZSTD),
+        (False, serde.ZSTD),
+        (True, serde.NO_COMPRESSION),
+        (False, serde.NO_COMPRESSION),
     ],
 )
 def test_hooked_tensor(compress, compress_scheme):
     if compress:
-        if compress_scheme == LZ4:
-            syft.serde._apply_compress_scheme = apply_lz4_compression
-        elif compress_scheme == ZSTD:
-            syft.serde._apply_compress_scheme = apply_zstd_compression
+        if compress_scheme == serde.LZ4:
+            syft.serde._apply_compress_scheme = serde.apply_lz4_compression
+        elif compress_scheme == serde.ZSTD:
+            syft.serde._apply_compress_scheme = serde.apply_zstd_compression
         else:
-            syft.serde._apply_compress_scheme = apply_no_compression
+            syft.serde._apply_compress_scheme = serde.apply_no_compression
     else:
-        syft.serde._apply_compress_scheme = apply_no_compression
+        syft.serde._apply_compress_scheme = serde.apply_no_compression
 
     t = Tensor(numpy.random.random((100, 100)))
-    t_serialized = serialize(t)
-    t_serialized_deserialized = deserialize(t_serialized)
+    t_serialized = serde.serialize(t)
+    t_serialized_deserialized = serde.deserialize(t_serialized)
     assert (t == t_serialized_deserialized).all()
 
 
@@ -549,8 +536,8 @@ def test_pointer_tensor(hook, workers):
     t = pointers.PointerTensor(
         id=1000, location=workers["alice"], owner=workers["alice"], id_at_location=12345
     )
-    t_serialized = serialize(t)
-    t_serialized_deserialized = deserialize(t_serialized)
+    t_serialized = serde.serialize(t)
+    t_serialized_deserialized = serde.deserialize(t_serialized)
     print(f"t.location - {t.location}")
     print(f"t_serialized_deserialized.location - {t_serialized_deserialized.location}")
     assert t.id == t_serialized_deserialized.id
@@ -574,8 +561,8 @@ def test_numpy_tensor_serde():
 
     tensor = torch.tensor(numpy.random.random((10, 10)), requires_grad=False)
 
-    tensor_serialized = serialize(tensor)
-    tensor_deserialized = deserialize(tensor_serialized)
+    tensor_serialized = serde.serialize(tensor)
+    tensor_deserialized = serde.deserialize(tensor_serialized)
 
     # Back to Pytorch serializer
     syft.serde._serialize_tensor = syft.serde.torch_tensor_serializer

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -7,6 +7,8 @@ from syft.workers.virtual import VirtualWorker
 from syft.codes import MSGTYPE
 from syft import serde
 
+from syft.frameworks.torch import pointers
+
 import pytest
 import torch
 import torch as th
@@ -226,3 +228,17 @@ def test_spinup_time(hook):
     dummy = sy.VirtualWorker(hook, id="dummy", data=data)
     end_time = time()
     assert (end_time - start_time) < 0.05
+
+
+def test_send_jit_scriptmodule(hook, workers):
+    bob = workers["bob"]
+
+    @torch.jit.script
+    def foo(x):
+        return x + 2
+
+    foo_wrapper = pointers.ObjectWrapper(obj=foo, id=99)
+    foo_ptr = hook.local_worker.send(foo_wrapper, bob)
+
+    res = foo_ptr(torch.tensor(4))
+    assert res == torch.tensor(6)

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -230,7 +230,8 @@ def test_spinup_time(hook):
     assert (end_time - start_time) < 0.05
 
 
-def test_send_jit_scriptmodule(hook, workers):
+@pytest.mark.skip(reason="bug in pytorch version 1.1.0, jit.trace returns raw C function")
+def test_send_jit_scriptmodule(hook, workers):  # pragma: no cover
     bob = workers["bob"]
 
     @torch.jit.script


### PR DESCRIPTION
This pull request modifies the serde module to support serialization for torch.jit.ScriptModule instances. 
This covers both functions decorated with @torch.jit.script (torch.jit.ScriptModule) and models traced using torch.jit.trace() (torch.jit.TopLevelTracedModule).