### PR TITLE
Add async send_command to websocket client

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -1186,6 +1186,18 @@ class BaseWorker(AbstractWorker, ObjectStorage):
     def feed_crypto_primitive_store(self, types_primitives: dict):
         self.crypto_store.add_primitives(types_primitives)
 
+    def list_tensors(self, *args):
+        return str(self._tensors)
+
+    def tensors_count(self, *args):
+        return len(self._tensors)
+
+    def list_objects(self, *args):
+        return str(self._objects)
+
+    def objects_count(self, *args):
+        return len(self._objects)
+
     @property
     def serializer(self, workers=None) -> codes.TENSOR_SERIALIZATION:
         """

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -1186,16 +1186,16 @@ class BaseWorker(AbstractWorker, ObjectStorage):
     def feed_crypto_primitive_store(self, types_primitives: dict):
         self.crypto_store.add_primitives(types_primitives)
 
-    def list_tensors(self, *args):
+    def list_tensors(self):
         return str(self._tensors)
 
-    def tensors_count(self, *args):
+    def tensors_count(self):
         return len(self._tensors)
 
-    def list_objects(self, *args):
+    def list_objects(self):
         return str(self._objects)
 
-    def objects_count(self, *args):
+    def objects_count(self):
         return len(self._objects)
 
     @property

--- a/syft/workers/node_client.py
+++ b/syft/workers/node_client.py
@@ -279,4 +279,4 @@ class NodeClient(WebsocketClientWorker, FederatedClient):
         return self._return_bool_result(response)
 
     def __str__(self) -> str:
-        return "Federated Worker < id: " + self.id + " >"
+        return f"<Federated Worker id:{self.id}>"

--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -92,7 +92,7 @@ class WebsocketClientWorker(BaseWorker):
 
     def _forward_to_websocket_server_worker(self, message: bin) -> bin:
         """
-        Note: is subclassed by the node client when yuo use the GridNode
+        Note: Is subclassed by the node client when you use the GridNode
         """
         self.ws.send(str(binascii.hexlify(message)))
         response = binascii.unhexlify(self.ws.recv()[2:-1])

--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -8,11 +8,18 @@ import websockets
 import logging
 import ssl
 import time
+import asyncio
 
 import syft as sy
+
+from syft.exceptions import ResponseSignatureError
+
+from syft.messaging.message import Message
 from syft.messaging.message import ObjectRequestMessage
 from syft.messaging.message import SearchMessage
+from syft.messaging.message import TensorCommandMessage
 from syft.generic.tensor import AbstractTensor
+from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.workers.base import BaseWorker
 
 logger = logging.getLogger(__name__)
@@ -84,6 +91,9 @@ class WebsocketClientWorker(BaseWorker):
         return self._recv_msg(message)
 
     def _forward_to_websocket_server_worker(self, message: bin) -> bin:
+        """
+        Note: is subclassed by the node client when yuo use the GridNode
+        """
         self.ws.send(str(binascii.hexlify(message)))
         response = binascii.unhexlify(self.ws.recv()[2:-1])
         return response
@@ -134,6 +144,87 @@ class WebsocketClientWorker(BaseWorker):
 
     def clear_objects_remote(self):
         return self._send_msg_and_deserialize("clear_objects", return_self=False)
+
+    async def async_dispatch(self, workers, commands):
+        results = await asyncio.gather(
+            *[
+                worker.async_send_command(message=command)
+                for worker, command in zip(workers, commands)
+            ]
+        )
+        return results
+
+    async def async_send_msg(self, message: Message) -> object:
+        """Asynchronous version of send_msg."""
+        print("async_send_msg", message)
+
+        async with websockets.connect(
+            self.url, timeout=TIMEOUT_INTERVAL, max_size=None, ping_timeout=TIMEOUT_INTERVAL
+        ) as websocket:
+            # Step 1: serialize the message to a binary
+            bin_message = sy.serde.serialize(message, worker=self)
+
+            # Step 2: send the message
+            await websocket.send(bin_message)
+
+            # Step 3: wait for a response
+            bin_response = await websocket.recv()
+
+            # Step 4: deserialize the response
+            response = sy.serde.deserialize(bin_response, worker=self)
+
+        return response
+
+    async def async_send_command(
+        self, message: tuple, return_ids: str = None, return_value: bool = False,
+    ) -> Union[List[PointerTensor], PointerTensor]:
+        """
+        Sends a command through a message to the server part attached to the client
+        Args:
+            message: A tuple representing the message being sent.
+            return_ids: A list of strings indicating the ids of the
+                tensors that should be returned as response to the command execution.
+        Returns:
+            A list of PointerTensors or a single PointerTensor if just one response is expected.
+        Note: this is the async version of send_command, with the major difference that you
+        directly call it on the client worker (so we don't have the recipient kw argument)
+        """
+
+        if return_ids is None:
+            return_ids = tuple([sy.ID_PROVIDER.pop()])
+
+        name, target, args_, kwargs_ = message
+
+        # Close the existing websocket connection in order to open a asynchronous connection
+        self.close()
+        try:
+            message = TensorCommandMessage.computation(
+                name, target, args_, kwargs_, return_ids, return_value
+            )
+            ret_val = await self.async_send_msg(message)
+
+        except ResponseSignatureError as e:
+            ret_val = None
+            return_ids = e.ids_generated
+        # Reopen the standard connection
+        self.connect()
+
+        if ret_val is None or type(ret_val) == bytes:
+            responses = []
+            for return_id in return_ids:
+                response = PointerTensor(
+                    location=self,
+                    id_at_location=return_id,
+                    owner=sy.local_worker,
+                    id=sy.ID_PROVIDER.pop(),
+                )
+                responses.append(response)
+
+            if len(return_ids) == 1:
+                responses = responses[0]
+        else:
+            responses = ret_val
+        return responses
 
     async def async_fit(self, dataset_key: str, device: str = "cpu", return_ids: List[int] = None):
         """Asynchronous call to fit function on the remote location.

--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -156,7 +156,8 @@ class WebsocketClientWorker(BaseWorker):
 
     async def async_send_msg(self, message: Message) -> object:
         """Asynchronous version of send_msg."""
-        print("async_send_msg", message)
+        if self.verbose:
+            print("async_send_msg", message)
 
         async with websockets.connect(
             self.url, timeout=TIMEOUT_INTERVAL, max_size=None, ping_timeout=TIMEOUT_INTERVAL

--- a/syft/workers/websocket_server.py
+++ b/syft/workers/websocket_server.py
@@ -176,15 +176,3 @@ class WebsocketServerWorker(VirtualWorker, FederatedClient):
             asyncio.get_event_loop().run_forever()
         except KeyboardInterrupt:
             logging.info("Websocket server stopped.")
-
-    def list_tensors(self, *args):
-        return str(self._tensors)
-
-    def tensors_count(self, *args):
-        return len(self._tensors)
-
-    def list_objects(self, *args):
-        return str(self._objects)
-
-    def objects_count(self, *args):
-        return len(self._objects)


### PR DESCRIPTION
**:warning: Is needed for https://github.com/OpenMined/PySyft/pull/3337**

## Description

Improves async support for grid nodes, by allowing to send async commands simultaneously to several remote servers.

Waiting for a global strategy to add tests, as tests require setting up a grid network.


## How to use it


```python
import asyncio
import syft as sy
import torch as th
from syft.workers.node_client import NodeClient

hook = sy.TorchHook(th)

alice = NodeClient(hook, "ws://localhost:7600")
bob = NodeClient(hook, "ws://localhost:7601")
charlie = NodeClient(hook, "ws://localhost:7602")
crypto_provider = charlie

me = sy.local_worker

my_grid = sy.PrivateGridNetwork(alice,bob,charlie)

x = th.tensor([-1., 2])
p_alice = x.send(alice)
p_bob = x.send(bob)

# async send command
p = asyncio.run(
    alice.async_send_command(
        message=('abs', p_alice.child, (), {})
    )
)
print(p)
p.get()

# async dispatch to several workers
results = asyncio.run(
    charlie.async_dispatch(
        [alice, bob],
        [('abs', p_alice.child, (), {}),
         ('abs', p_bob.child, (), {})]
    )
)
```