### PR TITLE
Fix double tracing bug

### DIFF
--- a/syft/execution/tracing.py
+++ b/syft/execution/tracing.py
@@ -29,6 +29,13 @@ class FrameworkWrapper:
 
             result = package_attr(*args, **kwargs)
 
+            if isinstance(result, PlaceHolder) or (
+                isinstance(result, (list, tuple))
+                and any(isinstance(r, PlaceHolder) for r in result)
+            ):
+                # In this case, the tracing was already done in Placeholder.handle_func_command
+                return result
+
             if isinstance(result, FrameworkTensor):
                 result = PlaceHolder.create_from(
                     result, owner=self.owner, role=self.role, tracing=True

--- a/test/execution/test_plan.py
+++ b/test/execution/test_plan.py
@@ -40,6 +40,21 @@ def test_plan_build():
     assert plan_abs.is_built
 
 
+def test_tracing_torch():
+    @sy.func2plan()
+    def plan_torch(x, torch=th):
+        a = torch.rand([2])
+        x = torch.mul(a, x)
+        return torch.split(x, 2)
+
+    plan_torch.build(th.tensor([1, 2]))
+    plan_torch.forward = None
+    res = plan_torch(th.tensor([1, 2]))
+
+    assert len(plan_torch.actions) == 3
+    assert len(res) == 2
+
+
 def test_plan_built_automatically_with_any_dimension():
     @sy.func2plan(args_shape=[(-1, 1)])
     def plan_abs(data):


### PR DESCRIPTION
## Description

There was a bug that actions were duplicated when tracing a torch function on Placeholders.

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [x] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
