### PR TITLE
Removing scikit-learn from workflow ymls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
         pip3 install -r pip-dep/requirements_dev.txt
         pip3 install -r pip-dep/requirements_udacity.txt
         pip3 install -r pip-dep/requirements_notebooks.txt
-        pip3 install scikit-learn
         python setup.py install
     - name: Lint, format, and type-check
       run: |

--- a/.github/workflows/translated-tutorials.yml
+++ b/.github/workflows/translated-tutorials.yml
@@ -43,7 +43,6 @@ jobs:
         pip3 install -r pip-dep/requirements_dev.txt
         pip3 install -r pip-dep/requirements_udacity.txt
         pip3 install -r pip-dep/requirements_notebooks.txt
-        pip3 install scikit-learn
         python setup.py install
     - name: Test with pytest
       run: |


### PR DESCRIPTION
As #3339 takes care of scikit-learn installation through `pip-dep/requirements_notebook.txt` , no need to use `pip install scikit-learn` separately.


@karlhigley 