### PR TITLE
Fix import in worker Docker image

### DIFF
--- a/docker-images/pysyft-worker/worker-server.py
+++ b/docker-images/pysyft-worker/worker-server.py
@@ -1,7 +1,7 @@
 import argparse
 import torch
 import syft as sy
-from syft.workers import WebsocketServerWorker
+from syft import WebsocketServerWorker
 
 
 def get_args():

--- a/examples/deploy_workers/deploy-and-connect.ipynb
+++ b/examples/deploy_workers/deploy-and-connect.ipynb
@@ -67,9 +67,9 @@
     }
    ],
    "source": [
-    "import syft\n",
     "import torch\n",
-    "from syft.workers import WebsocketClientWorker\n",
+    "import syft\n",
+    "from syft import WebsocketClientWorker\n",
     "\n",
     "hook = syft.TorchHook(torch)"
    ]


### PR DESCRIPTION
WebsocketServerWorker should now be imported from syft directly instead of syft.workers.