### PR TITLE
Split tutorial notebook translation test into separate tests per lang

### DIFF
--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -19,6 +19,7 @@ from syft.workers.websocket_server import WebsocketServerWorker
 
 # lets start by finding all notebooks currently available in examples and subfolders
 all_notebooks = [Path(n) for n in glob.glob("examples/tutorials/**/*.ipynb", recursive=True)]
+all_languages = [l.split("/")[-1] for l in glob.glob("examples/tutorials/translations/*")]
 
 # buggy notebooks with explanation what does not work
 exclusion_list_notebooks = [
@@ -76,9 +77,10 @@ def test_notebooks_basic(isolated_filesystem):
             assert isinstance(res, nbformat.notebooknode.NotebookNode)
 
 
-def test_notebooks_basic_translations(isolated_filesystem):
+@pytest.mark.parametrize("language", all_languages)
+def test_notebooks_basic_translations(isolated_filesystem, language):
     """Test Notebooks in the tutorial root folder."""
-    notebooks = glob.glob("translations/**/*.ipynb", recursive=True)
+    notebooks = glob.glob(f"translations/{language}/*.ipynb")
     for notebook in notebooks:
         list_name = Path("examples/tutorials/") / notebook
         if list_name in not_excluded_notebooks:


### PR DESCRIPTION
The single translation test was taking more than 10m to execute, which was leading Travis CI to infer that our tests were frozen and terminate the builds.