### PR TITLE
Add Syft version checking

### DIFF
--- a/syft/codes.py
+++ b/syft/codes.py
@@ -36,3 +36,4 @@ class RESPONSE_MSG(object):
     SUCCESS = "success"
     MODELS = "models"
     INFERENCE_RESULT = "prediction"
+    SYFT_VERSION = "syft_version"

--- a/syft/workers/node_client.py
+++ b/syft/workers/node_client.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 # Syft imports
 from syft.serde import serialize
+from syft.version import __version__
 from syft.execution.plan import Plan
 from syft.codes import REQUEST_MSG, RESPONSE_MSG
 from syft.federated.federated_client import FederatedClient
@@ -66,7 +67,7 @@ class NodeClient(WebsocketClientWorker, FederatedClient):
         )
 
         # Update Node reference using node's Id given by the remote node
-        self._update_node_reference(self._get_node_id())
+        self._update_node_reference(self._get_node_infos())
 
         if self.credential:
             self._authenticate()
@@ -135,13 +136,22 @@ class NodeClient(WebsocketClientWorker, FederatedClient):
         secure = True if url.scheme == "wss" else False
         return (secure, url.hostname, url.port)
 
-    def _get_node_id(self) -> str:
+    def _get_node_infos(self) -> str:
         """ Get Node ID from remote node worker
             Returns:
                 node_id (str) : node id used by remote worker.
         """
         message = {REQUEST_MSG.TYPE_FIELD: REQUEST_MSG.GET_ID}
         response = self._forward_json_to_websocket_server_worker(message)
+        node_version = response.get(RESPONSE_MSG.SYFT_VERSION, None)
+        if node_version != __version__:
+            raise RuntimeError(
+                "Library version mismatch, The PySyft version of your environment is "
+                + __version__
+                + " the Grid Node Syft version is "
+                + node_version
+            )
+
         return response.get(RESPONSE_MSG.NODE_ID, None)
 
     def _forward_json_to_websocket_server_worker(self, message: dict) -> dict:


### PR DESCRIPTION
## Description

One of the most common errors reported by PyGrid users is the Syft version mismatch between the grid nodes and the user environment. The purpose of this PR is to provide a debugging mechanism for this error.

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).