### PR TITLE
Fix TypeError when doing remainder

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/large_precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/large_precision.py
@@ -75,7 +75,7 @@ class LargePrecisionTensor(AbstractTensor):
         # floor is applied otherwise, long float is not accurate
         self_scaled = np.vectorize(math.floor)(self_scaled)
         # https://github.com/numpy/numpy/issues/6464
-        self_scaled = np.remainder(self_scaled, np.array(self.field), casting='unsafe')
+        self_scaled = np.remainder(self_scaled, np.array(self.field), casting="unsafe")
 
         # self_scaled can be an array of floats. As multiplying an array of int with an int
         # still gives an array of int, I think it should be because self.child is a float tensor at this point.

--- a/syft/frameworks/torch/tensors/interpreters/large_precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/large_precision.py
@@ -74,7 +74,8 @@ class LargePrecisionTensor(AbstractTensor):
 
         # floor is applied otherwise, long float is not accurate
         self_scaled = np.vectorize(math.floor)(self_scaled)
-        self_scaled %= self.field
+        # https://github.com/numpy/numpy/issues/6464
+        self_scaled = np.remainder(self_scaled, np.array(self.field), casting='unsafe')
 
         # self_scaled can be an array of floats. As multiplying an array of int with an int
         # still gives an array of int, I think it should be because self.child is a float tensor at this point.

--- a/test/torch/tensors/test_large_precision.py
+++ b/test/torch/tensors/test_large_precision.py
@@ -283,6 +283,13 @@ def test_share_sub(workers):
     assert torch.all(torch.eq(expected, y))
 
 
+def test_storage():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    enlarged = x.fix_prec(storage="large")
+    restored = enlarged.float_precision()
+    # And now x and restored must be the same
+    assert torch.all(torch.eq(x, restored))
+
 # def test_share_mul(workers):
 #     alice, bob, james = (workers["alice"], workers["bob"], workers["james"])
 #

--- a/test/torch/tensors/test_large_precision.py
+++ b/test/torch/tensors/test_large_precision.py
@@ -290,6 +290,7 @@ def test_storage():
     # And now x and restored must be the same
     assert torch.all(torch.eq(x, restored))
 
+
 # def test_share_mul(workers):
 #     alice, bob, james = (workers["alice"], workers["bob"], workers["james"])
 #


### PR DESCRIPTION
When performing remainder operation with floats and a large field numpy was throwing a `TypeError` exception.

This issue explains how to fix it

numpy/numpy#6464

Closes #2604