### PR TITLE
Failing tutorial translations should be ignored

### DIFF
--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -26,6 +26,11 @@ advanced_notebooks = [
 translated_notebooks = [
     n for n in glob.glob("examples/tutorials/translations/**/*.ipynb", recursive=True)
 ]
+# Exclude all translated basic tutorials that are also
+# excluded in their original version.
+excluded_translated_notebooks = [
+    nb for part in ["10", "13b", "13c"] for nb in translated_notebooks if part in nb
+]
 
 # buggy notebooks with explanation what does not work
 exclusion_list_notebooks = [
@@ -42,6 +47,9 @@ exclusion_list_notebooks = [
     # Outdated websocket client code
     "Federated learning with websockets and federated averaging.ipynb",
 ]
+
+# Add excluded translated notebooks to the exclusion list
+exclusion_list_notebooks += excluded_translated_notebooks
 
 exclusion_list_folders = [
     "examples/tutorials/websocket",


### PR DESCRIPTION
Some *"basic"* tutorials are ignored in [`test_notebooks.py`](https://github.com/OpenMined/PySyft/blob/master/test/notebooks/test_notebooks.py), namely part 10, 13b and 13c, for multiple reasons (e.g. numpy needs to be hooked for part 10 https://github.com/OpenMined/PySyft/pull/2990).

This PR excludes the translated versions of these *"basic"* tutorials so that the translations of these parts in all languages can be merged while the issues are resolved.  

See: 
- https://github.com/OpenMined/PySyft/pull/3031 
- https://github.com/OpenMined/PySyft/pull/2980