### PR TITLE
Wrapping for keras constructor hook

### DIFF
--- a/syft/frameworks/keras/layers/constructor.py
+++ b/syft/frameworks/keras/layers/constructor.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 import re
 
@@ -11,6 +12,7 @@ def add_constructor_registration(layer_cls):
     layer_cls._native_keras_constructor = layer_cls.__init__
     sig = inspect.signature(layer_cls.__init__)
 
+    @functools.wraps(layer_cls.__init__)
     def syft_keras_constructor(self, *args, **kwargs):
         self._constructor_parameters_store = sig.bind(self, *args, **kwargs)
         self._native_keras_constructor(*args, **kwargs)


### PR DESCRIPTION
This fixes the bug found in https://github.com/tf-encrypted/tf-encrypted/issues/624

For context, the most recent release of tf-encrypted (0.5.7) added functionality to help keep track of which layer constructor args had been switched from defaults, but when used in conjunction with the hooked version of tf.keras in PySyft, the signature for these constructors was changed to (self, *args, **kwargs), which would cause errors.  Fixed by using functools.wraps on the hooking decorator, which passes the original signature on to tho hooked function in Python 3.5+.