### PR TITLE
Fix the placeholder serialization.

### DIFF
--- a/syft/execution/placeholder.py
+++ b/syft/execution/placeholder.py
@@ -29,8 +29,6 @@ class PlaceHolder(AbstractTensor):
         """
         Add a tensor as a child attribute. All operations on the placeholder will be also
         executed on this child tensor.
-
-        We remove wrappers or Placeholders if is there are any.
         """
         if isinstance(tensor, PlaceHolder):
             self.child = tensor.child

--- a/syft/execution/placeholder.py
+++ b/syft/execution/placeholder.py
@@ -34,8 +34,6 @@ class PlaceHolder(AbstractTensor):
         """
         if isinstance(tensor, PlaceHolder):
             self.child = tensor.child
-        elif tensor.is_wrapper:
-            self.instantiate(tensor.child)
         else:
             self.child = tensor
         return self

--- a/syft/execution/placeholder.py
+++ b/syft/execution/placeholder.py
@@ -29,6 +29,8 @@ class PlaceHolder(AbstractTensor):
         """
         Add a tensor as a child attribute. All operations on the placeholder will be also
         executed on this child tensor.
+
+        We remove Placeholders if is there are any.
         """
         if isinstance(tensor, PlaceHolder):
             self.child = tensor.child

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 import syft as sy
+from itertools import starmap
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.generic.frameworks.types import FrameworkTensor
 from syft.execution.plan import Plan
@@ -640,7 +641,13 @@ def test_fetch_encrypted_stateful_plan(hook, is_func2plan, workers):
     # Compare with local plan
     assert th.all(decrypted - expected.detach() < 1e-2)
     # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
-    assert str(fetched_plan.state.tensors()) == str(plan.state.tensors())
+
+    assert all(
+        starmap(
+            lambda fetched_tensor, tensor: (fetched_tensor == tensor).get(),
+            zip(fetched_plan.state.tensors(), plan.state.tensors()),
+        )
+    )
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -7,8 +7,6 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 import syft as sy
-
-from itertools import starmap
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.generic.frameworks.types import FrameworkTensor
 from syft.execution.plan import Plan
@@ -482,7 +480,7 @@ def test_fetch_stateful_plan(hook, is_func2plan, workers):
     # Execute it locally
     x = th.tensor([-1.26])
     assert th.all(th.eq(fetched_plan(x), plan(x)))
-    assert str(fetched_plan.state.state_placeholders) == str(plan.state.state_placeholders)
+    # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None
@@ -528,7 +526,7 @@ def test_fetch_stateful_plan_remote(hook, is_func2plan, start_remote_worker):
 
     # Execute it locally
     assert th.all(th.eq(fetched_plan(x), expected))
-    assert str(fetched_plan.state.state_placeholders) == str(plan.state.state_placeholders)
+    # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None
@@ -641,7 +639,7 @@ def test_fetch_encrypted_stateful_plan(hook, is_func2plan, workers):
 
     # Compare with local plan
     assert th.all(decrypted - expected.detach() < 1e-2)
-    assert str(fetched_plan.state.state_placeholders) == str(plan.state.state_placeholders)
+    # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -640,6 +640,7 @@ def test_fetch_encrypted_stateful_plan(hook, is_func2plan, workers):
     # Compare with local plan
     assert th.all(decrypted - expected.detach() < 1e-2)
     # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
+    assert str(fetched_plan.state.tensors()) == str(plan.state.tensors())
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -7,6 +7,8 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 import syft as sy
+
+from itertools import starmap
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.generic.frameworks.types import FrameworkTensor
 from syft.execution.plan import Plan
@@ -480,7 +482,7 @@ def test_fetch_stateful_plan(hook, is_func2plan, workers):
     # Execute it locally
     x = th.tensor([-1.26])
     assert th.all(th.eq(fetched_plan(x), plan(x)))
-    # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
+    assert str(fetched_plan.state.state_placeholders) == str(plan.state.state_placeholders)
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None
@@ -526,7 +528,7 @@ def test_fetch_stateful_plan_remote(hook, is_func2plan, start_remote_worker):
 
     # Execute it locally
     assert th.all(th.eq(fetched_plan(x), expected))
-    # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
+    assert str(fetched_plan.state.state_placeholders) == str(plan.state.state_placeholders)
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None
@@ -639,7 +641,7 @@ def test_fetch_encrypted_stateful_plan(hook, is_func2plan, workers):
 
     # Compare with local plan
     assert th.all(decrypted - expected.detach() < 1e-2)
-    # assert fetched_plan.state.state_placeholders != plan.state.state_placeholders #TODO
+    assert str(fetched_plan.state.state_placeholders) == str(plan.state.state_placeholders)
 
     # Make sure fetched_plan is using the readable_plan
     assert fetched_plan.forward is None


### PR DESCRIPTION
Fixes #3214. 
The problem was that when reconstructing the network placeholders, the is_wrapper parameter from tensor was ignored.
The apparent issue with parameter serialization was due to the fact that when fetching a plan the wrapper parameter was incorrectly reconstructed as a plain parameter. This is actually done inside the placeholder deserialization function, where the "is_wrapper" field is stripped from the parameter tensors inside the instantiate method, hence the missing "Wrapper" when printing the deserialized network's parameters.