### PR TITLE
Add sk-learn to notebook docker image

### DIFF
--- a/docker-images/pysyft-notebook/Dockerfile
+++ b/docker-images/pysyft-notebook/Dockerfile
@@ -5,7 +5,7 @@ ENV WORKSPACE /workspace
 # Setup workspace environment
 RUN apt-get update && apt-get install -y gcc
 RUN conda install jupyter notebook
-RUN pip install --no-cache-dir syft[udacity]
+RUN pip install --no-cache-dir syft[udacity,sandbox]
 
 # Create jupyter notebook workspace
 RUN mkdir $WORKSPACE


### PR DESCRIPTION
[Tutorial 5](https://github.com/OpenMined/PySyft/blob/master/examples/tutorials/Part%2005%20-%20Welcome%20to%20the%20Sandbox.ipynb) and presumably some others require sk-learn in order to work correctly. This was causing some errors to run with the default notebook docker image.

This patch adds the `sandbox` option to installing syft for this the notebook docker image.