### PR TITLE
Support for OpenMined/PySyft-TensorFlow#6

### DIFF
--- a/syft/frameworks/tensorflow/__init__.py
+++ b/syft/frameworks/tensorflow/__init__.py
@@ -2,6 +2,7 @@ import syft
 
 if syft.dependency_check.tensorflow_available:
     from syft_tensorflow.hook import TensorFlowHook
+    from syft_tensorflow.hook import hook_args
     from syft_tensorflow.tensor import TensorFlowTensor
 
     setattr(syft, "TensorFlowHook", TensorFlowHook)

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -414,7 +414,8 @@ class TorchHook(FrameworkHook):
 
                 self._perform_function_overloading(torch_module, func)
 
-    def _get_hooked_func(hook_self, attr):
+    @classmethod
+    def _get_hooked_func(cls, attr):
         """Torch-specific implementation. See the subclass for more."""
         if attr.__module__ is None:
             attr.__module__ = "torch"

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -129,7 +129,7 @@ class TorchAttributes(FrameworkAttributes):
         for key in keys:
             self.guard[f"syft.{key}"] = self.guard[key]
 
-        # Concatenate torch functions and torch methods
+        # Concatenate torch functions
         self.allowed_commands = self._torch_functions
 
         # The equivalent concatenation of native torch function names and native torch method names

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -280,6 +280,21 @@ class FrameworkHook(ABC):
 
         tensor_type.__init__ = new___init__
 
+    @classmethod
+    def _perform_function_overloading(cls, parent, func):
+
+        # Where the overloading happens
+        # 1. Get native function
+        native_func = getattr(parent, func)
+        # 2. Check it is a proper function
+        if type(native_func) in [types.FunctionType, types.BuiltinFunctionType]:
+            # 3. Build the hooked function
+            new_func = self._get_hooked_func(native_func)
+            # 4. Move the native function
+            setattr(parent, f"native_{func}", native_func)
+            # 5. Put instead the hooked one
+            setattr(parent, func, new_func)
+
     def _get_hooked_syft_method(hook_self, attr):
         """
         Hook a method in order to replace all args/kwargs syft/torch tensors with
@@ -385,9 +400,6 @@ class FrameworkHook(ABC):
         Return:
             the hooked method
         """
-
-        if attr.__module__ is None:
-            attr.__module__ = "torch"
 
         cmd_name = f"{attr.__module__}.{attr.__name__}"
 

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -289,13 +289,14 @@ class FrameworkHook(ABC):
         # 2. Check it is a proper function
         if type(native_func) in [types.FunctionType, types.BuiltinFunctionType]:
             # 3. Build the hooked function
-            new_func = self._get_hooked_func(native_func)
+            new_func = cls._get_hooked_func(native_func)
             # 4. Move the native function
             setattr(parent, f"native_{func}", native_func)
             # 5. Put instead the hooked one
             setattr(parent, func, new_func)
 
-    def _get_hooked_syft_method(hook_self, attr):
+    @classmethod
+    def _get_hooked_syft_method(cls, attr):
         """
         Hook a method in order to replace all args/kwargs syft/torch tensors with
         their child attribute, forward this method with the new args and new self,
@@ -329,7 +330,8 @@ class FrameworkHook(ABC):
 
         return overloaded_syft_method
 
-    def _get_hooked_method(hook_self, method_name):
+    @classmethod
+    def _get_hooked_method(cls, method_name):
         """
         Hook a method in order to replace all args/kwargs syft/torch tensors with
         their child attribute if they exist
@@ -386,7 +388,8 @@ class FrameworkHook(ABC):
 
         return overloaded_native_method
 
-    def _get_hooked_func(hook_self, attr):
+    @classmethod
+    def _get_hooked_func(cls, attr):
         """
         Hook a function in order to inspect its args and search for pointer
         or other syft tensors.
@@ -428,7 +431,8 @@ class FrameworkHook(ABC):
 
         return overloaded_func
 
-    def _get_hooked_pointer_method(hook_self, attr):
+    @classmethod
+    def _get_hooked_pointer_method(cls, attr):
         """
         Hook a method to send it to remote worker
 
@@ -466,7 +470,8 @@ class FrameworkHook(ABC):
 
         return overloaded_pointer_method
 
-    def _get_hooked_multi_pointer_method(hook_self, attr):
+    @classmethod
+    def _get_hooked_multi_pointer_method(cls, attr):
         """
         Hook a method to send it multiple recmote workers
 


### PR DESCRIPTION
Accompanies https://github.com/OpenMined/PySyft-TensorFlow/pull/6 for hooking major TF modules.
- Move the inner function `perform_overloading` from `TorchHook._hook_torch_module` to the generic FrameworkHook
- Register PySyft-TF hook_args
- Make some TorchHook methods classmethods