### PR TITLE
Adjust comparison thresholds in `test_instantiate_tfe_layer`

### DIFF
--- a/test/keras/test_sequential.py
+++ b/test/keras/test_sequential.py
@@ -51,7 +51,7 @@ def test_instantiate_tfe_layer():  # pragma: no cover
             actual = sess.run(out.reveal())
 
     # compares results and raises error if not equal up to 0.001
-    np.testing.assert_allclose(actual, expected, rtol=0.001)
+    np.testing.assert_allclose(actual, expected, rtol=0.005, atol=0.001)
 
 
 @pytest.mark.skipif(not dependency_check.tfe_available, reason="tf_encrypted not installed")


### PR DESCRIPTION
This test has a known issue with sampling from a normal distribution
that might land close to zero, making small absolute errors result in
large relative errors. This bumps the relative tolerance and adds an
absolute tolerance to prevent the test from accepting large absolute
errors on large values that result in small relative errors.

More on this in [Issue #3344](https://github.com/OpenMined/PySyft/issues/3344#issuecomment-612652546).