### PR TITLE
Improve Plans flexibility

### DIFF
--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -1097,6 +1097,7 @@ def test_plan_can_be_jit_traced(hook, workers):
 
     assert (y == th.tensor([3.0, 5])).all()
 
+
 def test_plan_input_usage(hook):
     x11 = th.tensor([-1, 2.0]).tag("input_data")
     x12 = th.tensor([1, -2.0]).tag("input_data2")

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -1096,3 +1096,32 @@ def test_plan_can_be_jit_traced(hook, workers):
     y = torchscript_plan(t)
 
     assert (y == th.tensor([3.0, 5])).all()
+
+def test_plan_input_usage(hook):
+    x11 = th.tensor([-1, 2.0]).tag("input_data")
+    x12 = th.tensor([1, -2.0]).tag("input_data2")
+
+    device_1 = sy.VirtualWorker(hook, id="test_dev_1", data=(x11, x12))
+
+    @sy.func2plan()
+    def plan_test_1(x, y):
+        return x
+
+    @sy.func2plan()
+    def plan_test_2(x, y):
+        return y
+
+    pointer_to_data_1 = device_1.search("input_data")[0]
+    pointer_to_data_2 = device_1.search("input_data2")[0]
+
+    plan_test_1.build(th.tensor([1.0, -2.0]), th.tensor([1, 2]))
+    pointer_plan = plan_test_1.send(device_1)
+    pointer_to_result = pointer_plan(pointer_to_data_1, pointer_to_data_2)
+    result = pointer_to_result.get()
+    assert (result == x11).all()
+
+    plan_test_2.build(th.tensor([1.0, -2.0]), th.tensor([1, 2]))
+    pointer_plan = plan_test_2.send(device_1)
+    pointer_to_result = pointer_plan(pointer_to_data_1, pointer_to_data_2)
+    result = pointer_to_result.get()
+    assert (result == x12).all


### PR DESCRIPTION
This PR fixes #3184 

Solved:
* added support when input tensor is also output tensor.
* added a test case when input tensor is also output tensor.

To do:
* check for the number of parameters
* create support for nested structures