### PR TITLE
Change contribution documentation from dev to master branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To sync your fork with the OpenMined/PySyft repository please see this [Guide](h
 
 ### Installing PySyft after Cloning Repository
 
-To install the development version of the package, once the `dev` version of the requirements have been satisified, one should follow the instructions as laid out in [INSTALLATION.md](https://github.com/OpenMined/PySyft/blob/dev/INSTALLATION.md) to complete the installation process. Effectively do the following two steps after a clone has been made on one's local machine at the terminal and that the pre-commit hook has been set up as described above in [Setting up Pre-Commit Hook](#syncing-a-forked-repository):
+To install the development version of the package, once the `dev` version of the requirements have been satisified, one should follow the instructions as laid out in [INSTALLATION.md](https://github.com/OpenMined/PySyft/blob/master/INSTALLATION.md) to complete the installation process. Effectively do the following two steps after a clone has been made on one's local machine at the terminal and that the pre-commit hook has been set up as described above in [Setting up Pre-Commit Hook](#syncing-a-forked-repository):
 ```bash
 cd PySyft
 pip install -e .
@@ -111,7 +111,7 @@ Use following process:
  1. Make required changes in your PySyft and proto branches. [`helpers/update_types.py`](https://github.com/OpenMined/proto/blob/master/helpers/update_types.py) can help update `proto.json` automatically.
  1. Create PRs in both repos.
  1. PRs should pass CI checks.
- 1. After both PRs are merged, `requirements.txt` in PySyft@dev should be updated back to `git+git://github.com/OpenMined/proto@master`.
+ 1. After both PRs are merged, `requirements.txt` in PySyft@master should be updated back to `git+git://github.com/OpenMined/proto@master`.
 
 ### Documentation and Codestyle
 
@@ -155,7 +155,7 @@ As with any software project it's important to keep the amount of code to a mini
 ### Creating a Pull Request
 
 At any point in time you can create a pull request, so others can see your changes and give you feedback.
-Please create all pull requests to the `dev` branch.
+Please create all pull requests to the `master` branch.
 If your PR is still work in progress and not ready to be merged please add a `[WIP]` at the start of the title.
 Example:`[WIP] Serialization of PointerTensor`
 


### PR DESCRIPTION
Base branch switched from `dev` to `master`, this PR also change the contribution docs to this.