### PR TITLE
Multiple workers with same id issues #2333

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -678,7 +678,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
     def clear_objects(self):
         """Removes all objects from the worker."""
 
-        self._objects = {}
+        self._objects.clear()
         return self
 
     @staticmethod

--- a/test/workers/test_base.py
+++ b/test/workers/test_base.py
@@ -33,7 +33,6 @@ def test_clear_object_for_worker_created_with_pre_existing_id(hook):
     worker.clear_objects()
 
     ptr = th.tensor([1, 2, 3]).send(worker)
-    print(worker._objects)
 
     assert len(worker._known_workers[worker.id]._objects) == len(worker._objects)
     assert len(worker._objects) == 1
@@ -46,7 +45,6 @@ def test_clear_object_for_worker_created_with_pre_existing_id(hook):
     assert len(worker._objects) == 0
 
     ptr = th.tensor([1, 2, 3]).send(worker)
-    print(worker._objects)
 
     assert len(worker._known_workers[worker.id]._objects) == len(worker._objects)
     assert len(worker._objects) == 1

--- a/test/workers/test_base.py
+++ b/test/workers/test_base.py
@@ -27,6 +27,31 @@ def test_create_already_existing_worker(hook):
     _ = x + y * z
 
 
+def test_clear_object_for_worker_created_with_pre_existing_id(hook):
+
+    worker = sy.VirtualWorker(hook, id="worker")
+    worker.clear_objects()
+
+    ptr = th.tensor([1, 2, 3]).send(worker)
+    print(worker._objects)
+
+    assert len(worker._known_workers[worker.id]._objects) == len(worker._objects)
+    assert len(worker._objects) == 1
+
+    # create worker with pre-existing id
+    worker = sy.VirtualWorker(hook, id="worker")
+    worker.clear_objects()
+
+    assert len(worker._known_workers[worker.id]._objects) == len(worker._objects)
+    assert len(worker._objects) == 0
+
+    ptr = th.tensor([1, 2, 3]).send(worker)
+    print(worker._objects)
+
+    assert len(worker._known_workers[worker.id]._objects) == len(worker._objects)
+    assert len(worker._objects) == 1
+
+
 def test_create_already_existing_worker_with_different_type(hook, start_proc):
     # Shares tensor with bob
     bob = sy.VirtualWorker(hook, "bob")


### PR DESCRIPTION
The cause of this behavior is due to the way "_objects" dictionary is reset inside clear_objects() method using the statement "self._objects = {}"

When we create a worker with the same id as a pre-existing worker then its "__dict__" object is shared with the pre-existing worker using "self.__dict__.update(known_workers[self.id].__dict__)"

Due to this when we do "self._objects = {}" inside clear_object(), "__objects" now points to a new dictionary object and hence "known_workers" dictionary and "__object" dictionary are not in sync anymore.

To fix this we would need to call the clear() method rather than assigning {} inside clear_objects() method
self._objects.clear()

After the above change the sample code output is shown below-

```
import torch
import syft as sy
hook = sy.TorchHook(torch)

worker = sy.VirtualWorker(hook, id="worker")
worker.clear_objects()
ptr = torch.tensor([1,2,3]).send(worker)
print(worker._objects) # >>> Has 1 object!

worker = sy.VirtualWorker(hook, id="worker")
worker.clear_objects()
ptr = torch.tensor([1,2,3]).send(worker)
print(worker._objects) # >>> Empty!

```
Output-
{48603286308: tensor([1, 2, 3])}
{13171397894: tensor([1, 2, 3])}