### PR TITLE
Generalize TorchAttributes to FrameworkAttributes

### DIFF
--- a/syft/frameworks/attributes.py
+++ b/syft/frameworks/attributes.py
@@ -1,0 +1,92 @@
+from abc import ABC
+from abc import abstractmethod
+from types import ModuleType
+from typing import Union
+from typing import Callable
+from typing import Any
+
+from syft.frameworks.hook import FrameworkHook
+
+
+class FrameworkAttributes(ABC):
+    @abstractmethod
+    def __init__(self, framework: ModuleType, hook: FrameworkHook):
+        pass
+
+    # Forcing subclasses to define a class-level ALIAS constant; see
+    # https://stackoverflow.com/a/53417582 for nuance
+    @property
+    @classmethod
+    @abstractmethod
+    def ALIAS(cls):
+        pass
+
+    @abstractmethod
+    def is_inplace_method(self, method_name):
+        """Determine if a method is inplace or not.
+
+        Framework-dependent, see subclasses for details.
+
+        Args:
+            method_name: The name for the method.
+        Returns:
+            Boolean denoting if the method is inplace or not.
+        """
+        pass
+
+    def _command_guard(
+        self, command: str, get_native: bool = False
+    ) -> Union[Callable[..., Any], str]:
+        """Check command can be safely used.
+
+        Args:
+            command: A string indicating command name.
+            get_native: A boolean parameter (default False) to indicate whether
+                to return the command name or the native torch function. If
+                False, return command name else return the native torch
+                function.
+
+        Returns:
+            The command name or a native framework function
+        """
+        if command not in self.allowed_commands:
+            raise RuntimeError(f'Command "{command}" is not a supported {self.ALIAS} operation.')
+        if get_native:
+            return self.native_commands[command]
+        return command
+
+    def _is_command_valid_guard(self, command: str) -> bool:
+        """Validate the command.
+
+        Indicates whether a command is valid with respect to the framework
+        guard.
+
+        Args:
+            command: A string indicating command to test.
+            framework_domain: A string indicating the framework domain or
+                module in which the command is supposed to be, e.g.
+                dir(torch), dir(torch.Tensor), dir(tensorflow), etc. (roughly)
+
+        Returns:
+            A boolean indicating whether the command is valid.
+        """
+        try:
+            self._command_guard(command)
+        except RuntimeError:
+            return False
+        return True
+
+    @classmethod
+    def get_native_framework_name(cls, attr: str) -> str:
+        """Return the name of the native command for the given hooked command.
+
+        Args:
+            attr: A string indicating the hooked command name (ex: torch.add)
+
+        Returns:
+            The name of the native command (ex: torch.native_add)
+        """
+        parts = attr.split(".")
+        parts[-1] = "native_" + parts[-1]
+        native_func_name = ".".join(parts)
+        return native_func_name

--- a/syft/frameworks/hook.py
+++ b/syft/frameworks/hook.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from syft.workers import BaseWorker
 
 
-class BaseHook(ABC):
+class FrameworkHook(ABC):
     def __init__(self, framework_module, local_worker: BaseWorker = None, is_client: bool = True):
         pass
 

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -13,7 +13,7 @@ from syft import workers
 
 from syft.workers import BaseWorker
 from syft.messaging import Plan
-from syft.frameworks.hook import BaseHook
+from syft.frameworks.hook import FrameworkHook
 from syft.frameworks.torch.tensors.interpreters import AutogradTensor
 from syft.frameworks.torch.tensors.interpreters import TorchTensor
 from syft.frameworks.torch.tensors.decorators import LoggingTensor
@@ -32,7 +32,7 @@ from syft.exceptions import TensorsNotCollocatedException
 from math import inf
 
 
-class TorchHook(BaseHook):
+class TorchHook(FrameworkHook):
     """A Hook which Overrides Methods on PyTorch Tensors.
 
     The purpose of this class is to:
@@ -183,7 +183,7 @@ class TorchHook(BaseHook):
         syft.hook = self
 
     def create_wrapper(cls, child_to_wrap):
-        # Note this overrides BaseHook.create_wrapper, so it must conform to
+        # Note this overrides FrameworkHook.create_wrapper, so it must conform to
         # that classmethod's signature
         return torch.Tensor()
 

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -526,7 +526,7 @@ class TorchHook(FrameworkHook):
             response = owner.send_command(location, command)
 
             # For inplace methods, just directly return self
-            if syft.torch.is_inplace_method(attr):
+            if syft.framework.is_inplace_method(attr):
                 return self
 
             return response
@@ -690,7 +690,7 @@ class TorchHook(FrameworkHook):
                 response = method(*new_args, **new_kwargs)
 
                 # For inplace methods, just directly return self
-                if syft.torch.is_inplace_method(method_name):
+                if syft.framework.is_inplace_method(method_name):
                     return self
 
                 # Put back the wrappers where needed

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -1,10 +1,12 @@
+from types import ModuleType
 from typing import Union
 from typing import Callable
 from typing import Any
-from types import ModuleType
+
+from syft.frameworks.attributes import FrameworkAttributes
 
 
-class TorchAttributes(object):
+class TorchAttributes(FrameworkAttributes):
     """Adds torch module related custom attributes.
 
     TorchAttributes is a special class where all custom attributes related
@@ -20,15 +22,18 @@ class TorchAttributes(object):
 
     Args:
         torch: A ModuleType indicating the torch module
-        hook: A ModuleType indicating the modules to hook
+        hook: A TorchHook to stash
     """
+
+    ALIAS = "torch"
 
     def __init__(self, torch: ModuleType, hook: ModuleType) -> None:
         """Initialization of the TorchAttributes class."""
 
-        # SECTION: List all functions in torch module that we want to overload
-
+        # Stash the hook here for global access elsewhere
         self.hook = hook
+
+        # SECTION: List all functions in torch module that we want to overload
 
         # List modules that we will hook
         self.torch_modules = {
@@ -37,16 +42,9 @@ class TorchAttributes(object):
             "torch.nn.functional": torch.nn.functional,
         }
 
-        # List all the function names with module as prefix in the modules to hook
-        self.torch_modules_functions = {
+        # Set of all function names with module as prefix in the modules to hook
+        self._torch_functions = {
             f"{module_name}.{func_name}"
-            for module_name, torch_module in self.torch_modules.items()
-            for func_name in dir(torch_module)
-        }
-
-        # Store reference to all torch functions by string name stored in torch_modules_functions
-        self.eval_torch_modules_functions = {
-            f"{module_name}.{func_name}": getattr(torch_module, func_name)
             for module_name, torch_module in self.torch_modules.items()
             for func_name in dir(torch_module)
         }
@@ -107,14 +105,6 @@ class TorchAttributes(object):
             "zeros",
         ]
 
-        # SECTION: List all torch tensor methods we want to overload
-        self.tensor_types = [torch.Tensor]
-
-        self.tensorvar_methods = list(
-            {method for tensorvar in self.tensor_types for method in dir(tensorvar)}
-        )
-        self.tensorvar_methods += ["get_shape", "share", "fix_precision", "decode", "end_get"]
-
         # SECTION: Build the guard, that define which functions or methods can be safely called by
         # external or local workers
 
@@ -137,15 +127,12 @@ class TorchAttributes(object):
             self.guard[f"syft.{key}"] = self.guard[key]
 
         # Concatenate torch functions and torch methods
-        self.allowed_commands = {
-            "tensorvar_methods": self.tensorvar_methods,
-            "torch_modules": self.torch_modules_functions,
-        }
+        self.allowed_commands = self._torch_functions
 
         # The equivalent concatenation of native torch function names and native torch method names
         self.native_commands = {
-            command_type: {cmd: self.get_native_torch_name(cmd) for cmd in commands}
-            for command_type, commands in self.allowed_commands.items()
+            command_name: self.get_native_framework_name(command_name)
+            for command_name in self.allowed_commands
         }
 
         self.command_guard = self._command_guard
@@ -153,84 +140,16 @@ class TorchAttributes(object):
         # Dict {method_name: <is_inplace:bool>
         self.inplace_methods = {}
 
-    def _command_guard(
-        self, command: str, torch_domain: str, get_native: bool = False
-    ) -> Union[Callable[..., Any], str]:
-        """Checks command is in a given torch_domain and can be safely used.
-
-        Args:
-            command: A string indicating command name.
-            torch_domain: A string indicating torch domain name or module in
-                which the command is supposed to be.
-            get_native: A boolean parameter (default False) to indicate whether
-                to return the command name or the native torch function. If
-                False, return command name else return the native torch
-                function.
-
-        Returns:
-            The command name or a native torch function
-        """
-        if command not in self.allowed_commands[torch_domain]:
-            raise RuntimeError(f'Command "{command}" is not a supported Torch operation.')
-        if get_native:
-            return self.native_commands[torch_domain][command]
-        return command
-
-    def _is_command_valid_guard(self, command: str, torch_domain: str) -> bool:
-        """Validates the command.
-
-        Indicates whether a command is valid with respect to the torch guard
-
-        Args:
-            command: A string indicating command to test.
-            torch_domain: A string indicating the torch domain or module in
-                which the command is supposed to be.
-
-        Returns:
-            A boolean indicating whether the command is valid.
-        """
-        try:
-            self._command_guard(command, torch_domain)
-        except RuntimeError:
-            return False
-        return True
-
-    def eval_torch_modules(self) -> None:
-        """Builds a mapping between the hooked and native commands.
-
-        For each torch command functions in native_commands, transform the
-        dictionary so that to each key, which is the name of the hooked
-        command, now corresponds a value which is the evaluated native name of
-        the command, namely the native command.
-
-        Note that we don't do this for methods.
-        """
-        for cmd_name, native_cmd_name in self.native_commands["torch_modules"].items():
-            if cmd_name not in self.torch_exclude:
-                self.native_commands["torch_modules"][cmd_name] = self.eval_torch_modules_functions[
-                    cmd_name
-                ]
-
-    @staticmethod
-    def get_native_torch_name(attr: str) -> str:
-        """Returns the name of the native command for the given hooked command.
-
-        Args:
-            attr: A string indicating the hooked command name (ex: torch.add)
-
-        Returns:
-            The name of the native command (ex: torch.native_add)
-        """
-        parts = attr.split(".")
-        parts[-1] = "native_" + parts[-1]
-        native_func_name = ".".join(parts)
-        return native_func_name
-
     def is_inplace_method(self, method_name):
-        """
-        Says if a method is inplace or not by test if it ends by _ and is not a __xx__
-        :param method_name: the name for the method
-        :return: boolean
+        """Determine if a method is inplace or not.
+
+        Check if the method ends by _ and is not a __xx__, then stash for
+        constant-time lookup.
+
+        Args:
+            method_name: The name for the method.
+        Returns:
+            Boolean denoting if the method is inplace or not.
         """
         try:
             return self.inplace_methods[method_name]

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -68,7 +68,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
 
     def __init__(
         self,
-        hook: "sy.frameworks.BaseHook",
+        hook: "sy.frameworks.FrameworkHook",
         id: Union[int, str] = 0,
         data: Union[List, tuple] = None,
         is_client_worker: bool = False,

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -378,7 +378,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
                     return
             if type(_self) == str and _self == "self":
                 _self = self
-            if sy.torch.is_inplace_method(command_name):
+            if sy.framework.is_inplace_method(command_name):
                 # TODO[jvmancuso]: figure out a good way to generalize the
                 # above check (#2530)
                 getattr(_self, command_name)(*args, **kwargs)
@@ -398,7 +398,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             # function (i.e., torch.nn.functional.relu). Thus,
             # we need to fetch this function and run it.
 
-            sy.torch.command_guard(command_name, "torch_modules")  # TODO[jvmancuso]: generalize
+            sy.framework.command_guard(command_name)
 
             paths = command_name.split(".")
             command = self

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -17,12 +17,12 @@ def test___init__(hook):
 
 def test_torch_attributes():
     with pytest.raises(RuntimeError):
-        syft.torch._command_guard("false_command", "torch_modules")
+        syft.framework._command_guard("false_command")
 
-    assert syft.torch._is_command_valid_guard("torch.add", "torch_modules")
-    assert not syft.torch._is_command_valid_guard("false_command", "torch_modules")
+    assert syft.framework._is_command_valid_guard("torch.add")
+    assert not syft.framework._is_command_valid_guard("false_command")
 
-    syft.torch._command_guard("torch.add", "torch_modules", get_native=False)
+    syft.framework._command_guard("torch.add", get_native=False)
 
 
 def test_worker_registration(hook, workers):


### PR DESCRIPTION
In line with OpenMined/rfcs#3, we need to generalize `TorchAttributes` in order for hooking to be fully general (since this is where the command guard lives for `torch.xx` functions, and where it will live for other functions as well).

Other changes:
- Introduces `FrameworkAttributes` to accomplish the above.
- Generalize `TorchHook.is_inplace_method` to an abstractmethod in `BaseHook`
- Renames `BaseHook` to `FrameworkHook` to be consistent with the new `FrameworkAttributes` naming convention.