### PR TITLE
Add method to add/remove operations from base worker

### DIFF
--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -208,8 +208,6 @@ def run_multiworkers(
             if was_initialized:
                 crypten.init()
 
-            sy.local_worker.remove_crypten_support()
-
             return return_values
 
         return wrapper

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -25,10 +25,6 @@ def _launch(func, rank, world_size, master_addr, master_port, queue, func_args, 
     for key, val in communicator_args.items():
         os.environ[key] = str(val)
 
-    if rank == 1:
-        import pdb
-
-        pdb.set_trace()
     crypten.init()
     return_value = func(*func_args, **func_kwargs)
     crypten.uninit()

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -152,6 +152,7 @@ def run_multiworkers(
                 zip(range(1, len(workers) + 1), [worker.id for worker in workers])
             )
 
+            sy.local_worker.add_crypten_support()
             sy.local_worker._set_rank_to_worker_id(rank_to_worker_id)
 
             # Start local party
@@ -206,6 +207,8 @@ def run_multiworkers(
                 thread.join()
             if was_initialized:
                 crypten.init()
+
+            sy.local_worker.remove_crypten_support()
 
             return return_values
 

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -25,6 +25,10 @@ def _launch(func, rank, world_size, master_addr, master_port, queue, func_args, 
     for key, val in communicator_args.items():
         os.environ[key] = str(val)
 
+    if rank == 1:
+        import pdb
+
+        pdb.set_trace()
     crypten.init()
     return_value = func(*func_args, **func_kwargs)
     crypten.uninit()

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -93,7 +93,7 @@ def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
     return ObjectMessage(return_value)
 
 
-def add_support_to_workers(worker):
+def add_support_to_worker(worker):
     worker._message_router[CryptenInitPlan] = types.MethodType(run_crypten_party_plan, worker)
     worker._message_router[CryptenInitJail] = types.MethodType(run_crypten_party_jail, worker)
 

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -87,7 +87,7 @@ def add_support_to_workers(worker):
     worker._message_router[CryptenInitJail] = types.MethodType(run_crypten_party_jail, worker)
 
     for method in methods_to_add:
-        method_name = method.__name
+        method_name = method.__name__
         if not hasattr(worker, method_name):
             setattr(worker, method_name, types.MethodType(method, worker))
 

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -1,6 +1,7 @@
 from typing import Dict
 import types
 
+import syft as sy
 from syft.workers.base import BaseWorker
 
 from syft.messaging.message import ObjectMessage
@@ -65,6 +66,8 @@ def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
     from syft.frameworks.crypten import utils
 
     worker.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
+    sy.local_worker.rank_to_worker_id = worker.rank_to_worker_id
+
     ser_func = message.jail_runner
     onnx_model = message.model
     crypten_model = None if onnx_model is None else utils.onnx_to_crypten(onnx_model)

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -33,6 +33,7 @@ def run_crypten_party_plan(worker: BaseWorker, message: tuple) -> ObjectMessage:
     """
 
     worker.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
+    sy.local_worker.rank_to_worker_id = worker.rank_to_worker_id
 
     plans = worker.search("crypten_plan")
     assert len(plans) == 1

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -1,0 +1,99 @@
+from typing import Dict
+import types
+
+from syft.workers.base import BaseWorker
+
+from syft.messaging.message import ObjectMessage
+from syft.messaging.message import CryptenInitPlan
+from syft.messaging.message import CryptenInitJail
+
+from syft.frameworks.crypten import run_party
+
+
+def get_worker_from_rank(worker: BaseWorker, rank: int) -> BaseWorker:
+    assert hasattr(worker, "rank_to_worker_id"), "First need to call run_crypten_party"
+    return worker._get_worker_based_on_id(worker.rank_to_worker_id[rank])
+
+
+def _set_rank_to_worker_id(worker: BaseWorker, rank_to_worker_id: Dict[int, int]) -> None:
+    worker.rank_to_worker_id = rank_to_worker_id
+
+
+def run_crypten_party_plan(self, message: CryptenInitPlan):
+    """Run crypten party according to the information received.
+
+        Args:
+            message (CryptenInitPlan): should contain the rank, world_size, master_addr and master_port.
+
+        Returns:
+            An ObjectMessage containing the return value of the crypten function computed.
+        """
+
+    self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
+
+    plans = self.search("crypten_plan")
+    assert len(plans) == 1
+
+    plan = plans[0].get()
+
+    rank = None
+    for r, worker_id in self.rank_to_worker_id.items():
+        if worker_id == self.id:
+            rank = r
+            break
+
+    assert rank is not None
+
+    return_value = run_party(plan, rank, world_size, master_addr, master_port, (), {})
+    return ObjectMessage(return_value)
+
+
+def run_crypten_party_jail(self, message: CryptenInitJail):
+    """Run crypten party according to the information received.
+
+        Args:
+            message (CryptenInitJail): should contain the rank, world_size, master_addr and master_port.
+
+        Returns:
+            An ObjectMessage containing the return value of the crypten function computed.
+        """
+    from syft.frameworks.crypten.jail import JailRunner
+    from syft.frameworks.crypten import utils
+
+    self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
+    ser_func = message.jail_runner
+    onnx_model = message.model
+    crypten_model = None if onnx_model is None else utils.onnx_to_crypten(onnx_model)
+    jail_runner = JailRunner.detail(ser_func, model=crypten_model)
+
+    rank = None
+    for r, worker_id in self.rank_to_worker_id.items():
+        if worker_id == self.id:
+            rank = r
+            break
+
+    assert rank is not None
+
+    return_value = run_party(jail_runner, rank, world_size, master_addr, master_port, (), {})
+    return ObjectMessage(return_value)
+
+
+def add_support_to_workers(worker):
+    worker._message_router[CryptenInitPlan] = types.MethodType(run_crypten_party_plan, worker)
+    worker._message_router[CryptenInitJail] = types.MethodType(run_crypten_party_jail, worker)
+
+    for method in methods_to_add:
+        setattr(worker, method.__name__, types.MethodType(method, worker))
+
+
+def remove_support_from_workers(worker):
+    for method in methods_to_add:
+        delattr(worker, method.__name__)
+
+
+methods_to_add = [
+    run_crypten_party_plan,
+    run_crypten_party_jail,
+    get_worker_from_rank,
+    _set_rank_to_worker_id,
+]

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -62,7 +62,6 @@ def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
             An ObjectMessage containing the return value of the crypten function computed.
         """
     from syft.frameworks.crypten.jail import JailRunner
-<<<<<<< HEAD
     from syft.frameworks.crypten import utils
 
     worker.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
@@ -74,16 +73,6 @@ def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
     rank = None
     for r, worker_id in worker.rank_to_worker_id.items():
         if worker_id == worker.id:
-=======
-
-    self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
-    ser_func = message.jail_runner
-    jail_runner = JailRunner.detail(ser_func)
-
-    rank = None
-    for r, worker_id in self.rank_to_worker_id.items():
-        if worker_id == self.id:
->>>>>>> c21c2611... Add dict in dict for support
             rank = r
             break
 

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -19,26 +19,28 @@ def _set_rank_to_worker_id(worker: BaseWorker, rank_to_worker_id: Dict[int, int]
     worker.rank_to_worker_id = rank_to_worker_id
 
 
-def run_crypten_party_plan(self, message: CryptenInitPlan):
+def run_crypten_party_plan(worker: BaseWorker, message: tuple) -> ObjectMessage:
     """Run crypten party according to the information received.
 
-        Args:
-            message (CryptenInitPlan): should contain the rank, world_size, master_addr and master_port.
+    Args:
+        worker (BaseWorker): The worker which runs this method
+        message (CryptenInit): should contain the rank_to_worker_id, world_size,
+                            master_addr and master_port.
 
-        Returns:
-            An ObjectMessage containing the return value of the crypten function computed.
-        """
+    Returns:
+        An ObjectMessage containing the return value of the crypten function computed.
+    """
 
-    self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
+    worker.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
 
-    plans = self.search("crypten_plan")
+    plans = worker.search("crypten_plan")
     assert len(plans) == 1
 
     plan = plans[0].get()
 
     rank = None
-    for r, worker_id in self.rank_to_worker_id.items():
-        if worker_id == self.id:
+    for r, worker_id in worker.rank_to_worker_id.items():
+        if worker_id == worker.id:
             rank = r
             break
 
@@ -48,11 +50,13 @@ def run_crypten_party_plan(self, message: CryptenInitPlan):
     return ObjectMessage(return_value)
 
 
-def run_crypten_party_jail(self, message: CryptenInitJail):
+def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
     """Run crypten party according to the information received.
 
         Args:
-            message (CryptenInitJail): should contain the rank, world_size, master_addr and master_port.
+            worker (BaseWorker): The worker which runs this method
+            message (CryptenInitJail): should contain the rank, world_size,
+                                    master_addr and master_port.
 
         Returns:
             An ObjectMessage containing the return value of the crypten function computed.
@@ -60,15 +64,15 @@ def run_crypten_party_jail(self, message: CryptenInitJail):
     from syft.frameworks.crypten.jail import JailRunner
     from syft.frameworks.crypten import utils
 
-    self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
+    worker.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
     ser_func = message.jail_runner
     onnx_model = message.model
     crypten_model = None if onnx_model is None else utils.onnx_to_crypten(onnx_model)
     jail_runner = JailRunner.detail(ser_func, model=crypten_model)
 
     rank = None
-    for r, worker_id in self.rank_to_worker_id.items():
-        if worker_id == self.id:
+    for r, worker_id in worker.rank_to_worker_id.items():
+        if worker_id == worker.id:
             rank = r
             break
 
@@ -86,7 +90,7 @@ def add_support_to_workers(worker):
         setattr(worker, method.__name__, types.MethodType(method, worker))
 
 
-def remove_support_from_workers(worker):
+def remove_support_from_worker(worker):
     for method in methods_to_add:
         delattr(worker, method.__name__)
 

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -23,7 +23,7 @@ def run_crypten_party_plan(worker: BaseWorker, message: tuple) -> ObjectMessage:
     """Run crypten party according to the information received.
 
     Args:
-        worker (BaseWorker): The worker which runs this method
+        worker (BaseWorker): The worker which runs this (to be) method
         message (CryptenInit): should contain the rank_to_worker_id, world_size,
                             master_addr and master_port.
 
@@ -54,7 +54,7 @@ def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
     """Run crypten party according to the information received.
 
         Args:
-            worker (BaseWorker): The worker which runs this method
+            worker (BaseWorker): The worker which runs this (to be) method
             message (CryptenInitJail): should contain the rank, world_size,
                                     master_addr and master_port.
 
@@ -62,6 +62,7 @@ def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
             An ObjectMessage containing the return value of the crypten function computed.
         """
     from syft.frameworks.crypten.jail import JailRunner
+<<<<<<< HEAD
     from syft.frameworks.crypten import utils
 
     worker.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
@@ -73,6 +74,16 @@ def run_crypten_party_jail(worker: BaseWorker, message: CryptenInitJail):
     rank = None
     for r, worker_id in worker.rank_to_worker_id.items():
         if worker_id == worker.id:
+=======
+
+    self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
+    ser_func = message.jail_runner
+    jail_runner = JailRunner.detail(ser_func)
+
+    rank = None
+    for r, worker_id in self.rank_to_worker_id.items():
+        if worker_id == self.id:
+>>>>>>> c21c2611... Add dict in dict for support
             rank = r
             break
 

--- a/syft/frameworks/crypten/worker_support.py
+++ b/syft/frameworks/crypten/worker_support.py
@@ -87,7 +87,9 @@ def add_support_to_workers(worker):
     worker._message_router[CryptenInitJail] = types.MethodType(run_crypten_party_jail, worker)
 
     for method in methods_to_add:
-        setattr(worker, method.__name__, types.MethodType(method, worker))
+        method_name = method.__name
+        if not hasattr(worker, method_name):
+            setattr(worker, method_name, types.MethodType(method, worker))
 
 
 def remove_support_from_worker(worker):

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -28,16 +28,12 @@ from syft.messaging.message import WorkerCommandMessage
 from syft.messaging.message import ForceObjectDeleteMessage
 from syft.messaging.message import GetShapeMessage
 from syft.messaging.message import IsNoneMessage
-from syft.messaging.message import CryptenInitPlan
-from syft.messaging.message import CryptenInitJail
 from syft.messaging.message import Message
 from syft.messaging.message import ObjectMessage
 from syft.messaging.message import ObjectRequestMessage
 from syft.messaging.message import PlanCommandMessage
 from syft.messaging.message import SearchMessage
 from syft.workers.abstract import AbstractWorker
-
-from syft.frameworks.crypten import run_party
 
 from syft.exceptions import GetNotPermittedError
 from syft.exceptions import ObjectNotFoundError
@@ -132,8 +128,6 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             IsNoneMessage: self.is_object_none,
             GetShapeMessage: self.handle_get_shape_message,
             SearchMessage: self.respond_to_search,
-            CryptenInitPlan: self.run_crypten_party_plan,
-            CryptenInitJail: self.run_crypten_party_jail,
         }
 
         self._plan_command_router = {
@@ -183,8 +177,6 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             elif hasattr(hook, "tensorflow"):
                 self.tensorflow = self.framework
                 self.remote = Remote(self, "tensorflow")
-
-        self.rank_to_worker_id = None
 
     # SECTION: Methods which MUST be overridden by subclasses
     @abstractmethod
@@ -430,63 +422,6 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             pointer = obj
 
         return pointer
-
-    def run_crypten_party_plan(self, message: CryptenInitPlan):
-        """Run crypten party according to the information received.
-
-        Args:
-            message (CryptenInitPlan): should contain the rank, world_size, master_addr and master_port.
-
-        Returns:
-            An ObjectMessage containing the return value of the crypten function computed.
-        """
-
-        self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
-
-        plans = self.search("crypten_plan")
-        assert len(plans) == 1
-
-        plan = plans[0].get()
-
-        rank = None
-        for r, worker_id in self.rank_to_worker_id.items():
-            if worker_id == self.id:
-                rank = r
-                break
-
-        assert rank is not None
-
-        return_value = run_party(plan, rank, world_size, master_addr, master_port, (), {})
-        return ObjectMessage(return_value)
-
-    def run_crypten_party_jail(self, message: CryptenInitJail):
-        """Run crypten party according to the information received.
-
-        Args:
-            message (CryptenInitJail): should contain the rank, world_size, master_addr and master_port.
-
-        Returns:
-            An ObjectMessage containing the return value of the crypten function computed.
-        """
-        from syft.frameworks.crypten.jail import JailRunner
-        from syft.frameworks.crypten import utils
-
-        self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
-        ser_func = message.jail_runner
-        onnx_model = message.model
-        crypten_model = None if onnx_model is None else utils.onnx_to_crypten(onnx_model)
-        jail_runner = JailRunner.detail(ser_func, model=crypten_model)
-
-        rank = None
-        for r, worker_id in self.rank_to_worker_id.items():
-            if worker_id == self.id:
-                rank = r
-                break
-
-        assert rank is not None
-
-        return_value = run_party(jail_runner, rank, world_size, master_addr, master_port, (), {})
-        return ObjectMessage(return_value)
 
     def handle_object_msg(self, obj_msg: ObjectMessage):
         # This should be a good seam for separating Workers from ObjectStorage (someday),
@@ -847,12 +782,6 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         else:
             return self._get_worker(id_or_worker)
 
-    def get_worker_from_rank(self, rank: int):
-        return self._get_worker_based_on_id(self.rank_to_worker_id[rank])
-
-    def _set_rank_to_worker_id(self, rank_to_worker_id):
-        self.rank_to_worker_id = rank_to_worker_id
-
     def _get_worker(self, worker: AbstractWorker):
         if worker.id not in self._known_workers:
             self.add_worker(worker)
@@ -1189,6 +1118,18 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         """
 
         return sy.serde.deserialize(self.msg_history[index], worker=self)
+
+    def add_crypten_support(self):
+        """Add CrypTen specific methods"""
+        from syft.workers.worker_support import add_support
+
+        add_support(self, "crypten")
+
+    def remove_crypten_support(self):
+        """Remove CrypTen specifc methods"""
+        from syft.workers.worker_support import remove_support
+
+        remove_support(self, "crypten")
 
     @property
     def message_pending_time(self):

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -35,8 +35,6 @@ from syft.messaging.message import PlanCommandMessage
 from syft.messaging.message import SearchMessage
 from syft.workers.abstract import AbstractWorker
 
-from syft.workers.worker_support import add_support, remove_support
-
 
 from syft.exceptions import GetNotPermittedError
 from syft.exceptions import ObjectNotFoundError
@@ -1123,10 +1121,14 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         return sy.serde.deserialize(self.msg_history[index], worker=self)
 
     def add_crypten_support(self):
+        from syft.workers.worker_support import add_support
+
         """Add CrypTen specific methods"""
         add_support(self, "crypten")
 
     def remove_crypten_support(self):
+        from syft.workers.worker_support import remove_support
+
         """Remove CrypTen specifc methods"""
         remove_support(self, "crypten")
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -35,6 +35,9 @@ from syft.messaging.message import PlanCommandMessage
 from syft.messaging.message import SearchMessage
 from syft.workers.abstract import AbstractWorker
 
+from syft.workers.worker_support import add_support, remove_support
+
+
 from syft.exceptions import GetNotPermittedError
 from syft.exceptions import ObjectNotFoundError
 from syft.exceptions import PlanCommandUnknownError
@@ -1121,14 +1124,10 @@ class BaseWorker(AbstractWorker, ObjectStorage):
 
     def add_crypten_support(self):
         """Add CrypTen specific methods"""
-        from syft.workers.worker_support import add_support
-
         add_support(self, "crypten")
 
     def remove_crypten_support(self):
         """Remove CrypTen specifc methods"""
-        from syft.workers.worker_support import remove_support
-
         remove_support(self, "crypten")
 
     @property

--- a/syft/workers/worker_support.py
+++ b/syft/workers/worker_support.py
@@ -4,15 +4,19 @@ from syft.workers.base import BaseWorker
 
 from syft.frameworks.crypten.worker_support import add_support_to_worker, remove_support_from_worker
 
+
 supported_frameworks = {}
 
 if dependency_check.crypten_available:
-    supported_frameworks["crypten"] = [add_support_to_worker, remove_support_from_worker]
+    supported_frameworks["crypten"] = {
+        "add_support": add_support_to_worker,
+        "remove_support": remove_support_from_worker,
+    }
 
 
 def add_support(worker: BaseWorker, framework: str) -> None:
-    supported_frameworks[framework][0](worker)
+    supported_frameworks[framework]["add_support"](worker)
 
 
 def remove_support(worker: BaseWorker, framework: str) -> None:
-    supported_frameworks[framework][1](worker)
+    supported_frameworks[framework]["remove_support"](worker)

--- a/syft/workers/worker_support.py
+++ b/syft/workers/worker_support.py
@@ -2,20 +2,17 @@ from syft import dependency_check
 
 from syft.workers.base import BaseWorker
 
+from syft.frameworks.crypten.worker_support import add_support_to_worker, remove_support_from_worker
+
+supported_frameworks = {}
+
+if dependency_check.crypten_available:
+    supported_frameworks["crypten"] = [add_support_to_worker, remove_support_from_worker]
+
 
 def add_support(worker: BaseWorker, framework: str) -> None:
-    assert framework == "crypten", "Only CrypTen is supported for the moment"
-    assert dependency_check.crypten_available, "CrypTen not installed"
-
-    from syft.frameworks.crypten.worker_support import add_support_to_workers
-
-    add_support_to_workers(worker)
+    add_support_to_worker(worker)
 
 
 def remove_support(worker: BaseWorker, framework: str) -> None:
-    assert framework == "crypten", "Only CrypTen is supported for the moment"
-    assert dependency_check.crypten_available, "CrypTen not installed"
-
-    from syft.frameworks.crypten.worker_support import remove_support_from_workers
-
-    remove_support_from_workers(worker)
+    remove_support_from_worker(worker)

--- a/syft/workers/worker_support.py
+++ b/syft/workers/worker_support.py
@@ -2,7 +2,10 @@ from syft import dependency_check
 
 from syft.workers.base import BaseWorker
 
-from syft.frameworks.crypten.worker_support import add_support_to_worker as add_crypten_support, remove_support_from_worker as remove_crypten_support
+from syft.frameworks.crypten.worker_support import (
+    add_support_to_worker as add_crypten_support,
+    remove_support_from_worker as remove_crypten_support,
+)
 
 
 supported_frameworks = {}

--- a/syft/workers/worker_support.py
+++ b/syft/workers/worker_support.py
@@ -11,8 +11,8 @@ if dependency_check.crypten_available:
 
 
 def add_support(worker: BaseWorker, framework: str) -> None:
-    supported_frameworks[framework][0]()
+    supported_frameworks[framework][0](worker)
 
 
 def remove_support(worker: BaseWorker, framework: str) -> None:
-    supported_frameworks[framework][1]()
+    supported_frameworks[framework][1](worker)

--- a/syft/workers/worker_support.py
+++ b/syft/workers/worker_support.py
@@ -2,15 +2,15 @@ from syft import dependency_check
 
 from syft.workers.base import BaseWorker
 
-from syft.frameworks.crypten.worker_support import add_support_to_worker, remove_support_from_worker
+from syft.frameworks.crypten.worker_support import add_support_to_worker as add_crypten_support, remove_support_from_worker as remove_crypten_support
 
 
 supported_frameworks = {}
 
 if dependency_check.crypten_available:
     supported_frameworks["crypten"] = {
-        "add_support": add_support_to_worker,
-        "remove_support": remove_support_from_worker,
+        "add_support": add_crypten_support,
+        "remove_support": remove_crypten_support,
     }
 
 

--- a/syft/workers/worker_support.py
+++ b/syft/workers/worker_support.py
@@ -11,8 +11,8 @@ if dependency_check.crypten_available:
 
 
 def add_support(worker: BaseWorker, framework: str) -> None:
-    add_support_to_worker(worker)
+    supported_frameworks[framework][0]()
 
 
 def remove_support(worker: BaseWorker, framework: str) -> None:
-    remove_support_from_worker(worker)
+    supported_frameworks[framework][1]()

--- a/syft/workers/worker_support.py
+++ b/syft/workers/worker_support.py
@@ -1,0 +1,21 @@
+from syft import dependency_check
+
+from syft.workers.base import BaseWorker
+
+
+def add_support(worker: BaseWorker, framework: str) -> None:
+    assert framework == "crypten", "Only CrypTen is supported for the moment"
+    assert dependency_check.crypten_available, "CrypTen not installed"
+
+    from syft.frameworks.crypten.worker_support import add_support_to_workers
+
+    add_support_to_workers(worker)
+
+
+def remove_support(worker: BaseWorker, framework: str) -> None:
+    assert framework == "crypten", "Only CrypTen is supported for the moment"
+    assert dependency_check.crypten_available, "CrypTen not installed"
+
+    from syft.frameworks.crypten.worker_support import remove_support_from_workers
+
+    remove_support_from_workers(worker)

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -33,6 +33,12 @@ def test_context(workers):
     return_values = plan_func()
 
     expected_value = th.tensor([143, 85, 32, 4])
+
+    alice.remove_crypten_support()
+    bob.remove_crypten_support()
+
+    # A toy function is ran at each party, and they should all decrypt
+    # a tensor with value [143, 85]
     for rank in range(n_workers):
         assert th.all(
             return_values[rank] == expected_value

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -1,8 +1,10 @@
 import pytest
-import syft as sy
-from syft.frameworks.crypten.context import run_multiworkers
-import torch as th
 import crypten
+
+import torch as th
+import syft as sy
+
+from syft.frameworks.crypten.context import run_multiworkers
 
 
 def test_context(workers):
@@ -14,6 +16,9 @@ def test_context(workers):
 
     alice_tensor_ptr = th.tensor([42, 53, 3, 2]).tag("crypten_data").send(alice)
     bob_tensor_ptr = th.tensor([101, 32, 29, 2]).tag("crypten_data").send(bob)
+
+    alice.add_crypten_support()
+    bob.add_crypten_support()
 
     @run_multiworkers([alice, bob], master_addr="127.0.0.1")
     @sy.func2plan()

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -5,6 +5,28 @@ import torch as th
 import syft as sy
 
 from syft.frameworks.crypten.context import run_multiworkers
+from syft.frameworks.crypten.worker_support import methods_to_add
+
+
+def test_add_crypten_support(workers):
+    alice = workers["alice"]
+
+    for method in methods_to_add:
+        assert not hasattr(
+            alice, method.__name__
+        ), f"Worker should not have method {method.__name__}"
+
+    alice.add_crypten_support()
+
+    for method in methods_to_add:
+        assert hasattr(alice, method.__name__), f"Worker should have method {method.__name__}"
+
+    alice.remove_crypten_support()
+
+    for method in methods_to_add:
+        assert not hasattr(
+            alice, method.__name__
+        ), f"Worker should not have method {method.__name__}"
 
 
 def test_context(workers):

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -235,7 +235,7 @@ def test_spinup_time(hook):
     start_time = time()
     dummy = sy.VirtualWorker(hook, id="dummy", data=data)
     end_time = time()
-    assert (end_time - start_time) < 1
+    assert (end_time - start_time) < 2
 
 
 def test_send_jit_scriptmodule(hook, workers):  # pragma: no cover


### PR DESCRIPTION
Fixes #3363 

Some initial changes to add the mechanism to add/remove methods from a base worker such that it will be able to support the implemented CrypTen operations.

Currently, there is added only CrypTen support, but I choose to implement it in this way (is only an initial draft) such that we could easily add more frameworks in the future.

WIP: Need to add tests to make sure the add/remove mechanism work as intended.

