### PR TITLE
Add Scikit-Learn to Notebook requirements.txt

### DIFF
--- a/pip-dep/requirements_notebooks.txt
+++ b/pip-dep/requirements_notebooks.txt
@@ -4,3 +4,4 @@ matplotlib~=3.1.1
 nltk~=3.4.5
 papermill~=2.0.0
 statsmodels~=0.11.1
+scikit-learn~=0.22.2.post1


### PR DESCRIPTION
As per #3272 , there is a dependency missing issue while running Tutorial 5 notebook.