### PR TITLE
Fix flakiness in `test_local_remote_gradient_clipping`

### DIFF
--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -357,7 +357,7 @@ def test_local_remote_gradient_clipping(workers):
 
     # Is the output of the remote gradient clipping version equal to
     # the output of the local gradient clipping version?
-    assert total_norm_remote.get().item() == total_norm_local
+    assert total_norm_remote.get().item() == pytest.approx(total_norm_local)
 
 
 # Input: None

--- a/test/torch/test_hook.py
+++ b/test/torch/test_hook.py
@@ -357,7 +357,7 @@ def test_local_remote_gradient_clipping(workers):
 
     # Is the output of the remote gradient clipping version equal to
     # the output of the local gradient clipping version?
-    assert total_norm_remote.get() == total_norm_local
+    assert total_norm_remote.get().item() == total_norm_local
 
 
 # Input: None


### PR DESCRIPTION
This test was implicitly relying on `torch.Tensor's` approximate `eq`
when comparing a tensor with a float. Instead, let's compare floats
directly, which makes this test always fail.