### PR TITLE
Correct functions to add and scale models

### DIFF
--- a/syft/frameworks/torch/federated/utils.py
+++ b/syft/frameworks/torch/federated/utils.py
@@ -40,12 +40,12 @@ def add_model(dst_model, src_model):
 
         """
 
-    params1 = dst_model.named_parameters()
-    params2 = src_model.named_parameters()
+    params1 = src_model.named_parameters()
+    params2 = dst_model.named_parameters()
     dict_params2 = dict(params2)
     for name1, param1 in params1:
         if name1 in dict_params2:
-            dict_params2[name1].data.set_ = param1.data + dict_params2[name1].data
+            dict_params2[name1].data.set_(param1.data + dict_params2[name1].data)
     return dst_model
 
 
@@ -62,7 +62,7 @@ def scale_model(model, scale):
     params = model.named_parameters()
     dict_params = dict(params)
     for name, param in dict_params.items():
-        dict_params[name].data.set_ = dict_params[name].data * scale
+        dict_params[name].data.set_(dict_params[name].data * scale)
     return model
 
 

--- a/syft/frameworks/torch/federated/utils.py
+++ b/syft/frameworks/torch/federated/utils.py
@@ -43,9 +43,10 @@ def add_model(dst_model, src_model):
     params1 = src_model.named_parameters()
     params2 = dst_model.named_parameters()
     dict_params2 = dict(params2)
-    for name1, param1 in params1:
-        if name1 in dict_params2:
-            dict_params2[name1].data.set_(param1.data + dict_params2[name1].data)
+    with torch.no_grad():
+        for name1, param1 in params1:
+            if name1 in dict_params2:
+                dict_params2[name1].set_(param1.data + dict_params2[name1].data)
     return dst_model
 
 
@@ -61,8 +62,9 @@ def scale_model(model, scale):
     """
     params = model.named_parameters()
     dict_params = dict(params)
-    for name, param in dict_params.items():
-        dict_params[name].data.set_(dict_params[name].data * scale)
+    with torch.no_grad():
+        for name, param in dict_params.items():
+            dict_params[name].set_(dict_params[name].data * scale)
     return model
 
 

--- a/test/torch/federated/test_utils.py
+++ b/test/torch/federated/test_utils.py
@@ -39,14 +39,16 @@ def test_add_model():
     net1 = Net()
     params1 = net1.named_parameters()
     dict_params1 = dict(params1)
-    dict_params1["fc1.weight"].data.set_(weight1)
-    dict_params1["fc1.bias"].data.set_(bias1)
+    with th.no_grad():
+        dict_params1["fc1.weight"].set_(weight1)
+        dict_params1["fc1.bias"].set_(bias1)
 
     net2 = Net()
     params2 = net2.named_parameters()
     dict_params2 = dict(params2)
-    dict_params2["fc1.weight"].data.set_(weight2)
-    dict_params2["fc1.bias"].data.set_(bias2)
+    with th.no_grad():
+        dict_params2["fc1.weight"].set_(weight2)
+        dict_params2["fc1.bias"].set_(bias2)
 
     new_model = utils.add_model(net1, net2)
 
@@ -67,8 +69,9 @@ def test_scale_model():
     net1 = Net()
     params1 = net1.named_parameters()
     dict_params1 = dict(params1)
-    dict_params1["fc1.weight"].data.set_(weight1)
-    dict_params1["fc1.bias"].data.set_(bias1)
+    with th.no_grad():
+        dict_params1["fc1.weight"].set_(weight1)
+        dict_params1["fc1.bias"].set_(bias1)
 
     scale = 2.0
 

--- a/test/torch/federated/test_utils.py
+++ b/test/torch/federated/test_utils.py
@@ -22,3 +22,57 @@ def test_extract_batches_per_worker(workers):
     assert len(batches.keys()) == len(
         datasets
     ), "each worker should appear as key in the batches dictionary"
+
+
+def test_add_model():
+    class Net(th.nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.fc1 = th.nn.Linear(2, 2)
+
+    weight1 = th.tensor([1.0, 2.0, 3.0, 4.0])
+    weight2 = th.tensor([11.0, 22.0, 33.0, 44.0])
+
+    bias1 = th.tensor([-1.0, -2.0])
+    bias2 = th.tensor([1.0, 2.0])
+
+    net1 = Net()
+    params1 = net1.named_parameters()
+    dict_params1 = dict(params1)
+    dict_params1["fc1.weight"].data.set_(weight1)
+    dict_params1["fc1.bias"].data.set_(bias1)
+
+    net2 = Net()
+    params2 = net2.named_parameters()
+    dict_params2 = dict(params2)
+    dict_params2["fc1.weight"].data.set_(weight2)
+    dict_params2["fc1.bias"].data.set_(bias2)
+
+    new_model = utils.add_model(net1, net2)
+
+    assert (new_model.fc1.weight.data == (weight1 + weight2)).all()
+    assert (new_model.fc1.bias.data == (bias1 + bias2)).all()
+
+
+def test_scale_model():
+    class Net(th.nn.Module):
+        def __init__(self):
+            super(Net, self).__init__()
+            self.fc1 = th.nn.Linear(2, 2)
+
+    weight1 = th.tensor([1.0, 2.0, 3.0, 4.0])
+
+    bias1 = th.tensor([-1.0, -2.0])
+
+    net1 = Net()
+    params1 = net1.named_parameters()
+    dict_params1 = dict(params1)
+    dict_params1["fc1.weight"].data.set_(weight1)
+    dict_params1["fc1.bias"].data.set_(bias1)
+
+    scale = 2.0
+
+    new_model = utils.scale_model(net1, scale)
+
+    assert (new_model.fc1.weight.data == (weight1 * scale)).all()
+    assert (new_model.fc1.bias.data == (bias1 * scale)).all()


### PR DESCRIPTION
Bug fix and fix of compatibility issues with pytorch 1.1 for functions add_model and scale_model. These functions are used to calculate the federated average of models.