### PR TITLE
Fix `move` PT to its own location

### DIFF
--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -274,6 +274,9 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         if self.owner.id == destination.id:
             return self.get()
 
+        if self.location.id == destination.id:
+            return self
+
         ptr = self.remote_send(destination, requires_grad=requires_grad)
 
         # We make the pointer point at the remote value. As the id doesn't change,

--- a/test/torch/pointers/test_pointer_tensor.py
+++ b/test/torch/pointers/test_pointer_tensor.py
@@ -329,6 +329,12 @@ def test_move(workers):
     z = y.move(me)
     assert (z == t).all()
 
+    # Move object to same location
+    alice.clear_objects()
+    t = torch.tensor([1.0, 2, 3, 4, 5]).send(bob)
+    t = t.move(bob)
+    assert torch.all(torch.eq(t.get(), torch.tensor([1.0, 2, 3, 4, 5])))
+
 
 def test_combine_pointers(workers):
     """


### PR DESCRIPTION
## Description

> the move() method intended to throw an error, when trying to move an object to a virtual worker that already possesses the object

Fixes #3435 

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [x] I have added tests for my changes
* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
