### PR TITLE
No need to "get angry" arguments are mandatory

### DIFF
--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -36,7 +36,6 @@ class WebsocketClientWorker(BaseWorker):
         WebsocketServerWorker and receive all responses back from the server.
         """
 
-        # TODO get angry when we have no connection params
         self.port = port
         self.host = host
 


### PR DESCRIPTION
Fix TODO at websocket_client.py. No need to "get angry" arguments are mandatory.