### PR TITLE
Test non-native classes handled by msgpack have Protobuf schemas

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -7,7 +7,8 @@ phe~=1.4.0
 Pillow~=6.2.2
 requests~=2.22.0
 scipy~=1.4.1
-syft-proto~=0.4.4
+#syft-proto~=0.4.4
+git+git://github.com/karlhigley/syft-proto@feature/more-schemas#syft-proto
 tblib~=1.6.0
 torchvision~=0.5.0
 torch~=1.4.0

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -21,6 +21,7 @@ from syft.execution.computation import ComputationAction
 from syft.execution.communication import CommunicationAction
 from syft.execution.placeholder import PlaceHolder
 
+from syft_proto.messaging.v1.message_pb2 import IsNoneMessage as IsNoneMessagePB
 from syft_proto.messaging.v1.message_pb2 import ObjectMessage as ObjectMessagePB
 from syft_proto.messaging.v1.message_pb2 import TensorCommandMessage as CommandMessagePB
 
@@ -402,6 +403,32 @@ class IsNoneMessage(Message):
             message = detail(sy.local_worker, msg_tuple)
         """
         return IsNoneMessage(sy.serde.msgpack.serde._detail(worker, msg_tuple[0]))
+
+    @staticmethod
+    def get_protobuf_schema() -> IsNoneMessagePB:
+        return IsNoneMessagePB
+
+    @staticmethod
+    def bufferize(worker: AbstractWorker, message: "IsNoneMessage") -> "IsNoneMessagePB":
+        """
+        This function takes the attributes of an IsNoneMessage and saves them in a Protobuf object
+        Args:
+            message (IsNoneMessage): an IsNoneMessage
+        Returns:
+            protobuf: a protobuf object holding the unique attributes of the message
+        Examples:
+            data = bufferize(message)
+        """
+
+        protobuf_msg = IsNoneMessagePB()
+        sy.serde.protobuf.proto.set_protobuf_id(protobuf_msg.object_id, message.object_id)
+        return protobuf_msg
+
+    @staticmethod
+    def unbufferize(worker: AbstractWorker, protobuf_msg: "IsNoneMessagePB") -> "IsNoneMessage":
+        id_ = sy.serde.protobuf.proto.get_protobuf_id(protobuf_msg.object_id)
+        message = IsNoneMessage(id_)
+        return message
 
 
 class GetShapeMessage(Message):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,11 +26,6 @@ def pytest_runtest_makereport(item, call):  # pragma: no cover
         item.session.failed_tests.add(item.originalname)
 
 
-def pytest_runtest_setup(item):  # pragma: no cover
-    if item.originalname in item.session.failed_tests:
-        pytest.skip("previous test failed (%s)" % item.name)
-
-
 def _start_proc(participant, dataset: str = None, **kwargs):  # pragma: no cover
     """Helper function for spinning up a websocket participant."""
 

--- a/test/serde/protobuf/test_msgpack_parity.py
+++ b/test/serde/protobuf/test_msgpack_parity.py
@@ -1,0 +1,20 @@
+import pytest
+import syft
+
+from syft.serde import msgpack
+from syft.serde import protobuf
+
+from syft.serde.msgpack.native_serde import MAP_NATIVE_SIMPLIFIERS_AND_DETAILERS
+
+msgpack.serde.init_global_vars_msgpack()
+protobuf.serde.init_global_vars()
+
+
+@pytest.mark.parametrize(
+    "cls", msgpack.serde.simplifiers.keys() - dict(MAP_NATIVE_SIMPLIFIERS_AND_DETAILERS).keys()
+)
+def test_msgpack_parity(cls):
+    """Checks all types in msgpck serde are also covered by Protobuf"""
+    assert (
+        cls in dict(protobuf.serde.get_bufferizers()).keys()
+    ), f"{cls} doesn't have a Protobuf schema."

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -44,7 +44,7 @@ samples[syft.generic.pointers.pointer_tensor.PointerTensor] = make_pointertensor
 # Syft Messages
 samples[syft.messaging.message.ObjectMessage] = make_objectmessage
 samples[syft.messaging.message.TensorCommandMessage] = make_tensor_command_message
-
+samples[syft.syft.messaging.message.IsNoneMessage] = make_isnonemessage
 
 def test_serde_coverage():
     """Checks all types in serde are tested"""

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -46,6 +46,7 @@ samples[syft.messaging.message.ObjectMessage] = make_objectmessage
 samples[syft.messaging.message.TensorCommandMessage] = make_tensor_command_message
 samples[syft.syft.messaging.message.IsNoneMessage] = make_isnonemessage
 
+
 def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in protobuf.serde.get_bufferizers():


### PR DESCRIPTION
## Description

Generates a list of classes that are serializable with msgpack that don't yet have Protobuf schemas. Useful for completing the transition to Protobuf, but either need not be merged or can be deleted once the transition is complete.

## Checklist:
* [X] My changes are covered by tests.
* [X] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
* [X] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

(See the [the contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md) for additional tips.)
