### PR TITLE
Additive Sharing Tensor search tag and description

### DIFF
--- a/syft/serde/torch_serde.py
+++ b/syft/serde/torch_serde.py
@@ -241,6 +241,11 @@ def _detail_torch_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> torch.T
         hook=syft.torch.hook, obj=tensor, owner=worker, id=tensor_id, init_args=[], init_kwargs={}
     )
 
+    if chain is not None:
+        chain = syft.serde._detail(worker, chain)
+        tensor.child = chain
+        tensor.is_wrapper = True
+
     if tags is not None:
 
         tags = list(tags)
@@ -256,11 +261,6 @@ def _detail_torch_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> torch.T
         if isinstance(description, bytes):
             description = description.decode("utf-8")
         tensor.description = description
-
-    if chain is not None:
-        chain = syft.serde._detail(worker, chain)
-        tensor.child = chain
-        tensor.is_wrapper = True
 
     return tensor
 

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -873,3 +873,17 @@ def test_cnn_model(workers):
     sh_data = torch.zeros((1, 1, 28, 28)).fix_precision().share(alice, bob, crypto_provider=james)
 
     assert torch.allclose(sh_model(sh_data).get().float_prec(), model(data), atol=1e-2)
+
+
+def test_correct_tag_and_description_after_send(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+
+    x = torch.tensor([1, 2, 3]).share(alice, bob, james)
+    x.tags = ["tag_additive_test1", "tag_additive_test2"]
+    x.description = "description_additive_test"
+
+    pointer_x = x.send(alice)
+
+    assert alice.search("tag_additive_test1")
+    assert alice.search("tag_additive_test2")
+    assert alice.search("description_additive_test")


### PR DESCRIPTION
Fixes #2768.

In ```syft/frameworks/torch/tensors/interpreters/native.py``` **tags** will first look at the tensor, to see if it has any child and if it does it will take the tags from the child.
```
@property
     def tags(self):
         if self.has_child():
             return self.child.tags
         else:
             if not hasattr(self, "_tags"):
                 self._tags = None
             return self._tags
```

The same behavior is for the **description**:
```
@property
     def description(self):
         if self.has_child():
             return self.child.description
         else:
             if not hasattr(self, "_description"):
                 self._description = None
             return self._description
```

The problem was the order in which we put the fields for a new tensor (when we call ```_detail_torch_tensor```):
```
    if tags is not None:
         tags = list(tags)
         for i in range(len(tags)):
             tag = tags[i]
             if isinstance(tag, bytes):
                 tag = tag.decode("utf-8")
             tags[i] = tag
         tensor.tags = tags
 
     if description is not None:
         if isinstance(description, bytes):
             description = description.decode("utf-8")
         tensor.description = description
 
     if chain is not None:
         chain = syft.serde._detail(worker, chain)
         tensor.child = chain
         tensor.is_wrapper = True
```
We can see that the child is added at the end.

The flow of the problem is the next: we add the tag/description (if we have any) and after that we add the child. And THERE is the problem! we add a child without any tags/description. If we now want to access the **tags** field, it will see that we have a child and will access the tags from the child - and they are ```None```! 
The solution was to initialize first the child and then the tags and the description!