### PR TITLE
Downgrade Pillow to <7

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -7,6 +7,7 @@ numpy>=1.16.0
 tblib>=1.4.0
 torch==1.3
 torchvision==0.4.1
+Pillow<7
 websocket_client>=0.56.0
 websockets>=7.0
 zstd>=1.4.0.0


### PR DESCRIPTION
The tests are failling because ```PILLOW_VERSION``` is removed in ```Pillow7.0```
We need to keep track of the [torchvision release](https://github.com/python-pillow/Pillow/releases) that has [this fix](https://github.com/pytorch/vision/pull/1501) in it.

**LE**: This should unblock travis :)