### PR TITLE
ObjectRequestMessage for async example

### DIFF
--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -159,7 +159,7 @@ class WebsocketClientWorker(BaseWorker):
         self.connect()
 
         # Send an object request message to retrieve the result tensor of the fit() method
-        msg = ObjectRequestMessage(return_ids[0])
+        msg = ObjectRequestMessage((return_ids[0], None, ""))
         serialized_message = sy.serde.serialize(msg)
         response = self._send_msg(serialized_message)
 


### PR DESCRIPTION
The MNIST async websocket exampe fails because the workers cannot unpack an int. The message sent needs to be the tuple defined previously.