### PR TITLE
Send models with @run_multiworkers

### DIFF
--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -197,7 +197,7 @@ def run_multiworkers(
                 threads.append(thread)
 
             # Wait for local party and sender threads
-            # Joining the process blocks! But queue.get() can also wait for the party 
+            # Joining the process blocks! But queue.get() can also wait for the party
             # and it works fine.
             # process.join() -> blocks
             local_party_result = queue.get()

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -88,7 +88,9 @@ def _send_party_info(worker, rank, msg, return_values, model=None):
     return_values[rank] = utils.unpack_values(response.object, model)
 
 
-def run_multiworkers(workers: list, master_addr: str, master_port: int = 15463, model=None, dummy_input=None):
+def run_multiworkers(
+    workers: list, master_addr: str, master_port: int = 15463, model=None, dummy_input=None
+):
     """Defines decorator to run function across multiple workers.
 
     Args:

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -197,8 +197,11 @@ def run_multiworkers(
                 threads.append(thread)
 
             # Wait for local party and sender threads
-            process.join()
-            return_values[0] = utils.unpack_values(queue.get(), crypten_model)
+            # Joining the process blocks! But queue.get() can also wait for the party 
+            # and it works fine.
+            # process.join() -> blocks
+            local_party_result = queue.get()
+            return_values[0] = utils.unpack_values(local_party_result, crypten_model)
             for thread in threads:
                 thread.join()
             if was_initialized:

--- a/syft/frameworks/crypten/jail.py
+++ b/syft/frameworks/crypten/jail.py
@@ -121,7 +121,7 @@ class JailRunner:
         return (jail._func_src, jail._module_names)
 
     @staticmethod
-    def detail(jail_tuple: tuple) -> "JailRunner":
+    def detail(jail_tuple: tuple, **kwargs) -> "JailRunner":
         available_modules = {
             "torch": torch,
             "crypten": crypten,
@@ -131,4 +131,4 @@ class JailRunner:
         func_src, module_names = jail_tuple
         modules = [available_modules[name] for name in module_names]
 
-        return JailRunner(func_src=func_src, modules=modules)
+        return JailRunner(func_src=func_src, modules=modules, **kwargs)

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -139,7 +139,7 @@ class TorchHook(FrameworkHook):
 
         if dependency_check.crypten_available:
             self.to_auto_overload[crypten.mpc.MPCTensor] = ["get_plain_text"]
-            self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
+            # self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
             self._hook_syft_placeholder_methods(crypten.mpc.MPCTensor, PlaceHolder)
 
         # Add all hooked tensor methods to pointer but change behaviour to have the cmd sent

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -139,7 +139,7 @@ class TorchHook(FrameworkHook):
 
         if dependency_check.crypten_available:
             self.to_auto_overload[crypten.mpc.MPCTensor] = ["get_plain_text"]
-            # self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
+            self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
             self._hook_syft_placeholder_methods(crypten.mpc.MPCTensor, PlaceHolder)
 
         # Add all hooked tensor methods to pointer but change behaviour to have the cmd sent

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -469,10 +469,13 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             An ObjectMessage containing the return value of the crypten function computed.
         """
         from syft.frameworks.crypten.jail import JailRunner
+        from syft.frameworks.crypten import utils
 
         self.rank_to_worker_id, world_size, master_addr, master_port = message.crypten_context
         ser_func = message.jail_runner
-        jail_runner = JailRunner.detail(ser_func)
+        onnx_model = message.model
+        crypten_model = None if onnx_model is None else utils.onnx_to_crypten(onnx_model)
+        jail_runner = JailRunner.detail(ser_func, model=crypten_model)
 
         rank = None
         for r, worker_id in self.rank_to_worker_id.items():


### PR DESCRIPTION
## Description

After introducing Jails and the mechanisms for sending Crypten models across workers, we needed a way to send those models while initializing a Crypten computation using our `@run_multiworkers` decorator. 

With this PR, a function decorated with `@run_multiworkers([ALICE, BOB], master_addr="127.0.0.1", model=model, dummy_input=dummy_input)` where `model` is a `torch.nn.Module` and dummy input is a `torch.Tensor` that can be evaluated using the `model`, every party running on different workers will have access to the `model` inside their functions, which then should be an equivalent Crypten model.

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
