### PR TITLE
Added custom ObjectNotFoundException class

### DIFF
--- a/syft/generic/object_storage.py
+++ b/syft/generic/object_storage.py
@@ -4,6 +4,10 @@ from typing import Union
 from syft.generic.frameworks.types import FrameworkTensorType
 from syft.generic.tensor import AbstractTensor
 
+class ObjectNotFoundException(Exception):
+    """ A syft specific exception for object not found in object list of a worker
+    """
+    pass
 
 class ObjectStorage:
     """A storage of objects identifiable by their id.
@@ -81,7 +85,7 @@ class ObjectStorage:
                     "the remote object and sends it to the pointer). Check your code to "
                     "make sure you haven't already called .get() on this pointer!!!"
                 )
-                raise KeyError(msg)
+                raise ObjectNotFoundException(msg)
             else:
                 raise e
 


### PR DESCRIPTION
This PR is associated with issue #2608. It is able to raise a syft specific exception "ObjectNotFoundException" rather than native python "KeyError".
For this, a customized class `ObjectNotFoundException` - derived from `Exception` class is written.
When object id is not found in object list of, `ObjectNotFoundException` is raised instead of `KeyError`.

P.S.: This is my first PR.   