### PR TITLE
Fix errors / warnings with test of encrypted linear regression

### DIFF
--- a/test/torch/linalg/test_lr.py
+++ b/test/torch/linalg/test_lr.py
@@ -20,8 +20,8 @@ def test_crypto_lr(fit_intercept, hook, workers):
 
     K = 2  # number of features
 
-    beta = torch.Tensor([1.0, 10.0]).view(-1, 1)  # "real" coefficients
-    intercept = 3.0 if fit_intercept else 0  # "real" intercept
+    beta = torch.Tensor([1.0, 2.0]).view(-1, 1)  # "real" coefficients
+    intercept = 0.5 if fit_intercept else 0  # "real" intercept
 
     # Alice's data
     torch.manual_seed(0)  # Truncation might not always work so we set the random seed


### PR DESCRIPTION
This PR fixes #2680 .

As mentioned in the [Encrypted Linear Regression Tutorial](https://github.com/OpenMined/PySyft/blob/dev/examples/tutorials/advanced/Encrypted%20Linear%20Regression.ipynb), the inputs to the Encrypted Linear Regression model should be standardized. The test I had implemented was simulating data where one of the covariates had a standard error of 10 which was causing overflow