### PR TITLE
Disable `msgpack` serialization of raw `Message` objects

### DIFF
--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -58,6 +58,11 @@ class Message:
         """
         This function takes the attributes of a Message and saves them in a tuple.
         The detail() method runs the inverse of this method.
+
+        This method is provided as a convenience to make it easier to serialize
+        simple message type sub-classes, but other code should never rely on
+        round-trip serialization of raw Message objects.
+
         Args:
             worker (AbstractWorker): a reference to the worker doing the serialization
             ptr (Message): a Message
@@ -66,7 +71,6 @@ class Message:
         Examples:
             data = simplify(ptr)
         """
-
         return (sy.serde.msgpack.serde._simplify(worker, ptr.contents),)
 
     @staticmethod
@@ -75,8 +79,8 @@ class Message:
         This function takes the simplified tuple version of this message and converts
         it into a message. The simplify() method runs the inverse of this method.
 
-        This method shouldn't get called very often. It exists as a backup but in theory
-        every message type should have its own detailer.
+        This method should never get called, since every message type should have
+        its own detailer.
 
         Args:
             worker (AbstractWorker): a reference to the worker necessary for detailing. Read
@@ -87,13 +91,7 @@ class Message:
         Examples:
             message = detail(sy.local_worker, msg_tuple)
         """
-
-        # TODO: attempt to use the msg_tuple[0] to return the correct type instead of Message
-        # https://github.com/OpenMined/PySyft/issues/2514
-        # TODO: as an alternative, this detailer could raise NotImplementedException
-        # https://github.com/OpenMined/PySyft/issues/2514
-
-        return Message(sy.serde.msgpack.serde._detail(worker, msg_tuple[0]))
+        raise NotImplementedError
 
     def __str__(self):
         """Return a human readable version of this message"""

--- a/syft/serde/msgpack/serde.py
+++ b/syft/serde/msgpack/serde.py
@@ -119,7 +119,6 @@ OBJ_SIMPLIFIER_AND_DETAILERS = [
     TrainConfig,
     BaseWorker,
     AutogradTensor,
-    Message,
     Operation,
     ObjectMessage,
     ObjectRequestMessage,

--- a/test/serde/msgpack/test_msgpack_serde_full.py
+++ b/test/serde/msgpack/test_msgpack_serde_full.py
@@ -69,7 +69,6 @@ samples[syft.frameworks.torch.tensors.interpreters.autograd.AutogradTensor] = ma
 samples[syft.frameworks.torch.tensors.interpreters.private.PrivateTensor] = make_privatetensor
 samples[syft.frameworks.torch.tensors.interpreters.placeholder.PlaceHolder] = make_placeholder
 
-samples[syft.messaging.message.Message] = make_message
 samples[syft.messaging.message.Operation] = make_operation
 samples[syft.messaging.message.ObjectMessage] = make_objectmessage
 samples[syft.messaging.message.ObjectRequestMessage] = make_objectrequestmessage


### PR DESCRIPTION
Serializing generic messages won't work well in Protobuf, and this
capability isn't currently used in the existing code base, so let's
disable it.

Resolves #2514.