### PR TITLE
Send func src between workers to be executed in a secure env

### DIFF
--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -2,6 +2,11 @@ import functools
 import multiprocessing
 import threading
 import os
+import re
+import ast
+from dill.source import getsource
+from RestrictedPython import compile_restricted
+from RestrictedPython import safe_builtins
 
 import syft as sy
 from syft.messaging.message import CryptenInit
@@ -11,7 +16,20 @@ import crypten
 from crypten.communicator import DistributedCommunicator
 
 
-def _launch(func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs):
+def _check_func_def(func_src):
+    # The body should contain one element
+    tree = ast.parse(func_src)
+    if len(tree.body) != 1:
+        return (False, "")
+    # The body should contain a function defintion
+    func_def = tree.body[0]
+    if type(func_def) is not ast.FunctionDef:
+        return (False, "")
+
+    return (True, func_def.name)
+
+
+def _launch(func_src, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs):
     communicator_args = {
         "RANK": rank,
         "WORLD_SIZE": world_size,
@@ -23,6 +41,19 @@ def _launch(func, rank, world_size, master_addr, master_port, queue, func_args, 
     for key, val in communicator_args.items():
         os.environ[key] = str(val)
 
+    # func_src should contain one and only one function definition
+    is_func, func_name = _check_func_def(func_src)
+    if not is_func:
+        queue.put(-1)
+        return
+
+    # TODO: error handling
+    exec_globals = {'__builtins__': safe_builtins}
+    exec_globals['crypten'] = crypten
+    exec_locals = {}
+    compiled = compile_restricted(func_src)
+    exec(compiled, exec_globals, exec_locals)
+    func = exec_locals[func_name]
     crypten.init()
     return_value = func(*func_args, **func_kwargs)
     crypten.uninit()
@@ -30,20 +61,20 @@ def _launch(func, rank, world_size, master_addr, master_port, queue, func_args, 
     queue.put(return_value)
 
 
-def _new_party(func, rank, world_size, master_addr, master_port, func_args, func_kwargs):
+def _new_party(func_src, rank, world_size, master_addr, master_port, func_args, func_kwargs):
     queue = multiprocessing.Queue()
     process = multiprocessing.Process(
         target=_launch,
-        args=(func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs),
+        args=(func_src, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs),
     )
     return process, queue
 
 
-def run_party(func, rank, world_size, master_addr, master_port, func_args, func_kwargs):
+def run_party(func_src, rank, world_size, master_addr, master_port, func_args, func_kwargs):
     """Start crypten party localy and run computation.
 
     Args:
-        func (function): computation to be done.
+        func_src (str): function source code.
         rank (int): rank of the crypten party.
         world_size (int): number of crypten parties involved in the computation.
         master_addr (str): IP address of the master party (party with rank 0).
@@ -52,11 +83,11 @@ def run_party(func, rank, world_size, master_addr, master_port, func_args, func_
         func_kwargs (dict): keyword arguments to be passed to func.
 
     Returns:
-        The return value of func.
+        The return value of the executed function.
     """
 
     process, queue = _new_party(
-        func, rank, world_size, master_addr, master_port, func_args, func_kwargs
+        func_src, rank, world_size, master_addr, master_port, func_args, func_kwargs
     )
     was_initialized = DistributedCommunicator.is_initialized()
     if was_initialized:
@@ -109,9 +140,13 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
 
             world_size = len(workers) + 1
             return_values = {rank: None for rank in range(world_size)}
+            
+            # Get func_src without decorators
+            re_decorator = r'@[^\(]+\([^\)]*\)'
+            func_src = re.sub(re_decorator, '', getsource(func))
 
             # Start local party
-            process, queue = _new_party(toy_func, 0, world_size, master_addr, master_port, (), {})
+            process, queue = _new_party(func_src, 0, world_size, master_addr, master_port, (), {})
             was_initialized = DistributedCommunicator.is_initialized()
             if was_initialized:
                 crypten.uninit()
@@ -120,7 +155,7 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
             # TODO: run ttp in a specified worker
             if crypten.mpc.ttp_required():
                 ttp_process, _ = _new_party(
-                    crypten.mpc.provider.TTPServer,
+                    getsource(crypten.mpc.provider.TTPServer),
                     world_size,
                     world_size,
                     master_addr,
@@ -134,7 +169,7 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
             threads = []
             for i in range(len(workers)):
                 rank = i + 1
-                msg = CryptenInit((rank, world_size, master_addr, master_port))
+                msg = CryptenInit((func_src, rank, world_size, master_addr, master_port))
                 thread = threading.Thread(
                     target=_send_party_info, args=(workers[i], rank, msg, return_values)
                 )
@@ -143,7 +178,9 @@ def run_multiworkers(workers: list, master_addr: str, master_port: int = 15987):
 
             # Wait for local party and sender threads
             process.join()
-            return_values[0] = queue.get()
+            local_return = queue.get()
+            # TODO: check if bad function definition (or other error)
+            return_values[0] = local_return
             for thread in threads:
                 thread.join()
             if was_initialized:

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -409,8 +409,8 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             An ObjectMessage containing the return value of the crypten function computed.
         """
 
-        rank, world_size, master_addr, master_port = message
-        return_value = run_party(toy_func, rank, world_size, master_addr, master_port, (), {})
+        func_src, rank, world_size, master_addr, master_port = message
+        return_value = run_party(func_src, rank, world_size, master_addr, master_port, (), {})
         return ObjectMessage(return_value)
 
     def execute_command(self, message: tuple) -> PointerTensor:


### PR DESCRIPTION
CrypTen assume that each party will be running the same function as all the other ones, so we need a way to have Syft workers exchange functions. The first intuition was to use plans, but it also have its challenges as stated here #3027

Here I make Syft workers exchange function as source code, workers will make sure that the source code is a function definition and execute it in a secure environment. Built-in functions aren't accessible and someone can't import arbitrary module but is only limited to what CrypTen provide.