### PR TITLE
Remove unnecessary name off tutorials

### DIFF
--- a/examples/tutorials/advanced/split_neural_network/Tutorial 1 - SplitNN Introduction.ipynb
+++ b/examples/tutorials/advanced/split_neural_network/Tutorial 1 - SplitNN Introduction.ipynb
@@ -72,8 +72,7 @@
     "\n",
     "Authors:\n",
     "- Adam J Hall - Twitter: [@AJH4LL](https://twitter.com/AJH4LL) · GitHub:  [@H4LL](https://github.com/H4LL)\n",
-    "- Théo Ryffel - Twitter: [@theoryffel](https://twitter.com/theoryffel) · GitHub: [@LaRiffle](https://github.com/LaRiffle)\n",
-    "- Haofan Wang - github：[@haofanwang](https://github.com/haofanwang)"
+    "- Théo Ryffel - Twitter: [@theoryffel](https://twitter.com/theoryffel) · GitHub: [@LaRiffle](https://github.com/LaRiffle)"
    ]
   },
   {

--- a/examples/tutorials/advanced/split_neural_network/Tutorial 2 - MultiLayer Split Neural Network.ipynb
+++ b/examples/tutorials/advanced/split_neural_network/Tutorial 2 - MultiLayer Split Neural Network.ipynb
@@ -42,8 +42,7 @@
     "We use the exact same model as we used in the previous tutorial, only this time we are splitting over 3 hosts, not two. However, we see the same loss being reported as there is <b>no reduction in accuracy</b> when training in this way. While we only use 3 models this can be done for any arbitrary number of models.\n",
     "\n",
     "Author:\n",
-    "- Adam J Hall - Twitter: [@AJH4LL](https://twitter.com/AJH4LL) · GitHub:  [@H4LL](https://github.com/H4LL)\n",
-    "- Haofan Wang - github：[@haofanwang](https://github.com/haofanwang)"
+    "- Adam J Hall - Twitter: [@AJH4LL](https://twitter.com/AJH4LL) · GitHub:  [@H4LL](https://github.com/H4LL)"
    ]
   },
   {

--- a/examples/tutorials/advanced/split_neural_network/Tutorial 3 - Folded Split Neural Network.ipynb
+++ b/examples/tutorials/advanced/split_neural_network/Tutorial 3 - Folded Split Neural Network.ipynb
@@ -37,8 +37,7 @@
     "Again, we use the exact same model as we used in the previous tutorial and see the same accuracy. Neither Alice nor Bob have the full model and Bob can't see Alice's data. \n",
     "\n",
     "Author:\n",
-    "- Adam J Hall - Twitter: [@AJH4LL](https://twitter.com/AJH4LL) · GitHub:  [@H4LL](https://github.com/H4LL)\n",
-    "- Haofan Wang - github：[@haofanwang](https://github.com/haofanwang)"
+    "- Adam J Hall - Twitter: [@AJH4LL](https://twitter.com/AJH4LL) · GitHub:  [@H4LL](https://github.com/H4LL)"
    ]
   },
   {


### PR DESCRIPTION
This PR is requested by @H4LL in #3166, just fix my previous mistakes. Ready to be merged directly.