### PR TITLE
Syft DocString

### DIFF
--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -1,4 +1,8 @@
-"""Some syft imports..."""
+r"""
+PySyft is a Python library for secure, private Deep Learning. 
+PySyft decouples private data from model training, using Federated Learning,
+Differential Privacy, and Multi-Party Computation (MPC) within PyTorch.
+"""
 # Major imports
 from syft import frameworks
 from syft import workers


### PR DESCRIPTION
Currently on running command 
```
syft.__doc__
```
gives output:
```
>>> Some syft imports...
```

which is correct in the context of syft/__init__.py  but it should be more likely to describe PySyft briefly like:
```
>>> PySyft is a Python library for secure, private Deep Learning. 
>>> PySyft decouples private data from model training, using Federated Learning,
>>> Differential Privacy, and Multi-Party Computation (MPC) within PyTorch.
```