### PR TITLE
Add a missing `NodeClient` import to `AbstractGrid`

### DIFF
--- a/syft/grid/abstract_grid.py
+++ b/syft/grid/abstract_grid.py
@@ -8,6 +8,8 @@ from typing import Dict
 
 from abc import ABC, abstractmethod
 
+from syft.workers.node_client import NodeClient
+
 
 class AbstractGrid(ABC):
     def __init__(self):


### PR DESCRIPTION
## Description

This shows up as a `flake` linting error on several PRs after recent changes to the linting rules.

## Type of change

Please mark the options that are relevant.

- [ ] Added/Modified tutorials
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [ ] I have added tests for my changes
* [ ] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
* [ ] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
