### PR TITLE
Add Protobuf serialization for the remaining Torch types

### DIFF
--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -10,9 +10,14 @@ import torch
 
 from google.protobuf.empty_pb2 import Empty
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
+from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 
 
-MAP_PYTHON_TO_PROTOBUF_CLASSES = {type(None): Empty, torch.Tensor: TorchTensorPB}
+MAP_PYTHON_TO_PROTOBUF_CLASSES = {
+    type(None): Empty,
+    torch.Tensor: TorchTensorPB,
+    torch.device: DevicePB,
+}
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
 

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -13,6 +13,7 @@ from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 from syft_proto.types.torch.v1.c_function_pb2 import CFunction as CFunctionPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 from syft_proto.types.torch.v1.parameter_pb2 import Parameter as ParameterPB
+from syft_proto.types.torch.v1.size_pb2 import Size as SizePB
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 from syft_proto.types.torch.v1.script_module_pb2 import ScriptModule as ScriptModulePB
 from syft_proto.types.torch.v1.traced_module_pb2 import TracedModule as TracedModulePB
@@ -26,6 +27,7 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.jit.ScriptModule: ScriptModulePB,
     torch._C.Function: CFunctionPB,
     torch.jit.TopLevelTracedModule: TracedModulePB,
+    torch.Size: SizePB,
 }
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -10,9 +10,12 @@ import torch
 
 from google.protobuf.empty_pb2 import Empty
 from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
+from syft_proto.types.torch.v1.c_function_pb2 import CFunction as CFunctionPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 from syft_proto.types.torch.v1.parameter_pb2 import Parameter as ParameterPB
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
+from syft_proto.types.torch.v1.script_module_pb2 import ScriptModule as ScriptModulePB
+from syft_proto.types.torch.v1.traced_module_pb2 import TracedModule as TracedModulePB
 
 
 MAP_PYTHON_TO_PROTOBUF_CLASSES = {
@@ -20,6 +23,9 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.Tensor: TorchTensorPB,
     torch.device: DevicePB,
     torch.nn.Parameter: ParameterPB,
+    torch.jit.ScriptModule: ScriptModulePB,
+    torch._C.Function: CFunctionPB,
+    torch.jit.TopLevelTracedModule: TracedModulePB,
 }
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -30,11 +30,6 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.Size: SizePB,
 }
 
-MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
-
-for key, value in MAP_PYTHON_TO_PROTOBUF_CLASSES.items():
-    MAP_PROTOBUF_TO_PYTHON_CLASSES[value] = key
-
 
 def create_protobuf_id(id) -> IdPB:
     protobuf_id = IdPB()

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -9,17 +9,29 @@ a dependency in setup.py.
 import torch
 
 from google.protobuf.empty_pb2 import Empty
-from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
+from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
+from syft_proto.types.torch.v1.parameter_pb2 import Parameter as ParameterPB
+from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 
 
 MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     type(None): Empty,
     torch.Tensor: TorchTensorPB,
     torch.device: DevicePB,
+    torch.nn.Parameter: ParameterPB,
 }
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
 
 for key, value in MAP_PYTHON_TO_PROTOBUF_CLASSES.items():
     MAP_PROTOBUF_TO_PYTHON_CLASSES[value] = key
+
+
+def create_protobuf_id(id) -> IdPB:
+    protobuf_id = IdPB()
+    if type(id) == type("str"):
+        protobuf_id.id_str = id
+    else:
+        protobuf_id.id_int = id
+    return protobuf_id

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -325,7 +325,7 @@ def _bufferize(worker: AbstractWorker, obj: object, **kwargs) -> object:
                 # Store the inheritance_type in bufferizers so next time we see this type
                 # serde will be faster.
                 inherited_bufferizers_found[current_type] = bufferizers[inheritance_type]
-                result = (inherited_bufferizers_found[current_type](worker, obj, **kwargs),)
+                result = inherited_bufferizers_found[current_type](worker, obj, **kwargs)
                 return result
 
         no_bufferizers_found.add(current_type)

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -8,7 +8,6 @@ from syft.serde.protobuf.native_serde import MAP_NATIVE_PROTOBUF_TRANSLATORS
 from syft.workers.abstract import AbstractWorker
 
 from syft_proto.messaging.v1.message_pb2 import SyftMessage as SyftMessagePB
-from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 
 
 if dependency_check.torch_available:
@@ -273,15 +272,6 @@ def deserialize(binary: bin, worker: AbstractWorker = None, unbufferizes=True) -
     message_type = msg_wrapper.WhichOneof("contents")
     python_obj = _unbufferize(worker, getattr(msg_wrapper, message_type))
     return python_obj
-
-
-def create_protobuf_id(id) -> IdPB:
-    protobuf_id = IdPB()
-    if type(id) == type("str"):
-        protobuf_id.id_str = id
-    else:
-        protobuf_id.id_int = id
-    return protobuf_id
 
 
 def _bufferize(worker: AbstractWorker, obj: object, **kwargs) -> object:

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -20,7 +20,6 @@ else:
 # else:
 #     MAP_TF_PROTOBUF_TRANSLATORS = {}
 
-from syft.serde.protobuf.proto import MAP_PROTOBUF_TO_PYTHON_CLASSES
 from syft.serde.protobuf.proto import MAP_PYTHON_TO_PROTOBUF_CLASSES
 
 # Maps a type to its bufferizer and unbufferizer functions

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -26,6 +26,7 @@ from syft.serde.torch.serde import numpy_tensor_serializer
 from syft.serde.torch.serde import numpy_tensor_deserializer
 
 from syft_proto.types.syft.v1.shape_pb2 import Shape as ShapePB
+from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 from syft_proto.types.torch.v1.tensor_data_pb2 import TensorData as TensorDataPB
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 
@@ -233,7 +234,21 @@ def _unbufferize_torch_tensor(
     return tensor
 
 
+def _bufferize_torch_device(worker: AbstractWorker, device: torch.device) -> DevicePB:
+    protobuf_device = DevicePB()
+    protobuf_device.type = device.type
+    return protobuf_device
+
+
+def _unbufferize_torch_device(worker: AbstractWorker, protobuf_device: DevicePB) -> torch.device:
+    device_type = protobuf_device.type
+    return torch.device(type=device_type)
+
+
 # Maps a type to its bufferizer and unbufferizer functions
 MAP_TORCH_PROTOBUF_TRANSLATORS = OrderedDict(
-    {torch.Tensor: (_bufferize_torch_tensor, _unbufferize_torch_tensor)}
+    {
+        torch.Tensor: (_bufferize_torch_tensor, _unbufferize_torch_tensor),
+        torch.device: (_bufferize_torch_device, _unbufferize_torch_device),
+    }
 )

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -23,7 +23,7 @@ samples[torch._C.Function] = make_torch_cfunction
 samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
 samples[torch.nn.Parameter] = make_torch_parameter
 samples[torch.Tensor] = make_torch_tensor
-# samples[torch.Size] = make_torch_size
+samples[torch.Size] = make_torch_size
 
 
 def test_serde_coverage():

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -16,7 +16,8 @@ samples = OrderedDict()
 # Native
 samples[type(None)] = make_none
 
-# Torch
+# PyTorch
+samples[torch.device] = make_torch_device
 samples[torch.Tensor] = make_torch_tensor
 
 

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -18,7 +18,12 @@ samples[type(None)] = make_none
 
 # PyTorch
 samples[torch.device] = make_torch_device
+# samples[torch.jit.ScriptModule] = make_torch_scriptmodule
+# samples[torch._C.Function] = make_torch_cfunction
+# samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
+samples[torch.nn.Parameter] = make_torch_parameter
 samples[torch.Tensor] = make_torch_tensor
+# samples[torch.Size] = make_torch_size
 
 
 def test_serde_coverage():

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -18,9 +18,9 @@ samples[type(None)] = make_none
 
 # PyTorch
 samples[torch.device] = make_torch_device
-# samples[torch.jit.ScriptModule] = make_torch_scriptmodule
-# samples[torch._C.Function] = make_torch_cfunction
-# samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
+samples[torch.jit.ScriptModule] = make_torch_scriptmodule
+samples[torch._C.Function] = make_torch_cfunction
+samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
 samples[torch.nn.Parameter] = make_torch_parameter
 samples[torch.Tensor] = make_torch_tensor
 # samples[torch.Size] = make_torch_size


### PR DESCRIPTION
This covers all the Torch types except `torch.Tensor`, which was added in a previous PR.

Depends on OpenMined/syft-proto#23 and #2869.