### PR TITLE
Modify conv implementation and corresponding test to get exact match

### DIFF
--- a/test/torch/nn/test_conv.py
+++ b/test/torch/nn/test_conv.py
@@ -4,15 +4,15 @@ import torch.nn as nn
 import pytest
 
 
-# Disable mkldnn to avoid rounding errors due to difference in implementation
-th._C._set_mkldnn_enabled(False)
-
-
 def test_conv2d():
     """
     Test the Conv2d module to ensure that it produces the exact same
     output as the primary torch implementation, in the same order.
     """
+
+    # Disable mkldnn to avoid rounding errors due to difference in implementation
+    mkldnn_enabled_init = th._C._get_mkldnn_enabled()
+    th._C._set_mkldnn_enabled(False)
 
     model2 = nn2.Conv2d(1, 32, 3, bias=True)
 
@@ -36,5 +36,8 @@ def test_conv2d():
     out = model(data)
 
     out2 = model2(data)
+
+    # Reset mkldnn to the original state
+    th._C._set_mkldnn_enabled(mkldnn_enabled_init)
 
     assert th.eq(out, out2).all()

--- a/test/torch/nn/test_conv.py
+++ b/test/torch/nn/test_conv.py
@@ -4,6 +4,10 @@ import torch.nn as nn
 import pytest
 
 
+# Disable mkldnn to avoid rounding errors due to difference in implementation
+th._C._set_mkldnn_enabled(False)
+
+
 def test_conv2d():
     """
     Test the Conv2d module to ensure that it produces the exact same
@@ -33,4 +37,4 @@ def test_conv2d():
 
     out2 = model2(data)
 
-    assert th.isclose(out, out2, atol=1e-6).all()
+    assert th.eq(out, out2).all()


### PR DESCRIPTION
Solves #2927 by changing the convolution implementation and disabling mkldnn while running the test. Test for handcrafted convolution also modified to check for exact match. 