### PR TITLE
[WIP] Add `Size` method to `TorchTensor` (native)

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -138,8 +138,8 @@ class TorchTensor(AbstractTensor):
         else:
             return self.native_shape
 
-    def size(self):
-        return self.shape
+    def size(self, dim=None):
+        return self.shape if dim is None else self.shape[dim]
 
     @property
     def data(self):

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -138,6 +138,9 @@ class TorchTensor(AbstractTensor):
         else:
             return self.native_shape
 
+    def size(self):
+        return self.shape
+
     @property
     def data(self):
         if self.is_wrapper:


### PR DESCRIPTION
## Description
>After sending tensor to a worker the size() call returns torch.Size([0]) while .shape returns correct value.

Adds a `.size()` method to `TorchTensor`
Fixes #3382 

## Type of change

Please mark options that are relevant.

- [ ] Added/Modified tutorials
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).