### PR TITLE
Add .hook() convenience function

### DIFF
--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -43,7 +43,7 @@ from syft.frameworks.torch.hook.hook import TorchHook
 from syft.grid import VirtualGrid
 
 # Import sandbox
-from syft.sandbox import create_sandbox
+from syft.sandbox import create_sandbox, hook
 
 # Import federate learning objects
 from syft.frameworks.torch.fl import FederatedDataset, FederatedDataLoader, BaseDataset
@@ -110,6 +110,7 @@ __all__.extend(
         "MultiPointerTensor",
         "VirtualGrid",
         "create_sandbox",
+        "hook",
         "combine_pointers",
         "FederatedDataset",
         "FederatedDataLoader",

--- a/syft/sandbox.py
+++ b/syft/sandbox.py
@@ -162,3 +162,6 @@ def create_sandbox(gbs, verbose=True, download_data=True):
     gbs["grid"] = _grid
 
     print("Done!")
+
+def hook(gbs):
+    return create_sandbox(gbs, False, False)

--- a/syft/sandbox.py
+++ b/syft/sandbox.py
@@ -163,5 +163,6 @@ def create_sandbox(gbs, verbose=True, download_data=True):
 
     print("Done!")
 
+
 def hook(gbs):
     return create_sandbox(gbs, False, False)


### PR DESCRIPTION
I find it annoying to have to write hook=sy.TorchHook(th) all the time
and to create the same sample virtual workers over and over. So I short-
ened the .create_sandbox() to a shorter option called .hook(globals())
which hooks pytorch and creates a few virutal workers to play with