### PR TITLE
Fix stray objects from FSS `Worker/Plan` initialization

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -182,8 +182,6 @@ class BaseWorker(AbstractWorker):
 
         # storage object for crypto primitives
         self.crypto_store = PrimitiveStorage(owner=self)
-        # declare the plans used for crypto computations
-        sy.frameworks.torch.mpc.fss.initialize_crypto_plans(self)
 
     def register_obj(self, obj):
         self.object_store.register_obj(self, obj)

--- a/test/torch/nn/test_nn.py
+++ b/test/torch/nn/test_nn.py
@@ -19,8 +19,8 @@ def test_nn_linear(workers):
 
     y = model(x)
 
-    assert len(alice.object_store._objects) == 10  # x, y, weight, bias
-    assert len(bob.object_store._objects) == 10
+    assert len(alice.object_store._objects) == 4  # x, y, weight, bias
+    assert len(bob.object_store._objects) == 4
     assert y.get().float_prec() == torch.tensor([[2.0]])
 
 

--- a/test/torch/pointers/test_pointer_tensor.py
+++ b/test/torch/pointers/test_pointer_tensor.py
@@ -574,4 +574,4 @@ def test_iadd(workers):
 
     b_pt += a_pt
 
-    assert len(alice.object_store._objects) == 8
+    assert len(alice.object_store._objects) == 2

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -776,7 +776,7 @@ def test_max(workers, protocol):
     )
 
     if protocol == "fss":
-        for worker in workers:
+        for worker in workers.values():
             syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(
             ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=16

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -712,7 +712,7 @@ def test_comp(workers, protocol):
     )
 
     if protocol == "fss":
-        for worker in workers:
+        for worker in workers.values():
             syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(
             ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=50

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -679,6 +679,8 @@ def test_eq(workers, protocol):
     )
 
     if protocol == "fss":
+        for worker in workers:
+            syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(["fss_eq"], [alice, bob], n_instances=6)
 
     args = (alice, bob)
@@ -710,6 +712,8 @@ def test_comp(workers, protocol):
     )
 
     if protocol == "fss":
+        for worker in workers:
+            syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(
             ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=50
         )
@@ -772,6 +776,8 @@ def test_max(workers, protocol):
     )
 
     if protocol == "fss":
+        for worker in workers:
+            syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(
             ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=16
         )
@@ -805,6 +811,8 @@ def test_argmax(workers, protocol):
     )
 
     if protocol == "fss":
+        for worker in workers:
+            syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(
             ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=32
         )
@@ -1044,8 +1052,8 @@ def test_garbage_collect_reconstruct(workers):
     a_sh = a.encrypt(workers=[alice, bob], crypto_provider=james)
     a_recon = a_sh.child.child.reconstruct()
 
-    assert len(alice.object_store._objects) == 8
-    assert len(bob.object_store._objects) == 8
+    assert len(alice.object_store._objects) == 2
+    assert len(bob.object_store._objects) == 2
 
 
 def test_garbage_collect_move(workers):
@@ -1053,8 +1061,8 @@ def test_garbage_collect_move(workers):
     a = torch.ones(1, 5).send(alice)
     b = a.copy().move(bob)
 
-    assert len(alice.object_store._objects) == 7
-    assert len(bob.object_store._objects) == 7
+    assert len(alice.object_store._objects) == 1
+    assert len(bob.object_store._objects) == 1
 
 
 def test_garbage_collect_mul(workers):
@@ -1068,5 +1076,5 @@ def test_garbage_collect_mul(workers):
     for _ in range(3):
         c = a * b
 
-    assert len(alice.object_store._objects) == 9
-    assert len(bob.object_store._objects) == 9
+    assert len(alice.object_store._objects) == 3
+    assert len(bob.object_store._objects) == 3

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -811,7 +811,7 @@ def test_argmax(workers, protocol):
     )
 
     if protocol == "fss":
-        for worker in workers:
+        for worker in workers.values():
             syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(
             ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=32

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -679,7 +679,7 @@ def test_eq(workers, protocol):
     )
 
     if protocol == "fss":
-        for worker in workers:
+        for worker in workers.values():
             syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
         me.crypto_store.provide_primitives(["fss_eq"], [alice, bob], n_instances=6)
 

--- a/test/torch/tensors/test_autograd.py
+++ b/test/torch/tensors/test_autograd.py
@@ -802,7 +802,7 @@ def test_garbage_collection(workers):
         alice, bob, crypto_provider=crypto_provider, requires_grad=True
     )
     opt = optim.SGD(params=model.parameters(), lr=0.1).fix_precision()
-    num_objs = 17
+    num_objs = 11
     prev_loss = float("inf")
     for i in range(3):
         preds = classifier(a)


### PR DESCRIPTION
## Description

The extra objects initialized on every worker for FSS cause weird behavior in tests and very non-obvious object counts in unrelated parts of the code.

Resolves #3464

## Checklist:
* [X] My changes are covered by tests.
* [X] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
* [X] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

(See the [the contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md) for additional tips.)
