### PR TITLE
refactor BaseWorker.send_command to accept explicit arguments.

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -286,7 +286,10 @@ class TorchHook(FrameworkHook):
         @wraps(attr)
         def overloaded_attr(self_torch, *args, **kwargs):
             ptr = hook_self.local_worker.send_command(
-                recipient=self_torch.worker(), message=(f"{'torch'}.{attr}", None, args, kwargs)
+                recipient=self_torch.worker(),
+                cmd_name=f"{'torch'}.{attr}",
+                args_=args,
+                kwargs_=kwargs,
             )
 
             return ptr.wrap()

--- a/syft/frameworks/torch/mpc/fss.py
+++ b/syft/frameworks/torch/mpc/fss.py
@@ -63,10 +63,14 @@ def request_run_plan(worker, plan_tag, location, return_value, args=tuple(), kwa
     response_ids = (sy.ID_PROVIDER.pop(),)
     args = (args, response_ids)
 
-    command = ("run", plan_tag, args, kwargs)
-
     response = worker.send_command(
-        message=command, recipient=location, return_ids=response_ids, return_value=return_value
+        cmd_name="run",
+        target=plan_tag,
+        recipient=location,
+        return_ids=response_ids,
+        return_value=return_value,
+        kwargs_=kwargs,
+        args_=args,
     )
     return response
 

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -623,9 +623,7 @@ class FrameworkHook(ABC):
                         raise TensorsNotCollocatedException(pointer, args[0], attr)
 
             # Send the command
-            command = (attr, self, args, kwargs)
-
-            response = owner.send_command(location, command)
+            response = owner.send_command(location, attr, self, args, kwargs)
 
             # For inplace methods, just directly return self
             if syft.framework.is_inplace_method(attr):
@@ -783,10 +781,9 @@ class FrameworkHook(ABC):
             # Create a 'command' variable  that is understood by
             # the send_command() method of a worker.
             # command = (attr, id_at_location, args, kwargs)
-            command = (attr, _self, args, kwargs)
 
             # send the command
-            response = owner.send_command(location, command)
+            response = owner.send_command(location, attr, _self, args, kwargs)
 
             return response
 

--- a/syft/generic/pointers/callable_pointer.py
+++ b/syft/generic/pointers/callable_pointer.py
@@ -61,11 +61,15 @@ class CallablePointer(ObjectPointer):
         )
 
     def __call__(self, *args, **kwargs):
-        command = ("__call__", self.id_at_location, args, kwargs)
 
         return_ids = (sy.ID_PROVIDER.pop(),)
         response = self.owner.send_command(
-            message=command, recipient=self.location, return_ids=return_ids
+            cmd_name="__call__",
+            target=self.id_at_location,
+            args_=args,
+            kwargs_=kwargs,
+            recipient=self.location,
+            return_ids=return_ids,
         )
         return response
 

--- a/syft/generic/pointers/object_pointer.py
+++ b/syft/generic/pointers/object_pointer.py
@@ -207,8 +207,10 @@ class ObjectPointer(AbstractObject):
         owner = pointer.owner
         location = pointer.location
 
+        cmd, _, args_, kwargs_ = command
+
         # Send the command
-        response = owner.send_command(location, command)
+        response = owner.send_command(location, cmd_name=cmd, args_=args_, kwargs_=kwargs_)
 
         return response
 
@@ -363,7 +365,11 @@ class ObjectPointer(AbstractObject):
 
     def setattr(self, name, value):
         self.owner.send_command(
-            message=("__setattr__", self, (name, value), {}), recipient=self.location
+            cmd_name="__setattr__",
+            target=self,
+            args_=(name, value),
+            kwargs_={},
+            recipient=self.location,
         )
 
     @staticmethod

--- a/syft/generic/pointers/pointer_dataset.py
+++ b/syft/generic/pointers/pointer_dataset.py
@@ -32,14 +32,16 @@ class PointerDataset(ObjectPointer):
 
     @property
     def data(self):
-        command = ("get_data", self.id_at_location, (), {})
-        ptr = self.owner.send_command(message=command, recipient=self.location).wrap()
+        ptr = self.owner.send_command(
+            cmd_name="get_data", target=self.id_at_location, recipient=self.location
+        ).wrap()
         return ptr
 
     @property
     def targets(self):
-        command = ("get_targets", self.id_at_location, (), {})
-        ptr = self.owner.send_command(message=command, recipient=self.location).wrap()
+        ptr = self.owner.send_command(
+            cmd_name="get_targets", target=self.id_at_location, recipient=self.location
+        ).wrap()
         return ptr
 
     def wrap(self):
@@ -83,13 +85,18 @@ class PointerDataset(ObjectPointer):
         return out
 
     def __len__(self):
-        command = ("__len__", self.id_at_location, (), {})
-        len = self.owner.send_command(message=command, recipient=self.location)
+        len = self.owner.send_command(
+            cmd_name="__len__", target=self.id_at_location, recipient=self.location
+        )
         return len
 
     def __getitem__(self, index):
-        command = ("__getitem__", self.id_at_location, (index,), {})
-        data_elem, target_elem = self.owner.send_command(message=command, recipient=self.location)
+        data_elem, target_elem = self.owner.send_command(
+            cmd_name="__getitem__",
+            target=self.id_at_location,
+            args_=(index),
+            recipient=self.location,
+        )
         return data_elem.wrap(), target_elem.wrap()
 
     @staticmethod

--- a/syft/generic/pointers/pointer_dataset.py
+++ b/syft/generic/pointers/pointer_dataset.py
@@ -91,10 +91,11 @@ class PointerDataset(ObjectPointer):
         return len
 
     def __getitem__(self, index):
+        args = [index]
         data_elem, target_elem = self.owner.send_command(
             cmd_name="__getitem__",
             target=self.id_at_location,
-            args_=tuple(index),
+            args_=tuple(args),
             recipient=self.location,
         )
         return data_elem.wrap(), target_elem.wrap()

--- a/syft/generic/pointers/pointer_dataset.py
+++ b/syft/generic/pointers/pointer_dataset.py
@@ -94,7 +94,7 @@ class PointerDataset(ObjectPointer):
         data_elem, target_elem = self.owner.send_command(
             cmd_name="__getitem__",
             target=self.id_at_location,
-            args_=(index),
+            args_=tuple(index),
             recipient=self.location,
         )
         return data_elem.wrap(), target_elem.wrap()

--- a/syft/generic/pointers/pointer_plan.py
+++ b/syft/generic/pointers/pointer_plan.py
@@ -162,7 +162,11 @@ class PointerPlan(ObjectPointer):
                 break
 
         response = self.owner.send_command(
-            cmd_name="run", target=id_at_location, args_=tuple(args), recipient=location, return_ids=tuple(response_ids)
+            cmd_name="run",
+            target=id_at_location,
+            args_=tuple(args),
+            recipient=location,
+            return_ids=tuple(response_ids),
         )
         response = hook_args.hook_response(plan_name, response, wrap_type=FrameworkTensor[0])
         if isinstance(response, (list, tuple)):

--- a/syft/generic/pointers/pointer_plan.py
+++ b/syft/generic/pointers/pointer_plan.py
@@ -115,9 +115,9 @@ class PointerPlan(ObjectPointer):
         location = self._locations[0]
         id_at_location = self._ids_at_location[0]
 
-        command = ("parameters", id_at_location, (), {})
-
-        pointers = self.owner.send_command(message=command, recipient=location)
+        pointers = self.owner.send_command(
+            cmd_name="parameters", target=id_at_location, recipient=location
+        )
 
         for pointer in pointers:
             pointer.garbage_collect_data = False
@@ -161,10 +161,8 @@ class PointerPlan(ObjectPointer):
                 id_at_location = id_at_loc
                 break
 
-        command = ("run", id_at_location, tuple(args), kwargs)
-
         response = self.owner.send_command(
-            message=command, recipient=location, return_ids=tuple(response_ids)
+            cmd_name="run", target=id_at_location, args_=tuple(args), recipient=location, return_ids=tuple(response_ids)
         )
         response = hook_args.hook_response(plan_name, response, wrap_type=FrameworkTensor[0])
         if isinstance(response, (list, tuple)):

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -301,7 +301,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         return self
 
     def remote_get(self):
-        self.owner.send_command(message=("mid_get", self, (), {}), recipient=self.location)
+        self.owner.send_command(cmd_name="mid_get", target=self, recipient=self.location)
         return self
 
     def get(self, user=None, reason: str = "", deregister_ptr: bool = True):
@@ -362,8 +362,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         Returns:
             A pointer to an FixPrecisionTensor
         """
-        command = ("fix_prec", self, args, kwargs)
-        response = self.owner.send_command(self.location, command)
+        response = self.owner.send_command(self.location, "fix_prec", self, args, kwargs)
         return response
 
     fix_precision = fix_prec
@@ -375,8 +374,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         Returns:
             A pointer to a Tensor
         """
-        command = ("float_prec", self, args, kwargs)
-        response = self.owner.send_command(self.location, command)
+        response = self.owner.send_command(self.location, "float_prec", self, args, kwargs)
         return response
 
     float_precision = float_prec
@@ -391,8 +389,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         if len(args) < 2:
             raise RuntimeError("Error, share must have > 1 arguments all of type syft.workers")
 
-        command = ("share", self, args, kwargs)
-        response = self.owner.send_command(self.location, command)
+        response = self.owner.send_command(self.location, "share", self, args, kwargs)
         return response
 
     def share_(self, *args, **kwargs):
@@ -402,8 +399,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         Returns:
             A pointer to an AdditiveSharingTensor
         """
-        command = ("share_", self, args, kwargs)
-        response = self.owner.send_command(self.location, command)
+        response = self.owner.send_command(self.location, "share_", self, args, kwargs)
         return self
 
     def set_garbage_collect_data(self, value):

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -621,7 +621,10 @@ class BaseWorker(AbstractWorker, ObjectStorage):
 
         Args:
             recipient: A recipient worker.
-            message: A tuple representing the message being sent.
+            cmd_name: Command number.
+            target: Target pointer Tensor.
+            args_: additional args for command execution.
+            kwargs_: additional kwargs for command execution.
             return_ids: A list of strings indicating the ids of the
                 tensors that should be returned as response to the command execution.
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -609,7 +609,10 @@ class BaseWorker(AbstractWorker, ObjectStorage):
     def send_command(
         self,
         recipient: "BaseWorker",
-        message: tuple,
+        cmd_name: str,
+        target: PointerTensor = None,
+        args_: tuple = (),
+        kwargs_: dict = {},
         return_ids: str = None,
         return_value: bool = False,
     ) -> Union[List[PointerTensor], PointerTensor]:
@@ -628,11 +631,9 @@ class BaseWorker(AbstractWorker, ObjectStorage):
         if return_ids is None:
             return_ids = tuple([sy.ID_PROVIDER.pop()])
 
-        name, target, args_, kwargs_ = message
-
         try:
             message = TensorCommandMessage.computation(
-                name, target, args_, kwargs_, return_ids, return_value
+                cmd_name, target, args_, kwargs_, return_ids, return_value
             )
             ret_val = self.send_msg(message, location=recipient)
         except ResponseSignatureError as e:


### PR DESCRIPTION
refactor BaseWorker.send_command to accept explicit arguments.

## Description

Refactor the send_command method of BaseWorker class to accept explicit arguments. The message tuple argument is replaced with arguments in the message tuple.

Refactor: Issue #3481, [Link to issue.](https://github.com/OpenMined/PySyft/issues/3481)

Thank you for your contribution to the PySyft repository.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If your pull request closes a GitHub issue, then set its number below.

Fixes # (issue)

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [x] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
