### PR TITLE
Currently virtualworker search requires a list

### DIFF
--- a/examples/tutorials/Part 05 - Welcome to the Sandbox.ipynb
+++ b/examples/tutorials/Part 05 - Welcome to the Sandbox.ipynb
@@ -67,12 +67,12 @@
     {
      "data": {
       "text/plain": [
-       "[<VirtualWorker id:bob #tensors:14>,\n",
-       " <VirtualWorker id:theo #tensors:14>,\n",
-       " <VirtualWorker id:jason #tensors:14>,\n",
-       " <VirtualWorker id:alice #tensors:14>,\n",
-       " <VirtualWorker id:andy #tensors:14>,\n",
-       " <VirtualWorker id:jon #tensors:14>]"
+       "[<VirtualWorker id:bob #objects:14>,\n",
+       " <VirtualWorker id:theo #objects:14>,\n",
+       " <VirtualWorker id:jason #objects:14>,\n",
+       " <VirtualWorker id:alice #objects:14>,\n",
+       " <VirtualWorker id:andy #objects:14>,\n",
+       " <VirtualWorker id:jon #objects:14>]"
       ]
      },
      "execution_count": 2,
@@ -99,7 +99,7 @@
     {
      "data": {
       "text/plain": [
-       "<syft.frameworks.torch.hook.hook.TorchHook at 0x10476dac8>"
+       "<syft.frameworks.torch.hook.hook.TorchHook at 0x13c1d95d0>"
       ]
      },
      "execution_count": 3,
@@ -119,7 +119,7 @@
     {
      "data": {
       "text/plain": [
-       "<VirtualWorker id:bob #tensors:14>"
+       "<VirtualWorker id:bob #objects:14>"
       ]
      },
      "execution_count": 4,
@@ -180,7 +180,7 @@
      "data": {
       "text/plain": [
        "tensor([1, 2, 3, 4, 5])\n",
-       "\tTags: #boston #fun #housing \n",
+       "\tTags: #fun #boston #housing \n",
        "\tDescription: The input datapoints to the boston housing dataset....\n",
        "\tShape: torch.Size([5])"
       ]
@@ -205,7 +205,7 @@
     "z = z.send(bob)\n",
     "\n",
     "# this searches for exact match within a tag or within the description\n",
-    "results = bob.search(\"#boston\", \"#housing\")"
+    "results = bob.search([\"#boston\", \"#housing\"])"
    ]
   },
   {
@@ -216,20 +216,20 @@
     {
      "data": {
       "text/plain": [
-       "[(Wrapper)>[PointerTensor | me:24885664977 -> bob:99227560262]\n",
-       " \tTags: #boston _boston_dataset: #data #housing .. #boston_housing \n",
+       "[(Wrapper)>[PointerTensor | me:77684802315 -> bob:77965958533]\n",
+       " \tTags: #boston_housing #housing .. #data _boston_dataset: #boston \n",
        " \tShape: torch.Size([84, 13])\n",
        " \tDescription: .. _boston_dataset:...,\n",
-       " (Wrapper)>[PointerTensor | me:2401729741 -> bob:63304629126]\n",
-       " \tTags: #boston _boston_dataset: #housing .. #target #boston_housing \n",
+       " (Wrapper)>[PointerTensor | me:39080634601 -> bob:14246153496]\n",
+       " \tTags: #target #boston_housing #housing .. _boston_dataset: #boston \n",
        " \tShape: torch.Size([84])\n",
        " \tDescription: .. _boston_dataset:...,\n",
-       " (Wrapper)>[PointerTensor | me:51871883535 -> bob:98689637616]\n",
-       " \tTags: #boston #fun #housing \n",
+       " (Wrapper)>[PointerTensor | me:90438475210 -> bob:68537376586]\n",
+       " \tTags: #fun #boston #housing \n",
        " \tShape: torch.Size([5])\n",
        " \tDescription: The input datapoints to the boston housing dataset....,\n",
-       " (Wrapper)>[PointerTensor | me:69459187250 -> bob:67840467141]\n",
-       " \tTags: #boston #fun #housing \n",
+       " (Wrapper)>[PointerTensor | me:89614372433 -> bob:79220186800]\n",
+       " \tTags: #fun #boston #housing \n",
        " \tShape: torch.Size([5])\n",
        " \tDescription: The input datapoints to the boston housing dataset....]"
       ]
@@ -330,28 +330,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 4 results on <VirtualWorker id:bob #tensors:17> - [('#boston', 4), ('#housing', 4), ('_boston_dataset:', 2)]\n",
-      "Found 2 results on <VirtualWorker id:theo #tensors:14> - [('#boston', 2), ('_boston_dataset:', 2), ('#housing', 2)]\n",
-      "Found 2 results on <VirtualWorker id:jason #tensors:14> - [('#boston', 2), ('_boston_dataset:', 2), ('#housing', 2)]\n",
-      "Found 2 results on <VirtualWorker id:alice #tensors:14> - [('#boston', 2), ('_boston_dataset:', 2), ('#housing', 2)]\n",
-      "Found 2 results on <VirtualWorker id:andy #tensors:14> - [('#boston', 2), ('_boston_dataset:', 2), ('#housing', 2)]\n",
-      "Found 2 results on <VirtualWorker id:jon #tensors:14> - [('#boston', 2), ('_boston_dataset:', 2), ('#housing', 2)]\n",
+      "Found 4 results on <VirtualWorker id:bob #objects:17> - [('#housing', 4), ('#boston', 4), ('#boston_housing', 2)]\n",
+      "Found 2 results on <VirtualWorker id:theo #objects:14> - [('#boston_housing', 2), ('#housing', 2), ('..', 2)]\n",
+      "Found 2 results on <VirtualWorker id:jason #objects:14> - [('#boston_housing', 2), ('#housing', 2), ('..', 2)]\n",
+      "Found 2 results on <VirtualWorker id:alice #objects:14> - [('#boston_housing', 2), ('#housing', 2), ('..', 2)]\n",
+      "Found 2 results on <VirtualWorker id:andy #objects:14> - [('#boston_housing', 2), ('#housing', 2), ('..', 2)]\n",
+      "Found 2 results on <VirtualWorker id:jon #objects:14> - [('#boston_housing', 2), ('#housing', 2), ('..', 2)]\n",
       "\n",
       "Found 14 results in total.\n",
       "\n",
       "Tag Profile:\n",
-      "\t#boston found 14\n",
       "\t#housing found 14\n",
-      "\t_boston_dataset: found 12\n",
-      "\t.. found 12\n",
+      "\t#boston found 14\n",
       "\t#boston_housing found 12\n",
+      "\t.. found 12\n",
+      "\t_boston_dataset: found 12\n",
       "\t#data found 6\n",
       "\t#target found 6\n",
       "\t#fun found 2\n"
@@ -364,29 +364,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 1 results on <VirtualWorker id:bob #tensors:17> - [('#boston', 1), ('_boston_dataset:', 1), ('#data', 1)]\n",
-      "Found 1 results on <VirtualWorker id:theo #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#data', 1)]\n",
-      "Found 1 results on <VirtualWorker id:jason #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#data', 1)]\n",
-      "Found 1 results on <VirtualWorker id:alice #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#data', 1)]\n",
-      "Found 1 results on <VirtualWorker id:andy #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#data', 1)]\n",
-      "Found 1 results on <VirtualWorker id:jon #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#data', 1)]\n",
+      "Found 1 results on <VirtualWorker id:bob #objects:17> - [('#boston_housing', 1), ('#housing', 1), ('..', 1)]\n",
+      "Found 1 results on <VirtualWorker id:theo #objects:14> - [('#boston_housing', 1), ('#housing', 1), ('..', 1)]\n",
+      "Found 1 results on <VirtualWorker id:jason #objects:14> - [('#boston_housing', 1), ('#housing', 1), ('..', 1)]\n",
+      "Found 1 results on <VirtualWorker id:alice #objects:14> - [('#boston_housing', 1), ('#housing', 1), ('..', 1)]\n",
+      "Found 1 results on <VirtualWorker id:andy #objects:14> - [('#boston_housing', 1), ('#housing', 1), ('..', 1)]\n",
+      "Found 1 results on <VirtualWorker id:jon #objects:14> - [('#boston_housing', 1), ('#housing', 1), ('..', 1)]\n",
       "\n",
       "Found 6 results in total.\n",
       "\n",
       "Tag Profile:\n",
-      "\t#boston found 6\n",
-      "\t_boston_dataset: found 6\n",
-      "\t#data found 6\n",
+      "\t#boston_housing found 6\n",
       "\t#housing found 6\n",
       "\t.. found 6\n",
-      "\t#boston_housing found 6\n"
+      "\t#data found 6\n",
+      "\t_boston_dataset: found 6\n",
+      "\t#boston found 6\n"
      ]
     }
    ],
@@ -396,49 +396,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 1 results on <VirtualWorker id:bob #tensors:17> - [('#boston', 1), ('_boston_dataset:', 1), ('#housing', 1)]\n",
-      "Found 1 results on <VirtualWorker id:theo #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#housing', 1)]\n",
-      "Found 1 results on <VirtualWorker id:jason #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#housing', 1)]\n",
-      "Found 1 results on <VirtualWorker id:alice #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#housing', 1)]\n",
-      "Found 1 results on <VirtualWorker id:andy #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#housing', 1)]\n",
-      "Found 1 results on <VirtualWorker id:jon #tensors:14> - [('#boston', 1), ('_boston_dataset:', 1), ('#housing', 1)]\n",
+      "Found 1 results on <VirtualWorker id:bob #objects:17> - [('#target', 1), ('#boston_housing', 1), ('#housing', 1)]\n",
+      "Found 1 results on <VirtualWorker id:theo #objects:14> - [('#target', 1), ('#boston_housing', 1), ('#housing', 1)]\n",
+      "Found 1 results on <VirtualWorker id:jason #objects:14> - [('#target', 1), ('#boston_housing', 1), ('#housing', 1)]\n",
+      "Found 1 results on <VirtualWorker id:alice #objects:14> - [('#target', 1), ('#boston_housing', 1), ('#housing', 1)]\n",
+      "Found 1 results on <VirtualWorker id:andy #objects:14> - [('#target', 1), ('#boston_housing', 1), ('#housing', 1)]\n",
+      "Found 1 results on <VirtualWorker id:jon #objects:14> - [('#target', 1), ('#boston_housing', 1), ('#housing', 1)]\n",
       "\n",
       "Found 6 results in total.\n",
       "\n",
       "Tag Profile:\n",
-      "\t#boston found 6\n",
-      "\t_boston_dataset: found 6\n",
+      "\t#target found 6\n",
+      "\t#boston_housing found 6\n",
       "\t#housing found 6\n",
       "\t.. found 6\n",
-      "\t#target found 6\n",
-      "\t#boston_housing found 6\n"
+      "\t_boston_dataset: found 6\n",
+      "\t#boston found 6\n"
      ]
     }
    ],
    "source": [
     "boston_target, _ = grid.search(\"#boston\",\"#target\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -464,7 +450,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR should fix the non-working notebook (Part 05 under the `/examples` folder).  The reason for it is such:

`VirtualWorker.search()` requires a list (i.e. `VirtualWorker.search(['#boston', '#target'])`)

... while `VirtualGrid.search()` receives params as *args (i.e. `VirtualGrid.search('#boston', '#target')`)

I figure this may or may not be an intentional API change.  But it is a bit confusing.  Until the API standardizes between a list or *args, I've at least corrected the notebook.