### PR TITLE
Avg & Maxpooling with SMPC

### DIFF
--- a/syft/frameworks/torch/nn/__init__.py
+++ b/syft/frameworks/torch/nn/__init__.py
@@ -1,5 +1,7 @@
 from syft.frameworks.torch.nn.conv import Conv2d
-from syft.frameworks.torch.nn.functional import conv2d, maxpool2d, avgpool2d
+from syft.frameworks.torch.nn.functional import conv2d
+from syft.frameworks.torch.nn.functional import maxpool2d
+from syft.frameworks.torch.nn.functional import avgpool2d
 from syft.frameworks.torch.nn.functional import dropout
 from syft.frameworks.torch.nn.functional import linear
 from syft.frameworks.torch.nn.pool import AvgPool2d

--- a/syft/frameworks/torch/nn/__init__.py
+++ b/syft/frameworks/torch/nn/__init__.py
@@ -1,5 +1,5 @@
 from syft.frameworks.torch.nn.conv import Conv2d
-from syft.frameworks.torch.nn.functional import conv2d
+from syft.frameworks.torch.nn.functional import conv2d, maxpool2d, avgpool2d
 from syft.frameworks.torch.nn.functional import dropout
 from syft.frameworks.torch.nn.functional import linear
 from syft.frameworks.torch.nn.pool import AvgPool2d
@@ -26,6 +26,8 @@ def nn(module):
         module.conv2d = conv2d
         module.dropout = dropout
         module.linear = linear
+        module.max_pool2d = maxpool2d
+        module.avg_pool2d = avgpool2d
 
     module.functional = functional
 

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -170,9 +170,11 @@ def _pool(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
     if mode is "max":
         for channel in range(a_w.shape[0]):
             result.append(a_w[channel].max())
-    else:
+    elif mode is "mean":
         for channel in range(a_w.shape[0]):
             result.append(torch.mean(a_w[channel]))
+    else:
+        raise Exception("unknown pooling mode")
 
     result = torch.stack(result).reshape(output_shape)
     return result

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -181,8 +181,11 @@ def _pool(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
 
 
 def pool2d(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
-    assert len(tensor.shape) == 4
-
+    assert len(tensor.shape) < 5
+    if len(tensor.shape) == 2:
+        return _pool(tensor, kernel_size, stride, mode)
+    if len(tensor.shape) == 3:
+        return torch.squeeze(pool2d(torch.unsqueeze(tensor, dim=0), kernel_size, stride, mode))
     batches = tensor.shape[0]
     channels = tensor.shape[1]
     out_shape = (

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -150,3 +150,55 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
         .contiguous()
     )
     return res
+
+def _pool(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
+    output_shape = (
+        (tensor.shape[0] - kernel_size) // stride + 1,
+        (tensor.shape[1] - kernel_size) // stride + 1,
+    )
+    kernel_size = (kernel_size, kernel_size)
+    b = torch.ones(tensor.shape)  # when torch.Tensor.stride() is supported: replace with A.stride()
+    a_strides = b.stride()
+    a_w = torch.as_strided(
+        tensor,
+        size=output_shape + kernel_size,
+        stride=(stride * a_strides[0], stride * a_strides[1]) + a_strides,
+    )
+    a_w = a_w.reshape(-1, *kernel_size)
+    result = []
+    if mode is "max":
+        for channel in range(a_w.shape[0]):
+            result.append(a_w[channel].max())
+    else:
+        for channel in range(a_w.shape[0]):
+            result.append(torch.mean(a_w[channel]))
+
+    result = torch.stack(result).reshape(output_shape)
+    return result
+
+
+def pool2d(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
+    assert len(tensor.shape) == 4
+
+    batches = tensor.shape[0]
+    channels = tensor.shape[1]
+    out_shape = (
+        batches,
+        channels,
+        (tensor.shape[2] - kernel_size) // stride + 1,
+        (tensor.shape[3] - kernel_size) // stride + 1,
+    )
+    result = []
+    for batch in range(batches):
+        for channel in range(channels):
+            result.append(_pool(tensor[batch][channel], kernel_size, stride, mode))
+    result = torch.stack(result).reshape(out_shape)
+    return result
+
+
+def maxpool2d(tensor, kernel_size: int = 2, stride: int = 2):
+    return pool2d(tensor, kernel_size, stride)
+
+
+def avgpool2d(tensor, kernel_size: int = 2, stride: int = 2):
+    return pool2d(tensor, kernel_size, stride, mode="mean")

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -174,7 +174,7 @@ def _pool(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
         for channel in range(a_w.shape[0]):
             result.append(torch.mean(a_w[channel]))
     else:
-        raise Exception("unknown pooling mode")
+        raise ValueError("unknown pooling mode")
 
     result = torch.stack(result).reshape(output_shape)
     return result

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -151,6 +151,7 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     )
     return res
 
+
 def _pool(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
     output_shape = (
         (tensor.shape[0] - kernel_size) // stride + 1,

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -866,7 +866,7 @@ class AdditiveSharingTensor(AbstractTensor):
         def nn(module):
             @overloaded.module
             def functional(module):
-                def relu(tensor_shares):
+                def relu(tensor_shares, inplace=False):
                     return tensor_shares.relu()
 
                 module.relu = relu
@@ -887,7 +887,7 @@ class AdditiveSharingTensor(AbstractTensor):
 
     ## SECTION SNN
 
-    def relu(self):
+    def relu(self, inplace=False):
         return securenn.relu(self)
 
     def positive(self):

--- a/test/torch/nn/test_functional.py
+++ b/test/torch/nn/test_functional.py
@@ -124,3 +124,26 @@ def test_torch_nn_functional_conv2d(workers):
 
     assert (res0 == expected0).all()
     assert (res1 == expected1).all()
+
+def test_torch_nn_functional_maxpool(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+    enc_tensor = torch.tensor(
+        [[[[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]]]], dtype=torch.float
+    )
+    enc_tensor = enc_tensor.fix_prec().share(bob, alice, crypto_provider=james)
+    r_max = F.max_pool2d(enc_tensor, kernel_size=2)
+    r_max = r_max.get().float_prec()
+    exp_max = torch.tensor([[[[6.0, 8.0], [3.0, 4.0]]]])
+    assert (r_max == exp_max).all()
+
+
+def test_torch_nn_functional_avgpool(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+    enc_tensor = torch.tensor(
+        [[[[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]]]], dtype=torch.float
+    )
+    enc_tensor = enc_tensor.fix_prec().share(bob, alice, crypto_provider=james)
+    r_avg = F.avg_pool2d(enc_tensor, kernel_size=2)
+    r_avg = r_avg.get().float_prec()
+    exp_avg = torch.tensor([[[[3.2500, 5.2500], [2.0000, 2.0000]]]])
+    assert (r_avg == exp_avg).all()

--- a/test/torch/nn/test_functional.py
+++ b/test/torch/nn/test_functional.py
@@ -125,6 +125,7 @@ def test_torch_nn_functional_conv2d(workers):
     assert (res0 == expected0).all()
     assert (res1 == expected1).all()
 
+
 def test_torch_nn_functional_maxpool(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     enc_tensor = torch.tensor(

--- a/test/torch/nn/test_functional.py
+++ b/test/torch/nn/test_functional.py
@@ -136,6 +136,24 @@ def test_torch_nn_functional_maxpool(workers):
     r_max = r_max.get().float_prec()
     exp_max = torch.tensor([[[[6.0, 8.0], [3.0, 4.0]]]])
     assert (r_max == exp_max).all()
+    # 3d
+    enc_tensor = torch.tensor(
+        [[[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]]], dtype=torch.float
+    )
+    enc_tensor = enc_tensor.fix_prec().share(bob, alice, crypto_provider=james)
+    r_max = F.max_pool2d(enc_tensor, kernel_size=2)
+    r_max = r_max.get().float_prec()
+    exp_max = torch.tensor([[[6.0, 8.0], [3.0, 4.0]]])
+    assert (r_max == exp_max).all()
+    # 2d
+    enc_tensor = torch.tensor(
+        [[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]], dtype=torch.float
+    )
+    enc_tensor = enc_tensor.fix_prec().share(bob, alice, crypto_provider=james)
+    r_max = F.max_pool2d(enc_tensor, kernel_size=2)
+    r_max = r_max.get().float_prec()
+    exp_max = torch.tensor([[6.0, 8.0], [3.0, 4.0]])
+    assert (r_max == exp_max).all()
 
 
 def test_torch_nn_functional_avgpool(workers):
@@ -147,4 +165,22 @@ def test_torch_nn_functional_avgpool(workers):
     r_avg = F.avg_pool2d(enc_tensor, kernel_size=2)
     r_avg = r_avg.get().float_prec()
     exp_avg = torch.tensor([[[[3.2500, 5.2500], [2.0000, 2.0000]]]])
+    assert (r_avg == exp_avg).all()
+    # 3d
+    enc_tensor = torch.tensor(
+        [[[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]]], dtype=torch.float
+    )
+    enc_tensor = enc_tensor.fix_prec().share(bob, alice, crypto_provider=james)
+    r_avg = F.avg_pool2d(enc_tensor, kernel_size=2)
+    r_avg = r_avg.get().float_prec()
+    exp_avg = torch.tensor([[[3.2500, 5.2500], [2.0000, 2.0000]]])
+    assert (r_avg == exp_avg).all()
+    # 2d
+    enc_tensor = torch.tensor(
+        [[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]], dtype=torch.float
+    )
+    enc_tensor = enc_tensor.fix_prec().share(bob, alice, crypto_provider=james)
+    r_avg = F.avg_pool2d(enc_tensor, kernel_size=2)
+    r_avg = r_avg.get().float_prec()
+    exp_avg = torch.tensor([[3.2500, 5.2500], [2.0000, 2.0000]])
     assert (r_avg == exp_avg).all()


### PR DESCRIPTION
## Description
resolves issue #2573 
overloading torch.nn.F.max_pool2d and avg_pool2d in order to use it in architectures like ResNet

## Type of change

- [ ] Added/Modified tutorials
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [x] I have added tests for my changes
* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).