### PR TITLE
Add tag for sending tensors to crypten

### DIFF
--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -1,4 +1,46 @@
+import torch
+import syft
 from syft.frameworks.crypten.context import toy_func, run_party
+import crypten.communicator as comm
+import crypten
 
 
-__all__ = ["toy_func", "run_party"]
+def load(tag: str, src: int, id_worker: int):
+    if comm.get().get_rank() == src:
+        worker = syft.local_worker.get_worker(id_worker)
+        result = worker.search(tag)[0].get()
+
+        # file contains torch.tensor
+        if torch.is_tensor(result):
+            # Broadcast load type
+            load_type = torch.tensor(0, dtype=torch.long)
+            comm.get().broadcast(load_type, src=src)
+
+            # Broadcast size to other parties.
+            dim = torch.tensor(result.dim(), dtype=torch.long)
+            size = torch.tensor(result.size(), dtype=torch.long)
+
+            comm.get().broadcast(dim, src=src)
+            comm.get().broadcast(size, src=src)
+            result = crypten.mpc.MPCTensor(result, src=src)
+    else:
+        # Receive load type from source party
+        load_type = torch.tensor(-1, dtype=torch.long)
+        comm.get().broadcast(load_type, src=src)
+
+        # Load in tensor
+        if load_type.item() == 0:
+            # Receive size from source party
+            dim = torch.empty(size=(), dtype=torch.long)
+            comm.get().broadcast(dim, src=src)
+            size = torch.empty(size=(dim.item(),), dtype=torch.long)
+            comm.get().broadcast(size, src=src)
+            result = crypten.mpc.MPCTensor(torch.empty(size=tuple(size.tolist())), src=src)
+        else:
+            raise TypeError("Unrecognized load type on src")
+    # TODO: Encrypt modules before returning them
+
+    return result
+
+
+__all__ = ["toy_func", "run_party", "load"]

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -2,9 +2,13 @@ import functools
 import multiprocessing
 import threading
 import os
+
+import syft as sy
+from syft.messaging.message import CryptenInit
+from syft.frameworks import crypten as syft_crypt
+
 import crypten
 from crypten.communicator import DistributedCommunicator
-from syft.messaging.message import CryptenInit
 
 
 def _launch(func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs):
@@ -80,11 +84,11 @@ def _send_party_info(worker, rank, msg, return_values):
 
 
 def toy_func():
-    # Toy function to be called by each party
-    alice_t = crypten.cryptensor([73, 81], src=0)
-    bob_t = crypten.cryptensor([90, 100], src=1)
-    out = bob_t.get_plain_text()
-    return out.tolist()  # issues with putting torch tensors into queues
+    alice_tensor = syft_crypt.load("crypten_data", 1, "alice")
+    bob_tensor = syft_crypt.load("crypten_data", 2, "bob")
+
+    crypt = crypten.cat([alice_tensor, bob_tensor], dim=0)
+    return crypt.get_plain_text().tolist()
 
 
 def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -1,21 +1,27 @@
 import pytest
 from syft.frameworks.crypten.context import run_multiworkers
+import torch as th
 
 
 def test_context(workers):
     # self, alice and bob
     n_workers = 3
+
     alice = workers["alice"]
     bob = workers["bob"]
+
+    alice_tensor_ptr = th.tensor([42, 53]).tag("crypten_data").send(alice)
+    bob_tensor_ptr = th.tensor([101, 32]).tag("crypten_data").send(bob)
 
     @run_multiworkers([alice, bob], master_addr="127.0.0.1")
     def test_three_parties():
         pass  # pragma: no cover
 
     return_values = test_three_parties()
+    print(return_values)
     # A toy function is ran at each party, and they should all decrypt
-    # a tensor with value [90., 100.]
-    expected_value = [90.0, 100.0]
+    # a tensor with value [42, 53, 101, 32]
+    expected_value = [42, 53, 101, 32]
     for rank in range(n_workers):
         assert (
             return_values[rank] == expected_value


### PR DESCRIPTION
Added ```self``` such that we can reference the worker in the ```toy_func``` and use the tag to work with the specific data.

A possible fix for #2986