### PR TITLE
Make codecov statuses informational (always pass)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,11 @@
 coverage:
-    range: 95..100
-    round: up
-    precision: 2
     status:
-        threshold: 1%  # Allow 1% of changes in coverage
-
+        project:
+            default:
+                informational: true
+        patch:
+            default:
+                informational: true
 
 comment:
     layout: "reach, diff, flags, files"


### PR DESCRIPTION
## Description

Makes the codecov actions always pass. This is okay, because we have other test coverage checks in the normal test suite.

## Type of change

Please mark options that are relevant.

- [ ] Added/Modified tutorials
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).