### PR TITLE
Serde Façade

### DIFF
--- a/syft/generic/object.py
+++ b/syft/generic/object.py
@@ -4,6 +4,7 @@ from typing import List
 
 import syft as sy
 from syft.generic.frameworks.hook import hook_args
+from syft.serde import SerDe, SyftSerDe
 
 
 class AbstractObject(ABC):
@@ -20,6 +21,7 @@ class AbstractObject(ABC):
         tags: List[str] = None,
         description: str = None,
         child=None,
+        serde: SerDe = SyftSerDe,
     ):
         """Initializer for AbstractTensor
 
@@ -42,6 +44,7 @@ class AbstractObject(ABC):
         self.tags = tags
         self.description = description
         self.child = child
+        self.serde = serde
 
     def __str__(self) -> str:
         if hasattr(self, "child"):
@@ -95,7 +98,7 @@ class AbstractObject(ABC):
                 x = torch.Tensor([1,2,3,4,5])
                 x.serialize() # returns a serialized object
         """
-        return sy.serde.serialize(self)
+        return self.serde.serialize(self)
 
     def ser(self, *args, **kwargs):
         return self.serialize(*args, **kwargs)

--- a/syft/serde/serde.py
+++ b/syft/serde/serde.py
@@ -66,6 +66,7 @@ from syft.messaging.message import ForceObjectDeleteMessage
 from syft.messaging.message import SearchMessage
 from syft.messaging.message import PlanCommandMessage
 from syft.serde.native_serde import MAP_NATIVE_SIMPLIFIERS_AND_DETAILERS
+from syft.serde.serializer import SerDe
 from syft.workers.abstract import AbstractWorker
 from syft.workers.base import BaseWorker
 
@@ -233,6 +234,15 @@ simplifiers, forced_full_simplifiers, detailers = _generate_simplifiers_and_deta
 no_simplifiers_found, no_full_simplifiers_found = set(), set()
 
 
+class SyftSerDe(SerDe):
+
+    def serialize(self, obj, **kwargs) -> object:
+        return syft.serde.serialize(obj, kwargs)
+
+    def deserialize(self, serialized, **kwargs) -> object:
+        return syft.serde.deserialize(serialized, kwargs)
+
+
 ## SECTION:  High Level Public Functions (these are the ones you use)
 def serialize(
     obj: object,
@@ -274,6 +284,7 @@ def serialize(
     # simplify difficult-to-serialize objects. See the _simpliy method
     # for details on how this works. The general purpose is to handle types
     # which the fast serializer cannot handle
+    print(obj)
     if not simplified:
         if force_full_simplification:
             simple_objects = _force_full_simplify(obj)

--- a/syft/serde/serializer.py
+++ b/syft/serde/serializer.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+
+
+class MapperNeutral(ABC):
+    @abstractmethod
+    def to_neutral(self, obj) -> object:
+        pass
+
+    def from_neutral(self, obj) -> object:
+        pass
+
+
+class SerDe(ABC):
+
+    @abstractmethod
+    def serialize(self, obj, **kwargs) -> object:
+        pass
+
+    @abstractmethod
+    def deserialize(self, serialized, **kwargs) -> object:
+        pass


### PR DESCRIPTION
Alternative to current `serde` process.

The main idea is for PySyft to comply with a set of models while preserving the current implementation instead of following the opposite direction as we have been doing so far (PySyft defining what these models look like).

* By decoupling the current serde process in PySyft from the workers and making it go through the façade will allow PySyft to evolve without affecting the clients.

* PySyft should provide an implementation for the set of neutral models that are common to all clients.

* There is an overhead in the process as sending and receiving messages but it's a temporary price to pay while all clients and PySyft itself are aligned with a solution.

* Note that this PR does not define what the common models will look like.


Note: I am aware that once Protobuf implementation (or any other protocol) is in place will make this PR obsolete but by having a façade we can start implementing those other protocols step by step without requiring a one or nothing.
 