### PR TITLE
Store the message log in `BaseWorker` in an unserialized format

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -535,10 +535,9 @@ class BaseWorker(AbstractWorker, ObjectStorage):
             # Register response and create pointers for tensor elements
             try:
                 response = hook_args.register_response(op_name, response, list(return_ids), self)
+                # TODO: Does this mean I can set return_value to False and still get a response? That seems surprising.
                 if return_value or isinstance(response, (int, float, bool, str)):
-                    return (
-                        response
-                    )  # TODO: Does this mean I can set return_value to False and still get a response? That seems surprising.
+                    return response
                 else:
                     return None
             except ResponseSignatureError:


### PR DESCRIPTION
## Description

This bypasses some issues where serialization/deserialization changes
the state or type of the objects passed to the serdes. That also needs
to be fixed, but this is a smaller and still sensible change in the mean
time.

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
