### PR TITLE
Reduce websocket timeout to one minute

### DIFF
--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -17,7 +17,7 @@ from syft.workers.base import BaseWorker
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT_INTERVAL = 999_999
+TIMEOUT_INTERVAL = 60
 
 
 class WebsocketClientWorker(BaseWorker):


### PR DESCRIPTION
This is making CI tests hang ~forever. I think 278 hours is a bit
excessive, don't you? :)