### PR TITLE
Use v2 and fetch all in checkout during build for translations

### DIFF
--- a/.github/workflows/translated-tutorials.yml
+++ b/.github/workflows/translated-tutorials.yml
@@ -1,4 +1,4 @@
-name: Tutorials
+name: Tutorials-Translations
 
 on:
   push:
@@ -21,7 +21,9 @@ jobs:
         python-version: [3.6, 3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --no-tags --prune --depth=0 origin +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -39,5 +41,5 @@ jobs:
         python setup.py install
     - name: Test with pytest
       run: |
-        git diff --name-only ${{ github.event.before }} ${{ github.sha }} examples/tutorials/translations/ > ./test/notebooks/git-diff.txt
+        git diff --name-only origin/master HEAD examples/tutorials/translations/ > ./test/notebooks/git-diff.txt
         pytest test/notebooks/test_notebooks.py::test_notebooks_basic_translations_diff


### PR DESCRIPTION
Looks like what really works is this: https://github.com/actions/checkout/issues/160 regarding the problem with https://github.com/OpenMined/PySyft/pull/3084. Hopefully this will set the right track to solve at least problem 2 of this issue: https://github.com/OpenMined/PySyft/issues/2917