### PR TITLE
Add Protobuf serialization for `torch.Tensor` 

### DIFF
--- a/syft/serde/msgpack/torch_serde.py
+++ b/syft/serde/msgpack/torch_serde.py
@@ -19,27 +19,8 @@ from syft.workers.abstract import AbstractWorker
 from syft.serde.msgpack import serde
 from syft.codes import TENSOR_SERIALIZATION
 
-# Torch dtypes to string (and back) mappers
-TORCH_DTYPE_STR = {
-    torch.uint8: "uint8",
-    torch.int8: "int8",
-    torch.int16: "int16",
-    torch.int32: "int32",
-    torch.int64: "int64",
-    torch.float16: "float16",
-    torch.float32: "float32",
-    torch.float64: "float64",
-    torch.complex32: "complex32",
-    torch.complex64: "complex64",
-    torch.complex128: "complex128",
-    torch.bool: "bool",
-    torch.qint8: "qint8",
-    torch.quint8: "quint8",
-    torch.qint32: "qint32",
-    torch.bfloat16: "bfloat16",
-}
-TORCH_STR_DTYPE = {name: cls for cls, name in TORCH_DTYPE_STR.items()}
-
+from syft.serde.torch.serde import TORCH_DTYPE_STR
+from syft.serde.torch.serde import TORCH_STR_DTYPE
 
 def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
     """Serialize the tensor using as default Torch serialization strategy

--- a/syft/serde/msgpack/torch_serde.py
+++ b/syft/serde/msgpack/torch_serde.py
@@ -21,6 +21,11 @@ from syft.codes import TENSOR_SERIALIZATION
 
 from syft.serde.torch.serde import TORCH_DTYPE_STR
 from syft.serde.torch.serde import TORCH_STR_DTYPE
+from syft.serde.torch.serde import torch_tensor_serializer
+from syft.serde.torch.serde import torch_tensor_deserializer
+from syft.serde.torch.serde import numpy_tensor_serializer
+from syft.serde.torch.serde import numpy_tensor_deserializer
+
 
 def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
     """Serialize the tensor using as default Torch serialization strategy
@@ -36,7 +41,7 @@ def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
     serializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_serializer,
         TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
-        TENSOR_SERIALIZATION.ALL: generic_tensor_serializer,
+        TENSOR_SERIALIZATION.ALL: simplified_tensor_serializer,
     }
     if worker.serializer not in serializers:
         raise NotImplementedError(
@@ -61,7 +66,7 @@ def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> 
     deserializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_deserializer,
         TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
-        TENSOR_SERIALIZATION.ALL: generic_tensor_deserializer,
+        TENSOR_SERIALIZATION.ALL: simplified_tensor_deserializer,
     }
     if serializer not in deserializers:
         raise NotImplementedError(
@@ -71,26 +76,7 @@ def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> 
     return deserializer(worker, tensor_bin)
 
 
-def numpy_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
-    """Strategy to serialize a tensor using numpy npy format.
-    If tensor requires to calculate gradients, it will be detached.
-    """
-    if tensor.requires_grad:
-        warnings.warn(
-            "Torch to Numpy serializer can only be used with tensors that do not require grad. "
-            "Detaching tensor to continue"
-        )
-        tensor = tensor.detach()
-
-    np_tensor = tensor.numpy()
-    outfile = TemporaryFile()
-    numpy.save(outfile, np_tensor)
-    # Simulate close and open by calling seek
-    outfile.seek(0)
-    return outfile.read()
-
-
-def generic_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> tuple:
+def simplified_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> tuple:
     """Strategy to serialize a tensor to native python types.
     If tensor requires to calculate gradients, it will be detached.
     """
@@ -105,34 +91,12 @@ def generic_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> t
     return serde._simplify(worker, tensor_tuple)
 
 
-def generic_tensor_deserializer(worker: AbstractWorker, tensor_tuple: tuple) -> torch.Tensor:
+def simplified_tensor_deserializer(worker: AbstractWorker, tensor_tuple: tuple) -> torch.Tensor:
     """"Strategy to deserialize a simplified tensor into a Torch tensor"""
 
     size, dtype, data_arr = serde._detail(worker, tensor_tuple)
     tensor = torch.tensor(data_arr, dtype=TORCH_STR_DTYPE[dtype]).reshape(size)
     return tensor
-
-
-def numpy_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
-    """"Strategy to deserialize a binary input in npy format into a Torch tensor"""
-    input_file = TemporaryFile()
-    input_file.write(tensor_bin)
-    # read data from file
-    input_file.seek(0)
-    return torch.from_numpy(numpy.load(input_file))
-
-
-def torch_tensor_serializer(worker: AbstractWorker, tensor) -> bin:
-    """Strategy to serialize a tensor using Torch saver"""
-    binary_stream = io.BytesIO()
-    torch.save(tensor, binary_stream)
-    return binary_stream.getvalue()
-
-
-def torch_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
-    """"Strategy to deserialize a binary input using Torch load"""
-    bin_tensor_stream = io.BytesIO(tensor_bin)
-    return torch.load(bin_tensor_stream)
 
 
 # Simplify/Detail Torch Tensors

--- a/syft/serde/protobuf/__init__.py
+++ b/syft/serde/protobuf/__init__.py
@@ -1,6 +1,7 @@
+from syft.serde.protobuf import proto
 from syft.serde.protobuf import serde
 from syft.serde.protobuf import native_serde
-from syft.serde.protobuf import proto
+from syft.serde.protobuf import torch_serde
 
 from syft.serde.protobuf.serde import serialize
 from syft.serde.protobuf.serde import deserialize

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -12,10 +12,7 @@ from google.protobuf.empty_pb2 import Empty
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 
 
-MAP_PYTHON_TO_PROTOBUF_CLASSES = {
-    type(None): Empty,
-    torch.Tensor: TorchTensorPB,
-}
+MAP_PYTHON_TO_PROTOBUF_CLASSES = {type(None): Empty, torch.Tensor: TorchTensorPB}
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
 

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -6,10 +6,16 @@ not only by PySyft but also in other languages.
 https://github.com/OpenMined/syft-proto (`syft_proto` module) is included as
 a dependency in setup.py.
 """
+import torch
+
 from google.protobuf.empty_pb2 import Empty
+from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 
 
-MAP_PYTHON_TO_PROTOBUF_CLASSES = {type(None): Empty}
+MAP_PYTHON_TO_PROTOBUF_CLASSES = {
+    type(None): Empty,
+    torch.Tensor: TorchTensorPB,
+}
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
 

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -8,12 +8,13 @@ from syft.serde.protobuf.native_serde import MAP_NATIVE_PROTOBUF_TRANSLATORS
 from syft.workers.abstract import AbstractWorker
 
 from syft_proto.messaging.v1.message_pb2 import SyftMessage as SyftMessagePB
+from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 
 
-# if dependency_check.torch_available:
-#     from syft.serde.protobuf.torch_serde import MAP_TORCH_PROTOBUF_TRANSLATORS
-# else:
-#     MAP_TORCH_PROTOBUF_TRANSLATORS = {}
+if dependency_check.torch_available:
+    from syft.serde.protobuf.torch_serde import MAP_TORCH_PROTOBUF_TRANSLATORS
+else:
+    MAP_TORCH_PROTOBUF_TRANSLATORS = {}
 
 # if dependency_check.tensorflow_available:
 #     from syft_tensorflow.serde import MAP_TF_PROTOBUF_TRANSLATORS
@@ -26,7 +27,7 @@ from syft.serde.protobuf.proto import MAP_PYTHON_TO_PROTOBUF_CLASSES
 # Maps a type to its bufferizer and unbufferizer functions
 MAP_TO_PROTOBUF_TRANSLATORS = OrderedDict(
     list(MAP_NATIVE_PROTOBUF_TRANSLATORS.items())
-    # + list(MAP_TORCH_PROTOBUF_TRANSLATORS.items())
+    + list(MAP_TORCH_PROTOBUF_TRANSLATORS.items())
     # + list(MAP_TF_PROTOBUF_TRANSLATORS.items())
 )
 
@@ -272,6 +273,15 @@ def deserialize(binary: bin, worker: AbstractWorker = None, unbufferizes=True) -
     message_type = msg_wrapper.WhichOneof("contents")
     python_obj = _unbufferize(worker, getattr(msg_wrapper, message_type))
     return python_obj
+
+
+def create_protobuf_id(id) -> IdPB:
+    protobuf_id = IdPB()
+    if type(id) == type("str"):
+        protobuf_id.id_str = id
+    else:
+        protobuf_id.id_int = id
+    return protobuf_id
 
 
 def _bufferize(worker: AbstractWorker, obj: object, **kwargs) -> object:

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -133,9 +133,11 @@ def protobuf_tensor_deserializer(
 
 def _bufferize_torch_tensor(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
     """
-    This function converts a torch tensor into a serliaized torch tensor
-    using pickle. We choose to use this because PyTorch has a custom and
-    very fast PyTorch pickler.
+    This function converts a Torch tensor into a serialized tensor
+    using Protobuf. Depending on the worker's serializer, the tensor
+    contents may be serialized to binary representations using Torch
+    or Numpy, or to a generic inner Protobuf message for cross-platform
+    communication.
 
     Args:
         tensor (torch.Tensor): an input tensor to be serialized

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -1,0 +1,216 @@
+"""
+This file exists to provide one common place for all serialisation and bufferize_ and _unbufferize
+for all tensors (Torch and Numpy).
+"""
+from collections import OrderedDict
+import io
+from tempfile import TemporaryFile
+from typing import Tuple, List
+import warnings
+
+import numpy
+import torch
+
+import syft
+from syft.generic.pointers.pointer_tensor import PointerTensor
+from syft.generic.tensor import initialize_tensor
+from syft.generic.tensor import AbstractTensor
+from syft.workers.abstract import AbstractWorker
+from syft.codes import TENSOR_SERIALIZATION
+
+from syft.serde.torch.serde import TORCH_DTYPE_STR
+from syft.serde.torch.serde import TORCH_STR_DTYPE
+from syft.serde.torch.serde import torch_tensor_serializer
+from syft.serde.torch.serde import torch_tensor_deserializer
+from syft.serde.torch.serde import numpy_tensor_serializer
+from syft.serde.torch.serde import numpy_tensor_deserializer
+
+from syft_proto.types.syft.v1.shape_pb2 import Shape as ShapePB
+from syft_proto.types.syft.v1.tensor_pb2 import SyftTensor as SyftTensorPB
+from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
+
+
+def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
+    """Serialize the tensor using as default Torch serialization strategy
+    This function can be overridden to provide different tensor serialization strategies
+
+    Args
+        (torch.Tensor): an input tensor to be serialized
+
+    Returns
+        A serialized version of the input tensor
+
+    """
+    serializers = {
+        TENSOR_SERIALIZATION.TORCH: torch_tensor_serializer,
+        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
+        TENSOR_SERIALIZATION.ALL: protobuf_tensor_serializer
+    }
+    if worker.serializer not in serializers:
+        raise NotImplementedError(
+            f"Tensor serialization strategy is not supported: {worker.serializer}"
+        )
+    serializer = serializers[worker.serializer]
+    return serializer(worker, tensor)
+
+
+def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> torch.Tensor:
+    """Deserialize the input tensor passed as parameter into a Torch tensor.
+    `serializer` parameter selects different deserialization strategies
+
+    Args
+        worker: Worker
+        serializer: Strategy used for tensor deserialization (e.g.: torch, numpy, all)
+        tensor_bin: A simplified representation of a tensor
+
+    Returns
+        a Torch tensor
+    """
+    deserializers = {
+        TENSOR_SERIALIZATION.TORCH: torch_tensor_deserializer,
+        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_deserializer,
+        TENSOR_SERIALIZATION.ALL: protobuf_tensor_deserializer
+    }
+    if serializer not in deserializers:
+        raise NotImplementedError(
+            f"Cannot deserialize tensor serialized with '{serializer}' strategy"
+        )
+    deserializer = deserializers[serializer]
+    return deserializer(worker, tensor_bin)
+
+
+def protobuf_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> SyftTensorPB:
+    """Strategy to serialize a tensor using Protobuf"""
+    protobuf_tensor = SyftTensorPB()
+    protobuf_tensor.shape.dims.extend(tensor.size())
+    protobuf_tensor.contents.extend(torch.flatten(tensor).tolist())
+    return protobuf_tensor
+
+
+def protobuf_tensor_deserializer(worker: AbstractWorker, tensor: SyftTensorPB) -> torch.Tensor:
+    """"Strategy to deserialize a binary input using Protobuf"""
+    flattened_tensor = torch.Tensor(tensor.contents)
+    size = tuple(tensor.shape.dims)
+    return flattened_tensor.reshape(size)
+
+
+# Bufferize/Unbufferize Torch Tensors
+
+
+def _bufferize_torch_tensor(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
+    """
+    This function converts a torch tensor into a serliaized torch tensor
+    using pickle. We choose to use this because PyTorch has a custom and
+    very fast PyTorch pickler.
+
+    Args:
+        tensor (torch.Tensor): an input tensor to be serialized
+
+    Returns:
+        protobuf_obj: Protobuf version of torch tensor.
+    """
+    serialized_tensor = _serialize_tensor(worker, tensor)
+
+    if tensor.grad is not None:
+        if hasattr(tensor, "child"):
+            if isinstance(tensor.child, PointerTensor):
+                grad_chain = None
+            else:
+                grad_chain = _bufferize_torch_tensor(worker, tensor.grad)
+        else:
+            grad_chain = _bufferize_torch_tensor(worker, tensor.grad)
+
+    else:
+        grad_chain = None
+
+    chain = None
+    if hasattr(tensor, "child"):
+        chain = syft.serde.protobuf.serde._bufferize(worker, tensor.child)
+
+    protobuf_tensor = TorchTensorPB()
+
+    protobuf_tensor.id.CopyFrom(syft.serde.protobuf.serde.create_protobuf_id(tensor.id))
+
+    protobuf_tensor.shape.dims.extend(tensor.shape)
+
+    if worker.serializer == TENSOR_SERIALIZATION.TORCH:
+        protobuf_tensor.contents_bin = serialized_tensor
+        protobuf_tensor.serializer = TorchTensorPB.Serializer.SERIALIZER_TORCH
+    elif worker.serializer == TENSOR_SERIALIZATION.NUMPY:
+        protobuf_tensor.contents_bin = serialized_tensor
+        protobuf_tensor.serializer = TorchTensorPB.Serializer.SERIALIZER_TORCH
+    elif worker.serializer == TENSOR_SERIALIZATION.ALL:
+        protobuf_tensor.contents.CopyFrom(serialized_tensor)
+        protobuf_tensor.serializer = TorchTensorPB.Serializer.SERIALIZER_ALL
+    else:
+        protobuf_tensor.contents_bin = serialized_tensor
+        protobuf_tensor.serializer = TorchTensorPB.Serializer.SERIALIZER_UNSPECIFIED    
+
+    if chain:
+        protobuf_tensor.chain.CopyFrom(chain)
+    if grad_chain:
+        protobuf_tensor.grad_chain.CopyFrom(grad_chain)
+    if tensor.description:
+        protobuf_tensor.description = tensor.description
+
+    protobuf_tensor.tags.extend(tensor.tags)
+
+    return protobuf_tensor
+
+
+def _unbufferize_torch_tensor(worker: AbstractWorker, protobuf_tensor: "TensorPB") -> torch.Tensor:
+    """
+    This function converts a serialized torch tensor into a torch tensor
+    using pickle.
+
+    Args:
+        tensor_tuple (bin): serialized obj of torch tensor. It's a tuple where
+            the first value is the ID, the second vlaue is the binary for the
+            PyTorch object, the third value is the chain of tensor abstractions,
+            and the fourth object is the chain of gradients (.grad.grad, etc.)
+
+    Returns:
+        torch.Tensor: a torch tensor that was serialized
+    """
+    tensor_id = getattr(protobuf_tensor.id, protobuf_tensor.id.WhichOneof("id"))
+    tags = protobuf_tensor.tags
+    description = protobuf_tensor.description
+
+    serializer = ""
+    serialized_tensor = protobuf_tensor.contents_bin
+    if protobuf_tensor.serializer == TorchTensorPB.Serializer.SERIALIZER_TORCH:        
+        serializer = TENSOR_SERIALIZATION.TORCH
+    elif protobuf_tensor.serializer == TorchTensorPB.Serializer.SERIALIZER_NUMPY:
+        serializer = TENSOR_SERIALIZATION.NUMPY
+    elif protobuf_tensor.serializer == TorchTensorPB.Serializer.SERIALIZER_ALL:
+        serializer = TENSOR_SERIALIZATION.ALL
+        serialized_tensor = protobuf_tensor.contents
+
+    tensor = _deserialize_tensor(worker, (serializer), serialized_tensor)
+
+    # note we need to do this explicitly because torch.load does not
+    # include .grad information
+    if protobuf_tensor.HasField("grad_chain"):
+        grad_chain = protobuf_tensor.grad_chain
+        tensor.grad = _unbufferize_torch_tensor(worker, grad_chain)
+
+    initialize_tensor(
+        hook=syft.torch.hook, obj=tensor, owner=worker, id=tensor_id, init_args=[], init_kwargs={}
+    )
+
+    if protobuf_tensor.HasField("chain"):
+        chain = protobuf_tensor.chain
+        chain = syft.serde.protobuf.serde._unbufferize(worker, chain)
+        tensor.child = chain
+        tensor.is_wrapper = True
+
+    tensor.tags = set(tags)
+    tensor.description = description
+
+    return tensor
+
+
+# Maps a type to its bufferizer and unbufferizer functions
+MAP_TORCH_PROTOBUF_TRANSLATORS = OrderedDict(
+    {torch.Tensor: (_bufferize_torch_tensor, _unbufferize_torch_tensor)}
+)

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -26,7 +26,7 @@ from syft.serde.torch.serde import numpy_tensor_serializer
 from syft.serde.torch.serde import numpy_tensor_deserializer
 
 from syft_proto.types.syft.v1.shape_pb2 import Shape as ShapePB
-from syft_proto.types.syft.v1.tensor_pb2 import SyftTensor as SyftTensorPB
+from syft_proto.types.torch.v1.tensor_data_pb2 import TensorData as TensorDataPB
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 
 
@@ -79,11 +79,11 @@ def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> 
     return deserializer(worker, tensor_bin)
 
 
-def protobuf_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> SyftTensorPB:
+def protobuf_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> TensorDataPB:
     """Strategy to serialize a tensor using Protobuf"""
     dtype = TORCH_DTYPE_STR[tensor.dtype]
 
-    protobuf_tensor = SyftTensorPB()
+    protobuf_tensor = TensorDataPB()
 
     if tensor.is_quantized:
         protobuf_tensor.is_quantized = True
@@ -101,7 +101,7 @@ def protobuf_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> 
 
 
 def protobuf_tensor_deserializer(
-    worker: AbstractWorker, protobuf_tensor: SyftTensorPB
+    worker: AbstractWorker, protobuf_tensor: TensorDataPB
 ) -> torch.Tensor:
     """"Strategy to deserialize a binary input using Protobuf"""
     size = tuple(protobuf_tensor.shape.dims)

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -44,7 +44,7 @@ def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
     serializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_serializer,
         TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
-        TENSOR_SERIALIZATION.ALL: protobuf_tensor_serializer
+        TENSOR_SERIALIZATION.ALL: protobuf_tensor_serializer,
     }
     if worker.serializer not in serializers:
         raise NotImplementedError(
@@ -69,7 +69,7 @@ def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> 
     deserializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_deserializer,
         TENSOR_SERIALIZATION.NUMPY: numpy_tensor_deserializer,
-        TENSOR_SERIALIZATION.ALL: protobuf_tensor_deserializer
+        TENSOR_SERIALIZATION.ALL: protobuf_tensor_deserializer,
     }
     if serializer not in deserializers:
         raise NotImplementedError(
@@ -144,7 +144,7 @@ def _bufferize_torch_tensor(worker: AbstractWorker, tensor: torch.Tensor) -> bin
         protobuf_tensor.serializer = TorchTensorPB.Serializer.SERIALIZER_ALL
     else:
         protobuf_tensor.contents_bin = serialized_tensor
-        protobuf_tensor.serializer = TorchTensorPB.Serializer.SERIALIZER_UNSPECIFIED    
+        protobuf_tensor.serializer = TorchTensorPB.Serializer.SERIALIZER_UNSPECIFIED
 
     if chain:
         protobuf_tensor.chain.CopyFrom(chain)
@@ -158,7 +158,9 @@ def _bufferize_torch_tensor(worker: AbstractWorker, tensor: torch.Tensor) -> bin
     return protobuf_tensor
 
 
-def _unbufferize_torch_tensor(worker: AbstractWorker, protobuf_tensor: "TensorPB") -> torch.Tensor:
+def _unbufferize_torch_tensor(
+    worker: AbstractWorker, protobuf_tensor: "TorchTensorPB"
+) -> torch.Tensor:
     """
     This function converts a serialized torch tensor into a torch tensor
     using pickle.
@@ -178,7 +180,7 @@ def _unbufferize_torch_tensor(worker: AbstractWorker, protobuf_tensor: "TensorPB
 
     serializer = ""
     serialized_tensor = protobuf_tensor.contents_bin
-    if protobuf_tensor.serializer == TorchTensorPB.Serializer.SERIALIZER_TORCH:        
+    if protobuf_tensor.serializer == TorchTensorPB.Serializer.SERIALIZER_TORCH:
         serializer = TENSOR_SERIALIZATION.TORCH
     elif protobuf_tensor.serializer == TorchTensorPB.Serializer.SERIALIZER_NUMPY:
         serializer = TENSOR_SERIALIZATION.NUMPY

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -189,17 +189,17 @@ def _unbufferize_torch_tensor(
     worker: AbstractWorker, protobuf_tensor: "TorchTensorPB"
 ) -> torch.Tensor:
     """
-    This function converts a serialized torch tensor into a torch tensor
-    using pickle.
+    This function converts a Protobuf torch tensor back into a
+    Torch tensor. The tensor contents can be deserialized from
+    binary representations produced by Torch or Numpy, or from
+    the generic Protobuf message format for cross-platform
+    communication.
 
     Args:
-        tensor_tuple (bin): serialized obj of torch tensor. It's a tuple where
-            the first value is the ID, the second vlaue is the binary for the
-            PyTorch object, the third value is the chain of tensor abstractions,
-            and the fourth object is the chain of gradients (.grad.grad, etc.)
+        protobuf_tensor (bin): Protobuf message of torch tensor.
 
     Returns:
-        torch.Tensor: a torch tensor that was serialized
+        torch.Tensor: a torch tensor converted from Protobuf
     """
     tensor_id = getattr(protobuf_tensor.id, protobuf_tensor.id.WhichOneof("id"))
     tags = protobuf_tensor.tags

--- a/syft/serde/torch/serde.py
+++ b/syft/serde/torch/serde.py
@@ -1,0 +1,22 @@
+import torch
+
+# Torch dtypes to string (and back) mappers
+TORCH_DTYPE_STR = {
+    torch.uint8: "uint8",
+    torch.int8: "int8",
+    torch.int16: "int16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.float16: "float16",
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.complex32: "complex32",
+    torch.complex64: "complex64",
+    torch.complex128: "complex128",
+    torch.bool: "bool",
+    torch.qint8: "qint8",
+    torch.quint8: "quint8",
+    torch.qint32: "qint32",
+    torch.bfloat16: "bfloat16",
+}
+TORCH_STR_DTYPE = {name: cls for cls, name in TORCH_DTYPE_STR.items()}

--- a/syft/serde/torch/serde.py
+++ b/syft/serde/torch/serde.py
@@ -1,4 +1,11 @@
+import io
+from tempfile import TemporaryFile
+import warnings
+
+import numpy
 import torch
+
+from syft.workers.abstract import AbstractWorker
 
 # Torch dtypes to string (and back) mappers
 TORCH_DTYPE_STR = {
@@ -20,3 +27,44 @@ TORCH_DTYPE_STR = {
     torch.bfloat16: "bfloat16",
 }
 TORCH_STR_DTYPE = {name: cls for cls, name in TORCH_DTYPE_STR.items()}
+
+
+def torch_tensor_serializer(worker: AbstractWorker, tensor) -> bin:
+    """Strategy to serialize a tensor using Torch saver"""
+    binary_stream = io.BytesIO()
+    torch.save(tensor, binary_stream)
+    return binary_stream.getvalue()
+
+
+def torch_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
+    """"Strategy to deserialize a binary input using Torch load"""
+    bin_tensor_stream = io.BytesIO(tensor_bin)
+    return torch.load(bin_tensor_stream)
+
+
+def numpy_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
+    """"Strategy to deserialize a binary input in npy format into a Torch tensor"""
+    input_file = TemporaryFile()
+    input_file.write(tensor_bin)
+    # read data from file
+    input_file.seek(0)
+    return torch.from_numpy(numpy.load(input_file))
+
+
+def numpy_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
+    """Strategy to serialize a tensor using numpy npy format.
+    If tensor requires to calculate gradients, it will be detached.
+    """
+    if tensor.requires_grad:
+        warnings.warn(
+            "Torch to Numpy serializer can only be used with tensors that do not require grad. "
+            "Detaching tensor to continue"
+        )
+        tensor = tensor.detach()
+
+    np_tensor = tensor.numpy()
+    outfile = TemporaryFile()
+    numpy.save(outfile, np_tensor)
+    # Simulate close and open by calling seek
+    outfile.seek(0)
+    return outfile.read()

--- a/test/serde/protobuf/test_protobuf_serde.py
+++ b/test/serde/protobuf/test_protobuf_serde.py
@@ -44,7 +44,7 @@ def test_protobuf_serde_tensor_roundtrip(str_dtype):
     original_framework = serde_worker.framework
     serde_worker.framework = None
 
-    tensor = torch.rand([10, 100]) * 16
+    tensor = torch.rand([10, 10]) * 16
     tensor = tensor.to(TORCH_STR_DTYPE[str_dtype])
 
     protobuf_tensor = protobuf.serde._bufferize(serde_worker, tensor)
@@ -75,7 +75,7 @@ def test_protobuf_serde_tensor_roundtrip_quantized(str_dtype):
     original_framework = serde_worker.framework
     serde_worker.framework = None
 
-    tensor = torch.rand([10, 100]) * 16
+    tensor = torch.rand([10, 10]) * 16
     tensor = torch.quantize_per_tensor(tensor, 0.1, 10, TORCH_STR_DTYPE[str_dtype])
 
     protobuf_tensor = protobuf.serde._bufferize(serde_worker, tensor)

--- a/test/serde/protobuf/test_protobuf_serde.py
+++ b/test/serde/protobuf/test_protobuf_serde.py
@@ -1,0 +1,38 @@
+import torch
+
+import syft
+from syft.serde import protobuf
+from syft.serde.torch.serde import TORCH_STR_DTYPE
+
+from test.serde.serde_helpers import *
+
+
+# float16 and bfloat16 aren't supported on CPU
+# quantized types can't be created by conversion with `to`
+# complex types are not yet implemented
+dtypes = ["uint8", "int8", "int16", "int32", "int64", "float32", "float64", "bool", "qint8"]
+
+
+@pytest.mark.parametrize("str_dtype", dtypes)
+def test_serde_roundtrip_protobuf(str_dtype, workers):
+    """Checks that tensors passed through serialization-deserialization stay same"""
+
+    def compare(roundtrip, original):
+        assert type(roundtrip) == torch.Tensor
+        assert roundtrip.type() == original.type()
+        assert roundtrip.data.equal(original.data)
+        return True
+
+    serde_worker = syft.hook.local_worker
+    original_framework = serde_worker.framework
+    serde_worker.framework = None
+
+    tensor = torch.rand([10, 100]) * 16
+    tensor = tensor.to(TORCH_STR_DTYPE[str_dtype])
+
+    protobuf_tensor = protobuf.serde._bufferize(serde_worker, tensor)
+    roundtrip_tensor = protobuf.serde._unbufferize(serde_worker, protobuf_tensor)
+
+    serde_worker.framework = original_framework
+
+    assert compare(roundtrip_tensor, tensor) is True

--- a/test/serde/protobuf/test_protobuf_serde.py
+++ b/test/serde/protobuf/test_protobuf_serde.py
@@ -7,20 +7,37 @@ from syft.serde.torch.serde import TORCH_STR_DTYPE
 from test.serde.serde_helpers import *
 
 
-# float16 and bfloat16 aren't supported on CPU
-# quantized types can't be created by conversion with `to`
-# complex types are not yet implemented
-dtypes = ["uint8", "int8", "int16", "int32", "int64", "float32", "float64", "bool", "qint8"]
+dtypes = [
+    "uint8",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "float16",
+    "float32",
+    "float64",
+    "bool",
+    "bfloat16",
+]
+quantized_dtypes = ["qint8", "quint8", "qint32"]
+complex_types = []  # not yet implemented
 
 
 @pytest.mark.parametrize("str_dtype", dtypes)
-def test_serde_roundtrip_protobuf(str_dtype, workers):
+def test_protobuf_serde_tensor_roundtrip(str_dtype):
     """Checks that tensors passed through serialization-deserialization stay same"""
 
     def compare(roundtrip, original):
         assert type(roundtrip) == torch.Tensor
-        assert roundtrip.type() == original.type()
-        assert roundtrip.data.equal(original.data)
+        assert roundtrip.dtype == original.dtype
+
+        # PyTorch doesn't implement equality checking for bfloat16, so convert to float
+        if original.dtype == torch.bfloat16:
+            roundtrip = roundtrip.float()
+            original = original.float()
+
+        # PyTorch doesn't implement equality checking for float16, so use numpy
+        assert numpy.array_equal(roundtrip.data.numpy(), original.data.numpy())
         return True
 
     serde_worker = syft.hook.local_worker
@@ -29,6 +46,37 @@ def test_serde_roundtrip_protobuf(str_dtype, workers):
 
     tensor = torch.rand([10, 100]) * 16
     tensor = tensor.to(TORCH_STR_DTYPE[str_dtype])
+
+    protobuf_tensor = protobuf.serde._bufferize(serde_worker, tensor)
+    roundtrip_tensor = protobuf.serde._unbufferize(serde_worker, protobuf_tensor)
+
+    serde_worker.framework = original_framework
+
+    assert compare(roundtrip_tensor, tensor) is True
+
+
+# quantized types can't be created by conversion with `tensor.to()`
+@pytest.mark.parametrize("str_dtype", quantized_dtypes)
+def test_protobuf_serde_tensor_roundtrip_quantized(str_dtype):
+    """Checks that tensors passed through serialization-deserialization stay same"""
+
+    def compare(roundtrip, original):
+        assert type(roundtrip) == torch.Tensor
+        assert roundtrip.dtype == original.dtype
+        roundtrip_np = roundtrip.dequantize().numpy()
+        original_np = original.dequantize().numpy()
+        # PyTorch does implement equality checking for float tensors, but
+        # quantized tensors may not be exactly the same after a round trip
+        # plus dequantizing so use numpy close checking with a tolerance
+        assert numpy.allclose(roundtrip_np, original_np, atol=2 / original.q_scale())
+        return True
+
+    serde_worker = syft.hook.local_worker
+    original_framework = serde_worker.framework
+    serde_worker.framework = None
+
+    tensor = torch.rand([10, 100]) * 16
+    tensor = torch.quantize_per_tensor(tensor, 0.1, 10, TORCH_STR_DTYPE[str_dtype])
 
     protobuf_tensor = protobuf.serde._bufferize(serde_worker, tensor)
     roundtrip_tensor = protobuf.serde._unbufferize(serde_worker, protobuf_tensor)

--- a/test/serde/protobuf/test_protobuf_serde.py
+++ b/test/serde/protobuf/test_protobuf_serde.py
@@ -20,7 +20,7 @@ dtypes = [
     "bfloat16",
 ]
 quantized_dtypes = ["qint8", "quint8", "qint32"]
-complex_types = []  # not yet implemented
+complex_types = []  # not yet implemented in PyTorch
 
 
 @pytest.mark.parametrize("str_dtype", dtypes)

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -16,6 +16,9 @@ samples = OrderedDict()
 # Native
 samples[type(None)] = make_none
 
+# Torch
+samples[torch.Tensor] = make_torch_tensor
+
 
 def test_serde_coverage():
     """Checks all types in serde are tested"""
@@ -42,5 +45,9 @@ def test_serde_roundtrip_protobuf(cls, workers):
         if not isinstance(obj, Exception):
             roundtrip_obj = protobuf.serde._unbufferize(serde_worker, protobuf_obj)
 
-        assert type(roundtrip_obj) == type(obj)
-        assert roundtrip_obj == obj
+        if sample.get("cmp_detailed", None):
+            # Custom detailed objects comparison function.
+            assert sample.get("cmp_detailed")(roundtrip_obj, obj) is True
+        else:
+            assert type(roundtrip_obj) == type(obj)
+            assert roundtrip_obj == obj

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -27,6 +27,9 @@ def test_serde_coverage():
         assert has_sample is True, "Serde for %s is not tested" % cls
 
 
+# TODO: Test that tensor serialization works for all dtypes
+
+
 @pytest.mark.parametrize("cls", samples)
 def test_serde_roundtrip_protobuf(cls, workers):
     """Checks that values passed through serialization-deserialization stay same"""

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -27,9 +27,6 @@ def test_serde_coverage():
         assert has_sample is True, "Serde for %s is not tested" % cls
 
 
-# TODO: Test that tensor serialization works for all dtypes
-
-
 @pytest.mark.parametrize("cls", samples)
 def test_serde_roundtrip_protobuf(cls, workers):
     """Checks that values passed through serialization-deserialization stay same"""


### PR DESCRIPTION
This PR also extracts a Torch serde from the msgpack serialization and reuses it in the Protobuf serialization.

Depends on OpenMined/syft-proto#21.