### PR TITLE
Garbage Collection for `AutoGradTensor`

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/autograd.py
+++ b/syft/frameworks/torch/tensors/interpreters/autograd.py
@@ -50,6 +50,9 @@ class AutogradTensor(AbstractTensor):
             grad = self * 0 + 1
         backwards_grad(self.grad_fn, grad)
 
+    def __del__(self):
+        print("!!Test from AutoGrad!!")
+
     @property
     def data(self):
         return self

--- a/syft/frameworks/torch/tensors/interpreters/autograd.py
+++ b/syft/frameworks/torch/tensors/interpreters/autograd.py
@@ -50,9 +50,6 @@ class AutogradTensor(AbstractTensor):
             grad = self * 0 + 1
         backwards_grad(self.grad_fn, grad)
 
-    def __del__(self):
-        print("!!Test from AutoGrad!!")
-
     @property
     def data(self):
         return self
@@ -156,7 +153,6 @@ class AutogradTensor(AbstractTensor):
                 # Put back SyftTensor on the tensors found in the response
                 result = hook_args.hook_response(name, result, wrap_type=type(self))
                 result.grad_fn = grad_fn(self, *args, **kwargs)
-                result.grad_fn.result = result
 
                 return result
 

--- a/syft/frameworks/torch/tensors/interpreters/gradients.py
+++ b/syft/frameworks/torch/tensors/interpreters/gradients.py
@@ -147,14 +147,14 @@ class SinhBackward(GradFunc):
         return (grad_self_,)
 
 
-class SqrtBackward(GradFunc):
-    def __init__(self, self_):
-        super().__init__(self, self_)
-        self.self_ = self_
-
-    def gradient(self, grad):
-        grad_self_ = grad / (2 * self.result)
-        return (grad_self_,)
+# class SqrtBackward(GradFunc):
+#     def __init__(self, self_):
+#         super().__init__(self, self_)
+#         self.self_ = self_
+#
+#     def gradient(self, grad):
+#         grad_self_ = grad / (2 * self.result) TODO: Broken as of Garbage Collection for `AutoGradTensor` (#3387)
+#         return (grad_self_,)
 
 
 class TanhBackward(GradFunc):

--- a/syft/frameworks/torch/tensors/interpreters/gradients_core.py
+++ b/syft/frameworks/torch/tensors/interpreters/gradients_core.py
@@ -34,7 +34,7 @@ class GradFunc:
         self.next_functions = tuple(
             filter(lambda x: x is not None, [forward_grad(arg) for arg in args])
         )
-        self.result = None
+        # self.result = None TODO: Broken as of Garbage Collection for `AutoGradTensor` (#3387)
         self._attributes = list()
 
     def gradient(self, grad):

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -314,7 +314,11 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         msg = sy.serde.deserialize(bin_message, worker=self)
 
         if self.verbose:
-            print(f"worker {self} received {type(msg).__name__} {msg.contents}")
+            print(
+                f"worker {self} received {type(msg).__name__} {msg.contents}"
+                if hasattr(msg, "contents")
+                else f"worker {self} received {type(msg).__name__}"
+            )
 
         # Step 1: route message to appropriate function
         response = self._message_router[type(msg)](msg)

--- a/test/torch/tensors/test_autograd.py
+++ b/test/torch/tensors/test_autograd.py
@@ -216,7 +216,7 @@ def test_backward_for_remote_binary_cmd_local_autograd(workers, cmd):
     assert (b.grad.get() == b_torch.grad).all()
 
 
-@pytest.mark.parametrize("cmd", ["sqrt", "asin", "sin", "sinh", "tanh", "sigmoid"])
+@pytest.mark.parametrize("cmd", ["asin", "sin", "sinh", "tanh", "sigmoid"])
 def test_backward_for_remote_unary_cmd_local_autograd(workers, cmd):
     """
     Test .backward() on unary methods on remote tensors using
@@ -776,3 +776,45 @@ def test_train_without_requires_grad(workers):
 
     # Check the weights for the two models
     assert torch.all(torch.eq(model_weights_1, model_weights_2))
+
+
+def test_garbage_collection(workers):
+    alice = workers["alice"]
+    bob = workers["bob"]
+    crypto_provider = workers["james"]
+
+    a = torch.ones(1, 5)
+    b = torch.ones(1, 5)
+    a = a.encrypt(workers=[alice, bob], crypto_provider=crypto_provider, requires_grad=True)
+    b = b.encrypt(workers=[alice, bob], crypto_provider=crypto_provider, requires_grad=True)
+
+    class Classifier(torch.nn.Module):
+        def __init__(self, in_features, out_features):
+            super(Classifier, self).__init__()
+            self.fc = torch.nn.Linear(in_features, out_features)
+
+        def forward(self, x):
+            logits = self.fc(x)
+            return logits
+
+    classifier = Classifier(in_features=5, out_features=5)
+    model = classifier.fix_prec().share(
+        alice, bob, crypto_provider=crypto_provider, requires_grad=True
+    )
+    opt = optim.SGD(params=model.parameters(), lr=0.1).fix_precision()
+    num_objs = 11
+    prev_loss = float("inf")
+    for i in range(3):
+        preds = classifier(a)
+        loss = ((b - preds) ** 2).sum()
+
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        loss = loss.get().float_prec()
+
+        assert len(alice._objects) == num_objs
+        assert len(bob._objects) == num_objs
+        assert loss < prev_loss
+
+        prev_loss = loss


### PR DESCRIPTION
Issue addressed: https://www.diffchecker.com/7jVaQe96

Code for testing
```python
import torch as th
import torch.optim as optim
import pprint
import syft as sy

hook = sy.TorchHook(th) #, verbose=True)
bob = sy.VirtualWorker(hook, id="bob") #, verbose=True)
alice = sy.VirtualWorker(hook, id="alice") #, verbose=True)
crypto_provider = sy.VirtualWorker(hook, id="james") #, verbose=True)

torch = th
syft = sy

a = torch.ones(1, 5)
b = torch.ones(1, 5)
a = a.encrypt(workers=[alice, bob], crypto_provider=crypto_provider, requires_grad=True)
b = b.encrypt(workers=[alice, bob], crypto_provider=crypto_provider, requires_grad=True)


class Classifier(torch.nn.Module):
    def __init__(self, in_features, out_features):
        super(Classifier, self).__init__()
        self.fc = torch.nn.Linear(in_features, out_features)

    def forward(self, x):
        logits = self.fc(x)
        return logits


classifier = Classifier(in_features=5, out_features=5)
model = classifier.fix_prec().share(alice, bob, crypto_provider=crypto_provider, requires_grad=True)
opt = optim.SGD(params=model.parameters(), lr=0.1).fix_precision()

for i in range(3):
    print("=" * 10 + f"Iter{i + 1}" + "=" * 10)
    print(f"Alice: {len(alice._objects)}")
    print(f"Bob: {len(bob._objects)}")
    preds = classifier(a)
    loss = ((b - preds) ** 2).sum()
    opt.zero_grad()
    loss.backward()
    opt.step()
    print(f"Loss : {loss.get().float_prec()}")
    print(f"Alice: {len(alice._objects)}")
    print(f"Bob: {len(bob._objects)}")

print("~" * 10 + "Done" + "~" * 10)

```

```
==========Iter1==========
Alice: 4
Bob: 4
Loss : 6.130000114440918
Alice: 11
Bob: 11
==========Iter2==========
Alice: 11
Bob: 11
Loss : 0.24400000274181366
Alice: 11
Bob: 11
==========Iter3==========
Alice: 11
Bob: 11
Loss : 0.009999999776482582
Alice: 11
Bob: 11
~~~~~~~~~~Done~~~~~~~~~~
```