### PR TITLE
Add a `protocol` kwarg to `encrypt()` method to select between MPC and Paillier HE

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -1042,16 +1042,29 @@ class TorchTensor(AbstractTensor):
                 "Encryption and Secure Multi-Party Computation"
             )
 
-    def decrypt(self, private_key):
+    def decrypt(self, protocol="mpc", **kwargs):
         """This method will decrypt each value in the tensor, returning a normal
         torch tensor.
 
         Args:
             *private_key a private key created using
                 syft.frameworks.torch.he.paillier.keygen()
-            """
+        """
 
-        return self.child.decrypt(private_key)
+        if protocol.lower() == "mpc":
+            x_encrypted = self.copy()
+            x_decrypted = x_encrypted.get().float_prec()
+            return x_decrypted
+
+        elif protocol.lower() == "paillier":
+            private_key = kwargs.get("private_key")
+            return self.child.decrypt(private_key)
+
+        else:
+            raise NotImplementedError(
+                "Currently the .decrypt() method only supports Paillier Homomorphic "
+                "Encryption and Secure Multi-Party Computation"
+            )
 
     def numpy_tensor(self):
         """This method will cast the current tensor to one with numpy as the underlying

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -1022,13 +1022,9 @@ class TorchTensor(AbstractTensor):
             crypto_provider = kwargs.pop("crypto_provider")
             kwargs_fix_prec = kwargs  # Rest of kwargs for fix_prec method
 
-            if kwargs_fix_prec:
-                x_shared = self.fix_prec(**kwargs_fix_prec).share(
-                    *workers, crypto_provider=crypto_provider
-                )
-            else:  # If no kwargs for .fix_prec()
-                x_shared = self.fix_prec().share(*workers, crypto_provider=crypto_provider)
-
+            x_shared = self.fix_prec(**kwargs_fix_prec).share(
+                *workers, crypto_provider=crypto_provider
+            )
             return x_shared
 
         elif protocol.lower() == "paillier":

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -1043,12 +1043,26 @@ class TorchTensor(AbstractTensor):
             )
 
     def decrypt(self, protocol="mpc", **kwargs):
-        """This method will decrypt each value in the tensor, returning a normal
-        torch tensor.
+        """
+        This method will decrypt each value in the tensor using Multi Party
+        Computation (default) or Paillier Homomorphic Encryption
 
         Args:
-            *private_key a private key created using
-                syft.frameworks.torch.he.paillier.keygen()
+            protocol (str): Currently supports 'mpc' for Multi Party
+                Computation and 'paillier' for Paillier Homomorphic Encryption
+            **kwargs:
+                With Respect to MPC accepts:
+                    None
+
+                With Respect to Paillier accepts:
+                    private_key (phe.paillier.PaillierPrivateKey): Can be obtained using
+                        ```public_key, private_key = sy.frameworks.torch.he.paillier.keygen()```
+        Returns:
+            An decrypted version of the Tensor following the protocol specified
+
+        Raises:
+            NotImplementedError: If protocols other than the ones mentioned above are queried
+
         """
 
         if protocol.lower() == "mpc":
@@ -1057,6 +1071,7 @@ class TorchTensor(AbstractTensor):
             return x_decrypted
 
         elif protocol.lower() == "paillier":
+            # self.copy() not required as PaillierTensor's decrypt method is not inplace
             private_key = kwargs.get("private_key")
             return self.child.decrypt(private_key)
 

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -992,19 +992,41 @@ class TorchTensor(AbstractTensor):
         else:
             return self.child.torch_type()
 
-    def encrypt(self, public_key):
-        """This method will encrypt each value in the tensor using Paillier
-        homomorphic encryption.
-
-        Args:
-            *public_key a public key created using
-                syft.frameworks.torch.he.paillier.keygen()
+    # def encrypt(self, public_key):
+    #     """This method will encrypt each value in the tensor using Paillier
+    #     homomorphic encryption.
+    #
+    #     Args:
+    #         *public_key a public key created using
+    #             syft.frameworks.torch.he.paillier.keygen()
+    #     """
+    #
+    #     x = self.copy()
+    #     x2 = PaillierTensor().on(x)
+    #     x2.child.encrypt_(public_key)
+    #     return x2
+    def encrypt(self, encryption_method='mpc', **kwargs):
+        """This method will encrypt each value in the tensor using Multi Party
+        Computation (default) or Paillier homomorphic encryption.
+        :param encryption_method:
+        :param kwargs:
+        :return:
         """
-
-        x = self.copy()
-        x2 = PaillierTensor().on(x)
-        x2.child.encrypt_(public_key)
-        return x2
+        if encryption_method.lower() == 'mpc':
+            _fix_prec = kwargs.get('fix_prec')
+            _share = kwargs.get('share')
+            x_shared = self.fix_prec(_fix_prec).share(_share)
+            return x_shared
+        elif encryption_method.lower() == 'paillier':
+            x = self.copy()
+            x2 = PaillierTensor().on(x)
+            x2.child.encrypt_(kwargs['public_key'])
+            return x2
+        else:
+            raise NotImplementedError(
+                "Currently the .encrypt() method only supports Paillier Homomorphic "
+                "Encryption and Secure Multi-Party Computation"
+            )
 
     def decrypt(self, private_key):
         """This method will decrypt each value in the tensor, returning a normal

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -992,7 +992,7 @@ class TorchTensor(AbstractTensor):
         else:
             return self.child.torch_type()
 
-    def encrypt(self, encryption_method='mpc', **kwargs):
+    def encrypt(self, encryption_method="mpc", **kwargs):
         """
         This method will encrypt each value in the tensor using Multi Party
         Computation (default) or Paillier Homomorphic Encryption
@@ -1017,21 +1017,25 @@ class TorchTensor(AbstractTensor):
             NotImplementedError: If protocols other than the ones mentioned above are queried
 
         """
-        if encryption_method.lower() == 'mpc':
-            args_fix_prec = kwargs.pop('args_fix_prec')
-            workers = kwargs.pop('workers')
-            crypto_provider = kwargs.pop('crypto_provider')
+        if encryption_method.lower() == "mpc":
+            args_fix_prec = kwargs.pop("args_fix_prec")
+            workers = kwargs.pop("workers")
+            crypto_provider = kwargs.pop("crypto_provider")
 
             if args_fix_prec:
-                x_shared = self.fix_prec(**args_fix_prec).share(*workers, crypto_provider=crypto_provider, **kwargs)
+                x_shared = self.fix_prec(**args_fix_prec).share(
+                    *workers, crypto_provider=crypto_provider, **kwargs
+                )
             else:  # If no args for .fix_prec()
-                x_shared = self.fix_prec().share(*workers, crypto_provider=crypto_provider, **kwargs)
+                x_shared = self.fix_prec().share(
+                    *workers, crypto_provider=crypto_provider, **kwargs
+                )
             return x_shared
 
-        elif encryption_method.lower() == 'paillier':
+        elif encryption_method.lower() == "paillier":
             x = self.copy()
             x_encrypted = PaillierTensor().on(x)  # Instantiate the class
-            x_encrypted.child.encrypt_(kwargs['public_key'])  # Perform Homomorphic Encryption
+            x_encrypted.child.encrypt_(kwargs["public_key"])  # Perform blacHomomorphic Encryption
             return x_encrypted
 
         else:

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -992,41 +992,14 @@ class TorchTensor(AbstractTensor):
         else:
             return self.child.torch_type()
 
-    # def encrypt(self, public_key):
-    #     """This method will encrypt each value in the tensor using Paillier
-    #     homomorphic encryption.
-    #
-    #     Args:
-    #         *public_key a public key created using
-    #             syft.frameworks.torch.he.paillier.keygen()
-    #     """
-    #
-    #     x = self.copy()
-    #     x2 = PaillierTensor().on(x)
-    #     x2.child.encrypt_(public_key)
-    #     return x2
-    def encrypt(self, encryption_method='mpc', **kwargs):
+    def encrypt(self, *args, **kwargs):
         """This method will encrypt each value in the tensor using Multi Party
         Computation (default) or Paillier homomorphic encryption.
-        :param encryption_method:
         :param kwargs:
         :return:
         """
-        if encryption_method.lower() == 'mpc':
-            _fix_prec = kwargs.get('fix_prec')
-            _share = kwargs.get('share')
-            x_shared = self.fix_prec(_fix_prec).share(_share)
-            return x_shared
-        elif encryption_method.lower() == 'paillier':
-            x = self.copy()
-            x2 = PaillierTensor().on(x)
-            x2.child.encrypt_(kwargs['public_key'])
-            return x2
-        else:
-            raise NotImplementedError(
-                "Currently the .encrypt() method only supports Paillier Homomorphic "
-                "Encryption and Secure Multi-Party Computation"
-            )
+        x_shared = self.fix_prec().share(*args, **kwargs)
+        return x_shared
 
     def decrypt(self, private_key):
         """This method will decrypt each value in the tensor, returning a normal

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -219,6 +219,10 @@ def test_encrypt():
     assert torch.all(torch.eq(x_encrypted.get().float_prec(), x))
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
+    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james)
+    assert torch.all(torch.eq(x_encrypted.get().float_prec(), x))
+
+    x = torch.randint(10, (1, 5), dtype=torch.float32)
     public, private = syft.frameworks.torch.he.paillier.keygen()
     x_encrypted = x.encrypt(encryption_method="paillier", public_key=public)
     assert torch.all(torch.eq(x_encrypted.decrypt(private), x))

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -205,3 +205,20 @@ def test_complex_model(workers):
 
     ## Forward on the remote model
     pred = model_net(tensor_remote)
+
+
+def test_encrypt():
+    hook = syft.TorchHook(torch)
+
+    bob = syft.VirtualWorker(hook, id="bob")
+    alice = syft.VirtualWorker(hook, id="alice")
+    james = syft.VirtualWorker(hook, id="james")
+
+    x = torch.randint(10, (1, 5), dtype=torch.float32)
+    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james, args_fix_prec={'base': 10})
+    assert torch.all(torch.eq(x_encrypted.get().float_prec(), x))
+
+    x = torch.randint(10, (1, 5), dtype=torch.float32)
+    public, private = syft.frameworks.torch.he.paillier.keygen()
+    x_encrypted = x.encrypt(encryption_method='paillier', public_key=public)
+    assert torch.all(torch.eq(x_encrypted.decrypt(private), x))

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -215,10 +215,10 @@ def test_encrypt():
     james = syft.VirtualWorker(hook, id="james")
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
-    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james, args_fix_prec={'base': 10})
+    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james, args_fix_prec={"base": 10})
     assert torch.all(torch.eq(x_encrypted.get().float_prec(), x))
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
     public, private = syft.frameworks.torch.he.paillier.keygen()
-    x_encrypted = x.encrypt(encryption_method='paillier', public_key=public)
+    x_encrypted = x.encrypt(encryption_method="paillier", public_key=public)
     assert torch.all(torch.eq(x_encrypted.decrypt(private), x))

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -207,18 +207,21 @@ def test_complex_model(workers):
     pred = model_net(tensor_remote)
 
 
-def test_encrypt(workers):
+def test_encrypt_decrypt(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
     x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james, base=10)
-    assert torch.all(torch.eq(x_encrypted.get().float_prec(), x))
+    x_decrypted = x_encrypted.decrypt()
+    assert torch.all(torch.eq(x_decrypted, x))
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
     x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james)
-    assert torch.all(torch.eq(x_encrypted.get().float_prec(), x))
+    x_decrypted = x_encrypted.decrypt()
+    assert torch.all(torch.eq(x_decrypted, x))
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
     public, private = syft.frameworks.torch.he.paillier.keygen()
     x_encrypted = x.encrypt(protocol="paillier", public_key=public)
-    assert torch.all(torch.eq(x_encrypted.decrypt(private), x))
+    x_decrypted = x_encrypted.decrypt(protocol="paillier", private_key=private)
+    assert torch.all(torch.eq(x_decrypted, x))

--- a/test/torch/tensors/test_native.py
+++ b/test/torch/tensors/test_native.py
@@ -207,15 +207,11 @@ def test_complex_model(workers):
     pred = model_net(tensor_remote)
 
 
-def test_encrypt():
-    hook = syft.TorchHook(torch)
-
-    bob = syft.VirtualWorker(hook, id="bob")
-    alice = syft.VirtualWorker(hook, id="alice")
-    james = syft.VirtualWorker(hook, id="james")
+def test_encrypt(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
-    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james, args_fix_prec={"base": 10})
+    x_encrypted = x.encrypt(workers=[bob, alice], crypto_provider=james, base=10)
     assert torch.all(torch.eq(x_encrypted.get().float_prec(), x))
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
@@ -224,5 +220,5 @@ def test_encrypt():
 
     x = torch.randint(10, (1, 5), dtype=torch.float32)
     public, private = syft.frameworks.torch.he.paillier.keygen()
-    x_encrypted = x.encrypt(encryption_method="paillier", public_key=public)
+    x_encrypted = x.encrypt(protocol="paillier", public_key=public)
     assert torch.all(torch.eq(x_encrypted.decrypt(private), x))

--- a/test/torch/tensors/test_paillier.py
+++ b/test/torch/tensors/test_paillier.py
@@ -11,7 +11,7 @@ def test_encrypt_and_decrypt():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y = x.decrypt(pri)
 
@@ -26,7 +26,7 @@ def test_encrypted_encrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y = (x + x).decrypt(pri)
 
@@ -41,7 +41,7 @@ def test_encrypted_decrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y = (x + x_tensor).decrypt(pri)
 
@@ -56,7 +56,7 @@ def test_decrypted_encrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y = (x_tensor + x).decrypt(pri)
 
@@ -68,10 +68,10 @@ def test_encrypted_encrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
     z = (x - y).decrypt(pri)
 
@@ -83,10 +83,10 @@ def test_encrypted_decrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
     z = (x - y_tensor).decrypt(pri)
 
@@ -98,10 +98,10 @@ def test_decrypted_encrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
     z = (x_tensor - y).decrypt(pri)
 
@@ -113,10 +113,10 @@ def test_encrypted_decrypted_mul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
     z = (x * y_tensor).decrypt(pri)
 
@@ -128,10 +128,10 @@ def test_decrypted_encrypted_mul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
     z = (x_tensor * y).decrypt(pri)
 
@@ -143,10 +143,10 @@ def test_encrypted_decrypted_matmul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.tensor([1, 2, 3])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.tensor([2, 2, 2])
-    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
     z = (x.mm(y_tensor)).decrypt(pri)
 
@@ -158,10 +158,10 @@ def test_decrypted_encrypted_matmul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([[1, 2, 3]])
-    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([[2], [2], [2]])
-    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
+    y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
     z = (x_tensor.mm(y)).decrypt(pri)
 

--- a/test/torch/tensors/test_paillier.py
+++ b/test/torch/tensors/test_paillier.py
@@ -13,7 +13,7 @@ def test_encrypt_and_decrypt():
     x_tensor = torch.Tensor([1, 2, 3])
     x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = x.decrypt(pri)
+    y = x.decrypt(protocol="paillier", private_key=pri)
 
     assert (x_tensor == y).all()
 
@@ -28,7 +28,7 @@ def test_encrypted_encrypted_add():
     x_tensor = torch.Tensor([1, 2, 3])
     x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = (x + x).decrypt(pri)
+    y = (x + x).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor + x_tensor) == y).all()
 
@@ -43,7 +43,7 @@ def test_encrypted_decrypted_add():
     x_tensor = torch.Tensor([1, 2, 3])
     x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = (x + x_tensor).decrypt(pri)
+    y = (x + x_tensor).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor + x_tensor) == y).all()
 
@@ -58,7 +58,7 @@ def test_decrypted_encrypted_add():
     x_tensor = torch.Tensor([1, 2, 3])
     x = x_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    y = (x_tensor + x).decrypt(pri)
+    y = (x_tensor + x).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor + x_tensor) == y).all()
 
@@ -73,7 +73,7 @@ def test_encrypted_encrypted_sub():
     y_tensor = torch.Tensor([2, 2, 2])
     y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x - y).decrypt(pri)
+    z = (x - y).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor - y_tensor) == z).all()
 
@@ -88,7 +88,7 @@ def test_encrypted_decrypted_sub():
     y_tensor = torch.Tensor([2, 2, 2])
     y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x - y_tensor).decrypt(pri)
+    z = (x - y_tensor).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor - y_tensor) == z).all()
 
@@ -103,7 +103,7 @@ def test_decrypted_encrypted_sub():
     y_tensor = torch.Tensor([2, 2, 2])
     y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x_tensor - y).decrypt(pri)
+    z = (x_tensor - y).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor - y_tensor) == z).all()
 
@@ -118,7 +118,7 @@ def test_encrypted_decrypted_mul():
     y_tensor = torch.Tensor([2, 2, 2])
     y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x * y_tensor).decrypt(pri)
+    z = (x * y_tensor).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor * y_tensor) == z).all()
 
@@ -133,7 +133,7 @@ def test_decrypted_encrypted_mul():
     y_tensor = torch.Tensor([2, 2, 2])
     y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x_tensor * y).decrypt(pri)
+    z = (x_tensor * y).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor * y_tensor) == z).all()
 
@@ -148,7 +148,7 @@ def test_encrypted_decrypted_matmul():
     y_tensor = torch.tensor([2, 2, 2])
     y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x.mm(y_tensor)).decrypt(pri)
+    z = (x.mm(y_tensor)).decrypt(protocol="paillier", private_key=pri)
 
     assert (z == 12).all()
 
@@ -163,6 +163,6 @@ def test_decrypted_encrypted_matmul():
     y_tensor = torch.Tensor([[2], [2], [2]])
     y = y_tensor.encrypt(protocol="paillier", public_key=pub)
 
-    z = (x_tensor.mm(y)).decrypt(pri)
+    z = (x_tensor.mm(y)).decrypt(protocol="paillier", private_key=pri)
 
     assert ((x_tensor.mm(y_tensor)) == z).all()

--- a/test/torch/tensors/test_paillier.py
+++ b/test/torch/tensors/test_paillier.py
@@ -11,7 +11,7 @@ def test_encrypt_and_decrypt():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y = x.decrypt(pri)
 
@@ -26,7 +26,7 @@ def test_encrypted_encrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y = (x + x).decrypt(pri)
 
@@ -41,7 +41,7 @@ def test_encrypted_decrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y = (x + x_tensor).decrypt(pri)
 
@@ -56,7 +56,7 @@ def test_decrypted_encrypted_add():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y = (x_tensor + x).decrypt(pri)
 
@@ -68,10 +68,10 @@ def test_encrypted_encrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     z = (x - y).decrypt(pri)
 
@@ -83,10 +83,10 @@ def test_encrypted_decrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     z = (x - y_tensor).decrypt(pri)
 
@@ -98,10 +98,10 @@ def test_decrypted_encrypted_sub():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     z = (x_tensor - y).decrypt(pri)
 
@@ -113,10 +113,10 @@ def test_encrypted_decrypted_mul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     z = (x * y_tensor).decrypt(pri)
 
@@ -128,10 +128,10 @@ def test_decrypted_encrypted_mul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     z = (x_tensor * y).decrypt(pri)
 
@@ -143,10 +143,10 @@ def test_encrypted_decrypted_matmul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.tensor([1, 2, 3])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y_tensor = torch.tensor([2, 2, 2])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     z = (x.mm(y_tensor)).decrypt(pri)
 
@@ -158,10 +158,10 @@ def test_decrypted_encrypted_matmul():
     pub, pri = sy.keygen()
 
     x_tensor = torch.Tensor([[1, 2, 3]])
-    x = x_tensor.encrypt(pub)
+    x = x_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     y_tensor = torch.Tensor([[2], [2], [2]])
-    y = y_tensor.encrypt(pub)
+    y = y_tensor.encrypt(encryption_method="paillier", public_key=pub)
 
     z = (x_tensor.mm(y)).decrypt(pri)
 


### PR DESCRIPTION
Fixes [#3212](https://github.com/OpenMined/PySyft/issues/3212)

> Modify .encrypt() to add a kwarg and be used not only for Paillier encryption but only MPC (default should be MPC, and it should call for mpc .fix_prec(...).share(...) under the hood)