### PR TITLE
make the link to API doc explicit in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Slack.
 
 You can also install PySyft from source on a variety of operating systems by following this [installation guide](https://github.com/OpenMined/PySyft/blob/dev/INSTALLATION.md).
 
+## Documentation
+Latest official documentation is hosted here: [https://pysyft.readthedocs.io/](https://pysyft.readthedocs.io/en/latest/index.html#)
+
 ## Run Local Notebook Server
 
 All the examples can be played with by running the command


### PR DESCRIPTION
## Description
Make the link to API doc explicit in the `README.md` so new users could easily find the doc.

## Type of change

Please mark options that are relevant.

- [x] Added/Modified tutorials
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).