### PR TITLE
README.md update: specify python=3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Prompt](https://docs.anaconda.com/anaconda/user-guide/getting-started/) to
 work from the command line.
 
 ```bash
-conda create -n pysyft python=3
+conda create -n pysyft python=3.7
 conda activate pysyft # some older version of conda require "source activate pysyft" instead.
 conda install jupyter notebook
 ```


### PR DESCRIPTION
As of now, `conda create -n pysyft python=3` will create an environment with python 3.8, which will not be able to run PySift, due to its Tensorflow dependencies. By specifying `python=3.7`, we solve this issue.