### PR TITLE
Fix missing `device` param in `test_federated_client.py::test_fit`

### DIFF
--- a/test/federated/test_federated_client.py
+++ b/test/federated/test_federated_client.py
@@ -188,7 +188,11 @@ def test_fit(fit_dataset_key, epochs, device):
                 print(f"Loss not reduced, train more: {loss_after}")
 
             train_model(
-                fed_client, fit_dataset_key, available_dataset_key=dataset_key, nr_rounds=10
+                fed_client,
+                fit_dataset_key,
+                available_dataset_key=dataset_key,
+                nr_rounds=10,
+                device=device,
             )
             loss_after = evaluate_model(fed_client, model_id, loss_fn, data, target)
 


### PR DESCRIPTION
This test was failing unexpectedly in the automated test suite, which
appears to be due to randomization sometimes leading the `loss` to
increase instead of decrease. In that circumstance, the test would try
to train the model further until the loss decreased, but the line that
trains the model again was missing the `device` param, causing the test
to fail intermittently.