### PR TITLE
Remove `eval` & `import torch` from `Role` using framework package store

### DIFF
--- a/syft/execution/role.py
+++ b/syft/execution/role.py
@@ -132,17 +132,7 @@ class Role(AbstractObject):
         return_placeholder = self._fetch_placeholders_from_ids(return_placeholder)
 
         if _self is None:
-            cmd_path = cmd.split(".")
-
-            package_name = cmd_path[0]
-            subpackage_names = cmd_path[1:-1]
-            method_name = cmd_path[-1]
-
-            package = framework_packages[package_name]
-            for subpackage_name in subpackage_names:
-                package = getattr(package, subpackage_name)
-            method = getattr(package, method_name)
-
+            method = self._fetch_package_method(cmd)
             response = method(*args, **kwargs)
         else:
             response = getattr(_self, cmd)(*args, **kwargs)
@@ -150,6 +140,19 @@ class Role(AbstractObject):
         if isinstance(response, PlaceHolder) or isinstance(response, FrameworkTensor):
             response = (response,)
             PlaceHolder.instantiate_placeholders(return_placeholder, response)
+
+    def _fetch_package_method(self, cmd):
+        cmd_path = cmd.split(".")
+
+        package_name = cmd_path[0]
+        subpackage_names = cmd_path[1:-1]
+        method_name = cmd_path[-1]
+
+        package = framework_packages[package_name]
+        for subpackage_name in subpackage_names:
+            package = getattr(package, subpackage_name)
+        method = getattr(package, method_name)
+        return method
 
     def _build_placeholders(self, obj):
         """

--- a/syft/execution/role.py
+++ b/syft/execution/role.py
@@ -5,8 +5,7 @@ from typing import Union
 
 import copy
 
-# TODO torch shouldn't be used here
-import torch
+from syft.generic.frameworks.types import framework_packages
 
 import syft as sy
 from syft.execution.action import Action
@@ -133,7 +132,18 @@ class Role(AbstractObject):
         return_placeholder = self._fetch_placeholders_from_ids(return_placeholder)
 
         if _self is None:
-            response = eval(cmd)(*args, **kwargs)  # nosec
+            cmd_path = cmd.split(".")
+
+            package_name = cmd_path[0]
+            subpackage_names = cmd_path[1:-1]
+            method_name = cmd_path[-1]
+
+            package = framework_packages[package_name]
+            for subpackage_name in subpackage_names:
+                package = getattr(package, subpackage_name)
+            method = getattr(package, method_name)
+
+            response = method(*args, **kwargs)
         else:
             response = getattr(_self, cmd)(*args, **kwargs)
 

--- a/syft/execution/role.py
+++ b/syft/execution/role.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import copy
 
-from syft.generic.frameworks.types import framework_packages
+from syft.generic.frameworks import framework_packages
 
 import syft as sy
 from syft.execution.action import Action

--- a/syft/generic/frameworks/__init__.py
+++ b/syft/generic/frameworks/__init__.py
@@ -1,0 +1,1 @@
+from syft.generic.frameworks.types import framework_packages

--- a/syft/generic/frameworks/types.py
+++ b/syft/generic/frameworks/types.py
@@ -2,6 +2,8 @@ from typing import Union
 
 from syft import dependency_check
 
+framework_packages = {}
+
 framework_tensors = []
 framework_shapes = []
 framework_layer_modules = []
@@ -11,6 +13,8 @@ if dependency_check.tensorflow_available:
     from tensorflow.python.framework.ops import EagerTensor
     from tensorflow.python.ops.resource_variable_ops import ResourceVariable
 
+    framework_packages["tensorflow"] = tf
+
     framework_tensors.append(EagerTensor)
     framework_tensors.append(ResourceVariable)
     framework_shapes.append(tf.TensorShape)
@@ -19,6 +23,8 @@ if dependency_check.tensorflow_available:
 
 if dependency_check.torch_available:
     import torch
+
+    framework_packages["torch"] = torch
 
     framework_tensors.append(torch.Tensor)
     framework_tensors.append(torch.nn.Parameter)


### PR DESCRIPTION
This creates a global registry of the available framework packages,
which can be used when executing `Actions` in `Plans`. This removes the
last remaining `eval` in the code base, and removes the need for `Role`
to import framework packages referenced in `Plans` (like `torch` or
`crypten`.)