### PR TITLE
Automatically update Docker Hub using GitHub Actions (on push to master)

### DIFF
--- a/.github/workflows/update-docker-image.yml
+++ b/.github/workflows/update-docker-image.yml
@@ -1,0 +1,38 @@
+name: Update Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE: openmined/pysyft-notebook
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+
+      - name: Build image
+        run: docker build -t $IMAGE -f docker-images/pysyft-notebook/Dockerfile .
+
+      - name: Tag images
+        run: |
+          docker tag $IMAGE $IMAGE:latest
+          docker tag $IMAGE $IMAGE:$GITHUB_SHA
+
+      - name: Publish to docker hub
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" |  docker login -u ${{ secrets.DOCKER_LOGIN }} --password-stdin
+          docker push $IMAGE:latest
+          docker push $IMAGE:$GITHUB_SHA
+
+


### PR DESCRIPTION
Automatically update Docker Hub image at [https://hub.docker.com/r/openmined/pysyft-notebook](https://hub.docker.com/r/openmined/pysyft-notebook) on push to Master (using GitHub Actions).

Addresses https://github.com/OpenMined/PySyft/issues/2528


Requires:
- [ ] DOCKER_LOGIN & DOCKER_PASSWORD need to be added by Project Maintainers as secrets in repo settings

Questions:
- not sure how to explicitly test that this works, so I'm not sure if there is a way and I'm missing that test...
- Python version set to '3.x', is this okay? 
    - In the test workflows, both 3.6 and 3.7 are specifically tested
    - in the publish to pypi, 3.x is used
- Did not include publishing to GitHub Packages as per [the example](https://github.com/arkhn/fhir-pipe/blob/master/.github/workflows/main.yml) listed in https://github.com/OpenMined/PySyft/issues/2528. Do you want this feature? 

