### PR TITLE
websocketserver startup issue on Windows for websockets-example-MNIST/run_websocket_server.py

### DIFF
--- a/examples/tutorials/advanced/websockets-example-MNIST/run_websocket_server.py
+++ b/examples/tutorials/advanced/websockets-example-MNIST/run_websocket_server.py
@@ -46,8 +46,8 @@ kwargs = {
     "verbose": args.verbose,
 }
 
-if os.name != 'nt':
-   server = start_proc(WebsocketServerWorker, kwargs)
+if os.name != "nt":
+    server = start_proc(WebsocketServerWorker, kwargs)
 else:
-   server = WebsocketServerWorker(**kwargs)
-   server.start()
+    server = WebsocketServerWorker(**kwargs)
+    server.start()

--- a/examples/tutorials/advanced/websockets-example-MNIST/run_websocket_server.py
+++ b/examples/tutorials/advanced/websockets-example-MNIST/run_websocket_server.py
@@ -4,7 +4,7 @@ import syft as sy
 from syft.workers import WebsocketServerWorker
 import torch
 import argparse
-
+import os
 
 hook = sy.TorchHook(torch)
 
@@ -45,4 +45,9 @@ kwargs = {
     "hook": hook,
     "verbose": args.verbose,
 }
-server = start_proc(WebsocketServerWorker, kwargs)
+
+if os.name != 'nt':
+   server = start_proc(WebsocketServerWorker, kwargs)
+else:
+   server = WebsocketServerWorker(**kwargs)
+   server.start()


### PR DESCRIPTION
While running examples/tutorials/advanced/websockets-example-MNIST/run_websocket_server.py the websocketserver could not be started on Windows due to pickling error while creating a separate process for websocketserver.

Modified the code to create the websocketserver within the current process context itself rather than creating a separate process for the same. After this change the websocketserver could be started on Windows using run_websocket_server.py. Currently I have made this change only for Windows. For non-Windows the logic remains the same as earlier.