### PR TITLE
create manifest file to include pip-dep directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include pip-dep/*


### PR DESCRIPTION
## Description

`pip-dep` does not get included when building sdist, and creates issues such as #3413.

I have added a MANIFEST.in file so that the requirement files can be referenced at setup.py without breaking.
