### PR TITLE
Fixing __mul__ error for int multiplication issue 2341

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -216,8 +216,11 @@ class FixedPrecisionTensor(AbstractTensor):
             ), "In mul, all args should have the same precision_fractional"
 
         if isinstance(other, int):
-            new_self = self.child
-            new_other = other * self.base ** self.precision_fractional
+            response = getattr(self.child, "mul")(other)                
+            return syft.frameworks.torch.hook_args.hook_response(
+            "mul", response, wrap_type=type(self), wrap_args=self.get_class_attributes()
+            )
+            
         elif self.child.is_wrapper and not other.child.is_wrapper:
             # If we try to multiply a FPT>(wrap)>AST with a FPT>torch.tensor),
             # we want to perform AST * torch.tensor


### PR DESCRIPTION
When multiplying by integers, the expansion on other * self.base ** self.precision_fractional is not necessary. The values in self.child are already on fixed precision and the integer is also fixed precision, asl the previous implementation had some serious instabilities with float precision resulting in the errors found here https://github.com/OpenMined/PySyft/issues/2341.