### PR TITLE
Move abstract methods from `BaseWorker` to `AbstractWorker`

### DIFF
--- a/syft/workers/abstract.py
+++ b/syft/workers/abstract.py
@@ -1,6 +1,38 @@
 from abc import ABC
+from abc import abstractmethod
 from syft.serde.syft_serializable import SyftSerializable
 
 
 class AbstractWorker(ABC, SyftSerializable):
-    pass
+    @abstractmethod
+    def _send_msg(self, message: bin, location: "AbstractWorker"):
+        """Sends message from one worker to another.
+
+        As AbstractWorker implies, you should never instantiate this class by
+        itself. Instead, you should extend AbstractWorker in a new class which
+        instantiates _send_msg and _recv_msg, each of which should specify the
+        exact way in which two workers communicate with each other. The easiest
+        example to study is VirtualWorker.
+
+        Args:
+            message: A binary message to be sent from one worker
+                to another.
+            location: A AbstractWorker instance that lets you provide the
+                destination to send the message.
+        """
+        pass
+
+    @abstractmethod
+    def _recv_msg(self, message: bin):
+        """Receives the message.
+
+        As AbstractWorker implies, you should never instantiate this class by
+        itself. Instead, you should extend AbstractWorker in a new class which
+        instantiates _send_msg and _recv_msg, each of which should specify the
+        exact way in which two workers communicate with each other. The easiest
+        example to study is VirtualWorker.
+
+        Args:
+            message: The binary message being received.
+        """
+        pass

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -186,48 +186,6 @@ class BaseWorker(AbstractWorker):
         # declare the plans used for crypto computations
         sy.frameworks.torch.mpc.fss.initialize_crypto_plans(self)
 
-    # SECTION: Methods which MUST be overridden by subclasses
-    @abstractmethod
-    def _send_msg(self, message: bin, location: "BaseWorker"):
-        """Sends message from one worker to another.
-
-        As BaseWorker implies, you should never instantiate this class by
-        itself. Instead, you should extend BaseWorker in a new class which
-        instantiates _send_msg and _recv_msg, each of which should specify the
-        exact way in which two workers communicate with each other. The easiest
-        example to study is VirtualWorker.
-
-        Args:
-            message: A binary message to be sent from one worker
-                to another.
-            location: A BaseWorker instance that lets you provide the
-                destination to send the message.
-
-        Raises:
-            NotImplementedError: Method not implemented error.
-        """
-
-        raise NotImplementedError  # pragma: no cover
-
-    @abstractmethod
-    def _recv_msg(self, message: bin):
-        """Receives the message.
-
-        As BaseWorker implies, you should never instantiate this class by
-        itself. Instead, you should extend BaseWorker in a new class which
-        instantiates _send_msg and _recv_msg, each of which should specify the
-        exact way in which two workers communicate with each other. The easiest
-        example to study is VirtualWorker.
-
-        Args:
-            message: The binary message being received.
-
-        Raises:
-            NotImplementedError: Method not implemented error.
-
-        """
-        raise NotImplementedError  # pragma: no cover
-
     def register_obj(self, obj):
         self.object_store.register_obj(self, obj)
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from contextlib import contextmanager
 
 import logging


### PR DESCRIPTION
## Description

`AbstractWorker` is currently empty, while `BaseWorker` contains abstract methods. This consolidates the abstract definition of workers into one place.

## Checklist:

* [X] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

* [X] I did follow the [contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md)
