### PR TITLE
Update path triggers for automated test workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,15 @@ on:
   push:
     branches:
     - master
+    paths:
+    - '**.py'
+    - 'pip-dep/**'
+
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+    - '**.py'
+    - 'pip-dep/**'
 
 jobs:
   build:
@@ -22,7 +29,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v1.1.2 
+    - uses: actions/cache@v1.1.2
       id: cache-reqs
       with:
         path: ~/.cache/pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ on:
     - 'pip-dep/**'
 
 jobs:
-  build:
+  python-tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/translated-tutorials.yml
+++ b/.github/workflows/translated-tutorials.yml
@@ -6,6 +6,7 @@ on:
     - master
     paths:
     - "examples/tutorials/translations/**"
+
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/translated-tutorials.yml
+++ b/.github/workflows/translated-tutorials.yml
@@ -13,7 +13,7 @@ on:
     - "examples/tutorials/translations/**"
 
 jobs:
-  build:
+  translation-tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -15,10 +15,11 @@ on:
     paths:
     - '**.py'
     - '**.ipynb'
+    - 'pip-dep/**'
     - "!examples/tutorials/translations/**"
 
 jobs:
-  build:
+  tutorial-tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -4,13 +4,18 @@ on:
   push:
     branches:
     - master
-    paths-ignore:
-    - "examples/tutorials/translations/**"
+    paths:
+    - '**.py'
+    - '**.ipynb'
+    - 'pip-dep/**'
+    - "!examples/tutorials/translations/**"
 
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-    - "examples/tutorials/translations/**"
+    paths:
+    - '**.py'
+    - '**.ipynb'
+    - "!examples/tutorials/translations/**"
 
 jobs:
   build:


### PR DESCRIPTION
The test suite includes some flaky tests, which are hampering our ability
to merge translation PRs that don't touch the main code of the library.
This updates the paths that trigger the test suite so that it only runs
when `.py` requirements files are changed. The tutorials tests will only
run when `.py`, `.ipynb`, or requirements files are changed. The
translation tests will only run when there are changes to the translation
notebooks.