### PR TITLE
Making hook_args more robust against functions without a tensor in args

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -442,9 +442,6 @@ class TorchHook:
                 # 5. Put instead the hooked one
                 setattr(torch_module, func, new_func)
 
-        # Hard fix for PyTorch versions < 1.0.2
-        syft.torch.apply_fix16922(self.torch)
-
         torch_modules = syft.torch.torch_modules
 
         for module_name, torch_module in torch_modules.items():

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -51,18 +51,18 @@ class TorchAttributes(object):
             for func_name in dir(torch_module)
         }
 
-        # Add special functions to exclude from the hook
+        # Add special functions to exclude from the hook **in alphabetical order**
+        # Reasons can be:
+        # - Used for internal process like printing tensors
+        # - Don't use tensors so are bound to have local executions
+        # - etc
+        # DON'T put here:
+        # - functions like native_*
+        # - functions that could use pointers or syft tensors
         self.exclude = [
             "arange",
-            "typename",
-            "is_tensor",
-            "manual_seed",
-            "storage",
-            "storage_offset",
-            "size",
-            "stride",
+            "as_tensor",
             "from_numpy",
-            "set_",
             "get_default_dtype",
             "get_device",
             "get_file_path",
@@ -86,31 +86,24 @@ class TorchAttributes(object):
             "isclose",
             "isfinite",
             "load",
-            "native_add",
-            "native_batch_norm",
-            "native_clone",
-            "native_norm",
-            "native_pow",
-            "native_resize_as_",
-            "native_tensor",
-            "native_zero_",
+            "manual_seed",
             "ones",
             "rand",
             "randint",
-            "randn_like",
             "randn",
+            "randn_like",
+            "randperm",
             "range",
             "save",
+            "set_",
             "short",
-            "zeros",
+            "size",
+            "storage",
+            "storage_offset",
+            "stride",
             "tensor",
-            "get_default_dtype",
-            "is_grad_enabled",
-            "is_nonzero",
-            "is_storage",
-            "is_tensor",
-            "isfinite",
-            "randperm",
+            "typename",
+            "zeros",
         ]
 
         # SECTION: List all torch tensor methods we want to overload

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -237,21 +237,3 @@ class TorchAttributes(object):
             is_inplace = method_name[-1] == "_" and "__" not in method_name
             self.inplace_methods[method_name] = is_inplace
             return is_inplace
-
-    @staticmethod
-    def apply_fix16922(torch):
-        """
-        Apply the fix made in PR16922 of PyTorch until people use PyTorch 1.0.2
-        :param torch: the pytorch module
-        """
-        broken_funcs = [
-            "max_pool1d",
-            "max_pool2d",
-            "max_pool3d",
-            "adaptive_max_pool1d",
-            "adaptive_max_pool2d",
-            "adaptive_max_pool3d",
-        ]
-        for broken_func in broken_funcs:
-            getattr(torch.nn.functional, broken_func).__module__ = "torch.nn.functional"
-            getattr(torch.nn.functional, broken_func).__name__ = broken_func

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -223,6 +223,13 @@ def test_hook_args_and_cmd_signature_malleability():
     assert (r3 == syft.LoggingTensor().on(torch.tensor([2.0, 4]))).all()
 
 
+def test_torch_func_signature_without_tensor():
+    """The hook on the args of torch commands should work even if the args
+    don't contain any tensor"""
+    x = torch.as_tensor((0.1307,), dtype=torch.float32, device="cpu")
+    assert (x == torch.tensor([0.1307])).all()
+
+
 def test_RNN_grad_set_backpropagation(workers):
     """Perform backpropagation at a remote worker and check if the gradient updates
     and properly computed within the model"""


### PR DESCRIPTION
I just propose a alternate way to the fix for #2260 which doesn't need to list functions specifically:
Function like `as_tensor` when not identified are correctly handled by hook_args thanks to a fallback mechanism, but can also be included in the list of function not to hook.