### PR TITLE
Move `Placeholder` class to `execution` package

### DIFF
--- a/examples/experimental/FL Training Plan/Create Plan.ipynb
+++ b/examples/experimental/FL Training Plan/Create Plan.ipynb
@@ -76,7 +76,7 @@
     "from syft.serde import protobuf\n",
     "import os\n",
     "from syft.execution.state import State\n",
-    "from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder\n",
+    "from syft.execution.placeholder import PlaceHolder\n",
     "\n",
     "\n",
     "sy.hook(globals())\n",

--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -1,5 +1,6 @@
 flask_socketio~=4.2.1
 Flask~=1.1.1
+git+git://github.com/karlhigley/syft-proto@refactor/placeholder-pkg#egg=syft-proto
 lz4~=3.0.2
 msgpack~=1.0.0
 numpy~=1.18.1
@@ -7,7 +8,6 @@ phe~=1.4.0
 Pillow~=6.2.2
 requests~=2.22.0
 scipy~=1.4.1
-syft-proto~=0.2.4.a1
 tblib~=1.6.0
 torchvision~=0.5.0
 torch~=1.4.0

--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -1,6 +1,5 @@
 flask_socketio~=4.2.1
 Flask~=1.1.1
-git+git://github.com/karlhigley/syft-proto@refactor/placeholder-pkg#egg=syft-proto
 lz4~=3.0.2
 msgpack~=1.0.0
 numpy~=1.18.1
@@ -8,6 +7,7 @@ phe~=1.4.0
 Pillow~=6.2.2
 requests~=2.22.0
 scipy~=1.4.1
+syft-proto~=0.2.5.a1
 tblib~=1.6.0
 torchvision~=0.5.0
 torch~=1.4.0

--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -70,7 +70,7 @@ from syft.frameworks.torch.tensors.interpreters.precision import FixedPrecisionT
 from syft.frameworks.torch.tensors.interpreters.numpy import create_numpy_tensor as NumpyTensor
 from syft.frameworks.torch.tensors.interpreters.private import PrivateTensor
 from syft.frameworks.torch.tensors.interpreters.large_precision import LargePrecisionTensor
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 from syft.generic.pointers.pointer_plan import PointerPlan
 from syft.generic.pointers.pointer_protocol import PointerProtocol
 from syft.generic.pointers.pointer_tensor import PointerTensor

--- a/syft/execution/computation.py
+++ b/syft/execution/computation.py
@@ -2,7 +2,7 @@ import syft as sy
 from syft.workers.abstract import AbstractWorker
 
 from syft.execution.action import Action
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 
 from syft_proto.execution.v1.computation_action_pb2 import ComputationAction as ComputationActionPB
 
@@ -112,9 +112,7 @@ class ComputationAction(Action):
 
         if type(action.target) == sy.generic.pointers.pointer_tensor.PointerTensor:
             protobuf_owner = protobuf_op.target_pointer
-        elif (
-            type(action.target) == sy.frameworks.torch.tensors.interpreters.placeholder.PlaceHolder
-        ):
+        elif type(action.target) == sy.execution.placeholder.PlaceHolder:
             protobuf_owner = protobuf_op.target_placeholder
         else:
             protobuf_owner = protobuf_op.target_tensor

--- a/syft/execution/placeholder.py
+++ b/syft/execution/placeholder.py
@@ -1,5 +1,3 @@
-import torch
-
 import syft
 from syft.generic.frameworks.hook import hook_args
 from syft.generic.tensor import AbstractTensor

--- a/syft/execution/placeholder.py
+++ b/syft/execution/placeholder.py
@@ -4,9 +4,7 @@ import syft
 from syft.generic.frameworks.hook import hook_args
 from syft.generic.tensor import AbstractTensor
 from syft.workers.abstract import AbstractWorker
-from syft_proto.frameworks.torch.tensors.interpreters.v1.placeholder_pb2 import (
-    Placeholder as PlaceholderPB,
-)
+from syft_proto.execution.v1.placeholder_pb2 import Placeholder as PlaceholderPB
 
 
 class PlaceHolder(AbstractTensor):

--- a/syft/execution/plan.py
+++ b/syft/execution/plan.py
@@ -15,7 +15,7 @@ from syft.generic.object import AbstractObject
 from syft.generic.object_storage import ObjectStorage
 from syft.generic.pointers.pointer_plan import PointerPlan
 from syft.workers.abstract import AbstractWorker
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 
 from syft_proto.execution.v1.plan_pb2 import Plan as PlanPB
 from syft_proto.execution.v1.computation_action_pb2 import ComputationAction as ComputationActionPB

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -23,7 +23,7 @@ from syft.frameworks.torch.tensors.interpreters.precision import FixedPrecisionT
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
 from syft.frameworks.torch.tensors.interpreters.large_precision import LargePrecisionTensor
 from syft.frameworks.torch.tensors.interpreters.private import PrivateTensor
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 from syft.frameworks.torch.torch_attributes import TorchAttributes
 from syft.generic.pointers.multi_pointer import MultiPointerTensor
 from syft.generic.pointers.pointer_tensor import PointerTensor

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -18,7 +18,7 @@ from syft.workers.abstract import AbstractWorker
 from syft.execution.action import Action
 from syft.execution.computation import ComputationAction
 from syft.execution.communication import CommunicationAction
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 
 from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
 from syft_proto.messaging.v1.message_pb2 import TensorCommandMessage as CommandMessagePB

--- a/syft/serde/msgpack/serde.py
+++ b/syft/serde/msgpack/serde.py
@@ -46,7 +46,7 @@ from syft.frameworks.torch.tensors.interpreters.private import PrivateTensor
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
 from syft.frameworks.torch.tensors.interpreters.crt_precision import CRTPrecisionTensor
 from syft.frameworks.torch.tensors.interpreters.autograd import AutogradTensor
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 from syft.generic.pointers.multi_pointer import MultiPointerTensor
 from syft.generic.pointers.object_pointer import ObjectPointer
 from syft.generic.pointers.pointer_tensor import PointerTensor

--- a/syft/serde/protobuf/proto.py
+++ b/syft/serde/protobuf/proto.py
@@ -14,7 +14,7 @@ from syft.execution.plan import Plan
 from syft.execution.protocol import Protocol
 from syft.execution.state import State
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.messaging.message import TensorCommandMessage
 from syft.messaging.message import ObjectMessage
@@ -30,9 +30,7 @@ from syft_proto.execution.v1.state_pb2 import State as StatePB
 from syft_proto.frameworks.torch.tensors.interpreters.v1.additive_shared_pb2 import (
     AdditiveSharingTensor as AdditiveSharingTensorPB,
 )
-from syft_proto.frameworks.torch.tensors.interpreters.v1.placeholder_pb2 import (
-    Placeholder as PlaceholderPB,
-)
+from syft_proto.execution.v1.placeholder_pb2 import Placeholder as PlaceholderPB
 from syft_proto.generic.pointers.v1.pointer_tensor_pb2 import PointerTensor as PointerTensorPB
 from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
 from syft_proto.messaging.v1.message_pb2 import TensorCommandMessage as CommandMessagePB

--- a/syft/serde/protobuf/serde.py
+++ b/syft/serde/protobuf/serde.py
@@ -6,7 +6,7 @@ from syft import dependency_check
 from syft.execution.computation import ComputationAction
 from syft.execution.communication import CommunicationAction
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
-from syft.frameworks.torch.tensors.interpreters.placeholder import PlaceHolder
+from syft.execution.placeholder import PlaceHolder
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.messaging.message import ObjectMessage
 from syft.messaging.message import TensorCommandMessage

--- a/test/serde/msgpack/test_msgpack_serde_full.py
+++ b/test/serde/msgpack/test_msgpack_serde_full.py
@@ -70,7 +70,7 @@ samples[syft.federated.train_config.TrainConfig] = make_trainconfig
 samples[syft.workers.base.BaseWorker] = make_baseworker
 samples[syft.frameworks.torch.tensors.interpreters.autograd.AutogradTensor] = make_autogradtensor
 samples[syft.frameworks.torch.tensors.interpreters.private.PrivateTensor] = make_privatetensor
-samples[syft.frameworks.torch.tensors.interpreters.placeholder.PlaceHolder] = make_placeholder
+samples[syft.execution.placeholder.PlaceHolder] = make_placeholder
 samples[syft.frameworks.torch.fl.dataset.BaseDataset] = make_basedataset
 
 samples[syft.messaging.message.TensorCommandMessage] = make_command_message

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -29,7 +29,7 @@ samples[torch.Size] = make_torch_size
 samples[
     syft.frameworks.torch.tensors.interpreters.additive_shared.AdditiveSharingTensor
 ] = make_additivesharingtensor
-samples[syft.frameworks.torch.tensors.interpreters.placeholder.PlaceHolder] = make_placeholder
+samples[syft.execution.placeholder.PlaceHolder] = make_placeholder
 samples[syft.execution.computation.ComputationAction] = make_computation_action
 samples[syft.execution.communication.CommunicationAction] = make_communication_action
 samples[syft.execution.plan.Plan] = make_plan

--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -1298,12 +1298,12 @@ def make_privatetensor(**kwargs):
 
 # syft.frameworks.torch.tensors.interpreters.PlaceHolder
 def make_placeholder(**kwargs):
-    ph = syft.frameworks.torch.tensors.interpreters.placeholder.PlaceHolder()
+    ph = syft.execution.placeholder.PlaceHolder()
     ph.tag("tag1")
     ph.describe("just a placeholder")
 
     def compare(detailed, original):
-        assert type(detailed) == syft.frameworks.torch.tensors.interpreters.placeholder.PlaceHolder
+        assert type(detailed) == syft.execution.placeholder.PlaceHolder
         assert detailed.id == original.id
         assert detailed.tags == original.tags
         assert detailed.description == original.description
@@ -1313,7 +1313,7 @@ def make_placeholder(**kwargs):
         {
             "value": ph,
             "simplified": (
-                CODE[syft.frameworks.torch.tensors.interpreters.placeholder.PlaceHolder],
+                CODE[syft.execution.placeholder.PlaceHolder],
                 (
                     ph.id,  # (int) id
                     (CODE[set], ((CODE[str], (b"tag1",)),)),  # (set of str) tags


### PR DESCRIPTION
It's not actually specific to PyTorch and is most closely related to
the other classes in `execution` (e.g. `Plans`, `Protocols`.)