### PR TITLE
Remove `verbose` flag from code formatting check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         pip3 install pep8-naming
         # stop the build if there are Python syntax errors or undefined names
         flake8 --config=.flake8 .
-        black --check --verbose .
+        black --check .
         # exit-zero treats all errors as warnings.
         # diverting from the standard 79 character line length in
         # accordance with this:


### PR DESCRIPTION
## Description

The verbose output makes it harder to see where the problems are, because it includes files that already have the correct formatting. That makes it a needle/haystack problem trying to figure out what to change in order for the linting to pass.

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
