### PR TITLE
Fix typo and inspect warning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Fixes # (issue)
 
 ## Type of change
 
-Please mark options that are relevant.
+Please mark the options that are relevant.
 
 - [ ] Added/Modified tutorials
 - [ ] Bug fix (non-breaking change which fixes an issue)

--- a/syft/execution/plan.py
+++ b/syft/execution/plan.py
@@ -193,7 +193,7 @@ class Plan(AbstractObject):
         with trace(framework_packages["torch"], self.role, self.owner) as wrapped_torch:
             # Look for framework kwargs
             framework_kwargs = {}
-            forward_args = inspect.getargspec(self.forward).args
+            forward_args = inspect.getfullargspec(self.forward).args
             if "torch" in forward_args:
                 framework_kwargs["torch"] = wrapped_torch
 

--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -239,7 +239,7 @@ def hook_response(attr, response, wrap_type, wrap_args={}, new_self=None):
         new_response = response_hook_function(response)
 
     except (IndexError, KeyError, AssertionError):  # Update the function in case of an error
-        response_hook_function = build_wrap_reponse_from_function(response, wrap_type, wrap_args)
+        response_hook_function = build_wrap_response_from_function(response, wrap_type, wrap_args)
         # Store this utility function in the registry
         hook_method_response_functions[attr_id] = response_hook_function
         # Run it
@@ -252,7 +252,7 @@ def hook_response(attr, response, wrap_type, wrap_args={}, new_self=None):
     return new_response
 
 
-def build_wrap_reponse_from_function(response, wrap_type, wrap_args):
+def build_wrap_response_from_function(response, wrap_type, wrap_args):
     """
     Build the function that hook the response.
 
@@ -467,6 +467,7 @@ def build_wrap_response_with_rules(
         rules: the same structure objects but with boolean, at true when is replaces
             a tensor
         return_tuple: force to return a tuple even with a single element
+        return_list: force to return a list instead of a tuple
 
     Response:
         a function to "wrap" the response


### PR DESCRIPTION
## Description
Got an inspect warning while running some tests
```
/plan.py:199: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0,
use inspect.signature() or inspect.getfullargspec()
    forward_args = inspect.getargspec(self.forward).args
```
Also, I fixed some typos.

## Type of change

Please mark the options that are relevant.
* [x] Solve warning
* [x] Typos

## Checklist:

* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).