### PR TITLE
Coverage ignore errors when reading files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ before_script:
   - mypy syft || echo "Type errors found, continuing build..."
 script:
   - coverage run -m pytest test
-  - coverage report --fail-under 95 -m
+  - coverage report --ignore-errors --fail-under 95 -m
   # ensuring coverage of tests stays at 100 until entire coverage can be 100
-  - coverage report --fail-under 100 -m --include="test/*"
+  - coverage report --ignore-errors --fail-under 100 -m --include="test/*"
   # - bash scripts/execute_notebooks.sh
   # - if grep -q "Traceback (most recent call last):" nb_to_md.txt; then false; else true; fi
 notifications:


### PR DESCRIPTION
It seems there is problem when ```coverage``` tries to report for the ```preprocess``` file. The ```preprocess.py``` file was used in the ```SMS Spam prediction``` notebook - there might be a ```pyc``` file that can not be read.

Another solution would be to remove all the ```*.pyc``` files

Source: https://stackoverflow.com/questions/2386975/no-source-for-code-message-in-coverage-py