### PR TITLE
Trace communication actions into `Protocols`

### DIFF
--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -52,6 +52,7 @@ from syft.federated.train_config import TrainConfig
 
 # Import messaging objects
 from syft.execution.protocol import Protocol
+from syft.execution.protocol import func2protocol
 from syft.execution.plan import Plan
 from syft.execution.plan import func2plan
 
@@ -100,6 +101,8 @@ __all__.extend(
         "VirtualWorker",
         "WebsocketClientWorker",
         "WebsocketServerWorker",
+        "Protocol",
+        "func2protocol",
         "Plan",
         "func2plan",
         "make_plan",

--- a/syft/execution/protocol.py
+++ b/syft/execution/protocol.py
@@ -1,479 +1,614 @@
+from typing import List
+from typing import Tuple
+from typing import Union
+
+import copy
+import inspect
+import io
+import torch
 import warnings
-from typing import List, Optional, Tuple, Union, Set
 
 import syft as sy
-from syft.exceptions import WorkerNotFoundException
-from syft.generic.frameworks.hook import hook_args
+from syft.execution.placeholder import PlaceHolder
+from syft.execution.role import Role
+from syft.execution.state import State
+from syft.execution.tracing import trace
+from syft.execution.translation.abstract import AbstractProtocolTranslator
+from syft.execution.translation.default import ProtocolTranslatorDefault
+from syft.execution.translation.torchscript import ProtocolTranslatorTorchscript
+from syft.generic.frameworks import framework_packages
 from syft.generic.frameworks.types import FrameworkTensor
+from syft.generic.frameworks.types import FrameworkLayerModule
 from syft.generic.object import AbstractObject
 from syft.generic.pointers.pointer_protocol import PointerProtocol
-from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.workers.abstract import AbstractWorker
-from syft.workers.base import BaseWorker
+
 from syft_proto.execution.v1.protocol_pb2 import Protocol as ProtocolPB
+
+
+class func2protocol(object):
+    """Decorator which converts a function to a protocol.
+
+    Converts a function containing sequential pytorch code into
+    a protocol object which can be sent to any arbitrary worker.
+
+    This class should be used only as a decorator.
+    """
+
+    def __init__(self, args_shape=None, state=None):
+        self.args_shape = args_shape
+        self.state_tensors = state or tuple()
+        # include_state is used to distinguish if the initial protocol is a function or a class:
+        # if it's a function, then the state should be provided in the args, so include_state
+        # will be true. And to know if it was indeed a function, we just need to see if a
+        # "manual" state was provided.
+        self.include_state = state is not None
+
+    def __call__(self, protocol_function):
+        protocol = Protocol(
+            name=protocol_function.__name__,
+            include_state=self.include_state,
+            forward_func=protocol_function,
+            state_tensors=self.state_tensors,
+            id=sy.ID_PROVIDER.pop(),
+            owner=sy.local_worker,
+        )
+
+        # Build the protocol automatically
+        if self.args_shape:
+            args_ = PlaceHolder.create_placeholders(self.args_shape)
+            try:
+                protocol.build(*args_)
+            except TypeError as e:
+                raise ValueError(
+                    "Automatic build using @func2protocol failed!\nCheck that:\n"
+                    " - you have provided the correct number of shapes in args_shape\n"
+                    " - you have no simple numbers like int or float as args. If you do "
+                    "so, please consider using a tensor instead."
+                )
+        return protocol
 
 
 class Protocol(AbstractObject):
     """
-    A Protocol coordinates a sequence of Plans, deploys them on distant workers
-    and run them in a single pass.
+    A Protocol stores a sequence of torch actions, just like a function.
 
-    It's a high level object which contains the logic of a complex computation
-    distributed across several workers. The main feature of Protocol is the
-    ability to be sent / searched / fetched back between workers, and finally
-    deployed to identified workers. So a user can design a protocol, upload it
-    to a cloud worker, and any other workers will be able to search for it,
-    download it, and apply the computation program it contains on the workers
-    that it is connected to.
+    A Protocol is intended to store a sequence of torch actions, just like a function,
+    but it allows to send this sequence of actions to remote workers and to keep a
+    reference to it. This way, to compute remotely this sequence of actions on some remote
+    input referenced through pointers, instead of sending multiple messages you need now to send a
+    single message with the references of the protocol and the pointers.
 
+    All arguments are optional.
 
     Args:
-        plans: a list of pairs (worker, plan). "worker" can be either a real
-            worker or a worker id or a string to represent a fictive worker. This
-            last case can be used at creation to specify that two plans should be
-            owned (or not owned) by the same worker at deployment. "plan" can
-            either be a Plan or a PointerPlan.
-        id: the Protocol id
-        owner: the Protocol owner
-        tags: the Protocol tags (used for search)
-        description: the Protocol description
+        name: the name of the name
+        state: store the protocol tensors like model parameters
+        include_state: if true, implies that the protocol is a function, else a class. If true, the
+            state is re-integrated in the args to be accessed within the function
+        is_built: state if the protocol has already been built.
+        placeholders: dict of placeholders used in the protocol
+        actions: list of commands (called actions)
+        forward_func: the function to be transformed into a protocol
+        state_tensors: a tuple of state elements. It can be used to populate a state
+        id: protocol id
+        owner: protocol owner
+        tags: protocol tags
+        description: protocol description
     """
+
+    _build_translators = []
 
     def __init__(
         self,
-        plans: List = None,
-        id: int = None,
-        owner: BaseWorker = None,
+        name: str = None,
+        include_state: bool = False,
+        is_built: bool = False,
+        forward_func=None,
+        state_tensors=[],
+        role: Role = None,
+        # General kwargs
+        id: Union[str, int] = None,
+        owner: "sy.workers.BaseWorker" = None,
         tags: List[str] = None,
         description: str = None,
     ):
-        owner = owner or sy.framework.hook.local_worker
-        super(Protocol, self).__init__(id, owner, tags, description, child=None)
+        AbstractObject.__init__(self, id, owner, tags, description, child=None)
 
-        self.plans = plans or list()
-        self.workers_resolved = len(self.plans) and all(
-            isinstance(w, AbstractWorker) for w, p in self.plans
-        )
-        self.location: Optional[BaseWorker] = None
+        # Protocol instance info
+        self.name = name or self.__class__.__name__
 
-    def deploy(self, *workers: BaseWorker) -> "Protocol":
+        self.role = role or Role()
+
+        if role is None:
+            for st in state_tensors:
+                self.role.register_state_tensor(st, owner)
+
+        self.include_state = include_state
+        self.is_building = False
+        self.state_attributes = {}
+        self.is_built = is_built
+        self.torchscript = None
+        self.tracing = False
+
+        # The protocol has not been sent so it has no reference to remote locations
+        self.pointers = dict()
+
+        if not hasattr(self, "forward"):
+            self.forward = forward_func or None
+
+        self.__name__ = self.__repr__()  # For PyTorch jit tracing compatibility
+
+        # List of available translations
+        self.translations = []
+
+    @property
+    def state(self):
+        return self.role.state
+
+    @property
+    def actions(self):
+        return self.role.actions
+
+    def parameters(self):
         """
-        Calling .deploy() sends the plans to the designated workers.
+        This is defined to match the torch api of nn.Module where .parameters() return the model tensors / parameters
+        """
+        if self.state is not None:
+            return self.state.tensors()
+        else:
+            return []
 
-        This is done in 2 phases: first, we map the fictive workers provided at creation
-        (named by strings) to the provided workers, and second, we send the corresponding
-        plans to each of them.
-        For the first phase, either there is exactly one real worker per plan or one real
-        worker per fictive_worker. _resolve_workers replaces the fictive workers by the
-        real ones.
+    def build(self, *args):
+        """Builds the protocol.
+
+        First, run the function to be converted in a protocol in a context which
+        activates the tracing and record the actions in trace.logs
+
+        Second, store the result ids temporarily to helper ordering the output
+        placeholders at return time
+
+        Third, loop through the trace logs and replace the tensors found in the
+        actions logged by PlaceHolders. Record those actions in
+        protocol.actions
 
         Args:
-            workers: BaseWorker. The workers to which plans are to
-                be sent
-
-        Returns:
-            "Protocol": self
-
-        Raises:
-            RuntimeError: If protocol is already deployed OR
-                the number of workers provided does not equal the number of fictive workers
-                and does not equal the number of plans
+            args: Input arguments to run the protocol
         """
-        if self.workers_resolved:
-            raise RuntimeError(
-                f"This protocol is already deployed to {', '.join(worker.id for worker, plan in self.plans)}."
-            )
 
-        n_workers = len(set(worker for worker, plan in self.plans))
+        # Enable tracing
+        self.toggle_tracing(True)
+        self.is_building = True
 
-        # to correctly map workers, we must have exactly 1 worker for 1 plan
-        # or 1 worker for 1 fictive worker.
-        # If we don't, raise here
-        if len(self.plans) != len(workers) != n_workers:
-            raise RuntimeError(
-                f"This protocol is designed for {n_workers} workers, but {len(workers)} were provided."
-            )
+        # Run once to build the protocol
+        args = tuple(
+            PlaceHolder.create_from(arg, owner=sy.local_worker, role=self.role, tracing=True)
+            for arg in args
+        )
 
-        self._resolve_workers(workers)
+        # Add state to args if needed
+        if self.include_state:
+            args += (self.state,)
 
-        # update plans list with *pointers* to the plans
-        self.plans = [(worker, plan.send(worker)) for (worker, plan) in self.plans]
+        with trace(framework_packages["torch"], self.role, self.owner) as wrapped_torch:
+            # Look for framework kwargs
+            framework_kwargs = {}
+            forward_args = inspect.getfullargspec(self.forward).args
+            if "torch" in forward_args:
+                framework_kwargs["torch"] = wrapped_torch
 
+            results = self.forward(*args, **framework_kwargs)
+
+        # Disable tracing
+        self.toggle_tracing(False)
+        self.is_building = False
+
+        # Register inputs in role
+        self.role.register_inputs(args)
+
+        # Register outputs in role
+        self.role.register_outputs(results)
+
+        self.is_built = True
+
+        # Build registered translations
+        for translator in Protocol._build_translators:
+            try:
+                self.add_translation(translator)
+                self.translations.append(translator)
+            except:
+                warnings.warn(f"Failed to translate Protocol with {translator}")
+
+        return results
+
+    def toggle_tracing(self, value=None):
+        self.tracing = value if value is not None else not self.tracing
+        self.state.tracing = self.tracing
+        for ph in self.role.placeholders.values():
+            ph.tracing = self.tracing
+
+    def copy(self):
+        """Creates a copy of a protocol."""
+        protocol_copy = Protocol(
+            name=self.name,
+            role=self.role.copy(),
+            include_state=self.include_state,
+            is_built=self.is_built,
+            id=sy.ID_PROVIDER.pop(),
+            owner=self.owner,
+            tags=self.tags,
+            description=self.description,
+        )
+
+        protocol_copy.torchscript = self.torchscript
+
+        return protocol_copy
+
+    def __setattr__(self, name, value):
+        """Add new tensors or parameter attributes to the state and register them
+        in the owner's registry
+        """
+        if isinstance(value, torch.jit.ScriptModule):
+            object.__setattr__(self, name, value)
+        elif isinstance(value, FrameworkTensor):
+            self.role.register_state_tensor(value, self.owner)
+            self.state_attributes[name] = value
+        elif isinstance(value, FrameworkLayerModule):
+            for param in value.parameters():
+                self.role.register_state_tensor(param, self.owner)
+            self.state_attributes[name] = value
+        else:
+            object.__setattr__(self, name, value)
+
+    def __getattr__(self, name):
+        if name not in self.state_attributes:
+            raise AttributeError("State attribute not found.")
+
+        value = self.state_attributes[name]
+        if not self.is_building:
+            return value
+
+        if isinstance(value, FrameworkTensor):
+            return self.role.placeholders[value.id]
+        elif isinstance(value, FrameworkLayerModule):
+            # We need to deepcopy here otherwise the real layer is modified when the Protocol is being built
+            copied_layer = copy.deepcopy(value)
+            for copied_param, param in zip(copied_layer.named_parameters(), value.parameters()):
+                (copied_name, _) = copied_param
+                copied_layer._parameters[copied_name] = self.role.placeholders[param.id]
+
+            return copied_layer
+
+    def __call__(self, *args):
+        """
+        Calls a protocol execution with some arguments.
+
+        When possible, run the original function to improve efficiency. When
+        it's not, for example if you fetched the protocol from a remote worker,
+        then run it from the tape of actions:
+        - Instantiate input placeholders
+        - for each recorded action, run the action on the placeholders
+          and use the result(s) to instantiate to appropriate placeholder.
+        - Return the instantiation of all the output placeholders.
+        """
+        if self.forward is not None:
+            if self.include_state:
+                args = (*args, self.state)
+            return self.forward(*args)
+        else:
+            return self.role.execute(args)
+
+    def run(self, args_: Tuple, result_ids: List[Union[str, int]]):
+        """Controls local or remote protocol execution.
+        If the protocol doesn't have the protocol built, first build it using the original function.
+
+        Args:
+            args_: Arguments used to run protocol.
+            result_ids: List of ids where the results will be stored.
+        """
+        # TODO: can we reuse result_ids?
+        return self.__call__(*args_)
+
+    def send(self, *locations: AbstractWorker, force=False) -> PointerProtocol:
+        """Send protocol to locations.
+
+        If the protocol was not built locally it will raise an exception.
+        If `force` = true protocol is going to be sent either way.
+
+        Args:
+            locations: List of workers.
+            force: A boolean indicating if this action should be forced.
+        """
+        if not self.is_built and not force:
+            raise RuntimeError("A protocol needs to be built before being sent to a worker.")
+
+        if len(locations) == 1:
+            location = locations[0]
+
+            # Check if protocol was already sent at the location
+            if location in self.pointers:
+                return self.pointers[location]
+
+            # Send the Protocol
+            pointer = self.owner.send(self, workers=location)
+
+            self.pointers[location] = pointer
+        else:
+            ids_at_location = []
+            for location in locations:
+                if location in self.pointers:
+                    # Use the pointer that was already sent
+                    pointer = self.pointers[location]
+                else:
+                    # Send the Protocol
+                    pointer = self.owner.send(self, workers=location)
+
+                    self.pointers[location] = pointer
+
+                ids_at_location.append(pointer.id_at_location)
+
+            pointer = sy.PointerProtocol(location=locations, id_at_location=ids_at_location)
+
+        return pointer
+
+    def get_args_shape(self):
+        """Returns input tensors shapes"""
+        if not self.is_built:
+            raise RuntimeError("A protocol needs to be built before input shapes can be known.")
+
+        return [ph.expected_shape for ph in self.role.input_placeholders()]
+
+    @staticmethod
+    def register_build_translator(translator: "AbstractProtocolTranslator"):
+        Protocol._build_translators.append(translator)
+
+    def add_translation(self, protocol_translator: "AbstractProtocolTranslator"):
+        return protocol_translator(self).translate()
+
+    def remove_translation(
+        self, protocol_translator: "AbstractProtocolTranslator" = ProtocolTranslatorDefault
+    ):
+        protocol_translator(self).remove()
         return self
 
-    def __call__(self, *args, **kwargs):
-        return self.run(*args, **kwargs)
+    def get_(self):
+        self.state.get_()
+        return self
 
-    def run(self, *args, **kwargs):
-        """
-        Run the protocol by executing the plans sequentially
+    get = get_
 
-        The input args_ provided are sent to the first plan location. This first plan is
-        run and its output is moved to the second plan location, and so on. The final
-        result is returned after all plans have run, and it is composed of pointers to
-        the last plan location.
+    def get_pointers(self):
+        return self.pointers
 
-        Raises:
-            RuntimeError: If the protocol has a location attribute and it is not
-                the local worker
-        """
-        self._assert_is_resolved()
+    def fix_precision_(self, *args, **kwargs):
+        self.state.fix_precision_(*args, **kwargs)
+        return self
 
-        # This is an alternative to having PointerProtocol, when we send the protocol.
-        if self.location is not None:
-            location = Protocol.find_args_location(args)
-            if location != self.location:
-                raise RuntimeError(
-                    f"This protocol has been sent to {self.location.id}, but you provided "
-                    f"local arguments or pointers to {location.id}."
-                )
+    fix_precision = fix_prec_ = fix_prec = fix_precision_
 
-            print("send remote run request to", self.location.id)
-            response = self.request_remote_run(location, args, kwargs)
-            return response
+    def float_precision_(self):
+        self.state.float_precision_()
+        return self
 
-        # Local and sequential coordination of the plan execution
-        previous_worker_id = None
-        response = None
-        for worker, plan in self.plans:
-            # Transmit the args to the next worker if it's a different one % the previous
-            if None is not previous_worker_id != worker.id:
-                print("move", previous_worker_id, " -> ", worker.id)
-                args = [arg.move(worker) for arg in args]
-            else:
-                print("send", worker.id)
-                args = [arg.send(worker) for arg in args]
+    float_precision = float_prec_ = float_prec = float_precision_
 
-            previous_worker_id = worker.id
+    def share_(self, *args, **kwargs):
+        self.state.share_(*args, **kwargs)
+        return self
 
-            response = plan(*args)
-
-            args = response if isinstance(response, tuple) else (response,)
-
-        return response
-
-    def request_remote_run(
-        self, location: AbstractWorker, args_, kwargs_
-    ) -> Union[List[PointerTensor], PointerTensor]:
-        """
-        Requests protocol execution.
-
-        Send a request to execute the protocol on the remote location.
-
-        Args:
-            location: to which worker the request should be sent
-            args_: Arguments used as input data for the protocol.
-            kwargs_: Named arguments used as input data for the protocol.
-
-        Returns:
-            PointerTensor or list of PointerTensors: response from request to
-                execute protocol
-        """
-        plan_name = f"plan{self.id}"
-        args_, _, _ = hook_args.unwrap_args_from_function(plan_name, args_, {})
-
-        # return_ids = kwargs_.get("return_ids", {})
-        command = ("run", self.id, args_, kwargs_)
-
-        response = self.owner.send_command(
-            message=command, recipient=location  # , return_ids=return_ids
-        )
-        response = hook_args.hook_response(plan_name, response, wrap_type=FrameworkTensor[0])
-        return response
-
-    @staticmethod
-    def find_args_location(args_) -> BaseWorker:
-        """
-        Return location if args contain pointers else the local worker
-
-        Returns:
-            BaseWorker: The location of a pointer if in args, else local
-                worker
-        """
-        for arg in args_:
-            if isinstance(arg, FrameworkTensor):
-                if hasattr(arg, "child") and isinstance(arg.child, PointerTensor):
-                    return arg.location
-        return sy.framework.hook.local_worker
-
-    def send(self, location: BaseWorker) -> None:
-        """
-        Send a protocol to a worker, to be fetched by other workers
-
-        Args:
-            location: BaseWorker. The location to which a protocol
-                is to be sent
-        """
-        # If the workers have not been assigned, then the plans are still local
-        # and should be sent together with the protocol to the location
-        if not self.workers_resolved:
-            for _, plan in self.plans:
-                plan.send(location)
-        # Else, the plans are already deployed and we don't move them
-
-        self.owner.send_obj(obj=self, location=location)
-
-        self.location = location
-
-    @staticmethod
-    def simplify(worker: BaseWorker, protocol: "Protocol") -> Tuple:
-        """
-        This function takes the attributes of a Protocol and saves them in a tuple
-
-        Args:
-            worker (BaseWorker) : the worker doing the serialization
-            protocol (Protocol): a Protocol object
-
-        Returns:
-            tuple: a tuple holding the unique attributes of the Protocol object
-
-        Raises:
-            TypeError: if a plan is not sy.Plan or sy.PointerPlan
-        """
-        plans_reference = []
-        for worker, plan in protocol.plans:
-            if isinstance(plan, sy.Plan):
-                plan_id = plan.id
-            elif isinstance(plan, sy.PointerPlan):
-                plan_id = plan.id_at_location
-            else:
-                raise TypeError("This is not a valid Plan")
-
-            if isinstance(worker, str):
-                worker_id = worker
-            else:
-                worker_id = worker.id
-
-            plans_reference.append((worker_id, plan_id))
-
-        return (
-            sy.serde.msgpack.serde._simplify(worker, protocol.id),
-            sy.serde.msgpack.serde._simplify(worker, protocol.tags),
-            sy.serde.msgpack.serde._simplify(worker, protocol.description),
-            sy.serde.msgpack.serde._simplify(worker, plans_reference),
-            sy.serde.msgpack.serde._simplify(worker, protocol.workers_resolved),
-        )
-
-    @staticmethod
-    def create_from_attributes(
-        worker, id, tags, description, workers_resolved, plans_assignments
-    ) -> "Protocol":
-        """
-        This function reconstructs a Protocol object given its attributes.
-
-        Args:
-            worker: the worker doing the deserialization
-            id: Protocol id
-            tags: Protocol tags
-            description: Protocol description
-            workers_resolved: Flag whether workers are resolved
-            plans_assignments: List of workers/plans IDs
-
-        Returns:
-            protocol: a Protocol object
-        """
-        plans = []
-        for owner_id, plan_id in plans_assignments:
-            if workers_resolved:
-                plan_owner = worker.get_worker(owner_id, fail_hard=True)
-                plan_pointer = worker.request_search(plan_id, location=plan_owner)[0]
-                worker.register_obj(plan_pointer)
-                plans.append((plan_owner, plan_pointer))
-            else:
-                try:
-                    plan_owner = worker.get_worker(owner_id, fail_hard=True)
-                except WorkerNotFoundException:
-                    plan = worker.get_obj(plan_id)
-                else:
-                    plan_pointer = worker.request_search(plan_id, location=plan_owner)[0]
-                    plan = plan_pointer.get()
-                plans.append((worker.id, plan))
-
-        protocol = sy.Protocol(plans=plans, id=id, owner=worker, tags=tags, description=description)
-
-        return protocol
-
-    @staticmethod
-    def detail(worker: BaseWorker, protocol_tuple: Tuple) -> "Protocol":
-        """
-        This function reconstructs a Protocol object given its attributes in the form of a tuple.
-
-        Args:
-            worker: the worker doing the deserialization
-            protocol_tuple: a tuple holding the attributes of the Protocol
-
-        Returns:
-            protocol: a Protocol object
-        """
-        id, tags, description, plans_reference, workers_resolved = map(
-            lambda o: sy.serde.msgpack.serde._detail(worker, o), protocol_tuple
-        )
-
-        return Protocol.create_from_attributes(
-            worker, id, tags, description, workers_resolved, plans_reference
-        )
-
-    @staticmethod
-    def bufferize(worker: BaseWorker, protocol: "Protocol") -> ProtocolPB:
-        """
-        This function takes the attributes of a Protocol and saves them in protobuf ProtocolPB
-
-        Args:
-            worker (BaseWorker) : the worker doing the serialization
-            protocol (Protocol): a Protocol object
-
-        Returns:
-            ProtocolPB: a protobuf object holding the unique attributes of the Protocol object
-
-        Raises:
-            TypeError: if a plan is not sy.Plan or sy.PointerPlan
-        """
-        pb_protocol = ProtocolPB()
-        for worker, plan in protocol.plans:
-            if isinstance(plan, sy.Plan):
-                plan_id = plan.id
-            elif isinstance(plan, sy.PointerPlan):
-                plan_id = plan.id_at_location
-            else:
-                raise TypeError("This is not a valid Plan")
-
-            if isinstance(worker, str):
-                worker_id = worker
-            else:
-                worker_id = worker.id
-
-            plan_assignment = pb_protocol.plan_assignments.add()
-            sy.serde.protobuf.proto.set_protobuf_id(plan_assignment.worker_id, worker_id)
-            sy.serde.protobuf.proto.set_protobuf_id(plan_assignment.plan_id, plan_id)
-
-        sy.serde.protobuf.proto.set_protobuf_id(pb_protocol.id, protocol.id)
-        if protocol.tags:
-            pb_protocol.tags.extend(protocol.tags)
-        if protocol.description:
-            pb_protocol.description = protocol.description
-        pb_protocol.workers_resolved = protocol.workers_resolved
-        return pb_protocol
-
-    @staticmethod
-    def unbufferize(worker: AbstractWorker, pb_protocol: ProtocolPB) -> "Protocol":
-        """
-        This function reconstructs a Protocol object given protobuf object.
-
-        Args:
-            worker: the worker doing the deserialization
-            pb_protocol: a ProtocolPB object
-
-        Returns:
-            protocol: a Protocol object
-        """
-        id = sy.serde.protobuf.proto.get_protobuf_id(pb_protocol.id)
-        tags = set(pb_protocol.tags)
-        description = pb_protocol.description
-        workers_resolved = pb_protocol.workers_resolved
-        plans_assignments = [
-            (
-                sy.serde.protobuf.proto.get_protobuf_id(item.worker_id),
-                sy.serde.protobuf.proto.get_protobuf_id(item.plan_id),
-            )
-            for item in pb_protocol.plan_assignments
-        ]
-
-        return Protocol.create_from_attributes(
-            worker, id, tags, description, workers_resolved, plans_assignments
-        )
+    share = share_
 
     def create_pointer(
-        self, owner: AbstractWorker, garbage_collect_data: bool, tags: Set = None
-    ) -> PointerProtocol:
+        self, owner, garbage_collect_data, location=None, id_at_location=None, tags=None, **kwargs
+    ):
         """
         Create a pointer to the protocol
 
         Args:
             owner: the owner of the pointer
-            garbage_collect_data: bool
+            garbage_collect_data: if true, when the pointer is deleted, the remote target is garbaged collected
+            location: the location of the pointer
+            id_at_location: the remote id at location
             tags: the tags inherited from the Protocol
 
         Returns:
             PointerProtocol: pointer to the protocol
         """
         return PointerProtocol(
-            location=self.owner,
-            id_at_location=self.id,
             owner=owner,
+            location=location or self.owner,
+            id_at_location=id_at_location or self.id,
             garbage_collect_data=garbage_collect_data,
             tags=tags,
         )
 
+    def __str__(self):
+        """Returns the string representation of Protocol."""
+        out = "<"
+        out += str(type(self)).split("'")[1].split(".")[-1]
+        out += " " + str(self.name)
+        out += " id:" + str(self.id)
+        out += " owner:" + str(self.owner.id)
+
+        if self.tags is not None and len(self.tags):
+            out += " Tags:"
+            for tag in self.tags:
+                out += " " + str(tag)
+
+        if self.is_built:
+            out += " built"
+
+        out += ">"
+        out += "\n"
+        _self = self
+
+        # out += f"def {self.name}("
+        # out += ", ".join(f"arg_{extract_tag(p)}" for p in self.find_placeholders("input"))
+        # out += "):\n"
+        # for action in self.actions:
+        #     line = "    "
+        #     if action.return_ids is not None:
+        #         if isinstance(action.return_ids, PlaceHolder):
+        #             tag = extract_tag(action.return_ids)
+        #             line += f"_{tag} = "
+        #         elif isinstance(action.return_ids, tuple):
+        #             line += (
+        #                 ", ".join(
+        #                     f"_{extract_tag(o)}" if isinstance(o, PlaceHolder) else str(o)
+        #                     for o in action.return_ids
+        #                 )
+        #                 + " = "
+        #             )
+        #         else:
+        #             line += str(action.return_ids) + " = "
+        #     if action.target is not None:
+        #         line += f"_{extract_tag(self.placeholders[action.target.value])}."
+        #     line += action.name + "("
+        #     line += ", ".join(
+        #         f"_{extract_tag(arg)}" if isinstance(arg, PlaceHolder) else str(arg)
+        #         for arg in action.args
+        #     )
+        #     if action.kwargs:
+        #         line += ", " + ", ".join(f"{k}={w}" for k, w in action.kwargs.items())
+        #     line += ")\n"
+        #     out += line
+
+        # out += "    return "
+        # out += ", ".join(f"_{extract_tag(p)}" for p in self.find_placeholders("output"))
+
+        return out
+
     def __repr__(self):
-        repr = f"<Protocol id:{self.id} owner:{self.owner.id}{' resolved' if self.workers_resolved else ''}>"
-        for worker, plan in self.plans:
-            repr += "\n - "
-            if isinstance(worker, str):
-                repr += worker
-            else:
-                repr += str(worker.id)
-            repr += ": "
-            repr += plan.__repr__()
-        return repr
+        return self.__str__()
 
-    def __str__(self) -> str:
-        return self.__repr__()
+    @staticmethod
+    def replace_non_instanciated_placeholders(protocol: "Protocol") -> "Protocol":
+        # Replace non-instanciated placeholders from protocol.placeholders by instanciated placeholders
+        # from state.state_placeholders
+        # NOTE Maybe state shouldn't contain instanciated placeholders but values directly?
+        state_placeholders = {ph.id.value: ph for ph in protocol.state.state_placeholders}
+        protocol.placeholders = {**protocol.placeholders, **state_placeholders}
 
-    def _assert_is_resolved(self) -> None:
+        return protocol
+
+    @staticmethod
+    def simplify(worker: AbstractWorker, protocol: "Protocol") -> tuple:
         """
-        Check if protocol has already been resolved
-
-        Raises:
-            RuntimeError: If protocol has already been resolved
-        """
-        if not self.workers_resolved:
-            raise RuntimeError(
-                "Plans have not been allocated to existing workers. Call deploy(*workers) to do so."
-            )
-
-    def _resolve_workers(self, workers: Tuple[BaseWorker, ...]) -> None:
-        """
-        Map the abstract workers (named by strings) to the provided workers and
-        update the plans accordingly
-
+        This function takes the attributes of a Protocol and saves them in a tuple
         Args:
-            workers: Iterable of workers. The workers to map to workers
-                in the protocol
+            worker (AbstractWorker): the worker doing the serialization
+            protocol (Protocol): a Protocol object
+        Returns:
+            tuple: a tuple holding the unique attributes of the Protocol object
+
         """
-        dict_workers = {w.id: w for w in workers}
-        set_fake_ids = set(worker for worker, _ in self.plans)
-        set_real_ids = set(dict_workers.keys())
+        return (
+            sy.serde.msgpack.serde._simplify(worker, protocol.id),
+            sy.serde.msgpack.serde._simplify(worker, protocol.role),
+            sy.serde.msgpack.serde._simplify(worker, protocol.include_state),
+            sy.serde.msgpack.serde._simplify(worker, protocol.is_built),
+            sy.serde.msgpack.serde._simplify(worker, protocol.name),
+            sy.serde.msgpack.serde._simplify(worker, protocol.tags),
+            sy.serde.msgpack.serde._simplify(worker, protocol.description),
+            sy.serde.msgpack.serde._simplify(worker, protocol.torchscript),
+        )
 
-        if 0 < len(set_fake_ids.intersection(set_real_ids)) < len(set_real_ids):
-            # The user chose fake ids that correspond to real ids but not all of them match.
-            # Maybe it's a mistake so we warn the user.
-            warnings.warn(
-                "You are deploying a protocol with workers for which only a subpart"
-                "have ids that match an id chosen for the protocol."
-            )
+    @staticmethod
+    def detail(worker: AbstractWorker, protocol_tuple: tuple) -> "Protocol":
+        """This function reconstructs a Protocol object given its attributes in the form of a tuple.
+        Args:
+            worker: the worker doing the deserialization
+            protocol_tuple: a tuple holding the attributes of the Protocol
+        Returns:
+            protocol: a Protocol object
+        """
+        (id_, role, include_state, is_built, name, tags, description, torchscript) = protocol_tuple
 
-        # If the "fake" ids manually set by the user when writing the protocol exactly match the ids
-        # of the workers, these fake ids in self.plans are replaced with the real workers.
-        if set_fake_ids == set_real_ids:
-            self.plans = [(dict_workers[w], p) for w, p in self.plans]
+        id_ = sy.serde.msgpack.serde._detail(worker, id_)
+        role = sy.serde.msgpack.serde._detail(worker, role)
+        name = sy.serde.msgpack.serde._detail(worker, name)
+        tags = sy.serde.msgpack.serde._detail(worker, tags)
+        description = sy.serde.msgpack.serde._detail(worker, description)
+        torchscript = sy.serde.msgpack.serde._detail(worker, torchscript)
 
-        # If there is an exact one-to-one mapping, just iterate and keep the order
-        # provided when assigning the workers
-        elif len(workers) == len(self.plans):
-            self.plans = [(worker, plan) for (_, plan), worker in zip(self.plans, workers)]
+        protocol = sy.Protocol(
+            role=role,
+            include_state=include_state,
+            is_built=is_built,
+            id=id_,
+            owner=worker,
+            name=name,
+            tags=tags,
+            description=description,
+        )
 
-        # Else, there are duplicates in the self.plans keys and we need to build
-        # a small map
-        # Example:
-        #   protocol.plans == [("w1", plan1), ("w2", plan2), ("w1", plan3)
-        #   protocol.deploy(alice, bob)
-        else:
-            worker_map = {
-                abstract_worker_name: worker
-                for worker, abstract_worker_name in zip(
-                    workers, set(name for name, plan in self.plans)
-                )
-            }
-            self.plans = [(worker_map[name], plan) for name, plan in self.plans]
+        protocol.torchscript = torchscript
 
-        self.workers_resolved = True
+        return protocol
+
+    @staticmethod
+    def bufferize(worker: AbstractWorker, protocol: "Protocol") -> ProtocolPB:
+        """
+        This function takes the attributes of a Protocol and saves them in a Protobuf message
+        Args:
+            worker (AbstractWorker): the worker doing the serialization
+            protocol (Protocol): a Protocol object
+        Returns:
+            ProtocolPB: a Protobuf message holding the unique attributes of the Protocol object
+        """
+        protobuf_protocol = ProtocolPB()
+
+        sy.serde.protobuf.proto.set_protobuf_id(protobuf_protocol.id, protocol.id)
+
+        protobuf_protocol.role.CopyFrom(sy.serde.protobuf.serde._bufferize(worker, protocol.role))
+
+        protobuf_protocol.include_state = protocol.include_state
+        protobuf_protocol.is_built = protocol.is_built
+        protobuf_protocol.name = protocol.name
+        protobuf_protocol.tags.extend(protocol.tags)
+
+        if protobuf_protocol.description:
+            protobuf_protocol.description = protocol.description
+
+        if protocol.torchscript:
+            protobuf_protocol.torchscript = protocol.torchscript.save_to_buffer()
+
+        return protobuf_protocol
+
+    @staticmethod
+    def unbufferize(worker: AbstractWorker, protobuf_protocol: ProtocolPB) -> "Protocol":
+        """This function reconstructs a Protocol object given its attributes in the form of a Protobuf message
+        Args:
+            worker: the worker doing the deserialization
+            protobuf_protocol: a Protobuf message holding the attributes of the Protocol
+        Returns:
+            protocol: a Protocol object
+        """
+        id_ = sy.serde.protobuf.proto.get_protobuf_id(protobuf_protocol.id)
+
+        role = sy.serde.protobuf.serde._unbufferize(worker, protobuf_protocol.role)
+
+        name = protobuf_protocol.name
+        tags = set(protobuf_protocol.tags) if protobuf_protocol.tags else None
+        description = protobuf_protocol.description if protobuf_protocol.description else None
+
+        protocol = Protocol(
+            role=role,
+            include_state=protobuf_protocol.include_state,
+            is_built=protobuf_protocol.is_built,
+            id=id_,
+            owner=worker,
+            name=name,
+            tags=tags,
+            description=description,
+        )
+
+        if protobuf_protocol.torchscript:
+            torchscript = io.BytesIO(protobuf_protocol.torchscript)
+            protocol.torchscript = torch.jit.load(torchscript)
+
+        return protocol
+
+
+# Auto-register Protocol build-time translations
+Protocol.register_build_translator(ProtocolTranslatorTorchscript)

--- a/syft/execution/protocol.py
+++ b/syft/execution/protocol.py
@@ -13,9 +13,6 @@ from syft.execution.placeholder import PlaceHolder
 from syft.execution.role import Role
 from syft.execution.state import State
 from syft.execution.tracing import trace
-from syft.execution.translation.abstract import AbstractProtocolTranslator
-from syft.execution.translation.default import ProtocolTranslatorDefault
-from syft.execution.translation.torchscript import ProtocolTranslatorTorchscript
 from syft.generic.frameworks import framework_packages
 from syft.generic.frameworks.types import FrameworkTensor
 from syft.generic.frameworks.types import FrameworkLayerModule
@@ -97,8 +94,6 @@ class Protocol(AbstractObject):
         description: protocol description
     """
 
-    _build_translators = []
-
     def __init__(
         self,
         name: str = None,
@@ -138,9 +133,6 @@ class Protocol(AbstractObject):
             self.forward = forward_func or None
 
         self.__name__ = self.__repr__()  # For PyTorch jit tracing compatibility
-
-        # List of available translations
-        self.translations = []
 
     @property
     def state(self):
@@ -210,14 +202,6 @@ class Protocol(AbstractObject):
         self.role.register_outputs(results)
 
         self.is_built = True
-
-        # Build registered translations
-        for translator in Protocol._build_translators:
-            try:
-                self.add_translation(translator)
-                self.translations.append(translator)
-            except:
-                warnings.warn(f"Failed to translate Protocol with {translator}")
 
         return results
 
@@ -357,19 +341,6 @@ class Protocol(AbstractObject):
             raise RuntimeError("A protocol needs to be built before input shapes can be known.")
 
         return [ph.expected_shape for ph in self.role.input_placeholders()]
-
-    @staticmethod
-    def register_build_translator(translator: "AbstractProtocolTranslator"):
-        Protocol._build_translators.append(translator)
-
-    def add_translation(self, protocol_translator: "AbstractProtocolTranslator"):
-        return protocol_translator(self).translate()
-
-    def remove_translation(
-        self, protocol_translator: "AbstractProtocolTranslator" = ProtocolTranslatorDefault
-    ):
-        protocol_translator(self).remove()
-        return self
 
     def get_(self):
         self.state.get_()
@@ -608,7 +579,3 @@ class Protocol(AbstractObject):
             protocol.torchscript = torch.jit.load(torchscript)
 
         return protocol
-
-
-# Auto-register Protocol build-time translations
-Protocol.register_build_translator(ProtocolTranslatorTorchscript)

--- a/test/execution/test_protocol.py
+++ b/test/execution/test_protocol.py
@@ -2,201 +2,25 @@ import pytest
 import torch as th
 
 import syft as sy
-from syft.generic.frameworks.types import FrameworkTensor
-from syft.generic.pointers.pointer_protocol import PointerProtocol
-from syft.generic.pointers.pointer_tensor import PointerTensor
 
 
-def _create_inc_protocol():
-    @sy.func2plan(args_shape=[(1,)])
-    def inc1(x):
-        return x + 1
+def test_multi_role_tracing(workers):
+    alice, bob = workers["alice"], workers["bob"]
 
-    @sy.func2plan(args_shape=[(1,)])
-    def inc2(x):
-        return x + 1
+    @sy.func2protocol(args_shape=((1,), (1,)))
+    def protocol(tensor1, tensor2):
+        t1plus = tensor1 + 1
+        t2plus = tensor2 + 1
 
-    @sy.func2plan(args_shape=[(1,)])
-    def inc3(x):
-        return x + 1
+        return (t1plus, t2plus)
 
-    protocol = sy.Protocol([("worker1", inc1), ("worker2", inc2), ("worker3", inc3)])
-    return protocol
+    alice_tensor = th.tensor([1]).send(alice)
+    bob_tensor = th.tensor([1]).send(bob)
 
+    protocol.build(alice_tensor, bob_tensor)
 
-def test_deploy(workers):
-    """
-    This test validates the following scenario:
-    A creates a protocol
-    A deploys it on workers D, E and F
-    """
-    alice, bob, charlie = workers["alice"], workers["bob"], workers["charlie"]
+    assert protocol.is_built
 
-    protocol = _create_inc_protocol()
-
-    workers = alice, bob, charlie
-
-    protocol.deploy(*workers)
-
-    assert protocol.workers_resolved
-
-    protocol._assert_is_resolved()
-
-    # Assert the plan were sent to a consistent worker
-    assert all(plan_ptr.location.id == worker.id for worker, plan_ptr in protocol.plans)
-
-    # Assert the order of the worker was preserved
-    assert all(
-        plan_ptr.location.id == worker.id for (_, plan_ptr), worker in zip(protocol.plans, workers)
-    )
-
-
-def test_deploy_with_resolver(workers):
-    """
-    Like test_deploy, but now two of the three plans should be given to the same
-    worker
-    """
-    alice, bob, charlie = workers["alice"], workers["bob"], workers["charlie"]
-
-    protocol = _create_inc_protocol()
-    worker3_plan = protocol.plans[2][1]
-    protocol.plans[2] = ("worker1", worker3_plan)
-
-    workers = alice, bob
-
-    protocol.deploy(*workers)
-
-    assert protocol.workers_resolved
-
-    # Assert the plan were sent to a consistent worker
-    assert all(plan_ptr.location.id == worker.id for worker, plan_ptr in protocol.plans)
-
-    # Now test the error case
-    protocol = _create_inc_protocol()
-
-    with pytest.raises(RuntimeError):
-        protocol.deploy(alice, bob)
-
-
-def test_synchronous_run(workers):
-    """
-    This test validates the following scenario:
-    A creates a protocol
-    A deploys it on workers D, E and F
-    A runs the protocol
-    """
-    alice, bob, charlie = workers["alice"], workers["bob"], workers["charlie"]
-
-    protocol = _create_inc_protocol()
-
-    protocol.deploy(alice, bob, charlie)
-
-    x = th.tensor([1.0])
-    ptr = protocol.run(x)
-
-    assert ptr.location == charlie
-
-    assert (
-        isinstance(ptr, FrameworkTensor) and ptr.is_wrapper and isinstance(ptr.child, PointerTensor)
-    )
-
-    assert ptr.get() == th.tensor([4.0])
-
-
-def test_synchronous_remote_run(workers):
-    """
-    This test validates the following scenario:
-    A creates a protocol
-    A deploys it on workers D, E and F
-    A sends the protocol to the cloud C
-    A asks a remote run on C
-    """
-    alice, bob, charlie, james = (
-        workers["alice"],
-        workers["bob"],
-        workers["charlie"],
-        workers["james"],
-    )
-
-    protocol = _create_inc_protocol()
-
-    protocol.deploy(alice, bob, charlie)
-
-    protocol.send(james)
-
-    x = th.tensor([1.0]).send(james)
-    ptr = protocol.run(x)
-
-    assert ptr.location == james
-    assert isinstance(ptr, FrameworkTensor) and ptr.is_wrapper
-
-    ptr = ptr.get()
-
-    assert ptr.location == charlie
-    assert (
-        isinstance(ptr, FrameworkTensor) and ptr.is_wrapper and isinstance(ptr.child, PointerTensor)
-    )
-
-    res = ptr.get()
-
-    assert res == th.tensor([4.0])
-
-    # BONUS: Error case when data is not correctly located
-
-    x = th.tensor([1.0])
-    with pytest.raises(RuntimeError):
-        protocol.run(x)
-
-
-def test_search_and_deploy(workers):
-    """
-    This test validates the following scenario:
-    A creates a protocol (which is not deployed)
-    A sends it to the cloud C
-    B search C for a protocol and get it back
-    B deploys the protocol on workers D, E and F
-    B runs the protocol
-    """
-    alice, bob, charlie, james, me = (
-        workers["alice"],
-        workers["bob"],
-        workers["charlie"],
-        workers["james"],
-        workers["me"],
-    )
-
-    protocol = _create_inc_protocol()
-
-    protocol.send(james)
-
-    ptr_protocol = me.request_search([protocol.id], location=james)[0]
-
-    assert isinstance(ptr_protocol, PointerProtocol)
-
-    protocol_back = ptr_protocol.get()
-
-    protocol_back.deploy(alice, bob, charlie)
-
-    x = th.tensor([1.0])
-    ptr = protocol_back.run(x)
-
-    assert ptr.location == charlie
-    assert (
-        isinstance(ptr, FrameworkTensor) and ptr.is_wrapper and isinstance(ptr.child, PointerTensor)
-    )
-
-    res = ptr.get()
-
-    assert res == th.tensor([4.0])
-
-    # BONUS: Re-send to cloud and run remotely
-
-    james.clear_objects()
-    protocol = protocol_back
-
-    protocol.send(james)
-    ptr_protocol = me.request_search([protocol.id], location=james)[0]
-    x = th.tensor([1.0]).send(james)
-    ptr = ptr_protocol.run(x)
-    res = ptr.get().get()
-    assert res == th.tensor([4.0])
+    assert len(protocol.roles) == 2
+    assert len(protocol.roles[0].actions) == 1
+    assert len(protocol.roles[1].actions) == 1

--- a/test/execution/test_protocol.py
+++ b/test/execution/test_protocol.py
@@ -4,23 +4,15 @@ import torch as th
 import syft as sy
 
 
-def test_multi_role_tracing(workers):
+def test_trace_communication_actions(workers):
     alice, bob = workers["alice"], workers["bob"]
 
-    @sy.func2protocol(args_shape=((1,), (1,)))
-    def protocol(tensor1, tensor2):
-        t1plus = tensor1 + 1
-        t2plus = tensor2 + 1
+    @sy.func2protocol(args_shape=[(1,)])
+    def protocol(tensor):
+        tensor.send(bob)
 
-        return (t1plus, t2plus)
-
-    alice_tensor = th.tensor([1]).send(alice)
-    bob_tensor = th.tensor([1]).send(bob)
-
-    protocol.build(alice_tensor, bob_tensor)
+        return tensor
 
     assert protocol.is_built
 
-    assert len(protocol.roles) == 2
-    assert len(protocol.roles[0].actions) == 1
-    assert len(protocol.roles[1].actions) == 1
+    assert len(protocol.role.actions) == 1


### PR DESCRIPTION
## Description

This replaces the existing `Protocol` code with the `Plan` code as a starting point for refactoring it into shape we want. It sets up a single failing test to check whether or not we can trace `CommunicationActions` using our existing tracing tools.

## Type of change

Please mark options that are relevant.

- [ ] Added/Modified tutorials
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [X] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).