### PR TITLE
Use NumPy to compute log2 as LongTensor does not support it

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -13,6 +13,8 @@ from syft.workers import BaseWorker
 
 from syft.exceptions import PureTorchTensorFoundError
 
+import numpy as np
+
 
 def _get_maximum_precision():
     """This function returns the maximum value allowed for precision fractions before the chain decides to use LPT.
@@ -665,7 +667,8 @@ class TorchTensor(AbstractTensor):
         """Check if any of the elements in the tensor would require large precision.
         """
         base_fractional = math.log2(base ** precision_fractional)
-        return torch.any((self.abs() + 1).log2() + base_fractional > max_precision)
+        # We need to use NumPy here as log2 is not yet implemented for LongTensor PyTorch objects
+        return np.any(np.log2(np.abs(self.numpy())) + base_fractional > max_precision)
 
     def share(
         self,

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -668,7 +668,9 @@ class TorchTensor(AbstractTensor):
         """
         base_fractional = math.log2(base ** precision_fractional)
         # We need to use NumPy here as log2 is not yet implemented for LongTensor PyTorch objects
-        return np.any(np.log2(np.abs(self.clone().detach().numpy()) + 1) + base_fractional > max_precision)
+        return np.any(
+            np.log2(np.abs(self.clone().detach().numpy()) + 1) + base_fractional > max_precision
+        )
 
     def share(
         self,

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -668,7 +668,7 @@ class TorchTensor(AbstractTensor):
         """
         base_fractional = math.log2(base ** precision_fractional)
         # We need to use NumPy here as log2 is not yet implemented for LongTensor PyTorch objects
-        return np.any(np.log2(np.abs(self.numpy())) + base_fractional > max_precision)
+        return np.any(np.log2(np.abs(self.clone().detach().numpy()) + 1) + base_fractional > max_precision)
 
     def share(
         self,

--- a/test/torch/tensors/test_large_precision.py
+++ b/test/torch/tensors/test_large_precision.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from syft.frameworks.torch.tensors.interpreters import LargePrecisionTensor
 
 
@@ -220,15 +221,18 @@ def test_mod():
     assert torch.all(torch.eq(expected, result.float_precision()))
 
 
-test_data = [
-    (torch.tensor([1]), torch.tensor([1.0])),
-    (torch.tensor([1.0]), torch.tensor([1.0])),
-    (torch.tensor([2000.0, 1.0]), torch.tensor([2000.0, 1.0])),
-    (torch.tensor([2000.0, 1]), torch.tensor([2000.0, 1.0])),
-]
-
-
-@pytest.mark.parametrize("x, expected", test_data)
+@pytest.mark.parametrize(
+    "x, expected",
+    [
+        (torch.tensor([1]), torch.tensor([1.0])),
+        (torch.tensor([1.0]), torch.tensor([1.0])),
+        (torch.tensor([2000.0, 1.0]), torch.tensor([2000.0, 1.0])),
+        (torch.tensor([2000.0, 1]), torch.tensor([2000.0, 1.0])),
+        (torch.tensor([-2000.0]), torch.tensor([-2000.0])),
+        (torch.tensor([-2000.0, -50]), torch.tensor([-2000.0, -50.0])),
+        (torch.tensor([-2000.0123458910]), torch.tensor([-2000.0123458910])),
+    ],
+)
 def test_types(x, expected):
     enlarged = x.fix_prec(internal_type=torch.int16, precision_fractional=256)
     restored = enlarged.float_precision()

--- a/test/torch/tensors/test_large_precision.py
+++ b/test/torch/tensors/test_large_precision.py
@@ -220,9 +220,16 @@ def test_mod():
     assert torch.all(torch.eq(expected, result.float_precision()))
 
 
-def test_long():
-    x = torch.tensor([1])
-    expected = torch.tensor([1.0])
+test_data = [
+    (torch.tensor([1]), torch.tensor([1.0])),
+    (torch.tensor([1.0]), torch.tensor([1.0])),
+    (torch.tensor([2000.0, 1.0]), torch.tensor([2000.0, 1.0])),
+    (torch.tensor([2000.0, 1]), torch.tensor([2000.0, 1.0])),
+]
+
+
+@pytest.mark.parametrize("x, expected", test_data)
+def test_types(x, expected):
     enlarged = x.fix_prec(internal_type=torch.int16, precision_fractional=256)
     restored = enlarged.float_precision()
     # And now x and restored must be the same

--- a/test/torch/tensors/test_large_precision.py
+++ b/test/torch/tensors/test_large_precision.py
@@ -230,7 +230,10 @@ def test_mod():
         (torch.tensor([2000.0, 1]), torch.tensor([2000.0, 1.0])),
         (torch.tensor([-2000.0]), torch.tensor([-2000.0])),
         (torch.tensor([-2000.0, -50]), torch.tensor([-2000.0, -50.0])),
+        (torch.tensor([-2000.0, 50]), torch.tensor([-2000.0, 50.0])),
+        (torch.tensor([[-2000.0, 50], [1000.5, -25]]), torch.tensor([[-2000.0, 50.0], [1000.5, -25.0]])),
         (torch.tensor([-2000.0123458910]), torch.tensor([-2000.0123458910])),
+        (torch.tensor([2000.0123458910]), torch.tensor([2000.0123458910])),
     ],
 )
 def test_types(x, expected):

--- a/test/torch/tensors/test_large_precision.py
+++ b/test/torch/tensors/test_large_precision.py
@@ -231,7 +231,10 @@ def test_mod():
         (torch.tensor([-2000.0]), torch.tensor([-2000.0])),
         (torch.tensor([-2000.0, -50]), torch.tensor([-2000.0, -50.0])),
         (torch.tensor([-2000.0, 50]), torch.tensor([-2000.0, 50.0])),
-        (torch.tensor([[-2000.0, 50], [1000.5, -25]]), torch.tensor([[-2000.0, 50.0], [1000.5, -25.0]])),
+        (
+            torch.tensor([[-2000.0, 50], [1000.5, -25]]),
+            torch.tensor([[-2000.0, 50.0], [1000.5, -25.0]]),
+        ),
         (torch.tensor([-2000.0123458910]), torch.tensor([-2000.0123458910])),
         (torch.tensor([2000.0123458910]), torch.tensor([2000.0123458910])),
     ],

--- a/test/torch/tensors/test_large_precision.py
+++ b/test/torch/tensors/test_large_precision.py
@@ -218,3 +218,12 @@ def test_mod():
     lpt2 = x2.fix_prec(internal_type=internal_type, precision_fractional=precision_fractional)
     result = lpt1 % lpt2
     assert torch.all(torch.eq(expected, result.float_precision()))
+
+
+def test_long():
+    x = torch.tensor([1])
+    expected = torch.tensor([1.0])
+    enlarged = x.fix_prec(internal_type=torch.int16, precision_fractional=256)
+    restored = enlarged.float_precision()
+    # And now x and restored must be the same
+    assert torch.all(torch.eq(expected, restored))

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -18,15 +18,6 @@ def test_wrap(workers):
     assert isinstance(x.child.child, torch.Tensor)
 
 
-def test_long():
-    x = torch.tensor([1])
-    expected = torch.tensor([1.0])
-    enlarged = x.fix_prec()
-    restored = enlarged.float_precision()
-    # And now expected and restored must be the same
-    assert torch.all(torch.eq(expected, restored))
-
-
 @pytest.mark.parametrize("parameter", [False, True])
 def test_encode_decode(workers, parameter):
     x = torch.tensor([0.1, 0.2, 0.3])

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -18,6 +18,15 @@ def test_wrap(workers):
     assert isinstance(x.child.child, torch.Tensor)
 
 
+def test_long():
+    x = torch.tensor([1])
+    expected = torch.tensor([1.0])
+    enlarged = x.fix_prec()
+    restored = enlarged.float_precision()
+    # And now expected and restored must be the same
+    assert torch.all(torch.eq(expected, restored))
+
+
 @pytest.mark.parametrize("parameter", [False, True])
 def test_encode_decode(workers, parameter):
     x = torch.tensor([0.1, 0.2, 0.3])


### PR DESCRIPTION
Fixed issue when calculating whether to use LPT or FPT for LongTensor tensors.

Issue: https://github.com/OpenMined/PySyft/issues/2327