### PR TITLE
Remove `contents` methods (previously deprecated, partially removed)

### DIFF
--- a/syft/execution/communication.py
+++ b/syft/execution/communication.py
@@ -38,12 +38,6 @@ class CommunicationAction(Action):
         self.destinations = destinations
         self.kwargs = kwargs_
 
-    @property
-    def contents(self):
-        """Return a tuple with the contents of the operation (backwards compatability)."""
-
-        return (self.obj_id, self.name, self.source, self.destinations, self.kwargs)
-
     def __eq__(self, other):
         return (
             self.obj_id == other.obj_id

--- a/syft/execution/computation.py
+++ b/syft/execution/computation.py
@@ -40,20 +40,6 @@ class ComputationAction(Action):
         self.return_ids = return_ids
         self.return_value = return_value
 
-    @property
-    def contents(self):
-        """Return a tuple with the contents of the action (backwards compatability)
-
-        Some of our codebase still assumes that all message types have a .contents attribute. However,
-        the contents attribute is very opaque in that it doesn't put any constraints on what the contents
-        might be. Since we know this message is a action, we instead choose to store contents in two pieces,
-        self.message and self.return_ids, which allows for more efficient simplification (we don't have to
-        simplify return_ids because they are always a list of integers, meaning they're already simplified)."""
-
-        message = (self.name, self.target, self.args, self.kwargs)
-
-        return (message, self.return_ids, self.return_value)
-
     @staticmethod
     def simplify(worker: AbstractWorker, action: "ComputationAction") -> tuple:
         """

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -640,11 +640,6 @@ class WorkerCommandMessage(Message):
         """Return a human readable version of this message"""
         return f"({type(self).__name__} {(self.command_name, self.message)})"
 
-    @property
-    def contents(self):
-        """Returns a tuple with the contents of the operation (backwards compatability)."""
-        return (self.command_name, self.message)
-
     @staticmethod
     def simplify(worker: AbstractWorker, ptr: "WorkerCommandMessage") -> tuple:
         """

--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -1776,7 +1776,6 @@ def make_workercommandmessage(**kwargs):
 
     def compare(detailed, original):
         assert type(detailed) == syft.messaging.message.WorkerCommandMessage
-        assert detailed.contents == original.contents
         return True
 
     return [


### PR DESCRIPTION
## Description

Gets rid of a few stray `contents` methods, which are no longer needed due to changes to the way messages are routed and processed in #3175.

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
