### PR TITLE
Update msgpack version requirement

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -1,7 +1,7 @@
 Flask>=1.0.2
 flask_socketio>=3.3.2
 lz4>=2.1.6
-msgpack>=0.6.1
+msgpack>=1.0.0
 numpy>=1.16.0
 phe>=1.4.0
 Pillow<7


### PR DESCRIPTION
This is a follow-up to #3067. The changes in that PR broke compatibility with `msgpack<1.0.0`, requirements should reflect that.