### PR TITLE
Update egg name in proto git dependencity url

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=1.0.2
 flask_socketio>=3.3.2
-git+git://github.com/OpenMined/proto@master#egg=proto
+git+git://github.com/OpenMined/proto@master#egg=pysyft-proto
 lz4>=2.1.6
 msgpack>=0.6.1
 numpy>=1.16.0


### PR DESCRIPTION
When I try to `pip install -Ur pip-dep/requirements.txt` 
in Ubuntu 16.04 / python 3.6.9 / pip 19.3.1 / setuptools 41.6.0
I see following warning:
```
Collecting proto
  Cloning git://github.com/OpenMined/proto (to revision master) to /tmp/pip-install-e_sft7x2/proto
  Running command git clone -q git://github.com/OpenMined/proto /tmp/pip-install-e_sft7x2/proto
  WARNING: Generating metadata for package proto produced metadata for project name pysyft-proto. Fix your #egg=proto fragments.
```
Then it fails to install it.
It seems egg value should match with package name which is `pysyft-proto` (as defined in proto's setup.py).