### PR TITLE
Remove ** from kwargs when calling functiono function

### DIFF
--- a/run_websocket_server.py
+++ b/run_websocket_server.py
@@ -45,4 +45,4 @@ kwargs = {
     "hook": hook,
     "verbose": args.verbose,
 }
-server = start_proc(WebsocketServerWorker, **kwargs)
+server = start_proc(WebsocketServerWorker, kwargs)


### PR DESCRIPTION
### Description

Tried to start a local websocket server using:
```python run_websocket_server.py --id="alice" --port=3000 --host="localhost"```

But got a call error since we were expanding the dictionary (and there is no ```id``` parameter for the ```start_proc``` function)

Solved the issue by removing the ```**``` from the ```kwargs``` variable since it will get expanded in ```start_proc```

### Testing
Running
```python run_websocket_server.py --id="alice" --port=3000 --host="localhost"```

Should work fine