### PR TITLE
Allow syft to be imported without tf_encrypted being installed.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,6 @@ ipykernel>=5.1.0
 pre-commit>=1.16.1
 pyopenssl>=19.0.0
 pytest>=4.5.0
+setuptools>=41.0.0
 sphinx-markdown-builder>=0.4.1
 Sphinx>=2.1.1
-

--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -5,13 +5,38 @@ from syft import workers
 from syft import codes
 from syft import federated
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 # The purpose of the following import section is to increase the convenience of using
 # PySyft by making it possible to import the most commonly used objects from syft
 # directly (i.e., syft.TorchHook or syft.VirtualWorker or syft.LoggingTensor)
 
+# Tensorflow / Keras dependencies
 # Import Hooks
-from syft.frameworks.keras import KerasHook
+
+from syft import dependency_check
+
+if dependency_check.keras_available:
+    from syft.frameworks.keras import KerasHook
+    from syft.workers import TFEWorker
+else:
+    logger.warning("Keras (Tensorflow) not available.")
+
+# Pytorch dependencies
+# Import Hook
 from syft.frameworks.torch import TorchHook
+
+# Import Tensor Types
+from syft.frameworks.torch.tensors.decorators import LoggingTensor
+from syft.frameworks.torch.tensors.interpreters import AdditiveSharingTensor
+from syft.frameworks.torch.tensors.interpreters import MultiPointerTensor
+from syft.frameworks.torch.tensors.interpreters import AutogradTensor
+from syft.frameworks.torch.pointers import PointerTensor
+
+# import other useful classes
+from syft.frameworks.torch.federated import FederatedDataset, FederatedDataLoader, BaseDataset
 
 # Import grids
 from syft.grid import VirtualGrid
@@ -24,25 +49,15 @@ from syft.federated import method2plan
 from syft.federated import make_plan
 
 # Import Worker Types
-from syft.workers import TFEWorker
 from syft.workers import VirtualWorker
 
-# Import Tensor Types
-from syft.frameworks.torch.tensors.decorators import LoggingTensor
-from syft.frameworks.torch.tensors.interpreters import AdditiveSharingTensor
-from syft.frameworks.torch.tensors.interpreters import MultiPointerTensor
-from syft.frameworks.torch.tensors.interpreters import AutogradTensor
 from syft.frameworks.torch.pointers import ObjectPointer
 from syft.frameworks.torch.pointers import CallablePointer
-from syft.frameworks.torch.pointers import PointerTensor
 from syft.frameworks.torch.pointers import ObjectWrapper
 
 # Import serialization tools
 from syft import serde
 from syft.serde import torch_serde
-
-# import other useful classes
-from syft.frameworks.torch.federated import FederatedDataset, FederatedDataLoader, BaseDataset
 
 # import functions
 from syft.frameworks.torch.functions import combine_pointers

--- a/syft/dependency_check.py
+++ b/syft/dependency_check.py
@@ -1,0 +1,10 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import tf_encrypted as tfe
+
+    keras_available = True
+except ImportError as e:
+    keras_available = False

--- a/syft/frameworks/__init__.py
+++ b/syft/frameworks/__init__.py
@@ -1,4 +1,15 @@
-from . import keras
+import logging
+from syft import dependency_check
+
+logger = logging.getLogger(__name__)
+
+__all__ = list()
+
+if dependency_check.keras_available:
+    from . import keras
+
+    __all__.append("keras")
+
 from . import torch
 
-__all__ = ["keras", "torch"]
+__all__.append("torch")

--- a/syft/workers/__init__.py
+++ b/syft/workers/__init__.py
@@ -4,7 +4,12 @@ from syft.workers.virtual import VirtualWorker  # noqa: F401
 
 from syft.workers.websocket_client import WebsocketClientWorker  # noqa: F401
 from syft.workers.websocket_server import WebsocketServerWorker  # noqa: F401
-from syft.workers.tfe import TFEWorker  # noqa: F401
 
+from syft import dependency_check
 
-__all__ = ["base", "virtual", "websocket_client", "socketio_client", "tfe", "BaseWorker"]
+__all__ = ["base", "virtual", "websocket_client", "socketio_client", "BaseWorker"]
+
+if dependency_check.keras_available:
+    from syft.workers.tfe import TFEWorker  # noqa: F401
+
+    __all__.append("tfe")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from multiprocessing import Process
+import builtins
 
 import syft
 from syft import TorchHook
@@ -57,3 +58,17 @@ def workers(hook):
     alice.remove_worker_from_local_worker_registry()
     bob.remove_worker_from_local_worker_registry()
     james.remove_worker_from_local_worker_registry()
+
+
+@pytest.fixture
+def no_tf_encrypted():
+    import_orig = builtins.__import__
+
+    def mocked_import(name, globals, locals, fromlist, level):
+        if "tf_encrypted" in name:
+            raise ImportError()
+        return import_orig(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = mocked_import
+    yield
+    builtins.__import__ = import_orig

--- a/test/federated/test_federated_client.py
+++ b/test/federated/test_federated_client.py
@@ -7,7 +7,7 @@ from syft import federated
 from syft.frameworks.torch import pointers
 from syft.frameworks.torch.federated import utils
 
-PRINT_IN_UNITTESTS = False
+PRINT_IN_UNITTESTS = True
 
 
 def test_add_dataset():
@@ -141,8 +141,8 @@ def test_fit(fit_dataset_key, epochs):
         if PRINT_IN_UNITTESTS:  # pragma: no cover
             print("Loss after training: {}".format(loss_after))
 
-        if loss_after >= loss_before:
-            if PRINT_IN_UNITTESTS:  # pragma: no cover
+        if loss_after >= loss_before:  # pragma: no cover
+            if PRINT_IN_UNITTESTS:
                 print("Loss not reduced, train more: {}".format(loss_after))
 
             train_model(

--- a/test/federated/test_federated_client.py
+++ b/test/federated/test_federated_client.py
@@ -57,6 +57,26 @@ def test_set_obj_other():
     assert fed_client._objects[dummy_data.id] == dummy_data
 
 
+def evaluate_model(fed_client, model_id, loss_fn, data, target):  # pragma: no cover
+    new_model = fed_client.get_obj(model_id)
+    pred = new_model.obj(data)
+    loss_after = loss_fn(target=target, pred=pred)
+    return loss_after
+
+
+def train_model(fed_client, fit_dataset_key, available_dataset_key, nr_rounds):  # pragma: no cover
+    loss = None
+    for curr_round in range(nr_rounds):
+        if fit_dataset_key == available_dataset_key:
+            loss = fed_client.fit(dataset_key=fit_dataset_key)
+        else:
+            with pytest.raises(ValueError):
+                loss = fed_client.fit(dataset_key=fit_dataset_key)
+        if PRINT_IN_UNITTESTS and curr_round % 2 == 0:  # pragma: no cover
+            print("-" * 50)
+            print("Iteration %s: alice's loss: %s" % (curr_round, loss))
+
+
 @pytest.mark.parametrize(
     "fit_dataset_key, epochs",
     [("gaussian_mixture", 1), ("gaussian_mixture", 10), ("another_dataset", 1)],
@@ -114,22 +134,20 @@ def test_fit(fit_dataset_key, epochs):
     fed_client.set_obj(train_config)
     fed_client.optimizer = None
 
-    loss = loss_before
-    for curr_round in range(3):
-        if fit_dataset_key == dataset_key:
-            loss = fed_client.fit(dataset_key=fit_dataset_key)
-        else:
-            with pytest.raises(ValueError):
-                loss = fed_client.fit(dataset_key=fit_dataset_key)
-        if PRINT_IN_UNITTESTS and curr_round % 4 == 0:  # pragma: no cover
-            print("-" * 50)
-            print("Iteration %s: alice's loss: %s" % (curr_round, loss))
+    train_model(fed_client, fit_dataset_key, available_dataset_key=dataset_key, nr_rounds=3)
 
     if dataset_key == fit_dataset_key:
-        new_model = fed_client.get_obj(model_id)
-        pred = new_model.obj(data)
-        loss_after = loss_fn(target=target, pred=pred)
-        if PRINT_IN_UNITTESTS:  # pragma: no cover:
+        loss_after = evaluate_model(fed_client, model_id, loss_fn, data, target)
+        if PRINT_IN_UNITTESTS:  # pragma: no cover
             print("Loss after training: {}".format(loss_after))
+
+        if loss_after >= loss_before:
+            if PRINT_IN_UNITTESTS:  # pragma: no cover
+                print("Loss not reduced, train more: {}".format(loss_after))
+
+            train_model(
+                fed_client, fit_dataset_key, available_dataset_key=dataset_key, nr_rounds=10
+            )
+            loss_after = evaluate_model(fed_client, model_id, loss_fn, data, target)
 
         assert loss_after < loss_before

--- a/test/keras/test_sequential.py
+++ b/test/keras/test_sequential.py
@@ -1,11 +1,15 @@
 import pytest
 
 import numpy as np
-import tensorflow as tf
-import tf_encrypted as tfe
 import syft as sy
+from syft import dependency_check
+
+if dependency_check.keras_available:
+    import tensorflow as tf
+    import tf_encrypted as tfe
 
 
+@pytest.mark.skipif(not dependency_check.keras_available, reason="tf_encrypted not installed")
 def test_instantiate_tfe_layer():
 
     from syft.frameworks.keras.model.sequential import _instantiate_tfe_layer
@@ -43,6 +47,7 @@ def test_instantiate_tfe_layer():
     np.testing.assert_allclose(actual, expected, rtol=0.001)
 
 
+@pytest.mark.skipif(not dependency_check.keras_available, reason="tf_encrypted not installed")
 def test_share():
 
     from tensorflow.keras import Sequential

--- a/test/test___init__.py
+++ b/test/test___init__.py
@@ -1,0 +1,18 @@
+import sys
+import pytest
+
+
+@pytest.mark.usefixtures("no_tf_encrypted")
+def test_tf_encrypted_missing_import_syft():
+
+    sys.modules.pop("syft", None)
+    sys.modules.pop("syft.dependency_check", None)
+    sys.modules.pop("tf_encrypted", None)
+    sys.modules.pop("tfe", None)
+    import syft
+
+    with pytest.raises(AttributeError):
+        kerasHook = syft.KerasHook
+
+    with pytest.raises(AttributeError):
+        tfeWorker = syft.TFEWorker

--- a/test/test_dependency_check.py
+++ b/test/test_dependency_check.py
@@ -1,0 +1,21 @@
+import sys
+import pytest
+
+
+def test_tf_encrypted_available():
+    sys.modules.pop("syft", None)
+    sys.modules.pop("syft.dependency_check", None)
+    from syft import dependency_check
+
+    assert dependency_check.keras_available
+
+
+@pytest.mark.usefixtures("no_tf_encrypted")
+def test_tf_encrypted_missing():
+
+    sys.modules.pop("syft.dependency_check", None)
+    sys.modules.pop("tf_encrypted", None)
+    sys.modules.pop("tfe", None)
+    import syft.dependency_check
+
+    assert not syft.dependency_check.keras_available

--- a/test/test_dependency_check.py
+++ b/test/test_dependency_check.py
@@ -1,7 +1,9 @@
 import sys
 import pytest
+from syft import dependency_check
 
 
+@pytest.mark.skipif(not dependency_check.keras_available, reason="tf_encrypted not installed")
 def test_tf_encrypted_available():
     sys.modules.pop("syft", None)
     sys.modules.pop("syft.dependency_check", None)


### PR DESCRIPTION
Many applications of syft don't depend both on pytorch and tensorflow. This code makes it possible to run `import syft` without having tf_encrypted (and thereby tensorflow) installed. 

The goal is to reduce the resources needed for the library, especially for embedded devices.