### PR TITLE
Remove redundant check

### DIFF
--- a/syft/execution/plan.py
+++ b/syft/execution/plan.py
@@ -237,10 +237,6 @@ class Plan(AbstractObject):
             if self.include_state:
                 args = (*args, self.state)
             return self.forward(*args)
-
-        elif not self.is_built:
-            return self.build(args)
-
         else:
             return self.role.execute(args)
 


### PR DESCRIPTION
The worker that has the "original" plan will use ```forward``` and the other workers (which received the plan) will use the stored actions.

If the plan is not built, it can not be built on a remote worker since it does not have the ```forward```.
If my understanding is correct, then we should remove the specified lines.