### PR TITLE
Wrap our load function around crypten.load

### DIFF
--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -7,7 +7,15 @@ import crypten.communicator as comm
 import crypten
 
 
-def load(tag: str, src: int):
+def load(tag: str, src: int = 0, **kwargs):
+    """Load an object tagged with 'tag' located at the syft worker running
+    party with rank 'src'.
+
+    Args:
+        tag: tag of the object to be looked up.
+        src: rank of the party that should attempt to fetch the object.
+    """
+
     if src == comm.get().get_rank():
         results = syft.local_worker.search(tag)
 
@@ -15,38 +23,10 @@ def load(tag: str, src: int):
         assert len(results) == 1
 
         result = results[0].get()
-
-        if torch.is_tensor(result):
-
-            # Broadcast load type
-            load_type = torch.tensor(0, dtype=torch.long)
-            comm.get().broadcast(load_type, src=src)
-
-            # Broadcast size to other parties.
-            dim = torch.tensor(result.dim(), dtype=torch.long)
-            size = torch.tensor(result.size(), dtype=torch.long)
-
-            comm.get().broadcast(dim, src=src)
-            comm.get().broadcast(size, src=src)
-            result = crypten.mpc.MPCTensor(result, src=src)
-        else:
-            raise TypeError("Unrecognized load type on src")
+        result = crypten.load(preloaded=result, src=src, **kwargs)
 
     else:
-        # Receive load type from source party
-        load_type = torch.tensor(-1, dtype=torch.long)
-        comm.get().broadcast(load_type, src=src)
-
-        # Load in tensor
-        if load_type.item() == 0:
-            # Receive size from source party
-            dim = torch.empty(size=(), dtype=torch.long)
-            comm.get().broadcast(dim, src=src)
-            size = torch.empty(size=(dim.item(),), dtype=torch.long)
-            comm.get().broadcast(size, src=src)
-            result = crypten.mpc.MPCTensor(torch.empty(size=tuple(size.tolist())), src=src)
-        else:
-            raise TypeError("Unrecognized load type on src")
+        result = crypten.load(src=src, **kwargs)
 
     return result
 


### PR DESCRIPTION
This PR wraps our load functions around crypten.load and uses the preloaded argument to pass the object that we loaded from the worker.

This can only be merge when we support newer version of CrypTen.

Fixes #3228 