### PR TITLE
Skip the privacy attack notebooks during notebook tests

### DIFF
--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -70,7 +70,7 @@ exclusion_list_notebooks += excluded_translated_notebooks
 exclusion_list_folders = [
     "examples/tutorials/websocket",
     "examples/tutorials/advanced/monitor_network_traffic",
-    "examples/tutorials/advanced/privacy_attacks"
+    "examples/tutorials/advanced/privacy_attacks",
     "examples/tutorials/advanced/websockets_mnist_parallel",
     # To run these notebooks, we need to run grid nodes / grid gateway previously (they aren't  in this repository)
     "examples/tutorials/grid",

--- a/test/notebooks/test_notebooks.py
+++ b/test/notebooks/test_notebooks.py
@@ -70,6 +70,7 @@ exclusion_list_notebooks += excluded_translated_notebooks
 exclusion_list_folders = [
     "examples/tutorials/websocket",
     "examples/tutorials/advanced/monitor_network_traffic",
+    "examples/tutorials/advanced/privacy_attacks"
     "examples/tutorials/advanced/websockets_mnist_parallel",
     # To run these notebooks, we need to run grid nodes / grid gateway previously (they aren't  in this repository)
     "examples/tutorials/grid",


### PR DESCRIPTION
The black box model inversion notebook is downloading EMNIST and using
up all the space in the automated test environments.