### PR TITLE
(WIP) Add Protobuf serialization

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -9,6 +9,11 @@ from syft.generic.frameworks.hook import hook_args
 from syft.generic.frameworks.overload import overloaded
 from syft.workers.abstract import AbstractWorker
 
+from syft_proto.frameworks.torch.tensors.interpreters.v1.additive_shared_pb2 import (
+    AdditiveSharingTensor as AdditiveSharingTensorPB,
+)
+from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
+
 no_wrap = {"no_wrap": True}
 
 
@@ -1019,6 +1024,77 @@ class AdditiveSharingTensor(AbstractTensor):
 
         if chain is not None:
             chain = sy.serde.msgpack.serde._detail(worker, chain)
+            tensor.child = chain
+
+        return tensor
+
+    @staticmethod
+    def bufferize(
+        worker: AbstractWorker, tensor: "AdditiveSharingTensor"
+    ) -> "AdditiveSharingTensorPB":
+        """
+        This function takes the attributes of a AdditiveSharingTensor and saves them in a protobuf object
+        Args:
+            tensor (AdditiveSharingTensor): a AdditiveSharingTensor
+        Returns:
+            protobuf: a protobuf object holding the unique attributes of the additive shared tensor
+        Examples:
+            data = protobuf(tensor)
+        """
+
+        location_ids = []
+        shares = []
+        if hasattr(tensor, "child"):
+            for key, value in tensor.child.items():
+                location_ids.append(sy.serde.protobuf.serde.create_protobuf_id(key))
+                shares.append(value)
+
+        # Don't delete the remote values of the shares at simplification
+        tensor.set_garbage_collect_data(False)
+
+        protobuf_tensor = AdditiveSharingTensorPB()
+        protobuf_tensor.id.CopyFrom(sy.serde.protobuf.serde.create_protobuf_id(tensor.id))
+        protobuf_tensor.field_size = tensor.field
+        protobuf_tensor.crypto_provider_id.CopyFrom(
+            sy.serde.protobuf.serde.create_protobuf_id(tensor.crypto_provider.id)
+        )
+        protobuf_tensor.location_ids.extend(location_ids)
+        protobuf_tensor.shares.extend(shares)
+
+        return protobuf_tensor
+
+    @staticmethod
+    def unbufferize(
+        worker: AbstractWorker, protobuf_tensor: "AdditiveSharingTensorPB"
+    ) -> "AdditiveSharingTensor":
+        """
+            This function reconstructs a AdditiveSharingTensor given its' attributes in form of a protobuf object.
+            Args:
+                worker: the worker doing the deserialization
+                protobuf_tensor: a protobuf object holding the attributes of the AdditiveSharingTensor
+            Returns:
+                AdditiveSharingTensor: a AdditiveSharingTensor
+            Examples:
+                shared_tensor = unprotobuf(data)
+            """
+
+        tensor_id = getattr(protobuf_tensor, protobuf_tensor.WhichOneof("id"))
+        field = protobuf_tensor.field_size
+        crypto_provider_id = getattr(
+            protobuf_tensor, protobuf_tensor.WhichOneof("crypto_provider_id")
+        )
+
+        tensor = AdditiveSharingTensor(
+            owner=worker,
+            id=tensor_id,
+            field=field,
+            crypto_provider=worker.get_worker(crypto_provider_id),
+        )
+
+        if protobuf_tensor.location_ids is not None:
+            chain = {}
+            for location_id, share in zip(protobuf_tensor.location_ids, protobuf_tensor.shares):
+                chain[location_id] = share
             tensor.child = chain
 
         return tensor

--- a/syft/generic/object.py
+++ b/syft/generic/object.py
@@ -78,7 +78,7 @@ class AbstractObject(ABC):
                 x = torch.Tensor([1,2,3,4,5])
                 x.serialize() # returns a serialized object
         """
-        return sy.serde.serialize(self)
+        return sy.serde.protobuf.serde.serialize(self)
 
     def ser(self, *args, **kwargs):
         return self.serialize(*args, **kwargs)

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -11,6 +11,9 @@ import syft as sy
 from syft.workers.abstract import AbstractWorker
 
 
+from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
+
+
 class Message:
     """All syft message types extend this class
 
@@ -226,6 +229,31 @@ class ObjectMessage(Message):
             message = detail(sy.local_worker, msg_tuple)
         """
         return ObjectMessage(sy.serde.msgpack.serde._detail(worker, msg_tuple[0]))
+
+    @staticmethod
+    def bufferize(worker: AbstractWorker, message: "ObjectMessage") -> "ObjectMessagePB":
+        """
+        This function takes the attributes of an Object Message and saves them in a protobuf object
+        Args:
+            message (ObjectMessage): an ObjectMessage
+        Returns:
+            protobuf: a protobuf object holding the unique attributes of the object message
+        Examples:
+            data = bufferize(object_message)
+        """
+
+        protobuf_obj_msg = ObjectMessagePB()
+        bufferized_contents = sy.serde.protobuf.serde._bufferize(worker, message.contents)
+        protobuf_obj_msg.tensor.CopyFrom(bufferized_contents)
+        return protobuf_obj_msg
+
+    @staticmethod
+    def unbufferize(worker: AbstractWorker, protobuf_obj: "ObjectMessagePB") -> "ObjectMessage":
+        protobuf_contents = protobuf_obj.tensor
+        contents = sy.serde.protobuf.serde._unbufferize(worker, protobuf_contents)
+        object_msg = ObjectMessage(contents)
+
+        return object_msg
 
 
 class ObjectRequestMessage(Message):

--- a/syft/messaging/plan/plan.py
+++ b/syft/messaging/plan/plan.py
@@ -214,7 +214,7 @@ class Plan(AbstractObject, ObjectStorage):
 
             self.procedure.operations.append((msg_type, contents))
 
-        return sy.serde.serialize(None)
+        return sy.serde.protobuf.serde.serialize(None)
 
     def build(self, *args):
         """Builds the plan.
@@ -324,7 +324,7 @@ class Plan(AbstractObject, ObjectStorage):
 
     def execute_commands(self):
         for message in self.procedure.operations:
-            bin_message = sy.serde.serialize(message, simplified=True)
+            bin_message = sy.serde.protobuf.serde.serialize(message, simplified=True)
             _ = self.owner.recv_msg(bin_message)
 
     def run(self, args: Tuple, result_ids: List[Union[str, int]]):

--- a/syft/serde/protobuf/native_serde.py
+++ b/syft/serde/protobuf/native_serde.py
@@ -1,0 +1,40 @@
+"""
+This file exists to provide a common place for all Protobuf
+serialisation for native Python objects. If you're adding
+something here that isn't for `None`, think twice and either
+use an existing sub-class of Message or add a new one.
+"""
+
+from collections import OrderedDict
+from google.protobuf.empty_pb2 import Empty
+from syft.workers.abstract import AbstractWorker
+
+
+def _bufferize_none(worker: AbstractWorker, obj: "type(None)") -> "Empty":
+    """
+    This function converts None into an empty Protobuf message.
+
+    Args:
+        obj (None): makes signature match other bufferize methods
+
+    Returns:
+        protobuf_obj: Empty Protobuf message
+    """
+    return Empty()
+
+
+def _unbufferize_none(worker: AbstractWorker, obj: "Empty") -> "type(None)":
+    """
+    This function converts an empty Protobuf message back into None.
+
+    Args:
+        obj (Empty): Empty Protobuf message
+
+    Returns:
+        obj: None
+    """
+    return None
+
+
+# Maps a type to its bufferizer and unbufferizer functions
+MAP_NATIVE_PROTOBUF_TRANSLATORS = OrderedDict({type(None): (_bufferize_none, _unbufferize_none)})

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -11,17 +11,20 @@ import torch
 from google.protobuf.empty_pb2 import Empty
 
 from syft.messaging.message import ObjectMessage
+from syft.messaging.message import Operation
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
 
 from syft_proto.frameworks.torch.tensors.interpreters.v1.additive_shared_pb2 import (
     AdditiveSharingTensor as AdditiveSharingTensorPB,
 )
 from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
+from syft_proto.messaging.v1.message_pb2 import OperationMessage as OperationMessagePB
 from syft_proto.generic.v1.tensor_pb2 import Tensor as TensorPB
 
 
 MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     ObjectMessage: ObjectMessagePB,
+    Operation: OperationMessagePB,
     torch.Tensor: TensorPB,
     AdditiveSharingTensor: AdditiveSharingTensorPB,
     type(None): Empty,

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -1,0 +1,30 @@
+"""
+This file exists to translate python classes to and from Protobuf messages.
+The reason for this is to have stable serialization protocol that can be used
+not only by PySyft but also in other languages.
+
+https://github.com/OpenMined/syft-proto (`syft_proto` module) is included as
+a dependency in setup.py.
+"""
+import torch
+
+from syft.messaging.message import ObjectMessage
+from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
+
+from syft_proto.frameworks.torch.tensors.interpreters.v1.additive_shared_pb2 import (
+    AdditiveSharingTensor as AdditiveSharingTensorPB,
+)
+from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
+from syft_proto.generic.v1.tensor_pb2 import Tensor as TensorPB
+
+
+MAP_PYTHON_TO_PROTOBUF_CLASSES = {
+    ObjectMessage: ObjectMessagePB,
+    torch.Tensor: TensorPB,
+    AdditiveSharingTensor: AdditiveSharingTensorPB,
+}
+
+MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
+
+for key, value in MAP_PYTHON_TO_PROTOBUF_CLASSES.items():
+    MAP_PROTOBUF_TO_PYTHON_CLASSES[value] = key

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -8,6 +8,8 @@ a dependency in setup.py.
 """
 import torch
 
+from google.protobuf.empty_pb2 import Empty
+
 from syft.messaging.message import ObjectMessage
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
 
@@ -22,6 +24,7 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     ObjectMessage: ObjectMessagePB,
     torch.Tensor: TensorPB,
     AdditiveSharingTensor: AdditiveSharingTensorPB,
+    type(None): Empty,
 }
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -1,0 +1,355 @@
+from collections import OrderedDict
+
+import inspect
+import syft
+from syft import dependency_check
+from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
+from syft.messaging.message import ObjectMessage
+from syft.serde import compression
+from syft.workers.abstract import AbstractWorker
+
+from syft_proto.messaging.v1.message_pb2 import SyftMessage as SyftMessagePB
+from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
+
+
+if dependency_check.torch_available:
+    from syft.serde.protobuf.torch_serde import MAP_TORCH_PROTOBUF_TRANSLATORS
+else:
+    MAP_TORCH_PROTOBUF_TRANSLATORS = {}
+
+# if dependency_check.tensorflow_available:
+#     from syft_tensorflow.serde import MAP_TF_PROTOBUF_TRANSLATORS
+# else:
+#     MAP_TF_PROTOBUF_TRANSLATORS = {}
+
+from syft.serde.protobuf.proto import MAP_PROTOBUF_TO_PYTHON_CLASSES
+from syft.serde.protobuf.proto import MAP_PYTHON_TO_PROTOBUF_CLASSES
+
+# Maps a type to its bufferizer and unbufferizer functions
+MAP_TO_PROTOBUF_TRANSLATORS = OrderedDict(
+    list(MAP_TORCH_PROTOBUF_TRANSLATORS.items())
+    # + list(MAP_TF_PROTOBUF_TRANSLATORS.items())
+)
+
+# If an object implements its own bufferize and unbufferize functions it should be stored in this list
+OBJ_PROTOBUF_TRANSLATORS = [AdditiveSharingTensor, ObjectMessage]
+
+# If an object implements its own force_bufferize and force_unbufferize functions it should be stored in this list
+# OBJ_FORCE_FULL_PROTOBUF_TRANSLATORS = [BaseWorker]
+OBJ_FORCE_FULL_PROTOBUF_TRANSLATORS = []
+
+# For registering syft objects with custom bufferize and unbufferize methods
+# EXCEPTION_PROTOBUF_TRANSLATORS = [GetNotPermittedError, ResponseSignatureError]
+EXCEPTION_PROTOBUF_TRANSLATORS = []
+
+
+## SECTION: High Level Translation Router
+def _force_full_bufferize(worker: AbstractWorker, obj: object) -> object:
+    """To force a full bufferize conversion generally if the usual _bufferize is not suitable.
+
+    If we can not full convert an object we convert it as usual instead.
+
+    Args:
+        obj: The object.
+
+    Returns:
+        The bufferize object.
+    """
+    # check to see if there is a full bufferize converter
+    # for this type. If there is, return the full converted object.
+    current_type = type(obj)
+    if current_type in forced_full_bufferizers:
+        result = (
+            forced_full_bufferizers[current_type][0],
+            forced_full_bufferizers[current_type][1](worker, obj),
+        )
+        return result
+    # If we already tried to find a full bufferizer for this type but failed, we should
+    # bufferize it instead.
+    elif current_type in no_full_bufferizers_found:
+        return _bufferize(worker, obj)
+    else:
+        # If the object type is not in forced_full_bufferizers,
+        # we check the classes that this object inherits from.
+        # `inspect.getmro` give us all types this object inherits
+        # from, including `type(obj)`. We can skip the type of the
+        # object because we already tried this in the
+        # previous step.
+        classes_inheritance = inspect.getmro(type(obj))[1:]
+
+        for inheritance_type in classes_inheritance:
+            if inheritance_type in forced_full_bufferizers:
+                # Store the inheritance_type in forced_full_bufferizers so next
+                # time we see this type serde will be faster.
+                forced_full_bufferizers[current_type] = forced_full_bufferizers[inheritance_type]
+                result = (
+                    forced_full_bufferizers[current_type][0],
+                    forced_full_bufferizers[current_type][1](worker, obj),
+                )
+                return result
+
+        # If there is not a full_bufferizer for this
+        # object, then we bufferize it.
+        no_full_bufferizers_found.add(current_type)
+        return _bufferize(worker, obj)
+
+
+## SECTION: dinamically generate bufferizers and unbufferizers
+def _generate_bufferizers_and_unbufferizers():
+    """Generate bufferizers, forced full bufferizers and unbufferizers,
+    by registering native and torch types, syft objects with custom
+    bufferize and unbufferize methods, or syft objects with custom
+    force_bufferize and force_unbufferize methods.
+
+    NOTE: this function uses `proto_type_info` that translates python class into Serde constant defined in
+    https://github.com/OpenMined/proto. If the class used in `MAP_TO_SIMPLIFIERS_AND_DETAILERS`,
+    `OBJ_SIMPLIFIER_AND_DETAILERS`, `EXCEPTION_SIMPLIFIER_AND_DETAILERS`, `OBJ_FORCE_FULL_SIMPLIFIER_AND_DETAILERS`
+    is not defined in `proto.json` file in https://github.com/OpenMined/proto, this function will error.
+    Returns:
+        The bufferizers, forced_full_bufferizers, unbufferizers
+    """
+    bufferizers = OrderedDict()
+    forced_full_bufferizers = OrderedDict()
+    unbufferizers = OrderedDict()
+
+    def _add_bufferizer_and_unbufferizer(
+        curr_type, proto_type, bufferizer, unbufferizer, forced=False
+    ):
+        if forced:
+            forced_full_bufferizers[curr_type] = bufferizer
+            unbufferizers[proto_type] = unbufferizer
+        else:
+            bufferizers[curr_type] = bufferizer
+            unbufferizers[proto_type] = unbufferizer
+
+    # Register native and torch types
+    for curr_type in MAP_TO_PROTOBUF_TRANSLATORS:
+        proto_type = MAP_PYTHON_TO_PROTOBUF_CLASSES[curr_type]
+        bufferizer, unbufferizer = MAP_TO_PROTOBUF_TRANSLATORS[curr_type]
+        _add_bufferizer_and_unbufferizer(curr_type, proto_type, bufferizer, unbufferizer)
+
+    # Register syft objects with custom bufferize and unbufferize methods
+    for syft_type in OBJ_PROTOBUF_TRANSLATORS + EXCEPTION_PROTOBUF_TRANSLATORS:
+        proto_type = MAP_PYTHON_TO_PROTOBUF_CLASSES[syft_type]
+        bufferizer, unbufferizer = syft_type.bufferize, syft_type.unbufferize
+        _add_bufferizer_and_unbufferizer(syft_type, proto_type, bufferizer, unbufferizer)
+
+    # Register syft objects with custom force_bufferize and force_unbufferize methods
+    for syft_type in OBJ_FORCE_FULL_PROTOBUF_TRANSLATORS:
+        proto_type = MAP_PYTHON_TO_PROTOBUF_CLASSES[syft_type]
+        force_bufferizer, force_unbufferizer = (
+            syft_type.force_bufferize,
+            syft_type.force_unbufferize,
+        )
+        _add_bufferizer_and_unbufferizer(
+            syft_type, proto_type, force_bufferizer, force_unbufferizer, forced=True
+        )
+
+    return bufferizers, forced_full_bufferizers, unbufferizers
+
+
+bufferizers, forced_full_bufferizers, unbufferizers = _generate_bufferizers_and_unbufferizers()
+# Store types that are not simplifiable (int, float, None) so we
+# can ignore them during serialization.
+no_bufferizers_found, no_full_bufferizers_found = set(), set()
+
+
+## SECTION:  High Level Public Functions (these are the ones you use)
+def serialize(
+    obj: object,
+    worker: AbstractWorker = None,
+    simplified: bool = False,
+    force_no_compression: bool = False,
+    force_no_serialization: bool = False,
+    force_full_simplification: bool = False,
+) -> bin:
+    """This method can serialize any object PySyft needs to send or store.
+
+    This is the high level function for serializing any object or collection
+    of objects which PySyft needs to send over the wire. It includes three
+    steps, Simplify, Serialize, and Compress as described inline below.
+
+    Args:
+        obj (object): the object to be serialized
+        simplified (bool): in some cases we want to pass in data which has
+            already been simplified - in which case we must skip double
+            simplification - which would be bad.... so bad... so... so bad
+        force_no_compression (bool): If true, this will override ANY module
+            settings and not compress the objects being serialized. The primary
+            expected use of this functionality is testing and/or experimentation.
+        force_no_serialization (bool): Primarily a testing tool, this will force
+            this method to return human-readable Python objects which is very useful
+            for testing and debugging (forceably overrides module compression,
+            serialization, and the 'force_no_compression' override)). In other words,
+            only simplification operations are performed.
+        force_full_simplification (bool): Some objects are only partially serialized
+            by default. For objects where this is the case, setting this flag to True
+            will force the entire object to be serialized. For example, setting this
+            flag to True will cause a VirtualWorker to be serialized WITH all of its
+            tensors while by default VirtualWorker objects only serialize a small
+            amount of metadata.
+
+    Returns:
+        binary: the serialized form of the object.
+    """
+    if worker is None:
+        # TODO[jvmancuso]: This might be worth a standalone function.
+        worker = syft.framework.hook.local_worker
+
+    if force_no_serialization:
+        # 0) Simplify
+        # bufferize difficult-to-serialize objects. See the _bufferize method
+        # for unbufferizes on how this works. The general purpose is to handle types
+        # which the fast serializer cannot handle
+        simple_objects = obj
+        if not simplified:
+            if force_full_simplification:
+                simple_objects = _force_full_bufferize(worker, obj)
+            else:
+                simple_objects = _bufferize(worker, obj)
+        return simple_objects
+
+    # 1) Convert to Protobuf objects
+    msg_wrapper = SyftMessagePB()
+
+    protobuf_obj = _bufferize(worker, obj)
+    if type(obj) == ObjectMessage:
+        msg_wrapper.contents_object_msg.CopyFrom(protobuf_obj)
+
+    # 2) Serialize
+    # serialize into a binary
+    binary = msg_wrapper.SerializeToString()
+
+    # 3) Compress
+    # optionally compress the binary and return the result
+    # prepend a 1-byte header '0' or '1' to the output stream
+    # to denote whether output stream is compressed or not
+    # if compressed stream length is greater than input stream
+    # we output the input stream as it is with header set to '0'
+    # otherwise we output the compressed stream with header set to '1'
+    # even if compressed flag is set to false by the caller we
+    # output the input stream as it is with header set to '0'
+    if force_no_compression:
+        return binary
+    else:
+        return compression._compress(binary)
+
+
+def deserialize(binary: bin, worker: AbstractWorker = None, unbufferizes=True) -> object:
+    """ This method can deserialize any object PySyft needs to send or store.
+
+    This is the high level function for deserializing any object or collection
+    of objects which PySyft has sent over the wire or stored. It includes three
+    steps, Decompress, Deserialize, and Detail as described inline below.
+
+    Args:
+        binary (bin): the serialized object to be deserialized.
+        worker (AbstractWorker): the worker which is acquiring the message content,
+            for example used to specify the owner of a tensor received(not obvious
+            for virtual workers)
+        unbufferizes (bool): there are some cases where we need to perform the decompression
+            and deserialization part, but we don't need to unbufferize all the message.
+            This is the case for Plan workers for instance
+
+    Returns:
+        object: the deserialized form of the binary input.
+    """
+    if worker is None:
+        # TODO[jvmancuso]: This might be worth a standalone function.
+        worker = syft.framework.hook.local_worker
+
+    # 1) Decompress the binary if needed
+    binary = compression._decompress(binary)
+
+    # 2) Deserialize
+    msg_wrapper = SyftMessagePB()
+    msg_wrapper.ParseFromString(binary)
+
+    # 3) Convert back to a Python object
+    message_type = msg_wrapper.WhichOneof("contents")
+    python_obj = _unbufferize(worker, getattr(msg_wrapper, message_type))
+    return python_obj
+
+
+def create_protobuf_id(id) -> IdPB:
+    protobuf_id = IdPB()
+    if type(id) == type("str"):
+        protobuf_id.id_str = id
+    else:
+        protobuf_id.id_int = id
+    return protobuf_id
+
+
+def _bufferize(worker: AbstractWorker, obj: object, **kwargs) -> object:
+    """
+    This function takes an object as input and returns a
+    Protobuf object. The reason we have this function
+    is that some objects are either NOT supported by high level (fast)
+    serializers OR the high level serializers don't support the fastest
+    form of serialization. For example, PyTorch tensors have custom pickle
+    functionality thus its better to pre-serialize PyTorch tensors using
+    pickle and then serialize the binary in with the rest of the message
+    being sent.
+
+    Args:
+        obj: An object which needs to be converted to Protobuf.
+
+    Returns:
+        An Protobuf object which Protobuf can serialize.
+    """
+
+    # Check to see if there is a bufferizer
+    # for this type. If there is, return the bufferized object.
+    # breakpoint()
+    current_type = type(obj)
+    if current_type in bufferizers:
+        result = bufferizers[current_type](worker, obj, **kwargs)
+        return result
+
+    # If we already tried to find a bufferizer for this type but failed, we should
+    # just return the object as it is.
+    elif current_type in no_bufferizers_found:
+        raise Exception(f"No corresponding Protobuf message found for {current_type}")
+
+    else:
+        # If the object type is not in bufferizers,
+        # we check the classes that this object inherits from.
+        # `inspect.getmro` give us all types this object inherits
+        # from, including `type(obj)`. We can skip the type of the
+        # object because we already tried this in the
+        # previous step.
+        classes_inheritance = inspect.getmro(type(obj))[1:]
+
+        for inheritance_type in classes_inheritance:
+            if inheritance_type in bufferizers:
+                # Store the inheritance_type in bufferizers so next time we see this type
+                # serde will be faster.
+                bufferizers[current_type] = bufferizers[inheritance_type]
+                result = (bufferizers[current_type](worker, obj, **kwargs),)
+                return result
+
+        no_bufferizers_found.add(current_type)
+        raise Exception(f"No corresponding Protobuf message found for {current_type}")
+
+
+def _unbufferize(worker: AbstractWorker, obj: object, **kwargs) -> object:
+    """Reverses the functionality of _bufferize.
+    Where applicable, it converts simple objects into more complex objects such
+    as converting binary objects into torch tensors. Read _bufferize for more
+    information on why _bufferize and unbufferize are needed.
+
+    Args:
+        worker: the worker which is acquiring the message content, for example
+        used to specify the owner of a tensor received(not obvious for
+        virtual workers).
+        obj: a simple Python object which msgpack deserialized.
+
+    Returns:
+        obj: a more complex Python object which msgpack would have had trouble
+            deserializing directly.
+    """
+    current_type = type(obj)
+    if current_type in unbufferizers:
+        return unbufferizers[type(obj)](worker, obj, **kwargs)
+    else:
+        raise Exception(f"No unbufferizer found for {current_type}")

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -1,0 +1,238 @@
+"""
+This file exists to provide one common place for all serialisation and bufferize_ and _unbufferize
+for all tensors (Torch and Numpy).
+"""
+from collections import OrderedDict
+import io
+from tempfile import TemporaryFile
+from typing import Tuple, List
+import warnings
+
+import numpy
+import torch
+
+import syft
+from syft.generic.pointers.pointer_tensor import PointerTensor
+from syft.generic.tensor import initialize_tensor
+from syft.generic.tensor import AbstractTensor
+from syft.workers.abstract import AbstractWorker
+from syft.codes import TENSOR_SERIALIZATION
+
+from syft_proto.generic.v1.tensor_pb2 import Tensor as TensorPB
+
+# Torch dtypes to string (and back) mappers
+TORCH_DTYPE_STR = {
+    torch.uint8: "uint8",
+    torch.int8: "int8",
+    torch.int16: "int16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.float16: "float16",
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.complex32: "complex32",
+    torch.complex64: "complex64",
+    torch.complex128: "complex128",
+    torch.bool: "bool",
+    torch.qint8: "qint8",
+    torch.quint8: "quint8",
+    torch.qint32: "qint32",
+    torch.bfloat16: "bfloat16",
+}
+TORCH_STR_DTYPE = {name: cls for cls, name in TORCH_DTYPE_STR.items()}
+
+
+def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
+    """Serialize the tensor using as default Torch serialization strategy
+    This function can be overridden to provide different tensor serialization strategies
+
+    Args
+        (torch.Tensor): an input tensor to be serialized
+
+    Returns
+        A serialized version of the input tensor
+
+    """
+    serializers = {
+        TENSOR_SERIALIZATION.TORCH: torch_tensor_serializer,
+        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
+    }
+    if worker.serializer not in serializers:
+        raise NotImplementedError(
+            f"Tensor serialization strategy is not supported: {worker.serializer}"
+        )
+    serializer = serializers[worker.serializer]
+    return serializer(worker, tensor)
+
+
+def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> torch.Tensor:
+    """Deserialize the input tensor passed as parameter into a Torch tensor.
+    `serializer` parameter selects different deserialization strategies
+
+    Args
+        worker: Worker
+        serializer: Strategy used for tensor deserialization (e.g.: torch, numpy, all)
+        tensor_bin: A simplified representation of a tensor
+
+    Returns
+        a Torch tensor
+    """
+    deserializers = {
+        TENSOR_SERIALIZATION.TORCH: torch_tensor_deserializer,
+        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
+    }
+    if serializer not in deserializers:
+        raise NotImplementedError(
+            f"Cannot deserialize tensor serialized with '{serializer}' strategy"
+        )
+    deserializer = deserializers[serializer]
+    return deserializer(worker, tensor_bin)
+
+
+def numpy_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
+    """Strategy to serialize a tensor using numpy npy format.
+    If tensor requires to calculate gradients, it will be detached.
+    """
+    if tensor.requires_grad:
+        warnings.warn(
+            "Torch to Numpy serializer can only be used with tensors that do not require grad. "
+            "Detaching tensor to continue"
+        )
+        tensor = tensor.detach()
+
+    np_tensor = tensor.numpy()
+    outfile = TemporaryFile()
+    numpy.save(outfile, np_tensor)
+    # Simulate close and open by calling seek
+    outfile.seek(0)
+    return outfile.read()
+
+
+def numpy_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
+    """"Strategy to deserialize a binary input in npy format into a Torch tensor"""
+    input_file = TemporaryFile()
+    input_file.write(tensor_bin)
+    # read data from file
+    input_file.seek(0)
+    return torch.from_numpy(numpy.load(input_file))
+
+
+def torch_tensor_serializer(worker: AbstractWorker, tensor) -> bin:
+    """Strategy to serialize a tensor using Torch saver"""
+    binary_stream = io.BytesIO()
+    torch.save(tensor, binary_stream)
+    return binary_stream.getvalue()
+
+
+def torch_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
+    """"Strategy to deserialize a binary input using Torch load"""
+    bin_tensor_stream = io.BytesIO(tensor_bin)
+    return torch.load(bin_tensor_stream)
+
+
+# Bufferize/Unbufferize Torch Tensors
+
+
+def _bufferize_torch_tensor(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
+    """
+    This function converts a torch tensor into a serliaized torch tensor
+    using pickle. We choose to use this because PyTorch has a custom and
+    very fast PyTorch pickler.
+
+    Args:
+        tensor (torch.Tensor): an input tensor to be serialized
+
+    Returns:
+        protobuf_obj: Protobuf version of torch tensor.
+    """
+
+    tensor_bin = _serialize_tensor(worker, tensor)
+
+    if tensor.grad is not None:
+        if hasattr(tensor, "child"):
+            if isinstance(tensor.child, PointerTensor):
+                grad_chain = None
+            else:
+                grad_chain = _bufferize_torch_tensor(worker, tensor.grad)
+        else:
+            grad_chain = _bufferize_torch_tensor(worker, tensor.grad)
+
+    else:
+        grad_chain = None
+
+    chain = None
+    if hasattr(tensor, "child"):
+        chain = syft.serde.protobuf.serde._bufferize(worker, tensor.child)
+
+    protobuf_tensor = TensorPB()
+
+    protobuf_tensor.id.CopyFrom(syft.serde.protobuf.serde.create_protobuf_id(tensor.id))
+
+    protobuf_tensor.shape.dims.extend(tensor.shape)
+    protobuf_tensor.bin = tensor_bin
+
+    if chain:
+        protobuf_tensor.chain.CopyFrom(chain)
+    if grad_chain:
+        protobuf_tensor.grad_chain.CopyFrom(grad_chain)
+    if tensor.description:
+        protobuf_tensor.description = tensor.description
+
+    protobuf_tensor.tags.extend(tensor.tags)
+    protobuf_tensor.serializer = (
+        TensorPB.Serializer.SERIALIZER_TORCH
+    )  # TODO[karlhigley]: Fix this so the other serializer types also work
+
+    return protobuf_tensor
+
+
+def _unbufferize_torch_tensor(worker: AbstractWorker, protobuf_tensor: "TensorPB") -> torch.Tensor:
+    """
+    This function converts a serialized torch tensor into a torch tensor
+    using pickle.
+
+    Args:
+        tensor_tuple (bin): serialized obj of torch tensor. It's a tuple where
+            the first value is the ID, the second vlaue is the binary for the
+            PyTorch object, the third value is the chain of tensor abstractions,
+            and the fourth object is the chain of gradients (.grad.grad, etc.)
+
+    Returns:
+        torch.Tensor: a torch tensor that was serialized
+    """
+    tensor_id = getattr(protobuf_tensor.id, protobuf_tensor.id.WhichOneof("id"))
+    tensor_bin = protobuf_tensor.bin
+    tags = protobuf_tensor.tags
+    description = protobuf_tensor.description
+    serializer = (
+        TENSOR_SERIALIZATION.TORCH
+    )  # TODO[karlhigley]: Fix this so the other serializer types also work
+
+    tensor = _deserialize_tensor(worker, serializer, tensor_bin)
+
+    # note we need to do this explicitly because torch.load does not
+    # include .grad information
+    if protobuf_tensor.HasField("grad_chain"):
+        grad_chain = protobuf_tensor.grad_chain
+        tensor.grad = _unbufferize_torch_tensor(worker, grad_chain)
+
+    initialize_tensor(
+        hook=syft.torch.hook, obj=tensor, owner=worker, id=tensor_id, init_args=[], init_kwargs={}
+    )
+
+    if protobuf_tensor.HasField("chain"):
+        chain = protobuf_tensor.chain
+        chain = syft.serde.protobuf.serde._unbufferize(worker, chain)
+        tensor.child = chain
+        tensor.is_wrapper = True
+
+    tensor.tags = set(tags)
+    tensor.description = description
+
+    return tensor
+
+
+# Maps a type to its bufferizer and unbufferizer functions
+MAP_TORCH_PROTOBUF_TRANSLATORS = OrderedDict(
+    {torch.Tensor: (_bufferize_torch_tensor, _unbufferize_torch_tensor)}
+)

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -268,13 +268,13 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             print(f"worker {self} sending {message} to {location}")
 
         # Step 1: serialize the message to a binary
-        bin_message = sy.serde.serialize(message, worker=self)
+        bin_message = sy.serde.protobuf.serde.serialize(message, worker=self)
 
         # Step 2: send the message and wait for a response
         bin_response = self._send_msg(bin_message, location)
 
         # Step 3: deserialize the response
-        response = sy.serde.deserialize(bin_response, worker=self)
+        response = sy.serde.protobuf.serde.deserialize(bin_response, worker=self)
 
         return response
 
@@ -298,7 +298,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             self.msg_history.append(bin_message)
 
         # Step 0: deserialize message
-        msg = sy.serde.deserialize(bin_message, worker=self)
+        msg = sy.serde.protobuf.serde.deserialize(bin_message, worker=self)
 
         if self.verbose:
             print(f"worker {self} received {type(msg).__name__} {msg.contents}")
@@ -307,7 +307,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         response = self._message_router[type(msg)](msg.contents)
 
         # Step 2: Serialize the message to simple python objects
-        bin_response = sy.serde.serialize(response, worker=self)
+        bin_response = sy.serde.protobuf.serde.serialize(response, worker=self)
 
         return bin_response
 
@@ -972,7 +972,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
 
         """
 
-        return sy.serde.deserialize(self.msg_history[index], worker=self)
+        return sy.serde.protobuf.serde.deserialize(self.msg_history[index], worker=self)
 
     @staticmethod
     def create_message_execute_command(

--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -74,7 +74,7 @@ class WebsocketClientWorker(BaseWorker):
     def search(self, query):
         # Prepare a message requesting the websocket server to search among its objects
         message = SearchMessage(query)
-        serialized_message = sy.serde.serialize(message)
+        serialized_message = sy.serde.protobuf.serde.serialize(message)
         # Send the message and return the deserialized response.
         response = self._send_msg(serialized_message)
         return sy.serde.deserialize(response)
@@ -111,7 +111,7 @@ class WebsocketClientWorker(BaseWorker):
         )
 
         # Send the message and return the deserialized response.
-        serialized_message = sy.serde.serialize(message)
+        serialized_message = sy.serde.protobuf.serde.serialize(message)
         response = self._send_msg(serialized_message)
         return sy.serde.deserialize(response)
 
@@ -151,7 +151,7 @@ class WebsocketClientWorker(BaseWorker):
             )
 
             # Send the message and return the deserialized response.
-            serialized_message = sy.serde.serialize(message)
+            serialized_message = sy.serde.protobuf.serde.serialize(message)
             await websocket.send(str(binascii.hexlify(serialized_message)))
             await websocket.recv()  # returned value will be None, so don't care
 
@@ -160,7 +160,7 @@ class WebsocketClientWorker(BaseWorker):
 
         # Send an object request message to retrieve the result tensor of the fit() method
         msg = ObjectRequestMessage(return_ids[0])
-        serialized_message = sy.serde.serialize(msg)
+        serialized_message = sy.serde.protobuf.serde.serialize(msg)
         response = self._send_msg(serialized_message)
 
         # Return the deserialized response.
@@ -184,7 +184,7 @@ class WebsocketClientWorker(BaseWorker):
 
         msg = ObjectRequestMessage((return_ids[0], None, ""))
         # Send the message and return the deserialized response.
-        serialized_message = sy.serde.serialize(msg)
+        serialized_message = sy.serde.protobuf.serde.serialize(msg)
         response = self._send_msg(serialized_message)
         return sy.serde.deserialize(response)
 

--- a/syft/workers/websocket_server.py
+++ b/syft/workers/websocket_server.py
@@ -123,7 +123,7 @@ class WebsocketServerWorker(VirtualWorker, FederatedClient):
         try:
             return self.recv_msg(message)
         except (ResponseSignatureError, GetNotPermittedError) as e:
-            return sy.serde.serialize(e)
+            return sy.serde.protobuf.serde.serialize(e)
 
     async def _handler(self, websocket: websockets.WebSocketCommonProtocol, *unused_args):
         """Setup the consumer and producer response handlers with asyncio.

--- a/test/test_serde_full.py
+++ b/test/test_serde_full.py
@@ -8,6 +8,7 @@ import io
 
 import syft
 from syft.serde import msgpack
+from syft.serde.protobuf import serde as protobuf_serde
 
 # Make dict of type codes
 CODE = OrderedDict()
@@ -45,9 +46,15 @@ def make_dict(**kwargs):
             "simplified": (
                 CODE[dict],
                 (
-                    (1, (CODE[str], (b"hello",))),  # [not simplified tuple]  # key  # value
-                    (2, (CODE[str], (b"world",))),
-                ),
+                    (  # [not simplified tuple]
+                        1,  # key
+                        (CODE[str], (b"hello",))  # value
+                    ),
+                    (
+                        2,
+                        (CODE[str], (b"world",))
+                    ),
+                )
             ),
         },
         {
@@ -59,10 +66,16 @@ def make_dict(**kwargs):
                         (CODE[str], (b"hello",)),  # key
                         (CODE[str], (b"world",)),  # value
                     ),
-                ),
-            ),
+                )
+            )
         },
-        {"value": {}, "simplified": (CODE[dict], tuple())},
+        {
+            "value": {},
+            "simplified": (
+                CODE[dict],
+                tuple()
+            )
+        },
     ]
 
 
@@ -73,16 +86,38 @@ def make_list(**kwargs):
             "value": ["hello", "world"],
             "simplified": (
                 CODE[list],
-                ((CODE[str], (b"hello",)), (CODE[str], (b"world",))),  # item
-            ),
+                (
+                    (CODE[str], (b"hello",)),  # item
+                    (CODE[str], (b"world",))
+                )
+            )
         },
-        {"value": ["hello"], "simplified": (CODE[list], ((CODE[str], (b"hello",)),))},  # item
-        {"value": [], "simplified": (CODE[list], tuple())},
+        {
+            "value": ["hello"],
+            "simplified": (
+                CODE[list],
+                (
+                    (CODE[str], (b"hello",)),  # item
+                )
+            )
+        },
+        {
+            "value": [],
+            "simplified": (
+                CODE[list],
+                tuple()
+            )
+        },
         # Tests that forced full simplify should return just simplified object if it doesn't have full simplifier
         {
             "forced": True,
             "value": ["hello"],
-            "simplified": (CODE[list], ((CODE[str], (b"hello",)),)),  # item
+            "simplified": (
+                CODE[list],
+                (
+                    (CODE[str], (b"hello",)),  # item
+                )
+            )
         },
     ]
 
@@ -92,15 +127,36 @@ def make_tuple(**kwargs):
     return [
         {
             "value": ("hello", "world"),
-            "simplified": (CODE[tuple], ((CODE[str], (b"hello",)), (CODE[str], (b"world",)))),
+            "simplified": (
+                CODE[tuple],
+                (
+                    (CODE[str], (b"hello",)),
+                    (CODE[str], (b"world",)),
+                )
+            )
         },
-        {"value": ("hello",), "simplified": (CODE[tuple], ((CODE[str], (b"hello",)),))},
-        {"value": tuple(), "simplified": (CODE[tuple], tuple())},
+        {
+            "value": ("hello",),
+            "simplified": (
+                CODE[tuple],
+                (
+                    (CODE[str], (b"hello",)),
+                )
+            )
+        },
+        {
+            "value": tuple(),
+            "simplified": (
+                CODE[tuple],
+                tuple()
+            )
+        },
     ]
 
 
 # Set.
 def make_set(**kwargs):
+
     def compare_simplified(actual, expected):
         """When set is simplified and converted to tuple, elements order in tuple is random
         We compare tuples as sets because the set order is undefined"""
@@ -111,56 +167,137 @@ def make_set(**kwargs):
     return [
         {
             "value": {"hello", "world"},
-            "simplified": (CODE[set], ((CODE[str], (b"world",)), (CODE[str], (b"hello",)))),
-            "cmp_simplified": compare_simplified,
+            "simplified": (
+                CODE[set],
+                (
+                    (CODE[str], (b"world",)),
+                    (CODE[str], (b"hello",)),
+                )
+            ),
+            "cmp_simplified": compare_simplified
         },
-        {"value": {"hello"}, "simplified": (CODE[set], ((CODE[str], (b"hello",)),))},
-        {"value": set([]), "simplified": (CODE[set], tuple())},
+        {
+            "value": {"hello"},
+            "simplified": (
+                CODE[set],
+                (
+                    (CODE[str], (b"hello",)),
+                )
+            )
+        },
+        {
+            "value": set([]),
+            "simplified": (
+                CODE[set],
+                tuple()
+            )
+        },
     ]
 
 
 # Slice.
 def make_slice(**kwargs):
     return [
-        {"value": slice(10, 20, 30), "simplified": (CODE[slice], (10, 20, 30))},
-        {"value": slice(10, 20), "simplified": (CODE[slice], (10, 20, None))},
-        {"value": slice(10), "simplified": (CODE[slice], (None, 10, None))},
+        {
+            "value": slice(10, 20, 30),
+            "simplified": (CODE[slice], (10, 20, 30))
+        },
+        {
+            "value": slice(10, 20),
+            "simplified": (CODE[slice], (10, 20, None))
+        },
+        {
+            "value": slice(10),
+            "simplified": (CODE[slice], (None, 10, None))
+        },
     ]
 
 
 # Range.
 def make_range(**kwargs):
     return [
-        {"value": range(1, 3, 4), "simplified": (CODE[range], (1, 3, 4))},
-        {"value": range(1, 3), "simplified": (CODE[range], (1, 3, 1))},
+        {
+            "value": range(1, 3, 4),
+            "simplified": (
+                CODE[range],
+                (
+                    1, 3, 4
+                )
+            )
+        },
+        {
+            "value": range(1, 3),
+            "simplified": (
+                CODE[range],
+                (
+                    1, 3, 1
+                )
+            )
+        }
     ]
 
 
 # String.
 def make_str(**kwargs):
     return [
-        {"value": "a string", "simplified": (CODE[str], (b"a string",))},
-        {"value": "", "simplified": (CODE[str], (b"",))},
+        {
+            "value": "a string",
+            "simplified": (
+                CODE[str],
+                (
+                    b"a string",
+                )
+            )
+        },
+        {
+            "value": "",
+            "simplified": (
+                CODE[str],
+                (
+                    b"",
+                )
+            )
+        }
     ]
 
 
 # Int.
 def make_int(**kwargs):
     return [
-        {"value": 5, "simplified": 5},
+        {
+            "value": 5,
+            "simplified": 5
+        },
         # Tests that forced full simplify should return just simplified object if it doesn't have full simplifier
-        {"forced": True, "value": 5, "simplified": 5},
+        {
+            "forced": True,
+            "value": 5,
+            "simplified": 5
+        },
     ]
 
 
 # Float.
 def make_float(**kwargs):
-    return [{"value": 5.1, "simplified": 5.1}]
+    return [
+        {
+            "value": 5.1,
+            "simplified": 5.1
+        }
+    ]
 
 
 # Ellipsis.
 def make_ellipsis(**kwargs):
-    return [{"value": ..., "simplified": (CODE[type(Ellipsis)], (b"",))}]
+    return [
+        {
+            "value": ...,
+            "simplified": (
+                CODE[type(Ellipsis)],
+                (b"",)
+            )
+        }
+    ]
 
 
 ########################################################################
@@ -184,10 +321,10 @@ def make_numpy_ndarray(**kwargs):
                 (
                     np_array.tobytes(),  # (bytes) serialized bin
                     (CODE[tuple], (2, 2)),  # (tuple) shape
-                    (CODE[str], (b"float64",)),  # (str) dtype.name
-                ),
+                    (CODE[str], (b"float64",))  # (str) dtype.name
+                )
             ),
-            "cmp_detailed": compare,
+            "cmp_detailed": compare
         }
     ]
 
@@ -202,9 +339,9 @@ def make_numpy_number(dtype, **kwargs):
                 CODE[dtype],
                 (
                     num.tobytes(),  # (bytes)
-                    (CODE[str], (num.dtype.name.encode("utf-8"),)),  # (str) dtype.name
-                ),
-            ),
+                    (CODE[str], (num.dtype.name.encode('utf-8'),)),  # (str) dtype.name
+                )
+            )
         }
     ]
 
@@ -243,13 +380,19 @@ def make_torch_device(**kwargs):
     return [
         {
             "value": torch_device,
-            "simplified": (CODE[type(torch_device)], ((CODE[str], (b"cpu",)),)),  # (str) device
+            "simplified": (
+                CODE[type(torch_device)],
+                (
+                    (CODE[str], (b"cpu",)),  # (str) device
+                )
+            )
         }
     ]
 
 
 # torch.jit.ScriptModule
 def make_torch_scriptmodule(**kwargs):
+
     class ScriptModule(torch.jit.ScriptModule):
         def __init__(self):
             super(ScriptModule, self).__init__()
@@ -264,15 +407,18 @@ def make_torch_scriptmodule(**kwargs):
             "value": sm,
             "simplified": (
                 CODE[torch.jit.ScriptModule],
-                (sm.save_to_buffer(),),  # (bytes) serialized torchscript
+                (
+                    sm.save_to_buffer(),  # (bytes) serialized torchscript
+                )
             ),
-            "cmp_detailed": compare_modules,
+            "cmp_detailed": compare_modules
         }
     ]
 
 
 # torch._C.Function
 def make_torch_cfunction(**kwargs):
+
     @torch.jit.script
     def func(x):  # pragma: no cover
         return x + 2
@@ -282,9 +428,11 @@ def make_torch_cfunction(**kwargs):
             "value": func,
             "simplified": (
                 CODE[torch._C.Function],
-                (func.save_to_buffer(),),  # (bytes) serialized torchscript
+                (
+                    func.save_to_buffer(),  # (bytes) serialized torchscript
+                )
             ),
-            "cmp_detailed": compare_modules,
+            "cmp_detailed": compare_modules
         }
     ]
 
@@ -313,9 +461,11 @@ def make_torch_topleveltracedmodule(**kwargs):
             "value": tm,
             "simplified": (
                 CODE[torch.jit.TopLevelTracedModule],
-                (tm.save_to_buffer(),),  # (bytes) serialized torchscript
+                (
+                    tm.save_to_buffer(),  # (bytes) serialized torchscript
+                )
             ),
-            "cmp_detailed": compare_modules,
+            "cmp_detailed": compare_modules
         }
     ]
 
@@ -343,7 +493,7 @@ def make_torch_parameter(**kwargs):
                     None,
                 ),
             ),
-            "cmp_detailed": compare,
+            "cmp_detailed": compare
         }
     ]
 
@@ -376,7 +526,7 @@ def make_torch_tensor(**kwargs):
                     None,  # (AbstractTensor) grad_chain
                     (CODE[set], ((CODE[str], (b"tag1",)),)),  # (set of str) tags
                     (CODE[str], (b"desc",)),  # (str) description
-                    (CODE[str], (b"torch",)),  # (str) framework
+                    (CODE[str], (b"torch",))  # (str) framework
                 ),
             ),
             "cmp_detailed": compare,
@@ -389,26 +539,20 @@ def make_torch_tensor(**kwargs):
                 CODE[torch.Tensor],
                 (
                     tensor.id,  # (int) id
-                    (
-                        CODE[tuple],
-                        (  # serialized tensor
-                            (CODE[tuple], (3, 3)),  # tensor.shape
-                            (CODE[str], (b"float32",)),  # tensor.dtype
-                            (
-                                CODE[list],
-                                tuple(tensor.flatten().tolist()),
-                            ),  # tensor contents as flat list
-                        ),
-                    ),
+                    (CODE[tuple], (  # serialized tensor
+                        (CODE[tuple], (3, 3)),  # tensor.shape
+                        (CODE[str], (b"float32",)),  # tensor.dtype
+                        (CODE[list], tuple(tensor.flatten().tolist())),  # tensor contents as flat list
+                    )),
                     None,  # (AbstractTensor) chain
                     None,  # (AbstractTensor) grad_chain
                     (CODE[set], ((CODE[str], (b"tag1",)),)),  # (set of str) tags
                     (CODE[str], (b"desc",)),  # (str) description
-                    (CODE[str], (b"all",)),  # (str) framework
+                    (CODE[str], (b"all",))  # (str) framework
                 ),
             ),
             "cmp_detailed": compare,
-        },
+        }
     ]
 
 
@@ -417,7 +561,12 @@ def make_torch_size(**kwargs):
     return [
         {
             "value": torch.randn(3, 3).size(),
-            "simplified": (CODE[torch.Size], (3, 3)),  # (int) *shape
+            "simplified": (
+                CODE[torch.Size],
+                (
+                    3, 3  # (int) *shape
+                )
+            )
         }
     ]
 
@@ -453,10 +602,8 @@ def make_additivesharingtensor(**kwargs):
                 (
                     ast.id,  # (int or str) id
                     ast.field,  # (int) field
-                    (CODE[str], (ast.crypto_provider.id.encode("utf-8"),)),  # (str) worker_id
-                    msgpack.serde._simplify(
-                        syft.hook.local_worker, ast.child
-                    ),  # (dict of AbstractTensor) simplified chain
+                    (CODE[str], (ast.crypto_provider.id.encode('utf-8'),)),  # (str) worker_id
+                    msgpack.serde._simplify(syft.hook.local_worker, ast.child),  # (dict of AbstractTensor) simplified chain
                 ),
             ),
             "cmp_detailed": compare,
@@ -634,7 +781,7 @@ def make_plan(**kwargs):
 
     with syft.hook.local_worker.registration_enabled():
         model_plan = Net()
-        model_plan.build(torch.tensor([1.0, 2.0, 3.0]))
+        model_plan.build(torch.tensor([1., 2., 3.]))
 
     def compare(detailed, original):
         assert type(detailed) == syft.messaging.plan.plan.Plan
@@ -705,7 +852,7 @@ def make_plan(**kwargs):
                 ),
             ),
             "cmp_detailed": compare,
-        },
+        }
     ]
 
 
@@ -770,16 +917,13 @@ def make_procedure(**kwargs):
             "simplified": (
                 CODE[syft.messaging.plan.procedure.Procedure],
                 (
-                    (
-                        CODE[list],
-                        (  # (list of Operation) operations
-                            procedure.operations[0],  # (unsimplified Operation)
-                            procedure.operations[1],
-                        ),
-                    ),
+                    (CODE[list], (  # (list of Operation) operations
+                        procedure.operations[0],  # (unsimplified Operation)
+                        procedure.operations[1],
+                    )),
                     (CODE[tuple], (procedure.arg_ids[0],)),  # (tuple) arg_ids
                     (CODE[tuple], (procedure.result_ids[0],)),  # (tuple) result_ids
-                    None,  # (int) promise_out_id
+                    None  # (int) promise_out_id
                 ),
             ),
             "cmp_detailed": compare,
@@ -910,7 +1054,7 @@ def make_pointerplan(**kwargs):
                     ptr.id,  # (int) id
                     ptr.id_at_location,  # (int) id_at_location
                     (CODE[str], (b"alice",)),  # (str) worker_id
-                    False,  # (bool) garbage_collect_data
+                    False  # (bool) garbage_collect_data
                 ),
             ),
             "cmp_detailed": compare,
@@ -1099,7 +1243,9 @@ def make_baseworker(**kwargs):
             "value": bob,
             "simplified": (
                 CODE[syft.workers.base.BaseWorker],
-                ((CODE[str], (b"bob",)),),  # id (str)
+                (
+                    (CODE[str], (b"bob",)),  # id (str)
+                )
             ),
             "cmp_detailed": compare,
         },
@@ -1255,7 +1401,9 @@ def make_message(**kwargs):
             "value": syft.messaging.message.Message([1, 2, 3]),
             "simplified": (
                 CODE[syft.messaging.message.Message],
-                ((CODE[list], (1, 2, 3)),),  # (Any) simplified content
+                (
+                    (CODE[list], (1, 2, 3)),  # (Any) simplified content
+                )
             ),
             "cmp_detailed": compare,
         },
@@ -1263,7 +1411,9 @@ def make_message(**kwargs):
             "value": syft.messaging.message.Message((1, 2, 3)),
             "simplified": (
                 CODE[syft.messaging.message.Message],
-                ((CODE[tuple], (1, 2, 3)),),  # (Any) simplified content
+                (
+                    (CODE[tuple], (1, 2, 3)),  # (Any) simplified content
+                )
             ),
             "cmp_detailed": compare,
         },
@@ -1464,7 +1614,9 @@ def make_forceobjectdeletemessage(**kwargs):
             "value": del_message,
             "simplified": (
                 CODE[syft.messaging.message.ForceObjectDeleteMessage],
-                (id,),  # (int) id
+                (
+                    id,  # (int) id
+                ),
             ),
             "cmp_detailed": compare,
         }
@@ -1485,7 +1637,9 @@ def make_searchmessage(**kwargs):
             "value": search_message,
             "simplified": (
                 CODE[syft.messaging.message.SearchMessage],
-                ((CODE[list], (1, (CODE[str], (b"test",)), 3)),),  # (Any) message
+                (
+                    (CODE[list], (1, (CODE[str], (b"test",)), 3)),  # (Any) message
+                ),
             ),
             "cmp_detailed": compare,
         }
@@ -1551,7 +1705,7 @@ def make_getnotpermittederror(**kwargs):
                     msgpack.serde._simplify(
                         syft.hook.local_worker,
                         "Traceback (most recent call last):\n"
-                        + "".join(traceback.format_tb(err.__traceback__)),
+                        + "".join(traceback.format_tb(err.__traceback__))
                     ),  # (str) traceback
                     (CODE[dict], tuple()),  # (dict) attributes
                 ),
@@ -1587,7 +1741,7 @@ def make_responsesignatureerror(**kwargs):
                     msgpack.serde._simplify(
                         syft.hook.local_worker,
                         "Traceback (most recent call last):\n"
-                        + "".join(traceback.format_tb(err.__traceback__)),
+                        + "".join(traceback.format_tb(err.__traceback__))
                     ),  # (str) traceback
                     msgpack.serde._simplify(
                         syft.hook.local_worker, err.get_attributes()
@@ -1631,15 +1785,9 @@ samples[torch.Tensor] = make_torch_tensor
 samples[torch.Size] = make_torch_size
 
 # PySyft
-samples[
-    syft.frameworks.torch.tensors.interpreters.additive_shared.AdditiveSharingTensor
-] = make_additivesharingtensor
-samples[
-    syft.frameworks.torch.tensors.interpreters.precision.FixedPrecisionTensor
-] = make_fixedprecisiontensor
-samples[
-    syft.frameworks.torch.tensors.interpreters.crt_precision.CRTPrecisionTensor
-] = make_crtprecisiontensor
+samples[syft.frameworks.torch.tensors.interpreters.additive_shared.AdditiveSharingTensor] = make_additivesharingtensor
+samples[syft.frameworks.torch.tensors.interpreters.precision.FixedPrecisionTensor] = make_fixedprecisiontensor
+samples[syft.frameworks.torch.tensors.interpreters.crt_precision.CRTPrecisionTensor] = make_crtprecisiontensor
 samples[syft.frameworks.torch.tensors.decorators.logging.LoggingTensor] = make_loggingtensor
 samples[syft.generic.pointers.multi_pointer.MultiPointerTensor] = make_multipointertensor
 samples[syft.messaging.plan.plan.Plan] = make_plan
@@ -1670,9 +1818,8 @@ samples[syft.messaging.message.PlanCommandMessage] = make_plancommandmessage
 samples[syft.exceptions.GetNotPermittedError] = make_getnotpermittederror
 samples[syft.exceptions.ResponseSignatureError] = make_responsesignatureerror
 
-# Dynamically added to msgpack.serde.simplifiers by some other test
+# Dynamically added to serde.simplifiers by some other test
 samples[syft.workers.virtual.VirtualWorker] = make_baseworker
-
 
 def test_serde_coverage():
     """Checks all types in serde are tested"""
@@ -1712,6 +1859,37 @@ def test_serde_roundtrip(cls, workers):
 
 
 @pytest.mark.parametrize("cls", samples)
+def test_serde_roundtrip_protobuf(cls, workers):
+    """Checks that values passed through serialization-deserialization stay same"""
+    _samples = samples[cls](workers=workers)
+    for sample in _samples:
+        _to_protobuf = (
+            protobuf_serde._bufferize
+            if not sample.get("forced", False)
+            else protobuf_serde._force_full_bufferize
+        )
+        serde_worker = syft.hook.local_worker
+        serde_worker.framework = sample.get("framework", torch)
+        if serde_worker.framework:
+            obj = sample.get("value")
+            protobuf_obj = _to_protobuf(serde_worker, obj)
+            if not isinstance(obj, Exception):
+                roundtrip_obj = protobuf_serde._unbufferize(serde_worker, protobuf_obj)
+            else:
+                try:
+                    protobuf_serde._unbufferize(serde_worker, protobuf_obj)
+                except Exception as e:
+                    roundtrip_obj = e
+
+            if sample.get("cmp_detailed", None):
+                # Custom detailed objects comparison function.
+                assert sample.get("cmp_detailed")(roundtrip_obj, obj) is True
+            else:
+                assert type(roundtrip_obj) == type(obj)
+                assert roundtrip_obj == obj
+
+
+@pytest.mark.parametrize("cls", samples)
 def test_serde_simplify(cls, workers):
     """Checks that simplified structures match expected"""
     _samples = samples[cls](workers=workers)
@@ -1731,3 +1909,4 @@ def test_serde_simplify(cls, workers):
             assert sample.get("cmp_simplified")(simplified_obj, expected_simplified_obj) is True
         else:
             assert simplified_obj == expected_simplified_obj
+


### PR DESCRIPTION
This PR will add `bufferize` and `unbufferize` to the classes that currently define `simplify` and `detail` in order to provide de/serialization for Protobuf (instead of msgpack.)

Depends on OpenMined/syft-proto#12.