### PR TITLE
Handle torchscript state arg outside of Role

### DIFF
--- a/syft/execution/role.py
+++ b/syft/execution/role.py
@@ -122,19 +122,6 @@ class Role(AbstractObject):
         )
         PlaceHolder.instantiate_placeholders(input_placeholders, args_)
 
-        # Last extra argument is a state?
-        if (
-            len(self.state.state_placeholders) > 0
-            and len(args_) - len(input_placeholders) == 1
-            and isinstance(args_[-1], (list, tuple))
-            and len(args_[-1]) == len(self.state.state_placeholders)
-        ):
-            state_placeholders = tuple(
-                self.placeholders[ph.id.value] for ph in self.state.state_placeholders
-            )
-            PlaceHolder.instantiate_placeholders(self.state.state_placeholders, args_[-1])
-            PlaceHolder.instantiate_placeholders(state_placeholders, args_[-1])
-
     def _execute_action(self, action):
         """ Build placeholders and store action.
         """

--- a/syft/execution/translation/torchscript.py
+++ b/syft/execution/translation/torchscript.py
@@ -25,9 +25,8 @@ class PlanTranslatorTorchscript(AbstractPlanTranslator):
         def wrap_stateful_plan(*args):
             role = plan.role
             state = args[-1]
-            if (
-                0 < len(role.state.state_placeholders) == len(state)
-                and isinstance(state, (list, tuple))
+            if 0 < len(role.state.state_placeholders) == len(state) and isinstance(
+                state, (list, tuple)
             ):
                 state_placeholders = tuple(
                     role.placeholders[ph.id.value] for ph in role.state.state_placeholders

--- a/syft/execution/translation/torchscript.py
+++ b/syft/execution/translation/torchscript.py
@@ -19,11 +19,29 @@ class PlanTranslatorTorchscript(AbstractPlanTranslator):
         tmp_forward = plan.forward
         plan.forward = None
 
-        # To avoid storing Plan state tensors in torchscript, they will be send as parameters
+        # To avoid storing Plan state tensors inside the torchscript,
+        # we trace wrapper func, which accepts state parameters as last arg
+        # and sets them into the Plan before executing the Plan
+        def wrap_stateful_plan(*args):
+            role = plan.role
+            state = args[-1]
+            if (
+                0 < len(role.state.state_placeholders) == len(state)
+                and isinstance(state, (list, tuple))
+            ):
+                state_placeholders = tuple(
+                    role.placeholders[ph.id.value] for ph in role.state.state_placeholders
+                )
+                PlaceHolder.instantiate_placeholders(role.state.state_placeholders, state)
+                PlaceHolder.instantiate_placeholders(state_placeholders, state)
+
+            return plan(*args[:-1])
+
         plan_params = plan.parameters()
         if len(plan_params) > 0:
-            args = (*args, plan_params)
-        torchscript_plan = jit.trace(plan, args)
+            torchscript_plan = jit.trace(wrap_stateful_plan, (*args, plan_params))
+        else:
+            torchscript_plan = jit.trace(plan, args)
         plan.torchscript = torchscript_plan
         plan.forward = tmp_forward
 


### PR DESCRIPTION
In https://github.com/OpenMined/PySyft/pull/3263, plan with state was traced to torchscript with extra arg that passes state inside the plan. The last arg was handled in Role.

However, adding this extra argument interferes with #3296 by @tudorcebere

This PR moves handling of the last arg from Role into wrapper func in torchscript translator class, so the Role itself is not affected and gets correct number of arguments.


