### PR TITLE
Syft load based ONLY on rank

### DIFF
--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -1,17 +1,28 @@
 import torch
 import syft
+
 from syft.frameworks.crypten.context import toy_func, run_party
+from syft.exceptions import WorkerNotFoundException
+
 import crypten.communicator as comm
 import crypten
 
 
-def load(tag: str, src: int, id_worker: int):
-    if comm.get().get_rank() == src:
-        worker = syft.local_worker.get_worker(id_worker)
-        result = worker.search(tag)[0].get()
+def load(tag: str, id_worker: int):
 
-        # file contains torch.tensor
+    src = syft.local_worker.get_rank_from_id(id_worker)
+
+    try:
+        worker = syft.local_worker.get_worker(id_worker, fail_hard=True)
+
+        # It should be a tensor and not a pointer
+        results = worker.search(tag)
+        assert len(results) == 1
+
+        result = results[0]
+
         if torch.is_tensor(result):
+
             # Broadcast load type
             load_type = torch.tensor(0, dtype=torch.long)
             comm.get().broadcast(load_type, src=src)
@@ -23,7 +34,10 @@ def load(tag: str, src: int, id_worker: int):
             comm.get().broadcast(dim, src=src)
             comm.get().broadcast(size, src=src)
             result = crypten.mpc.MPCTensor(result, src=src)
-    else:
+        else:
+            raise TypeError("Unrecognized load type on src")
+
+    except WorkerNotFoundException:
         # Receive load type from source party
         load_type = torch.tensor(-1, dtype=torch.long)
         comm.get().broadcast(load_type, src=src)
@@ -38,7 +52,6 @@ def load(tag: str, src: int, id_worker: int):
             result = crypten.mpc.MPCTensor(torch.empty(size=tuple(size.tolist())), src=src)
         else:
             raise TypeError("Unrecognized load type on src")
-    # TODO: Encrypt modules before returning them
 
     return result
 

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -8,18 +8,18 @@ import crypten.communicator as comm
 import crypten
 
 
-def load(tag: str, id_worker: int):
-
-    src = syft.local_worker.get_rank_from_id(id_worker)
+def load(tag: str, src: int):
+    worker_id = syft.local_worker.get_worker_id_from_rank(src)
+    assert worker_id != -1
 
     try:
-        worker = syft.local_worker.get_worker(id_worker, fail_hard=True)
-
-        # It should be a tensor and not a pointer
+        worker = syft.local_worker.get_worker(worker_id, fail_hard=True)
         results = worker.search(tag)
+
+        # Make sure there is only one result
         assert len(results) == 1
 
-        result = results[0]
+        result = results[0].get()
 
         if torch.is_tensor(result):
 

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -2,18 +2,14 @@ import torch
 import syft
 
 from syft.frameworks.crypten.context import toy_func, run_party
-from syft.exceptions import WorkerNotFoundException
 
 import crypten.communicator as comm
 import crypten
 
 
 def load(tag: str, src: int):
-    worker_id = syft.local_worker.get_worker_id_from_rank(src)
-    assert worker_id != -1
-
-    try:
-        worker = syft.local_worker.get_worker(worker_id, fail_hard=True)
+    if src == comm.get().get_rank():
+        worker = syft.local_worker.get_worker_from_rank(src)
         results = worker.search(tag)
 
         # Make sure there is only one result
@@ -37,7 +33,7 @@ def load(tag: str, src: int):
         else:
             raise TypeError("Unrecognized load type on src")
 
-    except WorkerNotFoundException:
+    else:
         # Receive load type from source party
         load_type = torch.tensor(-1, dtype=torch.long)
         comm.get().broadcast(load_type, src=src)

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -84,8 +84,8 @@ def _send_party_info(worker, rank, msg, return_values):
 
 
 def toy_func():
-    alice_tensor = syft_crypt.load("crypten_data", "alice")
-    bob_tensor = syft_crypt.load("crypten_data", "bob")
+    alice_tensor = syft_crypt.load("crypten_data", 1)
+    bob_tensor = syft_crypt.load("crypten_data", 2)
 
     crypt = crypten.cat([alice_tensor, bob_tensor], dim=0)
     return crypt.get_plain_text().tolist()
@@ -110,11 +110,11 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
             world_size = len(workers) + 1
             return_values = {rank: None for rank in range(world_size)}
 
-            worker_id_to_rank = dict(
-                zip([worker.id for worker in workers], range(1, len(workers) + 1))
+            rank_to_worker_id = dict(
+                zip(range(1, len(workers) + 1), [worker.id for worker in workers])
             )
 
-            sy.local_worker._set_worker_id_to_rank(worker_id_to_rank)
+            sy.local_worker._set_rank_to_worker_id(rank_to_worker_id)
 
             # Start local party
             process, queue = _new_party(toy_func, 0, world_size, master_addr, master_port, (), {})
@@ -139,8 +139,8 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
             # Send messages to other workers so they start their parties
             threads = []
             for i in range(len(workers)):
-                rank = worker_id_to_rank[workers[i].id]
-                msg = CryptenInit((worker_id_to_rank, world_size, master_addr, master_port))
+                rank = i+1
+                msg = CryptenInit((rank_to_worker_id, world_size, master_addr, master_port))
                 thread = threading.Thread(
                     target=_send_party_info, args=(workers[i], rank, msg, return_values)
                 )

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -110,12 +110,6 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
             world_size = len(workers) + 1
             return_values = {rank: None for rank in range(world_size)}
 
-            rank_to_worker_id = dict(
-                zip(range(1, len(workers) + 1), [worker.id for worker in workers])
-            )
-
-            sy.local_worker._set_rank_to_worker_id(rank_to_worker_id)
-
             # Start local party
             process, queue = _new_party(toy_func, 0, world_size, master_addr, master_port, (), {})
             was_initialized = DistributedCommunicator.is_initialized()
@@ -139,8 +133,8 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
             # Send messages to other workers so they start their parties
             threads = []
             for i in range(len(workers)):
-                rank = i+1
-                msg = CryptenInit((rank_to_worker_id, world_size, master_addr, master_port))
+                rank = i + 1
+                msg = CryptenInit((rank, world_size, master_addr, master_port))
                 thread = threading.Thread(
                     target=_send_party_info, args=(workers[i], rank, msg, return_values)
                 )

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -18,7 +18,7 @@ def test_context(workers):
         pass  # pragma: no cover
 
     return_values = test_three_parties()
-    print(return_values)
+
     # A toy function is ran at each party, and they should all decrypt
     # a tensor with value [42, 53, 101, 32]
     expected_value = [42, 53, 101, 32]


### PR DESCRIPTION
Fixes #3043 
Send the party information in the init message such that we need to keep track only of the worker id.