### PR TITLE
Target correct notebook version

### DIFF
--- a/docker-images/pysyft-notebook/Dockerfile
+++ b/docker-images/pysyft-notebook/Dockerfile
@@ -4,7 +4,7 @@ ENV WORKSPACE /workspace
 
 # Setup workspace environment
 RUN apt-get update && apt-get install -y gcc
-RUN conda install jupyter notebook
+RUN conda install jupyter notebook=5.7.8
 RUN pip install --no-cache-dir syft[udacity,sandbox]
 
 # Create jupyter notebook workspace


### PR DESCRIPTION
Error coming up:
``` ERROR: syft 0.2.4 has requirement tornado==4.5.3, but you'll have tornado 5.1.1 which is incompatible.```