### PR TITLE
Run tests using tfe.LocalConfig

### DIFF
--- a/syft/frameworks/keras/model/sequential.py
+++ b/syft/frameworks/keras/model/sequential.py
@@ -15,7 +15,7 @@ _args_not_supported_by_tfe = [
 ]
 
 
-def share(model, *workers, target_graph=None):  # pragma: no cover
+def share(model, *workers, target_graph=None):
     """
     Secret share the model between `workers`.
 

--- a/syft/frameworks/keras/model/sequential.py
+++ b/syft/frameworks/keras/model/sequential.py
@@ -58,7 +58,6 @@ def share(model, *workers, target_graph=None):  # pragma: no cover
 
     # Push and initialize shared model on servers
     sess = tfe.Session(graph=target_graph)
-    tf.Session.reset(sess.target)
     sess.run(initializer)
 
     model._tfe_session = sess

--- a/test/keras/test_sequential.py
+++ b/test/keras/test_sequential.py
@@ -43,8 +43,7 @@ def test_instantiate_tfe_layer():
     np.testing.assert_allclose(actual, expected, rtol=0.001)
 
 
-@pytest.mark.skip(reason="Currently breaks on macos")
-def test_share():  # pragma: no cover
+def test_share():
 
     from tensorflow.keras import Sequential
     from tensorflow.keras.layers import Dense
@@ -62,10 +61,9 @@ def test_share():  # pragma: no cover
         Dense(5, kernel_initializer=initializer, batch_input_shape=input_shape, use_bias=True)
     )
 
-    AUTO = True
-    alice = sy.TFEWorker(host="localhost:4000", auto_managed=AUTO)
-    bob = sy.TFEWorker(host="localhost:4001", auto_managed=AUTO)
-    carol = sy.TFEWorker(host="localhost:4002", auto_managed=AUTO)
+    alice = sy.TFEWorker(host=None)
+    bob = sy.TFEWorker(host=None)
+    carol = sy.TFEWorker(host=None)
 
     model.share(alice, bob, carol)
 


### PR DESCRIPTION
Tests where previously running using a `tfe.RemoteConfig` but that is fragile due to process starting and concurrency. This patch changes the tests to use `tfe.LocalConfig` instead.

Closes https://github.com/OpenMined/PySyft/issues/2211.