### PR TITLE
Add Protobuf serialization for `Object` and `Operation` messages, `AST` tensor

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -1081,11 +1081,11 @@ class AdditiveSharingTensor(AbstractTensor):
                 shared_tensor = unprotobuf(data)
             """
 
-        tensor_id = getattr(protobuf_tensor.id, protobuf_tensor.id.WhichOneof("id"))
-        field = protobuf_tensor.field_size
-        crypto_provider_id = getattr(
-            protobuf_tensor.crypto_provider_id, protobuf_tensor.crypto_provider_id.WhichOneof("id")
+        tensor_id = sy.serde.protobuf.proto.get_protobuf_id(protobuf_tensor.id)
+        crypto_provider_id = sy.serde.protobuf.proto.get_protobuf_id(
+            protobuf_tensor.crypto_provider_id
         )
+        field = protobuf_tensor.field_size
 
         tensor = AdditiveSharingTensor(
             owner=worker,
@@ -1097,7 +1097,7 @@ class AdditiveSharingTensor(AbstractTensor):
         if protobuf_tensor.location_ids is not None:
             chain = {}
             for pb_location_id, share in zip(protobuf_tensor.location_ids, protobuf_tensor.shares):
-                location_id = getattr(pb_location_id, pb_location_id.WhichOneof("id"))
+                location_id = sy.serde.protobuf.proto.get_protobuf_id(pb_location_id)
                 chain[location_id] = sy.serde.protobuf.serde._unbufferize(worker, share)
             tensor.child = chain
 

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -557,13 +557,13 @@ class PointerTensor(ObjectPointer, AbstractTensor):
     @staticmethod
     def bufferize(worker: AbstractWorker, ptr: "PointerTensor") -> PointerTensorPB:
         protobuf_pointer = PointerTensorPB()
-        protobuf_pointer.object_id.CopyFrom(syft.serde.protobuf.proto.create_protobuf_id(ptr.id))
-        protobuf_pointer.location_id.CopyFrom(
-            syft.serde.protobuf.proto.create_protobuf_id(ptr.location.id)
+
+        syft.serde.protobuf.proto.set_protobuf_id(protobuf_pointer.object_id, ptr.id)
+        syft.serde.protobuf.proto.set_protobuf_id(protobuf_pointer.location_id, ptr.location.id)
+        syft.serde.protobuf.proto.set_protobuf_id(
+            protobuf_pointer.object_id_at_location, ptr.id_at_location
         )
-        protobuf_pointer.object_id_at_location.CopyFrom(
-            syft.serde.protobuf.proto.create_protobuf_id(ptr.id_at_location)
-        )
+
         if ptr.point_to_attr:
             protobuf_pointer.point_to_attr = ptr.point_to_attr
         protobuf_pointer.garbage_collect_data = ptr.garbage_collect_data

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -573,14 +573,11 @@ class PointerTensor(ObjectPointer, AbstractTensor):
     def unbufferize(worker: AbstractWorker, protobuf_tensor: PointerTensorPB) -> "PointerTensor":
         # Extract the field values
 
-        obj_id = getattr(protobuf_tensor.object_id, protobuf_tensor.object_id.WhichOneof("id"))
-        obj_id_at_location = getattr(
-            protobuf_tensor.object_id_at_location,
-            protobuf_tensor.object_id_at_location.WhichOneof("id"),
+        obj_id = syft.serde.protobuf.proto.get_protobuf_id(protobuf_tensor.object_id)
+        obj_id_at_location = syft.serde.protobuf.proto.get_protobuf_id(
+            protobuf_tensor.object_id_at_location
         )
-        worker_id = getattr(
-            protobuf_tensor.location_id, protobuf_tensor.location_id.WhichOneof("id")
-        )
+        worker_id = syft.serde.protobuf.proto.get_protobuf_id(protobuf_tensor.location_id)
         point_to_attr = protobuf_tensor.point_to_attr
         shape = syft.hook.create_shape(protobuf_tensor.shape.dims)
         garbage_collect_data = protobuf_tensor.garbage_collect_data

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -266,7 +266,8 @@ class Operation(Message):
             kwargs[key] = Operation._unbufferize_arg(worker, protobuf_obj.operation.kwargs[key])
 
         return_ids = [
-            getattr(pb_id, pb_id.WhichOneof("id")) for pb_id in protobuf_obj.operation.return_ids
+            sy.serde.protobuf.proto.get_protobuf_id(pb_id)
+            for pb_id in protobuf_obj.operation.return_ids
         ]
 
         operation_msg = Operation(command, owner, tuple(args), kwargs, tuple(return_ids))

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -11,6 +11,9 @@ import syft as sy
 from syft.workers.abstract import AbstractWorker
 
 
+from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
+
+
 class Message:
     """All syft message types extend this class
 
@@ -226,6 +229,31 @@ class ObjectMessage(Message):
             message = detail(sy.local_worker, msg_tuple)
         """
         return ObjectMessage(sy.serde.msgpack.serde._detail(worker, msg_tuple[0]))
+
+    @staticmethod
+    def bufferize(worker: AbstractWorker, message: "ObjectMessage") -> "ObjectMessagePB":
+        """
+        This function takes the attributes of an Object Message and saves them in a protobuf object
+        Args:
+            message (ObjectMessage): an ObjectMessage
+        Returns:
+            protobuf: a protobuf object holding the unique attributes of the object message
+        Examples:
+            data = bufferize(object_message)
+        """
+
+        protobuf_obj_msg = ObjectMessagePB()
+        bufferized_contents = sy.serde.protobuf.serde._bufferize(worker, message.contents)
+        protobuf_obj_msg.tensor.CopyFrom(bufferized_contents)
+        return protobuf_obj_msg
+
+    @staticmethod
+    def unbufferize(worker: AbstractWorker, protobuf_obj: "ObjectMessagePB") -> "ObjectMessage":
+        protobuf_contents = protobuf_obj.tensor
+        contents = sy.serde.protobuf.serde._unbufferize(worker, protobuf_contents)
+        object_msg = ObjectMessage(contents)
+
+        return object_msg
 
 
 class ObjectRequestMessage(Message):

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -231,11 +231,8 @@ class Operation(Message):
                     Operation._bufferize_arg(worker, value)
                 )
 
-        return_ids = []
         for return_id in operation.return_ids:
-            return_ids.append(sy.serde.protobuf.proto.create_protobuf_id(return_id))
-
-        protobuf_op.return_ids.extend(return_ids)
+            sy.serde.protobuf.proto.set_protobuf_id(protobuf_op.return_ids.add(), return_id)
 
         protobuf_op_msg.operation.CopyFrom(protobuf_op)
         return protobuf_op_msg

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -9,8 +9,11 @@ a dependency in setup.py.
 import torch
 
 from syft.messaging.message import ObjectMessage
+from syft.messaging.message import Operation
+
 from google.protobuf.empty_pb2 import Empty
 from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
+from syft_proto.messaging.v1.message_pb2 import OperationMessage as OperationMessagePB
 from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 from syft_proto.types.torch.v1.c_function_pb2 import CFunction as CFunctionPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
@@ -31,6 +34,7 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.jit.TopLevelTracedModule: TracedModulePB,
     torch.Size: SizePB,
     ObjectMessage: ObjectMessagePB,
+    Operation: OperationMessagePB,
 }
 
 

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -10,9 +10,14 @@ import torch
 
 from google.protobuf.empty_pb2 import Empty
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
+from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 
 
-MAP_PYTHON_TO_PROTOBUF_CLASSES = {type(None): Empty, torch.Tensor: TorchTensorPB}
+MAP_PYTHON_TO_PROTOBUF_CLASSES = {
+    type(None): Empty,
+    torch.Tensor: TorchTensorPB,
+    torch.device: DevicePB,
+}
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
 

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -13,6 +13,7 @@ from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 from syft_proto.types.torch.v1.c_function_pb2 import CFunction as CFunctionPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 from syft_proto.types.torch.v1.parameter_pb2 import Parameter as ParameterPB
+from syft_proto.types.torch.v1.size_pb2 import Size as SizePB
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 from syft_proto.types.torch.v1.script_module_pb2 import ScriptModule as ScriptModulePB
 from syft_proto.types.torch.v1.traced_module_pb2 import TracedModule as TracedModulePB
@@ -26,6 +27,7 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.jit.ScriptModule: ScriptModulePB,
     torch._C.Function: CFunctionPB,
     torch.jit.TopLevelTracedModule: TracedModulePB,
+    torch.Size: SizePB,
 }
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -8,7 +8,9 @@ a dependency in setup.py.
 """
 import torch
 
+from syft.messaging.message import ObjectMessage
 from google.protobuf.empty_pb2 import Empty
+from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
 from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 from syft_proto.types.torch.v1.c_function_pb2 import CFunction as CFunctionPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
@@ -28,6 +30,7 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch._C.Function: CFunctionPB,
     torch.jit.TopLevelTracedModule: TracedModulePB,
     torch.Size: SizePB,
+    ObjectMessage: ObjectMessagePB,
 }
 
 

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -10,9 +10,12 @@ import torch
 
 from google.protobuf.empty_pb2 import Empty
 from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
+from syft_proto.types.torch.v1.c_function_pb2 import CFunction as CFunctionPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 from syft_proto.types.torch.v1.parameter_pb2 import Parameter as ParameterPB
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
+from syft_proto.types.torch.v1.script_module_pb2 import ScriptModule as ScriptModulePB
+from syft_proto.types.torch.v1.traced_module_pb2 import TracedModule as TracedModulePB
 
 
 MAP_PYTHON_TO_PROTOBUF_CLASSES = {
@@ -20,6 +23,9 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.Tensor: TorchTensorPB,
     torch.device: DevicePB,
     torch.nn.Parameter: ParameterPB,
+    torch.jit.ScriptModule: ScriptModulePB,
+    torch._C.Function: CFunctionPB,
+    torch.jit.TopLevelTracedModule: TracedModulePB,
 }
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -8,11 +8,15 @@ a dependency in setup.py.
 """
 import torch
 
+from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.messaging.message import ObjectMessage
 from syft.messaging.message import Operation
 
 from google.protobuf.empty_pb2 import Empty
+from syft_proto.frameworks.torch.tensors.interpreters.v1.additive_shared_pb2 import (
+    AdditiveSharingTensor as AdditiveSharingTensorPB,
+)
 from syft_proto.generic.pointers.v1.pointer_tensor_pb2 import PointerTensor as PointerTensorPB
 from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
 from syft_proto.messaging.v1.message_pb2 import OperationMessage as OperationMessagePB
@@ -38,6 +42,7 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     ObjectMessage: ObjectMessagePB,
     Operation: OperationMessagePB,
     PointerTensor: PointerTensorPB,
+    AdditiveSharingTensor: AdditiveSharingTensorPB,
 }
 
 

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -51,3 +51,7 @@ def set_protobuf_id(field, id):
         field.id_str = id
     else:
         field.id_int = id
+
+
+def get_protobuf_id(field):
+    return getattr(field, field.WhichOneof("id"))

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -30,11 +30,6 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.Size: SizePB,
 }
 
-MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
-
-for key, value in MAP_PYTHON_TO_PROTOBUF_CLASSES.items():
-    MAP_PROTOBUF_TO_PYTHON_CLASSES[value] = key
-
 
 def create_protobuf_id(id) -> IdPB:
     protobuf_id = IdPB()

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -8,10 +8,12 @@ a dependency in setup.py.
 """
 import torch
 
+from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.messaging.message import ObjectMessage
 from syft.messaging.message import Operation
 
 from google.protobuf.empty_pb2 import Empty
+from syft_proto.generic.pointers.v1.pointer_tensor_pb2 import PointerTensor as PointerTensorPB
 from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
 from syft_proto.messaging.v1.message_pb2 import OperationMessage as OperationMessagePB
 from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
@@ -35,6 +37,7 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     torch.Size: SizePB,
     ObjectMessage: ObjectMessagePB,
     Operation: OperationMessagePB,
+    PointerTensor: PointerTensorPB,
 }
 
 

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -46,10 +46,8 @@ MAP_PYTHON_TO_PROTOBUF_CLASSES = {
 }
 
 
-def create_protobuf_id(id) -> IdPB:
-    protobuf_id = IdPB()
+def set_protobuf_id(field, id):
     if type(id) == type("str"):
-        protobuf_id.id_str = id
+        field.id_str = id
     else:
-        protobuf_id.id_int = id
-    return protobuf_id
+        field.id_int = id

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -9,17 +9,29 @@ a dependency in setup.py.
 import torch
 
 from google.protobuf.empty_pb2 import Empty
-from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
+from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
+from syft_proto.types.torch.v1.parameter_pb2 import Parameter as ParameterPB
+from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 
 
 MAP_PYTHON_TO_PROTOBUF_CLASSES = {
     type(None): Empty,
     torch.Tensor: TorchTensorPB,
     torch.device: DevicePB,
+    torch.nn.Parameter: ParameterPB,
 }
 
 MAP_PROTOBUF_TO_PYTHON_CLASSES = {}
 
 for key, value in MAP_PYTHON_TO_PROTOBUF_CLASSES.items():
     MAP_PROTOBUF_TO_PYTHON_CLASSES[value] = key
+
+
+def create_protobuf_id(id) -> IdPB:
+    protobuf_id = IdPB()
+    if type(id) == type("str"):
+        protobuf_id.id_str = id
+    else:
+        protobuf_id.id_int = id
+    return protobuf_id

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import inspect
 import syft
 from syft import dependency_check
+from syft.messaging.message import ObjectMessage
 from syft.serde import compression
 from syft.serde.protobuf.native_serde import MAP_NATIVE_PROTOBUF_TRANSLATORS
 from syft.workers.abstract import AbstractWorker
@@ -30,7 +31,7 @@ MAP_TO_PROTOBUF_TRANSLATORS = OrderedDict(
 )
 
 # If an object implements its own bufferize and unbufferize functions it should be stored in this list
-OBJ_PROTOBUF_TRANSLATORS = []
+OBJ_PROTOBUF_TRANSLATORS = [ObjectMessage]
 
 # If an object implements its own force_bufferize and force_unbufferize functions it should be stored in this list
 # OBJ_FORCE_FULL_PROTOBUF_TRANSLATORS = [BaseWorker]
@@ -215,8 +216,11 @@ def serialize(
 
     protobuf_obj = _bufferize(worker, obj)
 
-    if type(obj) == type(None):
+    obj_type = type(obj)
+    if obj_type == type(None):
         msg_wrapper.contents_empty_msg.CopyFrom(protobuf_obj)
+    elif obj_type == ObjectMessage:
+        msg_wrapper.contents_object_msg.CopyFrom(protobuf_obj)
 
     # 2) Serialize
     # serialize into a binary

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -34,7 +34,7 @@ MAP_TO_PROTOBUF_TRANSLATORS = OrderedDict(
 )
 
 # If an object implements its own bufferize and unbufferize functions it should be stored in this list
-OBJ_PROTOBUF_TRANSLATORS = [ObjectMessage, Operation, PointerTensor]
+OBJ_PROTOBUF_TRANSLATORS = [AdditiveSharingTensor, ObjectMessage, Operation, PointerTensor]
 
 # If an object implements its own force_bufferize and force_unbufferize functions it should be stored in this list
 # OBJ_FORCE_FULL_PROTOBUF_TRANSLATORS = [BaseWorker]

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -4,6 +4,7 @@ import inspect
 import syft
 from syft import dependency_check
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
+from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.messaging.message import ObjectMessage
 from syft.messaging.message import Operation
 from syft.serde import compression
@@ -33,7 +34,7 @@ MAP_TO_PROTOBUF_TRANSLATORS = OrderedDict(
 )
 
 # If an object implements its own bufferize and unbufferize functions it should be stored in this list
-OBJ_PROTOBUF_TRANSLATORS = [ObjectMessage, Operation]
+OBJ_PROTOBUF_TRANSLATORS = [ObjectMessage, Operation, PointerTensor]
 
 # If an object implements its own force_bufferize and force_unbufferize functions it should be stored in this list
 # OBJ_FORCE_FULL_PROTOBUF_TRANSLATORS = [BaseWorker]

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -325,7 +325,7 @@ def _bufferize(worker: AbstractWorker, obj: object, **kwargs) -> object:
                 # Store the inheritance_type in bufferizers so next time we see this type
                 # serde will be faster.
                 inherited_bufferizers_found[current_type] = bufferizers[inheritance_type]
-                result = (inherited_bufferizers_found[current_type](worker, obj, **kwargs),)
+                result = inherited_bufferizers_found[current_type](worker, obj, **kwargs)
                 return result
 
         no_bufferizers_found.add(current_type)

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -8,7 +8,6 @@ from syft.serde.protobuf.native_serde import MAP_NATIVE_PROTOBUF_TRANSLATORS
 from syft.workers.abstract import AbstractWorker
 
 from syft_proto.messaging.v1.message_pb2 import SyftMessage as SyftMessagePB
-from syft_proto.types.syft.v1.id_pb2 import Id as IdPB
 
 
 if dependency_check.torch_available:
@@ -273,15 +272,6 @@ def deserialize(binary: bin, worker: AbstractWorker = None, unbufferizes=True) -
     message_type = msg_wrapper.WhichOneof("contents")
     python_obj = _unbufferize(worker, getattr(msg_wrapper, message_type))
     return python_obj
-
-
-def create_protobuf_id(id) -> IdPB:
-    protobuf_id = IdPB()
-    if type(id) == type("str"):
-        protobuf_id.id_str = id
-    else:
-        protobuf_id.id_int = id
-    return protobuf_id
 
 
 def _bufferize(worker: AbstractWorker, obj: object, **kwargs) -> object:

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -20,7 +20,6 @@ else:
 # else:
 #     MAP_TF_PROTOBUF_TRANSLATORS = {}
 
-from syft.serde.protobuf.proto import MAP_PROTOBUF_TO_PYTHON_CLASSES
 from syft.serde.protobuf.proto import MAP_PYTHON_TO_PROTOBUF_CLASSES
 
 # Maps a type to its bufferizer and unbufferizer functions

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -3,7 +3,9 @@ from collections import OrderedDict
 import inspect
 import syft
 from syft import dependency_check
+from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
 from syft.messaging.message import ObjectMessage
+from syft.messaging.message import Operation
 from syft.serde import compression
 from syft.serde.protobuf.native_serde import MAP_NATIVE_PROTOBUF_TRANSLATORS
 from syft.workers.abstract import AbstractWorker
@@ -31,7 +33,7 @@ MAP_TO_PROTOBUF_TRANSLATORS = OrderedDict(
 )
 
 # If an object implements its own bufferize and unbufferize functions it should be stored in this list
-OBJ_PROTOBUF_TRANSLATORS = [ObjectMessage]
+OBJ_PROTOBUF_TRANSLATORS = [ObjectMessage, Operation]
 
 # If an object implements its own force_bufferize and force_unbufferize functions it should be stored in this list
 # OBJ_FORCE_FULL_PROTOBUF_TRANSLATORS = [BaseWorker]
@@ -221,6 +223,8 @@ def serialize(
         msg_wrapper.contents_empty_msg.CopyFrom(protobuf_obj)
     elif obj_type == ObjectMessage:
         msg_wrapper.contents_object_msg.CopyFrom(protobuf_obj)
+    elif obj_type == Operation:
+        msg_wrapper.contents_operation_msg.CopyFrom(protobuf_obj)
 
     # 2) Serialize
     # serialize into a binary

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -26,6 +26,7 @@ from syft.serde.torch.serde import numpy_tensor_serializer
 from syft.serde.torch.serde import numpy_tensor_deserializer
 
 from syft_proto.types.syft.v1.shape_pb2 import Shape as ShapePB
+from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
 from syft_proto.types.torch.v1.tensor_data_pb2 import TensorData as TensorDataPB
 from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensorPB
 
@@ -233,7 +234,21 @@ def _unbufferize_torch_tensor(
     return tensor
 
 
+def _bufferize_torch_device(worker: AbstractWorker, device: torch.device) -> DevicePB:
+    protobuf_device = DevicePB()
+    protobuf_device.type = device.type
+    return protobuf_device
+
+
+def _unbufferize_torch_device(worker: AbstractWorker, protobuf_device: DevicePB) -> torch.device:
+    device_type = protobuf_device.type
+    return torch.device(type=device_type)
+
+
 # Maps a type to its bufferizer and unbufferizer functions
 MAP_TORCH_PROTOBUF_TRANSLATORS = OrderedDict(
-    {torch.Tensor: (_bufferize_torch_tensor, _unbufferize_torch_tensor)}
+    {
+        torch.Tensor: (_bufferize_torch_tensor, _unbufferize_torch_tensor),
+        torch.device: (_bufferize_torch_device, _unbufferize_torch_device),
+    }
 )

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -18,6 +18,7 @@ from syft.generic.tensor import AbstractTensor
 from syft.workers.abstract import AbstractWorker
 from syft.codes import TENSOR_SERIALIZATION
 
+from syft.serde.protobuf.proto import get_protobuf_id
 from syft.serde.protobuf.proto import set_protobuf_id
 from syft.serde.torch.serde import TORCH_DTYPE_STR
 from syft.serde.torch.serde import TORCH_STR_DTYPE
@@ -207,7 +208,7 @@ def _unbufferize_torch_tensor(
     Returns:
         torch.Tensor: a torch tensor converted from Protobuf
     """
-    tensor_id = getattr(protobuf_tensor.id, protobuf_tensor.id.WhichOneof("id"))
+    tensor_id = get_protobuf_id(protobuf_tensor.id)
     tags = protobuf_tensor.tags
     description = protobuf_tensor.description
 
@@ -265,7 +266,7 @@ def _unbufferize_torch_parameter(
 ) -> torch.nn.Parameter:
     data = syft.serde.protobuf.serde._unbufferize(worker, protobuf_param.tensor)
     param = torch.nn.Parameter(data, requires_grad=protobuf_param.requires_grad)
-    param.id = getattr(protobuf_param.id, protobuf_param.id.WhichOneof("id"))
+    param.id = get_protobuf_id(protobuf_param.id)
     if protobuf_param.HasField("grad"):
         param.grad = syft.serde.protobuf.serde._unbufferize(worker, protobuf_param.grad)
     return param

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -18,7 +18,7 @@ from syft.generic.tensor import AbstractTensor
 from syft.workers.abstract import AbstractWorker
 from syft.codes import TENSOR_SERIALIZATION
 
-from syft.serde.protobuf.proto import create_protobuf_id
+from syft.serde.protobuf.proto import set_protobuf_id
 from syft.serde.torch.serde import TORCH_DTYPE_STR
 from syft.serde.torch.serde import TORCH_STR_DTYPE
 from syft.serde.torch.serde import torch_tensor_serializer
@@ -171,7 +171,7 @@ def _bufferize_torch_tensor(worker: AbstractWorker, tensor: torch.Tensor) -> bin
         chain = syft.serde.protobuf.serde._bufferize(worker, tensor.child)
 
     protobuf_tensor = TorchTensorPB()
-    protobuf_tensor.id.CopyFrom(syft.serde.protobuf.proto.create_protobuf_id(tensor.id))
+    set_protobuf_id(protobuf_tensor.id, tensor.id)
 
     protobuf_tensor.serializer = SERIALIZERS_SYFT_TO_PROTOBUF[worker.serializer]
     if worker.serializer == TENSOR_SERIALIZATION.ALL:
@@ -252,7 +252,7 @@ def _unbufferize_torch_device(worker: AbstractWorker, protobuf_device: DevicePB)
 
 def _bufferize_torch_parameter(worker: AbstractWorker, param: torch.nn.Parameter) -> ParameterPB:
     protobuf_param = ParameterPB()
-    protobuf_param.id.CopyFrom(create_protobuf_id(param.id))
+    set_protobuf_id(protobuf_param.id, param.id)
     protobuf_param.tensor.CopyFrom(syft.serde.protobuf.serde._bufferize(worker, param.data))
     protobuf_param.requires_grad = param.requires_grad
     if param.grad:

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -26,6 +26,10 @@ samples[torch.Tensor] = make_torch_tensor
 samples[torch.Size] = make_torch_size
 
 
+# Syft Messages
+samples[syft.messaging.message.ObjectMessage] = make_objectmessage
+
+
 def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in protobuf.serde.bufferizers.items():

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -23,7 +23,7 @@ samples[torch._C.Function] = make_torch_cfunction
 samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
 samples[torch.nn.Parameter] = make_torch_parameter
 samples[torch.Tensor] = make_torch_tensor
-# samples[torch.Size] = make_torch_size
+samples[torch.Size] = make_torch_size
 
 
 def test_serde_coverage():

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -16,7 +16,8 @@ samples = OrderedDict()
 # Native
 samples[type(None)] = make_none
 
-# Torch
+# PyTorch
+samples[torch.device] = make_torch_device
 samples[torch.Tensor] = make_torch_tensor
 
 

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -26,6 +26,9 @@ samples[torch.Tensor] = make_torch_tensor
 samples[torch.Size] = make_torch_size
 
 # PySyft
+samples[
+    syft.frameworks.torch.tensors.interpreters.additive_shared.AdditiveSharingTensor
+] = make_additivesharingtensor
 samples[syft.generic.pointers.pointer_tensor.PointerTensor] = make_pointertensor
 
 # Syft Messages

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -25,6 +25,8 @@ samples[torch.nn.Parameter] = make_torch_parameter
 samples[torch.Tensor] = make_torch_tensor
 samples[torch.Size] = make_torch_size
 
+# PySyft
+samples[syft.generic.pointers.pointer_tensor.PointerTensor] = make_pointertensor
 
 # Syft Messages
 samples[syft.messaging.message.ObjectMessage] = make_objectmessage

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -18,7 +18,12 @@ samples[type(None)] = make_none
 
 # PyTorch
 samples[torch.device] = make_torch_device
+# samples[torch.jit.ScriptModule] = make_torch_scriptmodule
+# samples[torch._C.Function] = make_torch_cfunction
+# samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
+samples[torch.nn.Parameter] = make_torch_parameter
 samples[torch.Tensor] = make_torch_tensor
+# samples[torch.Size] = make_torch_size
 
 
 def test_serde_coverage():

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -18,9 +18,9 @@ samples[type(None)] = make_none
 
 # PyTorch
 samples[torch.device] = make_torch_device
-# samples[torch.jit.ScriptModule] = make_torch_scriptmodule
-# samples[torch._C.Function] = make_torch_cfunction
-# samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
+samples[torch.jit.ScriptModule] = make_torch_scriptmodule
+samples[torch._C.Function] = make_torch_cfunction
+samples[torch.jit.TopLevelTracedModule] = make_torch_topleveltracedmodule
 samples[torch.nn.Parameter] = make_torch_parameter
 samples[torch.Tensor] = make_torch_tensor
 # samples[torch.Size] = make_torch_size

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -28,6 +28,7 @@ samples[torch.Size] = make_torch_size
 
 # Syft Messages
 samples[syft.messaging.message.ObjectMessage] = make_objectmessage
+samples[syft.messaging.message.Operation] = make_operation
 
 
 def test_serde_coverage():

--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -1321,9 +1321,15 @@ def make_message(**kwargs):
 def make_operation(**kwargs):
     bob = kwargs["workers"]["bob"]
     bob.log_msgs = True
+
     x = torch.tensor([1, 2, 3, 4]).send(bob)
     y = x * 2
-    op = bob._get_msg(-1)
+    op1 = bob._get_msg(-1)
+
+    a = torch.tensor([[1, 2], [3, 4]]).send(bob)
+    b = a.sum(1, keepdim=True)
+    op2 = bob._get_msg(-1)
+
     bob.log_msgs = False
 
     def compare(detailed, original):
@@ -1348,20 +1354,32 @@ def make_operation(**kwargs):
         assert detailed.return_ids == original.return_ids
         return True
 
-    message = (op.cmd_name, op.cmd_owner, op.cmd_args, op.cmd_kwargs)
+    message1 = (op1.cmd_name, op1.cmd_owner, op1.cmd_args, op1.cmd_kwargs)
+    message2 = (op2.cmd_name, op2.cmd_owner, op2.cmd_args, op2.cmd_kwargs)
 
     return [
         {
-            "value": op,
+            "value": op1,
             "simplified": (
                 CODE[syft.messaging.message.Operation],
                 (
-                    msgpack.serde._simplify(syft.hook.local_worker, message),  # (Any) message
-                    (CODE[tuple], (op.return_ids[0],)),  # (tuple) return_ids
+                    msgpack.serde._simplify(syft.hook.local_worker, message1),  # (Any) message
+                    (CODE[tuple], (op1.return_ids[0],)),  # (tuple) return_ids
                 ),
             ),
             "cmp_detailed": compare,
-        }
+        },
+        {
+            "value": op2,
+            "simplified": (
+                CODE[syft.messaging.message.Operation],
+                (
+                    msgpack.serde._simplify(syft.hook.local_worker, message2),  # (Any) message
+                    (CODE[tuple], (op2.return_ids[0],)),  # (tuple) return_ids
+                ),
+            ),
+            "cmp_detailed": compare,
+        },
     ]
 
 


### PR DESCRIPTION
This adds serialization for all the types required to make round-trip serialization of `AdditiveSharingTensor` work (at least to the extent that serialization tests pass.)

Depends on OpenMined/syft-proto#24 and #2876.