### PR TITLE
Added fix_prec for Linear Object

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -1037,6 +1037,7 @@ class TorchHook:
             return nn_self
 
         self.torch.nn.Module.fix_precision = module_fix_precision_
+        self.torch.nn.Module.fix_prec = module_fix_precision_
 
         def module_float_precision_(nn_self):
             """Overloads float_precision for torch.nn.Module, convert fix_precision


### PR DESCRIPTION
I encountered the issue
"AttributeError: 'Linear' object has no attribute 'fix_prec'"

while I replaced fix_precision with fix_prec as shown in this tutorial https://github.com/OpenMined/PySyft/blob/dev/examples/tutorials/Part%2012%20-%20Train%20an%20Encrypted%20Neural%20Network%20on%20Encrypted%20Data.ipynb

