### PR TITLE
Pate test specify type

### DIFF
--- a/test/torch/differential_privacy/test_pate.py
+++ b/test/torch/differential_privacy/test_pate.py
@@ -58,5 +58,5 @@ def test_torch_ref_match():
         preds, indices, noise_eps=0.1, delta=1e-5
     )
 
-    assert torch.isclose(data_dep_eps, torch.tensor(data_dep_eps_ref))
-    assert torch.isclose(data_ind_eps, torch.tensor(data_ind_eps_ref))
+    assert torch.isclose(data_dep_eps, torch.tensor(data_dep_eps_ref, dtype=torch.float32))
+    assert torch.isclose(data_ind_eps, torch.tensor(data_ind_eps_ref, dtype=torch.float32))


### PR DESCRIPTION
Tested Pysyft with torch nightly and found this problem.
The PR can be checked out [here](https://github.com/OpenMined/PySyft/pull/3315).
The problem I had is:
```
  def test_torch_ref_match():
    
        # Verify if the torch implementation values match the original Numpy implementation.
    
        num_teachers, num_examples, num_labels = (100, 50, 10)
        preds = (np.random.rand(num_teachers, num_examples) * num_labels).astype(int)  # fake preds
    
        indices = (np.random.rand(num_examples) * num_labels).astype(int)  # true answers
    
        preds[:, 0:10] *= 0
    
        data_dep_eps, data_ind_eps = pate.perform_analysis_torch(
            preds, indices, noise_eps=0.1, delta=1e-5
        )
    
        data_dep_eps_ref, data_ind_eps_ref = pate.perform_analysis(
            preds, indices, noise_eps=0.1, delta=1e-5
        )
    
>       assert torch.isclose(data_dep_eps, torch.tensor(data_dep_eps_ref))
E       RuntimeError: Float did not match Double
```