### PR TITLE
Rework `PlanTranslatorTorchscript` so it doesn't strip `Parameters`

### DIFF
--- a/syft/execution/translation/torchscript.py
+++ b/syft/execution/translation/torchscript.py
@@ -11,20 +11,17 @@ class PlanTranslatorTorchscript(AbstractPlanTranslator):
         super().__init__(plan)
 
     def translate(self):
-        plan = self.plan
+        translation_plan = self.plan.copy()
+        translation_plan.forward = None
 
-        args_shape = plan.get_args_shape()
+        args_shape = translation_plan.get_args_shape()
         args = PlaceHolder.create_placeholders(args_shape)
 
-        # Temporarily remove reference to original function
-        tmp_forward = plan.forward
-        plan.forward = None
-
-        # To avoid storing Plan state tensors inside the torchscript,
+        # To avoid storing Plan state tensors in torchscript, they will be send as parameters
         # we trace wrapper func, which accepts state parameters as last arg
         # and sets them into the Plan before executing the Plan
         def wrap_stateful_plan(*args):
-            role = plan.role
+            role = translation_plan.role
             state = args[-1]
             if 0 < len(role.state.state_placeholders) == len(state) and isinstance(
                 state, (list, tuple)
@@ -35,23 +32,21 @@ class PlanTranslatorTorchscript(AbstractPlanTranslator):
                 PlaceHolder.instantiate_placeholders(role.state.state_placeholders, state)
                 PlaceHolder.instantiate_placeholders(state_placeholders, state)
 
-            return plan(*args[:-1])
+            return translation_plan(*args[:-1])
 
-        plan_params = plan.parameters()
+        plan_params = translation_plan.parameters()
         if len(plan_params) > 0:
             torchscript_plan = jit.trace(wrap_stateful_plan, (*args, plan_params))
         else:
-            torchscript_plan = jit.trace(plan, args)
-        plan.torchscript = torchscript_plan
-        plan.forward = tmp_forward
+            torchscript_plan = jit.trace(translation_plan, args)
 
-        return plan
+        self.plan.torchscript = torchscript_plan
+        return self.plan
 
     def remove(self):
-        plan = self.plan
-        plan.torchscript = None
+        self.plan.torchscript = None
 
-        return plan
+        return self.plan
 
 
 # Register translators that should apply at Plan build time


### PR DESCRIPTION
Resolve Conficts, merge with master
>It turns out `jit.trace()` strips `Parameters` out of the tensor chain,
which causes issues with `fix_precision`. Don't fully understand why
`jit.trace()` does that, but operating on a copy of the original Plan
avoid mutating the original State tensors, which fixes the issue.
@karlhigley #3375 
