### PR TITLE
Add handling of ResponseSignatureError across socket workers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ torchvision
 websocket_client
 websockets>=7.0
 zstd
+tblib

--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -137,6 +137,12 @@ class ResponseSignatureError(Exception):
     def __init__(self, ids_generated=None):
         self.ids_generated = ids_generated
 
+    def get_attributes(self):
+        """
+        Specify all the attributes need to report an error correctly.
+        """
+        return {"ids_generated": self.ids_generated}
+
 
 class GetNotPermittedError(Exception):
     """Raised when calling get on a pointer to a tensor which does not allow

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -1354,7 +1354,7 @@ simplifiers = {
     MultiPointerTensor: [14, _simplify_multi_pointer_tensor],
     Plan: [15, _simplify_plan],
     VirtualWorker: [16, _simplify_worker],
-    str: [17, _simplify_str],
+    str: [18, _simplify_str],
     pointers.ObjectWrapper: [19, _simplify_object_wrapper],
     GetNotPermittedError: [20, _simplify_exception],
     ResponseSignatureError: [20, _simplify_exception],
@@ -1365,7 +1365,7 @@ simplifiers = {
     ],  # treat as torch.jit.ScriptModule
 }
 
-forced_full_simplifiers = {VirtualWorker: [18, _force_full_simplify_worker]}
+forced_full_simplifiers = {VirtualWorker: [17, _force_full_simplify_worker]}
 
 
 def _detail(worker: AbstractWorker, obj: object) -> object:
@@ -1411,8 +1411,8 @@ detailers = [
     _detail_multi_pointer_tensor,
     _detail_plan,
     _detail_worker,
-    _detail_str,
     _force_full_detail_worker,
+    _detail_str,
     _detail_object_wrapper,
     _detail_exception,
     _detail_script_module,

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -46,7 +46,6 @@ import numpy
 from tblib import Traceback
 import traceback
 from six import reraise
-import sys
 import warnings
 import zstd
 
@@ -1182,14 +1181,15 @@ def _simplify_exception(e):
     """
     Serialize information about an Exception which was raised to forward it
     """
-    # Get information about the exception: type of error, error obj, traceback
-    tp, value, tb = sys.exc_info()
+    # Get information about the exception: type of error,  traceback
+    tp = type(e)
+    tb = e.__traceback__
     # Serialize the traceback
     traceback_str = "Traceback (most recent call last):\n" + "".join(traceback.format_tb(tb))
     # Include special attributes if relevant
-    if hasattr(e, "get_attributes"):
+    try:
         attributes = e.get_attributes()
-    else:
+    except AttributeError:
         attributes = {}
     return tp.__name__, traceback_str, _simplify(attributes)
 

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -1177,44 +1177,6 @@ def _detail_worker(worker: AbstractWorker, worker_tuple: tuple) -> pointers.Poin
     return referenced_worker
 
 
-def _simplify_exception(e):
-    """
-    Serialize information about an Exception which was raised to forward it
-    """
-    # Get information about the exception: type of error,  traceback
-    tp = type(e)
-    tb = e.__traceback__
-    # Serialize the traceback
-    traceback_str = "Traceback (most recent call last):\n" + "".join(traceback.format_tb(tb))
-    # Include special attributes if relevant
-    try:
-        attributes = e.get_attributes()
-    except AttributeError:
-        attributes = {}
-    return tp.__name__, traceback_str, _simplify(attributes)
-
-
-def _detail_exception(worker: AbstractWorker, error_tuple: Tuple[str, str, dict]):
-    """
-    Detail and re-raise an Exception forwarded by another worker
-    """
-    error_name, traceback_str, attributes = error_tuple
-    error_name, traceback_str = error_name.decode("utf-8"), traceback_str.decode("utf-8")
-    attributes = _detail(worker, attributes)
-    # De-serialize the traceback
-    tb = Traceback.from_string(traceback_str)
-    # Check that the error belongs to a valid set of Exceptions
-    if error_name in dir(sy.exceptions):
-        error_type = getattr(sy.exceptions, error_name)
-        error = error_type()
-        # Include special attributes if any
-        for attr_name, attr in attributes.items():
-            setattr(error, attr_name, attr)
-        reraise(error_type, error, tb.as_traceback())
-    else:
-        raise ValueError(f"Invalid Exception returned:\n{traceback_str}")
-
-
 def _force_full_simplify_worker(worker: AbstractWorker) -> tuple:
     """
 
@@ -1258,6 +1220,44 @@ def _detail_object_wrapper(
         id=obj_wrapper_tuple[0], obj=_detail(worker, obj_wrapper_tuple[1])
     )
     return obj_wrapper
+
+
+def _simplify_exception(e):
+    """
+    Serialize information about an Exception which was raised to forward it
+    """
+    # Get information about the exception: type of error,  traceback
+    tp = type(e)
+    tb = e.__traceback__
+    # Serialize the traceback
+    traceback_str = "Traceback (most recent call last):\n" + "".join(traceback.format_tb(tb))
+    # Include special attributes if relevant
+    try:
+        attributes = e.get_attributes()
+    except AttributeError:
+        attributes = {}
+    return tp.__name__, traceback_str, _simplify(attributes)
+
+
+def _detail_exception(worker: AbstractWorker, error_tuple: Tuple[str, str, dict]):
+    """
+    Detail and re-raise an Exception forwarded by another worker
+    """
+    error_name, traceback_str, attributes = error_tuple
+    error_name, traceback_str = error_name.decode("utf-8"), traceback_str.decode("utf-8")
+    attributes = _detail(worker, attributes)
+    # De-serialize the traceback
+    tb = Traceback.from_string(traceback_str)
+    # Check that the error belongs to a valid set of Exceptions
+    if error_name in dir(sy.exceptions):
+        error_type = getattr(sy.exceptions, error_name)
+        error = error_type()
+        # Include special attributes if any
+        for attr_name, attr in attributes.items():
+            setattr(error, attr_name, attr)
+        reraise(error_type, error, tb.as_traceback())
+    else:
+        raise ValueError(f"Invalid Exception returned:\n{traceback_str}")
 
 
 def _simplify_script_module(obj: torch.jit.ScriptModule) -> str:

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -1352,9 +1352,9 @@ simplifiers = {
     str: [18, _simplify_str],
     pointers.ObjectWrapper: [20, _simplify_object_wrapper],
     ResponseSignatureError: [21, _simplify_exception],
-    torch.jit.ScriptModule: [21, _simplify_script_module],
+    torch.jit.ScriptModule: [22, _simplify_script_module],
     torch.jit.TopLevelTracedModule: [
-        21,
+        22,
         _simplify_script_module,
     ],  # treat as torch.jit.ScriptModule
 }

--- a/syft/serde.py
+++ b/syft/serde.py
@@ -1178,26 +1178,6 @@ def _detail_worker(worker: AbstractWorker, worker_tuple: tuple) -> pointers.Poin
     return referenced_worker
 
 
-def _simplify_GetNotPermittedError(error: GetNotPermittedError) -> tuple:
-    """Simplifies a GetNotPermittedError into its message"""
-    return (getattr(error, "message", str(error)),)
-
-
-def _detail_GetNotPermittedError(
-    worker: AbstractWorker, error_tuple: tuple
-) -> GetNotPermittedError:
-    """Details and raises a GetNotPermittedError
-
-    Args:
-        worker: the worker doing the deserialization
-        error_tuple: a tuple holding the message of the GetNotPermittedError
-    Raises:
-        GetNotPermittedError: the error thrown when get is not permitted
-    """
-
-    raise GetNotPermittedError(error_tuple[0])
-
-
 def _simplify_exception(e):
     """
     Serialize information about an Exception which was raised to forward it
@@ -1216,7 +1196,7 @@ def _simplify_exception(e):
 
 def _detail_exception(worker: AbstractWorker, error_tuple: Tuple[str, str, dict]):
     """
-    Re-raise an Exception forwarded by another worker
+    Detail and re-raise an Exception forwarded by another worker
     """
     error_name, traceback_str, attributes = error_tuple
     error_name, traceback_str = error_name.decode("utf-8"), traceback_str.decode("utf-8")
@@ -1374,18 +1354,18 @@ simplifiers = {
     MultiPointerTensor: [14, _simplify_multi_pointer_tensor],
     Plan: [15, _simplify_plan],
     VirtualWorker: [16, _simplify_worker],
-    GetNotPermittedError: [17, _simplify_GetNotPermittedError],
-    str: [18, _simplify_str],
-    pointers.ObjectWrapper: [20, _simplify_object_wrapper],
-    ResponseSignatureError: [21, _simplify_exception],
-    torch.jit.ScriptModule: [22, _simplify_script_module],
+    str: [17, _simplify_str],
+    pointers.ObjectWrapper: [19, _simplify_object_wrapper],
+    GetNotPermittedError: [20, _simplify_exception],
+    ResponseSignatureError: [20, _simplify_exception],
+    torch.jit.ScriptModule: [21, _simplify_script_module],
     torch.jit.TopLevelTracedModule: [
-        22,
+        21,
         _simplify_script_module,
     ],  # treat as torch.jit.ScriptModule
 }
 
-forced_full_simplifiers = {VirtualWorker: [19, _force_full_simplify_worker]}
+forced_full_simplifiers = {VirtualWorker: [18, _force_full_simplify_worker]}
 
 
 def _detail(worker: AbstractWorker, obj: object) -> object:
@@ -1431,7 +1411,6 @@ detailers = [
     _detail_multi_pointer_tensor,
     _detail_plan,
     _detail_worker,
-    _detail_GetNotPermittedError,
     _detail_str,
     _force_full_detail_worker,
     _detail_object_wrapper,

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -468,7 +468,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
 
         obj = self.get_obj(obj_id)
         if hasattr(obj, "allowed_to_get") and not obj.allowed_to_get():
-            return GetNotPermittedError()
+            raise GetNotPermittedError()
         else:
             self.de_register_obj(obj)
             return obj

--- a/syft/workers/websocket_server.py
+++ b/syft/workers/websocket_server.py
@@ -14,6 +14,7 @@ tblib.pickling_support.install()
 import syft as sy
 from syft.frameworks.torch.tensors.interpreters import AbstractTensor
 from syft.workers.virtual import VirtualWorker
+from syft.exceptions import GetNotPermittedError
 from syft.exceptions import ResponseSignatureError
 
 
@@ -112,7 +113,7 @@ class WebsocketServerWorker(VirtualWorker):
     def _recv_msg(self, message: bin) -> bin:
         try:
             return self.recv_msg(message)
-        except ResponseSignatureError as e:
+        except (ResponseSignatureError, GetNotPermittedError) as e:
             return sy.serde.serialize(e)
 
     async def _handler(self, websocket: websockets.WebSocketCommonProtocol, *unused_args):

--- a/test/federated/test_plan.py
+++ b/test/federated/test_plan.py
@@ -207,7 +207,7 @@ def test_plan_execute_remotely(hook, start_proc):
     x = th.tensor([-1, 2, 3])
     my_plan(x)
 
-    kwargs = {"id": "test_plan_worker", "host": "localhost", "port": 8768, "hook": hook}
+    kwargs = {"id": "test_plan_worker", "host": "localhost", "port": 8799, "hook": hook}
     server = start_proc(WebsocketServerWorker, kwargs)
 
     time.sleep(0.1)

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -25,7 +25,7 @@ def test_tuple_simplify():
     for tuples so that the detailer knows how to interpret it."""
 
     input = ("hello", "world")
-    target = (2, ((18, (b"hello",)), (18, (b"world",))))
+    target = (2, ((17, (b"hello",)), (17, (b"world",))))
     assert serde._simplify(input) == target
 
 
@@ -37,7 +37,7 @@ def test_list_simplify():
     for lists so that the detailer knows how to interpret it."""
 
     input = ["hello", "world"]
-    target = (3, [(18, (b"hello",)), (18, (b"world",))])
+    target = (3, [(17, (b"hello",)), (17, (b"world",))])
     assert serde._simplify(input) == target
 
 
@@ -49,7 +49,7 @@ def test_set_simplify():
     for sets so that the detailer knows how to interpret it."""
 
     input = set(["hello", "world"])
-    target = (4, [(18, (b"hello",)), (18, (b"world",))])
+    target = (4, [(17, (b"hello",)), (17, (b"world",))])
     assert serde._simplify(input)[0] == target[0]
     assert set(serde._simplify(input)[1]) == set(target[1])
 
@@ -83,7 +83,7 @@ def test_string_simplify():
     themselves, with no tuple/id necessary."""
 
     input = "hello"
-    target = (18, (b"hello",))
+    target = (17, (b"hello",))
     assert serde._simplify(input) == target
 
 
@@ -95,7 +95,7 @@ def test_dict_simplify():
     for dicts so that the detailer knows how to interpret it."""
 
     input = {"hello": "world"}
-    target = (5, [((18, (b"hello",)), (18, (b"world",)))])
+    target = (5, [((17, (b"hello",)), (17, (b"world",)))])
     assert serde._simplify(input) == target
 
 

--- a/test/test_serde.py
+++ b/test/test_serde.py
@@ -25,7 +25,7 @@ def test_tuple_simplify():
     for tuples so that the detailer knows how to interpret it."""
 
     input = ("hello", "world")
-    target = (2, ((17, (b"hello",)), (17, (b"world",))))
+    target = (2, ((18, (b"hello",)), (18, (b"world",))))
     assert serde._simplify(input) == target
 
 
@@ -37,7 +37,7 @@ def test_list_simplify():
     for lists so that the detailer knows how to interpret it."""
 
     input = ["hello", "world"]
-    target = (3, [(17, (b"hello",)), (17, (b"world",))])
+    target = (3, [(18, (b"hello",)), (18, (b"world",))])
     assert serde._simplify(input) == target
 
 
@@ -49,7 +49,7 @@ def test_set_simplify():
     for sets so that the detailer knows how to interpret it."""
 
     input = set(["hello", "world"])
-    target = (4, [(17, (b"hello",)), (17, (b"world",))])
+    target = (4, [(18, (b"hello",)), (18, (b"world",))])
     assert serde._simplify(input)[0] == target[0]
     assert set(serde._simplify(input)[1]) == set(target[1])
 
@@ -83,7 +83,7 @@ def test_string_simplify():
     themselves, with no tuple/id necessary."""
 
     input = "hello"
-    target = (17, (b"hello",))
+    target = (18, (b"hello",))
     assert serde._simplify(input) == target
 
 
@@ -95,7 +95,7 @@ def test_dict_simplify():
     for dicts so that the detailer knows how to interpret it."""
 
     input = {"hello": "world"}
-    target = (5, [((17, (b"hello",)), (17, (b"world",)))])
+    target = (5, [((18, (b"hello",)), (18, (b"world",)))])
     assert serde._simplify(input) == target
 
 

--- a/test/workers/test_websocket_worker.py
+++ b/test/workers/test_websocket_worker.py
@@ -70,7 +70,7 @@ def test_websocket_worker_multiple_output_response(hook, start_proc):
     """Evaluates that you can do basic tensor operations using
     WebsocketServerWorker"""
 
-    kwargs = {"id": "fed1", "host": "localhost", "port": 8768, "hook": hook}
+    kwargs = {"id": "socket_multiple_output", "host": "localhost", "port": 8768, "hook": hook}
     server = start_proc(WebsocketServerWorker, kwargs)
 
     time.sleep(0.1)


### PR DESCRIPTION
Provides an implementation to solve #2214

Version 1:
Keep all stack trace just like if the error was happening locally, but uses pickle c742c9b

Version 2:
Keep a serialized version of the stack trace which contains less information, but doesn't use pickle 8466e4f