### PR TITLE
Change `Operation` constructor to take named args (instead of tuple)

### DIFF
--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -126,10 +126,10 @@ class Operation(Message):
         # call the parent constructor - setting the type integer correctly
         super().__init__()
 
-        self.command_name = cmd_name
-        self.command_owner = cmd_owner
-        self.args = cmd_args
-        self.kwargs = cmd_kwargs
+        self.cmd_name = cmd_name
+        self.cmd_owner = cmd_owner
+        self.cmd_args = cmd_args
+        self.cmd_kwargs = cmd_kwargs
         self.return_ids = return_ids
 
     @property
@@ -142,7 +142,7 @@ class Operation(Message):
         self.message and self.return_ids, which allows for more efficient simplification (we don't have to
         simplify return_ids because they are always a list of integers, meaning they're already simplified)."""
 
-        message = (self.command_name, self.command_owner, self.args, self.kwargs)
+        message = (self.cmd_name, self.cmd_owner, self.cmd_args, self.cmd_kwargs)
 
         return (message, self.return_ids)
 
@@ -160,7 +160,7 @@ class Operation(Message):
         """
         # NOTE: we can skip calling _simplify on return_ids because they should already be
         # a list of simple types.
-        message = (ptr.command_name, ptr.command_owner, ptr.args, ptr.kwargs)
+        message = (ptr.cmd_name, ptr.cmd_owner, ptr.cmd_args, ptr.cmd_kwargs)
 
         return (
             sy.serde.msgpack.serde._simplify(worker, message),

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -109,7 +109,7 @@ class Operation(Message):
     worker to take two tensors and add them together is an operation. However, sending an object
     from one worker to another is not an operation (and would instead use the ObjectMessage type)."""
 
-    def __init__(self, message, return_ids):
+    def __init__(self, cmd_name, cmd_owner, cmd_args, cmd_kwargs, return_ids):
         """Initialize an operation message
 
         Args:
@@ -126,11 +126,10 @@ class Operation(Message):
         # call the parent constructor - setting the type integer correctly
         super().__init__()
 
-        self.command_name = message[0]
-        self.command_owner = message[1]
-        self.args = message[2]
-        self.kwargs = message[3]
-
+        self.command_name = cmd_name
+        self.command_owner = cmd_owner
+        self.args = cmd_args
+        self.kwargs = cmd_kwargs
         self.return_ids = return_ids
 
     @property
@@ -183,10 +182,18 @@ class Operation(Message):
         Examples:
             message = detail(sy.local_worker, msg_tuple)
         """
-        return Operation(
-            sy.serde.msgpack.serde._detail(worker, msg_tuple[0]),
-            sy.serde.msgpack.serde._detail(worker, msg_tuple[1]),
-        )
+        message = msg_tuple[0]
+        return_ids = msg_tuple[1]
+
+        detailed_msg = sy.serde.msgpack.serde._detail(worker, message)
+        detailed_ids = sy.serde.msgpack.serde._detail(worker, return_ids)
+
+        cmd_name = detailed_msg[0]
+        cmd_owner = detailed_msg[1]
+        cmd_args = detailed_msg[2]
+        cmd_kwargs = detailed_msg[3]
+
+        return Operation(cmd_name, cmd_owner, cmd_args, cmd_kwargs, detailed_ids)
 
 
 class ObjectMessage(Message):

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -126,7 +126,11 @@ class Operation(Message):
         # call the parent constructor - setting the type integer correctly
         super().__init__()
 
-        self.message = message
+        self.command_name = message[0]
+        self.command_owner = message[1]
+        self.args = message[2]
+        self.kwargs = message[3]
+
         self.return_ids = return_ids
 
     @property
@@ -139,7 +143,9 @@ class Operation(Message):
         self.message and self.return_ids, which allows for more efficient simplification (we don't have to
         simplify return_ids because they are always a list of integers, meaning they're already simplified)."""
 
-        return (self.message, self.return_ids)
+        message = (self.command_name, self.command_owner, self.args, self.kwargs)
+
+        return (message, self.return_ids)
 
     @staticmethod
     def simplify(worker: AbstractWorker, ptr: "Operation") -> tuple:
@@ -155,8 +161,10 @@ class Operation(Message):
         """
         # NOTE: we can skip calling _simplify on return_ids because they should already be
         # a list of simple types.
+        message = (ptr.command_name, ptr.command_owner, ptr.args, ptr.kwargs)
+
         return (
-            sy.serde.msgpack.serde._simplify(worker, ptr.message),
+            sy.serde.msgpack.serde._simplify(worker, message),
             sy.serde.msgpack.serde._simplify(worker, ptr.return_ids),
         )
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -994,7 +994,7 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         """
         if return_ids is None:
             return_ids = []
-        return Operation((command_name, command_owner, args, kwargs), return_ids)
+        return Operation(command_name, command_owner, args, kwargs, return_ids)
 
     @property
     def serializer(self, workers=None) -> codes.TENSOR_SERIALIZATION:

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -482,14 +482,14 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         return command(*args)
 
     def send_command(
-        self, recipient: "BaseWorker", message: str, return_ids: str = None
+        self, recipient: "BaseWorker", message: tuple, return_ids: str = None
     ) -> Union[List[PointerTensor], PointerTensor]:
         """
         Sends a command through a message to a recipient worker.
 
         Args:
             recipient: A recipient worker.
-            message: A string representing the message being sent.
+            message: A tuple representing the message being sent.
             return_ids: A list of strings indicating the ids of the
                 tensors that should be returned as response to the command execution.
 
@@ -499,8 +499,15 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         if return_ids is None:
             return_ids = tuple([sy.ID_PROVIDER.pop()])
 
+        cmd_name = message[0]
+        cmd_owner = message[1]
+        cmd_args = message[2]
+        cmd_kwargs = message[3]
+
         try:
-            ret_val = self.send_msg(Operation(message, return_ids), location=recipient)
+            ret_val = self.send_msg(
+                Operation(cmd_name, cmd_owner, cmd_args, cmd_kwargs, return_ids), location=recipient
+            )
         except ResponseSignatureError as e:
             ret_val = None
             return_ids = e.ids_generated

--- a/test/test_serde_full.py
+++ b/test/test_serde_full.py
@@ -1280,14 +1280,28 @@ def make_operation(**kwargs):
     bob.log_msgs = False
 
     def compare(detailed, original):
+        detailed_msg = (
+            detailed.cmd_name,
+            detailed.cmd_owner,
+            detailed.cmd_args,
+            detailed.cmd_kwargs,
+        )
+        original_msg = (
+            original.cmd_name,
+            original.cmd_owner,
+            original.cmd_args,
+            original.cmd_kwargs,
+        )
         assert type(detailed) == syft.messaging.message.Operation
-        for i in range(len(original.message)):
-            if type(original.message[i]) != torch.Tensor:
-                assert detailed.message[i] == original.message[i]
+        for i in range(len(original_msg)):
+            if type(original_msg[i]) != torch.Tensor:
+                assert detailed_msg[i] == original_msg[i]
             else:
-                assert detailed.message[i].equal(original.message[i])
+                assert detailed_msg[i].equal(original_msg[i])
         assert detailed.return_ids == original.return_ids
         return True
+
+    message = (op.cmd_name, op.cmd_owner, op.cmd_args, op.cmd_kwargs)
 
     return [
         {
@@ -1295,7 +1309,7 @@ def make_operation(**kwargs):
             "simplified": (
                 CODE[syft.messaging.message.Operation],
                 (
-                    msgpack.serde._simplify(syft.hook.local_worker, op.message),  # (Any) message
+                    msgpack.serde._simplify(syft.hook.local_worker, message),  # (Any) message
                     (CODE[tuple], (op.return_ids[0],)),  # (tuple) return_ids
                 ),
             ),


### PR DESCRIPTION
This change sacrifices some generality in order to make the actually-in-use contents more explicit and visible. It's a bit awkward in the current code, but should make it easier to construct Protobuf schemas with appropriate types for the parameters. Some of the awkwardness comes from maintaining backwards compatibility for msgpack serialization, some of it comes from the structure of the code that sends commands. It may still be possible to push these named arguments "farther out" into the code that sends commands, which could either be added to this PR or saved for a later one.