### PR TITLE
Turn existing formatted strings into f-strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,13 @@ repos:
     rev: v1.1.0
     hooks:
     -   id: python-use-type-annotations
+-   repo: local
+    hooks:
+    -   id: flynt
+        name: flynt
+        entry: flynt
+        args: [--fail-on-change]
+        types: [python]
+        language: python
+        additional_dependencies:
+        -   flynt

--- a/examples/tutorials/advanced/websockets-example-MNIST-parallel/run_websocket_client.py
+++ b/examples/tutorials/advanced/websockets-example-MNIST-parallel/run_websocket_client.py
@@ -162,10 +162,10 @@ def evaluate_model_on_worker(
     logger.info(
         "%s: Average loss: %s, Accuracy: %s/%s (%s%%)",
         model_identifier,
-        "{:.4f}".format(test_loss),
+        f"{test_loss:.4f}",
         correct,
         len_dataset,
-        "{:.2f}".format(100.0 * correct / len_dataset),
+        f"{100.0 * correct / len_dataset:.2f}",
     )
 
 

--- a/examples/tutorials/advanced/websockets-example-MNIST/run_websocket_client.py
+++ b/examples/tutorials/advanced/websockets-example-MNIST/run_websocket_client.py
@@ -127,9 +127,7 @@ def train(
     counter = 0
 
     while True:
-        logger.debug(
-            "Starting training round, batches [{}, {}]".format(counter, counter + nr_batches)
-        )
+        logger.debug(f"Starting training round, batches [{counter}, {counter + nr_batches}]")
         data_for_all_workers = True
         for worker in batches:
             curr_batches = batches[worker]

--- a/syft/execution/plan.py
+++ b/syft/execution/plan.py
@@ -162,7 +162,7 @@ class Plan(AbstractObject, ObjectStorage):
         mapped_shapes = []
         for shape in args_shape:
             if list(filter(lambda x: x < -1, shape)):
-                raise ValueError("Invalid shape {}".format(shape))
+                raise ValueError(f"Invalid shape {shape}")
             mapped_shapes.append(tuple(map(lambda y: 1 if y == -1 else y, shape)))
 
         return [sy.framework.hook.create_zeros(shape) for shape in mapped_shapes]

--- a/syft/execution/state.py
+++ b/syft/execution/state.py
@@ -28,7 +28,7 @@ class State(object):
         out = "<"
         out += "State:"
         for state_placeholder in self.state_placeholders:
-            out += " {}".format(state_placeholder)
+            out += f" {state_placeholder}"
         out += ">"
         return out
 

--- a/syft/federated/federated_client.py
+++ b/syft/federated/federated_client.py
@@ -60,7 +60,7 @@ class FederatedClient(ObjectStorage):
             optimizer_args.setdefault("params", model.parameters())
             self.optimizer = optimizer(**optimizer_args)
         else:
-            raise ValueError("Unknown optimizer: {}".format(optimizer_name))
+            raise ValueError(f"Unknown optimizer: {optimizer_name}")
         return self.optimizer
 
     def fit(self, dataset_key: str, device: str = "cpu", **kwargs):
@@ -76,7 +76,7 @@ class FederatedClient(ObjectStorage):
         self._check_train_config()
 
         if dataset_key not in self.datasets:
-            raise ValueError("Dataset {} unknown.".format(dataset_key))
+            raise ValueError(f"Dataset {dataset_key} unknown.")
 
         model = self.get_obj(self.train_config._model_id).obj
         loss_fn = self.get_obj(self.train_config._loss_fn_id).obj
@@ -158,7 +158,7 @@ class FederatedClient(ObjectStorage):
         self._check_train_config()
 
         if dataset_key not in self.datasets:
-            raise ValueError("Dataset {} unknown.".format(dataset_key))
+            raise ValueError(f"Dataset {dataset_key} unknown.")
 
         eval_result = dict()
         model = self.get_obj(self.train_config._model_id).obj

--- a/syft/frameworks/keras/model/sequential.py
+++ b/syft/frameworks/keras/model/sequential.py
@@ -69,7 +69,7 @@ def serve(model, num_requests=5):
 
     def step_fn():
         global request_ix
-        print("Served encrypted prediction {i} to client.".format(i=request_ix))
+        print(f"Served encrypted prediction {request_ix} to client.")
         request_ix += 1
 
     model._queue_server.run(model._tfe_session, num_steps=num_requests, step_fn=step_fn)
@@ -137,9 +137,7 @@ def _instantiate_tfe_layer(keras_layer, stored_keras_weights):
     except AttributeError:
         # TODO: rethink how we warn the user about this, maybe codegen a list of
         #       supported layers in a doc somewhere
-        raise RuntimeError(
-            "TF Encrypted does not yet support the " "{lcls} layer.".format(lcls=keras_layer_type)
-        )
+        raise RuntimeError(f"TF Encrypted does not yet support the {keras_layer_type} layer.")
 
     # Extract argument list expected by layer __init__
     # TODO[jason]: find a better way

--- a/syft/frameworks/torch/fl/dataset.py
+++ b/syft/frameworks/torch/fl/dataset.py
@@ -135,7 +135,7 @@ def dataset_federate(dataset, workers):
     into a sy.FederatedDataset. The dataset given is split in len(workers)
     part and sent to each workers
     """
-    logger.info("Scanning and sending data to {}...".format(", ".join([w.id for w in workers])))
+    logger.info(f"Scanning and sending data to {', '.join([w.id for w in workers])}...")
 
     # take ceil to have exactly len(workers) sets after splitting
     data_size = math.ceil(len(dataset) / len(workers))
@@ -203,6 +203,6 @@ class FederatedDataset:
     def __repr__(self):
 
         fmt_str = "FederatedDataset\n"
-        fmt_str += "    Distributed accross: {}\n".format(", ".join(str(x) for x in self.workers))
-        fmt_str += "    Number of datapoints: {}\n".format(self.__len__())
+        fmt_str += f"    Distributed accross: {', '.join(str(x) for x in self.workers)}\n"
+        fmt_str += f"    Number of datapoints: {self.__len__()}\n"
         return fmt_str

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -294,8 +294,7 @@ class TorchHook(FrameworkHook):
         @wraps(attr)
         def overloaded_attr(self_torch, *args, **kwargs):
             ptr = hook_self.local_worker.send_command(
-                recipient=self_torch.worker(),
-                message=("{}.{}".format("torch", attr), None, args, kwargs),
+                recipient=self_torch.worker(), message=(f"{'torch'}.{attr}", None, args, kwargs)
             )
 
             return ptr.wrap()

--- a/syft/frameworks/torch/linalg/lr.py
+++ b/syft/frameworks/torch/linalg/lr.py
@@ -174,17 +174,17 @@ class EncryptedLinearRegression:
         print("-" * 52)
         for i, cf in enumerate(self.coef):
             print(
-                "coef" + "{:<3d}".format(i + 1),
-                "{:>14.4f}".format(cf),
-                "{:>14.4f}".format(self.se_coef[i]),
-                "{:>14.4f}".format(self.pvalue_coef[i]),
+                "coef" + f"{i + 1:<3d}",
+                f"{cf:>14.4f}",
+                f"{self.se_coef[i]:>14.4f}",
+                f"{self.pvalue_coef[i]:>14.4f}",
             )
         if self.fit_intercept:
             print(
                 "intercept",
-                "{:>12.4f}".format(self.intercept),
-                "{:>14.4f}".format(self.se_intercept),
-                "{:>14.4f}".format(self.pvalue_intercept),
+                f"{self.intercept:>12.4f}",
+                f"{self.se_intercept:>14.4f}",
+                f"{self.pvalue_intercept:>14.4f}",
             )
         print("-" * 52)
 

--- a/syft/frameworks/torch/nn/rnn.py
+++ b/syft/frameworks/torch/nn/rnn.py
@@ -68,7 +68,7 @@ class RNNCell(RNNCellBase):
         elif nonlinearity == "relu":
             self.nonlinearity = torch.relu
         else:
-            raise ValueError("Unknown nonlinearity: {}".format(nonlinearity))
+            raise ValueError(f"Unknown nonlinearity: {nonlinearity}")
 
     def forward(self, x, h=None):
 

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -84,7 +84,7 @@ class AdditiveSharingTensor(AbstractTensor):
             for v in self.child.values():
                 out += "\n\t-> " + str(v)
         if self.crypto_provider is not None:
-            out += "\n\t*crypto provider: {}*".format(self.crypto_provider.id)
+            out += f"\n\t*crypto provider: {self.crypto_provider.id}*"
         return out
 
     def __bool__(self):

--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -654,7 +654,7 @@ def register_response(
     if not response_is_tuple:
         response = (response, 1)
 
-    attr_id = "{}".format(attr)
+    attr_id = f"{attr}"
 
     try:
         assert attr not in ambiguous_functions

--- a/syft/generic/id_provider.py
+++ b/syft/generic/id_provider.py
@@ -57,7 +57,7 @@ class IdProvider:
         if check_ids:
             intersect = self.generated.intersection(set(given_ids))
             if len(intersect) > 0:
-                message = "Provided IDs {} are contained in already generated IDs".format(intersect)
+                message = f"Provided IDs {intersect} are contained in already generated IDs"
                 raise exceptions.IdNotUniqueError(message)
 
         self.given_ids += given_ids

--- a/syft/generic/pointers/object_pointer.py
+++ b/syft/generic/pointers/object_pointer.py
@@ -345,7 +345,7 @@ class ObjectPointer(AbstractObject):
 
     def _create_attr_name_string(self, attr_name):
         if self.point_to_attr is not None:
-            point_to_attr = "{}.{}".format(self.point_to_attr, attr_name)
+            point_to_attr = f"{self.point_to_attr}.{attr_name}"
         else:
             point_to_attr = attr_name
         return point_to_attr

--- a/syft/serde/msgpack/proto.py
+++ b/syft/serde/msgpack/proto.py
@@ -36,7 +36,7 @@ class TypeInfo:
         if "code" in self.obj:
             return self.obj["code"]
         else:
-            raise UndefinedProtocolTypePropertyError("code is not set for %s" % self.name)
+            raise UndefinedProtocolTypePropertyError(f"code is not set for {self.name}")
 
     @property
     def forced_code(self):
@@ -45,7 +45,7 @@ class TypeInfo:
         if "forced_code" in self.obj:
             return self.obj["forced_code"]
         else:
-            raise UndefinedProtocolTypePropertyError("forced_code is not set for %s" % self.name)
+            raise UndefinedProtocolTypePropertyError(f"forced_code is not set for {self.name}")
 
 
 def fullname(cls):
@@ -68,4 +68,4 @@ def proto_type_info(cls):
     if type_name in proto_info["TYPES"]:
         return TypeInfo(name=type_name, obj=proto_info["TYPES"][type_name])
     else:
-        raise UndefinedProtocolTypeError("%s is not defined in the protocol file" % type_name)
+        raise UndefinedProtocolTypeError(f"{type_name} is not defined in the protocol file")

--- a/syft/workers/tfe.py
+++ b/syft/workers/tfe.py
@@ -73,7 +73,7 @@ class TFEWorker:
     def connect_to_model(self, input_shape, output_shape, cluster, sess=None):
         """
         Connect to a TF Encrypted model being served by the given cluster.
-        
+
         This must be done before querying the model.
         """
 
@@ -96,7 +96,7 @@ class TFEWorker:
     def query_model(self, data):
         """
         Encrypt data and sent it as input to the model being served.
-        
+
         This will block until a result is ready, and requires that
         a connection to the model has already been established via
         `connect_to_model()`.
@@ -108,7 +108,7 @@ class TFEWorker:
         """
         Asynchronous version of `query_model` that will not block until a
         result is ready. Call `query_model_join` to retrive result.
-        
+
         This requires that a connection to the model has already been
         established via `connect_to_model()`.
         """
@@ -154,7 +154,7 @@ class TFECluster:
 
     def _build_cluster(self, workers):
         if len(workers) != 3:
-            raise ValueError("Expected three workers but {} were given".format(len(workers)))
+            raise ValueError(f"Expected three workers but {len(workers)} were given")
 
         player_to_worker_mapping = OrderedDict()
         player_to_worker_mapping["server0"] = workers[0]

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -494,7 +494,7 @@ def test_fetch_stateful_plan(hook, is_func2plan, workers):
 def test_fetch_stateful_plan_remote(hook, is_func2plan, start_remote_worker):
 
     server, remote_proxy = start_remote_worker(
-        id="test_fetch_stateful_plan_remote_{}".format(is_func2plan), hook=hook, port=8802
+        id=f"test_fetch_stateful_plan_remote_{is_func2plan}", hook=hook, port=8802
     )
 
     if is_func2plan:

--- a/test/federated/test_federated_client.py
+++ b/test/federated/test_federated_client.py
@@ -104,7 +104,7 @@ def train_model(
                 loss = fed_client.fit(dataset_key=fit_dataset_key, device=device)
         if PRINT_IN_UNITTESTS and curr_round % 2 == 0:  # pragma: no cover
             print("-" * 50)
-            print("Iteration %s: alice's loss: %s" % (curr_round, loss))
+            print(f"Iteration {curr_round}: alice's loss: {loss}")
 
 
 @pytest.mark.parametrize(
@@ -156,7 +156,7 @@ def test_fit(fit_dataset_key, epochs, device):
     pred = model(data_device)
     loss_before = loss_fn(target=target_device, pred=pred)
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Loss before training: {}".format(loss_before))
+        print(f"Loss before training: {loss_before}")
 
     # Create and send train config
     train_config = sy.TrainConfig(
@@ -181,11 +181,11 @@ def test_fit(fit_dataset_key, epochs, device):
     if dataset_key == fit_dataset_key:
         loss_after = evaluate_model(fed_client, model_id, loss_fn, data_device, target_device)
         if PRINT_IN_UNITTESTS:  # pragma: no cover
-            print("Loss after training: {}".format(loss_after))
+            print(f"Loss after training: {loss_after}")
 
         if loss_after >= loss_before:  # pragma: no cover
             if PRINT_IN_UNITTESTS:
-                print("Loss not reduced, train more: {}".format(loss_after))
+                print(f"Loss not reduced, train more: {loss_after}")
 
             train_model(
                 fed_client, fit_dataset_key, available_dataset_key=dataset_key, nr_rounds=10
@@ -237,7 +237,7 @@ def test_evaluate():  # pragma: no cover
     pred = model(data)
     loss_before = loss_fn(target=target, pred=pred)
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Loss before training: {}".format(loss_before))
+        print(f"Loss before training: {loss_before}")
 
     # Create and send train config
     train_config = sy.TrainConfig(
@@ -266,7 +266,7 @@ def test_evaluate():  # pragma: no cover
     hist_target = result["histogram_target"]
 
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Evaluation result before training: {}".format(result))
+        print(f"Evaluation result before training: {result}")
 
     assert len_dataset == 30
     assert (hist_target == [10, 10, 10]).all()
@@ -298,7 +298,7 @@ def test_evaluate():  # pragma: no cover
     hist_target = result["histogram_target"]
 
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Evaluation result: {}".format(result))
+        print(f"Evaluation result: {result}")
 
     assert len_dataset == 30
     assert (hist_target == [10, 10, 10]).all()

--- a/test/federated/test_train_config.py
+++ b/test/federated/test_train_config.py
@@ -60,7 +60,7 @@ def test_train_config_with_jit_script_module(hook, workers):  # pragma: no cover
         loss = alice.fit(dataset="vectors")
         if PRINT_IN_UNITTESTS:  # pragma: no cover:
             print("-" * 50)
-            print("Iteration %s: alice's loss: %s" % (epoch, loss))
+            print(f"Iteration {epoch}: alice's loss: {loss}")
 
     if PRINT_IN_UNITTESTS:
         print(alice)
@@ -75,8 +75,8 @@ def test_train_config_with_jit_script_module(hook, workers):  # pragma: no cover
     loss_after = loss_fn(real=target, pred=pred)
 
     if PRINT_IN_UNITTESTS:  # pragma: no cover:
-        print("Loss before training: {}".format(loss_before))
-        print("Loss after training: {}".format(loss_after))
+        print(f"Loss before training: {loss_before}")
+        print(f"Loss after training: {loss_after}")
 
     assert loss_after < loss_before
 
@@ -117,7 +117,7 @@ def test_train_config_with_jit_trace(hook, workers):  # pragma: no cover
     loss_before = loss_fn(target=target, pred=pred)
 
     if PRINT_IN_UNITTESTS:
-        print("Loss: {}".format(loss_before))
+        print(f"Loss: {loss_before}")
 
     # Create and send train config
     train_config = sy.TrainConfig(model=model, loss_fn=loss_fn, batch_size=2)
@@ -127,15 +127,15 @@ def test_train_config_with_jit_trace(hook, workers):  # pragma: no cover
         loss = alice.fit(dataset_key="gaussian_mixture")
         if PRINT_IN_UNITTESTS:  # pragma: no cover:
             print("-" * 50)
-            print("Iteration %s: alice's loss: %s" % (epoch, loss))
+            print(f"Iteration {epoch}: alice's loss: {loss}")
 
     new_model = train_config.model_ptr.get()
     pred = new_model.obj(data)
     loss_after = loss_fn(target=target, pred=pred)
 
     if PRINT_IN_UNITTESTS:  # pragma: no cover:
-        print("Loss before training: {}".format(loss_before))
-        print("Loss after training: {}".format(loss_after))
+        print(f"Loss before training: {loss_before}")
+        print(f"Loss after training: {loss_after}")
 
     assert loss_after < loss_before
 
@@ -153,7 +153,7 @@ def test_train_config_with_jit_trace_send_twice_with_fit(hook, workers):  # prag
         loss = alice.fit(dataset_key=dataset_key)
         if PRINT_IN_UNITTESTS:  # pragma: no cover:
             print("-" * 50)
-            print("TrainConfig 0, iteration %s: alice's loss: %s" % (epoch, loss))
+            print(f"TrainConfig 0, iteration {epoch}: alice's loss: {loss}")
 
     new_model = train_config_0.model_ptr.get()
     pred = new_model.obj(data)
@@ -169,14 +169,14 @@ def test_train_config_with_jit_trace_send_twice_with_fit(hook, workers):  # prag
 
         if PRINT_IN_UNITTESTS:  # pragma: no cover:
             print("-" * 50)
-            print("TrainConfig 1, iteration %s: alice's loss: %s" % (epoch, loss))
+            print(f"TrainConfig 1, iteration {epoch}: alice's loss: {loss}")
 
     new_model = train_config.model_ptr.get()
     pred = new_model.obj(data)
     loss_after = loss_fn(pred=pred, target=target)
     if PRINT_IN_UNITTESTS:  # pragma: no cover:
-        print("Loss after training with TrainConfig 0: {}".format(loss_after_0))
-        print("Loss after training with TrainConfig 1:   {}".format(loss_after))
+        print(f"Loss after training with TrainConfig 0: {loss_after_0}")
+        print(f"Loss after training with TrainConfig 1:   {loss_after}")
 
     assert loss_after < loss_before
 
@@ -327,7 +327,7 @@ async def test_train_config_with_jit_trace_async(hook, start_proc):  # pragma: n
         loss = await remote_proxy.async_fit(dataset_key=dataset_key)
         if PRINT_IN_UNITTESTS:  # pragma: no cover
             print("-" * 50)
-            print("Iteration %s: alice's loss: %s" % (epoch, loss))
+            print(f"Iteration {epoch}: alice's loss: {loss}")
 
     new_model = train_config.model_ptr.get()
 
@@ -342,8 +342,8 @@ async def test_train_config_with_jit_trace_async(hook, start_proc):  # pragma: n
     pred = new_model.obj(data)
     loss_after = loss_fn(target=target, pred=pred)
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Loss before training: {}".format(loss_before))
-        print("Loss after training: {}".format(loss_after))
+        print(f"Loss before training: {loss_before}")
+        print(f"Loss after training: {loss_after}")
 
     remote_proxy.close()
     # server.terminate()
@@ -392,7 +392,7 @@ def test_train_config_with_jit_trace_sync(hook, start_remote_worker):  # pragma:
         loss = remote_proxy.fit(dataset_key=dataset_key)
         if PRINT_IN_UNITTESTS:  # pragma: no cover
             print("-" * 50)
-            print("Iteration %s: alice's loss: %s" % (epoch, loss))
+            print(f"Iteration {epoch}: alice's loss: {loss}")
 
     new_model = train_config.model_ptr.get()
 
@@ -421,8 +421,8 @@ def test_train_config_with_jit_trace_sync(hook, start_remote_worker):  # pragma:
     loss_after = loss_fn(pred=pred, target=target)
 
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Loss before training: {}".format(loss_before))
-        print("Loss after training: {}".format(loss_after))
+        print(f"Loss before training: {loss_before}")
+        print(f"Loss after training: {loss_after}")
 
     remote_proxy.close()
     server.terminate()

--- a/test/serde/msgpack/test_msgpack_serde_full.py
+++ b/test/serde/msgpack/test_msgpack_serde_full.py
@@ -95,7 +95,7 @@ def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in msgpack.serde.simplifiers.items():
         has_sample = cls in samples
-        assert has_sample is True, "Serde for %s is not tested" % cls
+        assert has_sample is True, f"Serde for {cls} is not tested"
 
 
 @pytest.mark.parametrize("cls", samples)

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -45,7 +45,7 @@ def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in protobuf.serde.bufferizers.items():
         has_sample = cls in samples
-        assert has_sample is True, "Serde for %s is not tested" % cls
+        assert has_sample is True, f"Serde for {cls} is not tested"
 
 
 @pytest.mark.parametrize("cls", samples)

--- a/test/torch/federated/test_dataloader.py
+++ b/test/torch/federated/test_dataloader.py
@@ -43,11 +43,11 @@ def test_federated_dataloader_shuffle(workers):
             if counter < 1:  # one batch for bob, two batches for alice (batch_size == 2)
                 assert (
                     data.location.id == "bob"
-                ), "id should be bob, counter = {0}, epoch = {1}".format(counter, epoch)
+                ), f"id should be bob, counter = {counter}, epoch = {epoch}"
             else:
                 assert (
                     data.location.id == "alice"
-                ), "id should be alice, counter = {0}, epoch = {1}".format(counter, epoch)
+                ), f"id should be alice, counter = {counter}, epoch = {epoch}"
             counter += 1
         assert counter == len(fdataloader), f"{counter} == {len(fdataloader)}"
 

--- a/test/workers/test_websocket_worker.py
+++ b/test/workers/test_websocket_worker.py
@@ -310,7 +310,7 @@ def test_evaluate(hook, start_proc):  # pragma: no cover
     pred = model(data)
     loss_before = loss_fn(target=target, pred=pred)
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Loss: {}".format(loss_before))
+        print(f"Loss: {loss_before}")
 
     # Create and send train config
     train_config = sy.TrainConfig(
@@ -332,7 +332,7 @@ def test_evaluate(hook, start_proc):  # pragma: no cover
     hist_target = result["histogram_target"]
 
     if PRINT_IN_UNITTESTS:  # pragma: no cover
-        print("Evaluation result before training: {}".format(result))
+        print(f"Evaluation result before training: {result}")
 
     assert len_dataset == 30
     assert (hist_target == [10, 10, 10]).all()


### PR DESCRIPTION
**This PR**:
- Ran a linter, [`flynt`](https://github.com/ikamensh/flynt), to turn formatted strings which already exist in the codebase to f-strings
- Adds `flynt` to pre-commit

f-strings are quicker than other types of formatting strings.

I can remove the pre-commit addition if needed. It may not be worth the additional overhead of running pre-commit so long as non-f strings in new PRs are caught in review.

There is no existing issue relating to this PR.

**To test**:
1. Check  than the converted strings have been formatted correctly
2. Check pre-commit compiles and works as expected