### PR TITLE
Plans support for typechecking, lists and dicts

### DIFF
--- a/syft/execution/plan.py
+++ b/syft/execution/plan.py
@@ -231,16 +231,17 @@ class Plan(AbstractObject, ObjectStorage):
                         f"torch.FloatTensor, torch.IntTensor, etc, which are not supported. "
                         f"Please use instead torch.tensor(..., dtype=torch.int32) for example."
                     )
-                placeholder.tags.add(f"#input-{arg_ids.index(tensor.id)}")
-                if tensor.id in result_ids:
-                    placeholder.tags.add(f"#output-{result_ids.index(tensor.id)}")
+
+                placeholder.tags.add(f"#input-{self._tmp_args_ids.index(tensor.id)}")
+                if tensor.id in self._tmp_result_ids:
+                    placeholder.tags.add(f"#output-{self._tmp_result_ids.index(tensor.id)}")
 
             elif node_type == "output":
-                if tensor.id in result_ids:
-                    placeholder.tags.add(f"#output-{result_ids.index(tensor.id)}")
+                if tensor.id in self._tmp_result_ids:
+                    placeholder.tags.add(f"#output-{self._tmp_result_ids.index(tensor.id)}")
 
-                if tensor.id in arg_ids:
-                    placeholder.tags.add(f"#input-{result_ids.index(tensor.id)}")
+                if tensor.id in self._tmp_args_ids:
+                    placeholder.tags.add(f"#input-{self._tmp_result_ids.index(tensor.id)}")
             else:
                 raise ValueError("node_type should be 'input' or 'output'.")
 
@@ -329,6 +330,9 @@ class Plan(AbstractObject, ObjectStorage):
 
         for arg in args:
             self.replace_with_placeholders(arg, arg_ids, result_ids, node_type="input")
+
+        for arg in args:
+            self.replace_with_placeholders(arg, node_type="input")
 
         for log in sy.hook.trace.logs:
             command, response = log

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -1143,7 +1143,7 @@ def test_plan_wrong_number_of_parameters(hook):
 
     dummy_input_list = [th.tensor([1, -2]), th.tensor([1, 2]), 2, False]
     input_list = [pointer_to_data_1, pointer_to_data_2, 5, True]
-    corect_number_of_params = 5
+    corect_number_of_params = 4
 
     for i in range(len(input_list)):
         plan_test.build(*dummy_input_list)

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -1145,7 +1145,7 @@ def test_plan_wrong_number_of_parameters(hook):
     input_list = [pointer_to_data_1, pointer_to_data_2, 5, True]
     corect_number_of_params = 4
 
-    for i in range(len(input_list)):
+    for i in range(len(input_list) + 1):
         plan_test.build(*dummy_input_list)
         pointer_plan = plan_test.send(device_1)
 

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -1125,7 +1125,7 @@ def test_plan_input_usage(hook):
     pointer_plan = plan_test_2.send(device_1)
     pointer_to_result = pointer_plan(pointer_to_data_1, pointer_to_data_2)
     result = pointer_to_result.get()
-    assert (result == x12).all
+    assert (result == x12).all()
 
 
 def test_plan_wrong_number_of_parameters(hook):

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -1143,7 +1143,7 @@ def test_plan_wrong_number_of_parameters(hook):
 
     dummy_input_list = [th.tensor([1, -2]), th.tensor([1, 2]), 2, False]
     input_list = [pointer_to_data_1, pointer_to_data_2, 5, True]
-    corect_number_of_params = 4
+    corect_number_of_params = 5
 
     for i in range(len(input_list)):
         plan_test.build(*dummy_input_list)


### PR DESCRIPTION
# Description

This PR fixes #3184. 

New features:

- Plans now have support for type-checking at runtime based on the type provided at build time.
- Plans now support usage of lists, tuples and dicts as inputs.
- Plans now have a number of arguments check, build time and call time should have the same number of arguments.


# Type of change:
-  Bug fix
- New feature

# How Has This Been Tested?

Wrote a few tests that verify that:

- type-checking works, it should raise a RunTimeWarning if the types differ.
- argument number check works, build time and call time should not differ, if they differ, a RunTimeError should occur.
- lists of tensors work as input.
- dicts work as input. 
- a nested structure containing lists and dicts works as input.

# TODO:
- add support for variables when building plans. Not sure if this behaviour is wanted, I will open an issue with this.
- add support for lists, dicts and tuples as output.
- make a better scheme on dicts as inputs, as they are unordered.