### PR TITLE
Add cache for location2pointerplan

### DIFF
--- a/pip-dep/requirements_dev.txt
+++ b/pip-dep/requirements_dev.txt
@@ -7,7 +7,6 @@ pre-commit>=1.16.1
 pyopenssl>=19.0.0
 pyshark>=0.4.2.4
 pytest>=4.5.0
-scipy
 setuptools>=41.0.0
 sphinx-markdown-builder>=0.4.1
 Sphinx>=2.1.1

--- a/pip-dep/requirements_dev.txt
+++ b/pip-dep/requirements_dev.txt
@@ -7,6 +7,7 @@ pre-commit>=1.16.1
 pyopenssl>=19.0.0
 pyshark>=0.4.2.4
 pytest>=4.5.0
+scipy
 setuptools>=41.0.0
 sphinx-markdown-builder>=0.4.1
 Sphinx>=2.1.1

--- a/syft/messaging/plan/plan.py
+++ b/syft/messaging/plan/plan.py
@@ -124,7 +124,7 @@ class Plan(AbstractObject, ObjectStorage):
         self.is_built = is_built
 
         # The plan has not been sent
-        self.location_to_pointer = dict()
+        self.pointers = dict()
 
         if blueprint is not None:
             self.forward = blueprint
@@ -351,29 +351,28 @@ class Plan(AbstractObject, ObjectStorage):
             location = locations[0]
 
             # Check if plan was already sent at the location
-            if location in self.location_to_pointer:
-                return self.location_to_pointer[location]
+            if location in self.pointers:
+                return self.pointers[location]
 
             self.procedure.update_worker_ids(self.owner.id, location.id)
             # Send the Plan
             pointer = self.owner.send(self, workers=location)
             # Revert ids
             self.procedure.update_worker_ids(location.id, self.owner.id)
-
-            self.location_to_pointer[location] = pointer
+            self.pointers[location] = pointer
         else:
             ids_at_location = []
             for location in locations:
-                if location in self.location_to_pointer:
+                if location in self.pointers:
                     # Use the pointer that was already sent
-                    pointer = self.location_to_pointer[location]
+                    pointer = self.pointers[location]
                 else:
                     self.procedure.update_worker_ids(self.owner.id, location.id)
                     # Send the Plan
                     pointer = self.owner.send(self, workers=location)
                     # Revert ids
                     self.procedure.update_worker_ids(location.id, self.owner.id)
-                    self.location_to_pointer[location] = pointer
+                    self.pointers[location] = pointer
 
                 ids_at_location.append(pointer.id_at_location)
 
@@ -386,6 +385,9 @@ class Plan(AbstractObject, ObjectStorage):
         return self
 
     get = get_
+
+    def get_pointers(self):
+        return self.pointers
 
     def fix_precision_(self, *args, **kwargs):
         self.state.fix_precision_(*args, **kwargs)

--- a/test/message/test_plan.py
+++ b/test/message/test_plan.py
@@ -962,7 +962,7 @@ def test_cached_plan_send(workers):
     pointers = plan_abs.get_pointers()
 
     assert len(pointers) == 1
-    assert plan_bob_ptr1 == plan_bob_ptr2
+    assert plan_bob_ptr1 is plan_bob_ptr2
 
 
 def test_cached_multiple_location_plan_send(workers):

--- a/test/message/test_plan.py
+++ b/test/message/test_plan.py
@@ -93,7 +93,7 @@ def test_raise_exception_for_invalid_shape():
 
 
 def test_raise_exception_when_sending_unbuilt_plan(workers):
-    me, bob = workers["me"], workers["bob"]
+    bob = workers["bob"]
 
     @sy.func2plan()
     def plan(data):
@@ -184,7 +184,7 @@ def test_stateful_plan_method_execute_locally(hook):
 
 
 def test_plan_multiple_send(workers):
-    me, bob, alice = workers["me"], workers["bob"], workers["alice"]
+    bob, alice = workers["bob"], workers["alice"]
 
     @sy.func2plan(args_shape=[(1,)])
     def plan_abs(data):
@@ -207,7 +207,7 @@ def test_plan_multiple_send(workers):
 
 
 def test_stateful_plan_multiple_send(hook, workers):
-    me, bob, alice = workers["me"], workers["bob"], workers["alice"]
+    bob, alice = workers["bob"], workers["alice"]
 
     with hook.local_worker.registration_enabled():
 
@@ -283,7 +283,7 @@ def test_plan_built_on_class(hook):
 
 
 def test_multiple_workers(workers):
-    me, bob, alice = workers["me"], workers["bob"], workers["alice"]
+    bob, alice = workers["bob"], workers["alice"]
 
     @sy.func2plan(args_shape=[(1,)])
     def plan_abs(data):
@@ -302,7 +302,7 @@ def test_multiple_workers(workers):
 
 
 def test_stateful_plan_multiple_workers(hook, workers):
-    me, bob, alice = workers["me"], workers["bob"], workers["alice"]
+    bob, alice = workers["bob"], workers["alice"]
 
     with hook.local_worker.registration_enabled():
 
@@ -948,3 +948,33 @@ def test_send_with_plan(workers):
     assert isinstance(ptr_result.child, sy.PointerTensor)
     result = ptr_result.get()
     assert th.equal(result, expected)
+
+
+def test_cached_plan_send(workers):
+    bob = workers["bob"]
+
+    @sy.func2plan(args_shape=[(1,)])
+    def plan_abs(data):
+        return data.abs()
+
+    plan_bob_ptr1 = plan_abs.send(bob)
+    plan_bob_ptr2 = plan_abs.send(bob)
+    pointers = plan_abs.get_pointers()
+
+    assert len(pointers) == 1
+    assert plan_bob_ptr1 == plan_bob_ptr2
+
+
+def test_cached_multiple_location_plan_send(workers):
+    bob, alice = workers["bob"], workers["alice"]
+
+    @sy.func2plan(args_shape=[(1,)])
+    def plan_abs(data):
+        return data.abs()
+
+    plan_group_ptr1 = plan_abs.send(bob, alice)
+    plan_group_ptr2 = plan_abs.send(bob, alice)
+
+    pointers = plan_abs.get_pointers()
+
+    assert len(pointers) == 2


### PR DESCRIPTION
Solves #2710 
Add a cache mechanism for the Plan class.
1-to-1 mapping between a location and a possible pointer plan that was sent to a worker.
Should reduce the bandwidth usage when the same plan might be sent multiple times to the same worker.