### PR TITLE
Hooking crypten.nn.Module

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -221,6 +221,7 @@ class TorchHook(FrameworkHook):
         # Hook the Crypten module
         if dependency_check.crypten_available:
             self._hook_crypten()
+            self._hook_crypten_module()
 
         # Add the local_worker to syft so that it can be found if the hook is
         # called several times
@@ -491,6 +492,150 @@ class TorchHook(FrameworkHook):
 
         new_func = get_hooked_crypten_func("load", crypten_load)
         setattr(crypten, "load", new_func)
+
+    def _hook_crypten_module(self):
+        """Overloading crypten.nn.Module with PySyft functionality, the primary module
+           responsible for core ML functionality such as Neural network layers and
+           loss functions.
+           It is important to note that all the operations are actually in-place.
+        """
+        import crypten
+
+        def _check_encrypted(model):
+            if model.encrypted:
+                raise RuntimeError("Crypten model must be unencrypted to run PySyft operations")
+
+        crypten.nn.Module._check_encrypted = _check_encrypted
+
+        def module_is_missing_grad(model):
+            """Checks if all the parameters in the model have been assigned a gradient"""
+            for p in model.parameters():
+                if p.grad is None:
+                    return True
+            return False
+
+        def create_grad_objects(model):
+            """Assigns gradient to model parameters if not assigned"""
+            for p in model.parameters():
+                if p.requires_grad:  # check if the object requires a grad object
+                    o = p.sum()
+                    o.backward()
+                    if p.grad is not None:
+                        p.grad -= p.grad
+
+        def module_send_(nn_self, *dest, force_send=False, **kwargs):
+            """Overloads torch.nn instances so that they could be sent to other workers"""
+            nn_self._check_encrypted()
+
+            if module_is_missing_grad(nn_self):
+                create_grad_objects(nn_self)
+
+            for p in nn_self.parameters():
+                p.send_(*dest, **kwargs)
+
+            if isinstance(nn_self.forward, Plan):
+                nn_self.forward.send(*dest, force=force_send)
+
+            return nn_self
+
+        crypten.nn.Module.send = module_send_
+        crypten.nn.Module.send_ = module_send_
+
+        def module_move_(nn_self, destination):
+            nn_self._check_encrypted()
+            params = list(nn_self.parameters())
+            for p in params:
+                p.move(destination)
+
+        crypten.nn.Module.move = module_move_
+
+        def module_get_(nn_self):
+            """overloads torch.nn instances with get method so that parameters could be sent back to owner"""
+            nn_self._check_encrypted()
+            for p in nn_self.parameters():
+                p.get_()
+
+            if isinstance(nn_self.forward, Plan):
+                nn_self.forward.get()
+
+            return nn_self
+
+        crypten.nn.Module.get_ = module_get_
+        crypten.nn.Module.get = module_get_
+
+        def module_share_(nn_self, *args, **kwargs):
+            """Overloads fix_precision for torch.nn.Module."""
+            # TODO: add .data and .grad to syft tensors
+            nn_self._check_encrypted()
+            if module_is_missing_grad(nn_self):
+                create_grad_objects(nn_self)
+
+            for p in nn_self.parameters():
+                p.share_(*args, **kwargs)
+
+            return nn_self
+
+        crypten.nn.Module.share_ = module_share_
+        crypten.nn.Module.share = module_share_
+
+        def module_fix_precision_(nn_self, *args, **kwargs):
+            """Overloads fix_precision for torch.nn.Module."""
+            nn_self._check_encrypted()
+            if module_is_missing_grad(nn_self):
+                create_grad_objects(nn_self)
+
+            for p in nn_self.parameters():
+                p.fix_precision_(*args, **kwargs)
+
+            return nn_self
+
+        crypten.nn.Module.fix_precision_ = module_fix_precision_
+        crypten.nn.Module.fix_precision = module_fix_precision_
+        crypten.nn.Module.fix_prec = module_fix_precision_
+
+        def module_float_precision_(nn_self):
+            """Overloads float_precision for torch.nn.Module, convert fix_precision
+            parameters to normal float parameters"""
+            # TODO: add .data and .grad to syft tensors
+            # if module_is_missing_grad(nn_self):
+            #    create_grad_objects(nn_self)
+            nn_self._check_encrypted()
+            for p in nn_self.parameters():
+                p.float_precision_()
+
+            return nn_self
+
+        crypten.nn.Module.float_precision_ = module_float_precision_
+        crypten.nn.Module.float_precision = module_float_precision_
+        crypten.nn.Module.float_prec = module_float_precision_
+
+        def module_copy(nn_self):
+            """Returns a copy of a torch.nn.Module"""
+            nn_self._check_encrypted()
+            return copy.deepcopy(nn_self)
+
+        crypten.nn.Module.copy = module_copy
+
+        @property
+        def owner(nn_self):
+            nn_self._check_encrypted()
+            for p in nn_self.parameters():
+                return p.owner
+
+        crypten.nn.Module.owner = owner
+
+        @property
+        def location(nn_self):
+            nn_self._check_encrypted()
+            try:
+                for p in nn_self.parameters():
+                    return p.location
+            except AttributeError:
+                raise AttributeError(
+                    "Module has no attribute location, did you already send it to some location?"
+                )
+
+        crypten.nn.Module.location = location
 
     def _get_hooked_additive_shared_method(hook_self, attr):
         """

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -524,7 +524,7 @@ class TorchHook(FrameworkHook):
                         p.grad -= p.grad
 
         def module_send_(nn_self, *dest, force_send=False, **kwargs):
-            """Overloads torch.nn instances so that they could be sent to other workers"""
+            """Overloads crypten.nn instances so that they could be sent to other workers"""
             nn_self._check_encrypted()
 
             if module_is_missing_grad(nn_self):
@@ -550,7 +550,7 @@ class TorchHook(FrameworkHook):
         crypten.nn.Module.move = module_move_
 
         def module_get_(nn_self):
-            """overloads torch.nn instances with get method so that parameters could be sent back to owner"""
+            """Overloads crypten.nn instances with get method so that parameters could be sent back to owner"""
             nn_self._check_encrypted()
             for p in nn_self.parameters():
                 p.get_()
@@ -564,7 +564,7 @@ class TorchHook(FrameworkHook):
         crypten.nn.Module.get = module_get_
 
         def module_share_(nn_self, *args, **kwargs):
-            """Overloads fix_precision for torch.nn.Module."""
+            """Overloads share for crypten.nn.Module."""
             # TODO: add .data and .grad to syft tensors
             nn_self._check_encrypted()
             if module_is_missing_grad(nn_self):
@@ -579,7 +579,7 @@ class TorchHook(FrameworkHook):
         crypten.nn.Module.share = module_share_
 
         def module_fix_precision_(nn_self, *args, **kwargs):
-            """Overloads fix_precision for torch.nn.Module."""
+            """Overloads fix_precision for crypten.nn.Module."""
             nn_self._check_encrypted()
             if module_is_missing_grad(nn_self):
                 create_grad_objects(nn_self)
@@ -594,7 +594,7 @@ class TorchHook(FrameworkHook):
         crypten.nn.Module.fix_prec = module_fix_precision_
 
         def module_float_precision_(nn_self):
-            """Overloads float_precision for torch.nn.Module, convert fix_precision
+            """Overloads float_precision for crypten.nn.Module, convert fix_precision
             parameters to normal float parameters"""
             # TODO: add .data and .grad to syft tensors
             # if module_is_missing_grad(nn_self):
@@ -610,7 +610,7 @@ class TorchHook(FrameworkHook):
         crypten.nn.Module.float_prec = module_float_precision_
 
         def module_copy(nn_self):
-            """Returns a copy of a torch.nn.Module"""
+            """Returns a copy of a crypten.nn.Module"""
             nn_self._check_encrypted()
             return copy.deepcopy(nn_self)
 

--- a/test/crypten/test_hook.py
+++ b/test/crypten/test_hook.py
@@ -1,0 +1,44 @@
+import pytest
+import crypten
+import torch
+import syft
+
+
+@pytest.fixture(scope="function")
+def model():
+    l_in, l_h, l_out = 32, 16, 2
+    model = crypten.nn.Sequential(
+        [crypten.nn.Linear(l_in, l_h), crypten.nn.ReLU(), crypten.nn.Linear(l_h, l_out)]
+    )
+    return model
+
+
+def test_send_module(workers, model):
+    alice = workers["alice"]
+    model_cmp = model.copy()
+    params = [p.data for p in model_cmp.parameters()]
+
+    assert model.location is None
+    assert model.owner == syft.local_worker
+    model.send(alice)
+    assert model.location == alice
+    assert model.owner == syft.local_worker
+    model.get()
+    assert model.location is None
+    assert model.owner == syft.local_worker
+
+    for p, p_cmp in zip(model.parameters(), params):
+        assert torch.all(p.data == p_cmp)
+
+
+def test_move_module(workers, model):
+    alice = workers["alice"]
+    bob = workers["bob"]
+
+    assert model.location is None
+    model.send(alice)
+    assert model.location == alice
+    model.move(bob)
+    assert model.location == bob
+    model.get()
+    assert model.location is None

--- a/test/crypten/test_hook.py
+++ b/test/crypten/test_hook.py
@@ -42,3 +42,14 @@ def test_move_module(workers, model):
     assert model.location == bob
     model.get()
     assert model.location is None
+
+
+def test_copy(model):
+    copy_model = model.copy()
+    with torch.no_grad():
+        for p in model.parameters():
+            assert isinstance(p, torch.Tensor)
+            p.set_(torch.zeros_like(p))
+
+        for p in copy_model.parameters():
+            assert not torch.all(p == 0)


### PR DESCRIPTION
## Description

In a parallel PR #3365 , I was wrapping the crypten model and adding functionalities such as sending and sharing crypten models. In this PR, I add the same features by hooking into `crypten.nn.Module` instead of wrapping it.

## Type of change

Please mark options that are relevant.

- [ ] Added/Modified tutorials
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [x] I have added tests for my changes
* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).