### PR TITLE
Restrict `pytest-randomly` version to avoid `3.3.0`

### DIFF
--- a/pip-dep/requirements_dev.txt
+++ b/pip-dep/requirements_dev.txt
@@ -1,3 +1,4 @@
+bandit
 black>=10.3b0
 bumpversion>=0.5.3
 coverage>=4.5.3
@@ -6,11 +7,10 @@ mypy>=0.711
 pre-commit>=1.16.1
 pyopenssl>=19.0.0
 pyshark>=0.4.2.4
-pytest>=4.5.0
-pytest-randomly
+pytest-randomly~=3.2.1
+pytest>=5.4.1
 setuptools>=41.0.0
-sphinx-markdown-builder>=0.4.1
-Sphinx>=2.1.1
 sphinx-autoapi
+sphinx-markdown-builder>=0.4.1
 sphinx-rtd-theme
-bandit
+Sphinx>=2.1.1


### PR DESCRIPTION
`pytest-randomly 3.3.0` adds support for `pytest-xdist` but does so in a
way that requires `pytest-xdist` to be installed, which we don't need.
It's probably an accidental change, but until it's resolved we'll just
avoid that version (which breaks our builds.)