### PR TITLE
update example section of class TorchHook 

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -62,11 +62,13 @@ class TorchHook(FrameworkHook):
             max length of the list that stores the messages to be sent.
 
     Example:
+        >>> import torch as th
         >>> import syft as sy
-        >>> hook = sy.TorchHook()
+        >>> hook = sy.TorchHook(th)
         Hooking into Torch...
         Overloading Complete.
-        >>> x = sy.Tensor([-2,-1,0,1,2,3])
+        # constructing a normal torch tensor in pysyft
+        >>> x = th.Tensor([-2,-1,0,1,2,3])
         >>> x
         -2
         -1


### PR DESCRIPTION
The example section in TorchHook class is shown wrongly at two points :
* hook = sy.TorchHook() is not working and giving error TypeError: __init__() missing 1 required positional argument: 'torch'

*  x = sy.Tensor([-2,-1,0,1,2,3]) is giving error as AttributeError: module 'syft' has no attribute 'Tensor'