### PR TITLE
Don't assume `self` is in `known_workers` in `BaseWorker.serializer`

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -1178,14 +1178,13 @@ class BaseWorker(AbstractWorker, ObjectStorage):
                 'torch': serialization will only work between workers that support PyTorch
                 (more to come: 'tensorflow', 'numpy', etc)
         """
-        if workers is not None:
-            if not isinstance(workers, list):
-                workers = [workers]
-            workers.append(self)
-        else:
-            # self is referenced in self.__known_workers
-            # NOTE: for some reason self._known_workers may contain a Plan
-            workers = [w for _, w in self._known_workers.items() if isinstance(w, AbstractWorker)]
+        if workers is None:
+            workers = [w for w in self._known_workers.values() if isinstance(w, AbstractWorker)]
+
+        if not isinstance(workers, list):
+            workers = [workers]
+
+        workers.append(self)
 
         frameworks = set()
         for worker in workers:


### PR DESCRIPTION
That assumption makes it possible to have a case where `known_workers`
is empty, which leads `len(frameworks) == 1` to be `False`, which
defaults to the wrong serialization strategy when `self.framework` is
`torch`.

Fixes #3359