### PR TITLE
Patch tf-encrypted version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ msgpack>=0.6.1
 numpy>=1.14.0
 scikit-learn>=0.21.0
 tblib>=1.4.0
-tf_encrypted>=0.5.4
+tf_encrypted>=0.5.4,!=0.5.7
 torch>=1.1
 torchvision>=0.3.0
 websocket_client>=0.56.0


### PR DESCRIPTION
Users are experiencing broken notebooks for the tf-encrypted sections, see here: https://github.com/tf-encrypted/tf-encrypted/issues/624

This is simply a hotfix until the next release of tf-encrypted.