### PR TITLE
Change GHA checkout version in translation tests

### DIFF
--- a/.github/workflows/translated-tutorials.yml
+++ b/.github/workflows/translated-tutorials.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: [3.6, 3.7]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -39,5 +39,5 @@ jobs:
         python setup.py install
     - name: Test with pytest
       run: |
-        git diff --name-only ${{ github.base_ref }} examples/tutorials/translations/ > ./test/notebooks/git-diff.txt
+        git diff --name-only ${{ github.event.before }} ${{ github.sha }} examples/tutorials/translations/ > ./test/notebooks/git-diff.txt
         pytest test/notebooks/test_notebooks.py::test_notebooks_basic_translations_diff


### PR DESCRIPTION
Failing changes here: https://github.com/OpenMined/PySyft/pull/3082 
Potential solution [here](https://github.community/t5/GitHub-Actions/GitHub-actions-does-not-print-git-diff/td-p/43755)