### PR TITLE
Added method to return support for framework in BaseWorker

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -15,7 +15,7 @@ from syft.execution.computation import ComputationAction
 from syft.execution.communication import CommunicationAction
 from syft.generic.frameworks.hook import hook_args
 from syft.generic.frameworks.remote import Remote
-from syft.generic.frameworks.types import FrameworkTensorType
+from syft.generic.frameworks.types import FrameworkTensorType, framework_packages
 from syft.generic.frameworks.types import FrameworkTensor
 from syft.generic.frameworks.types import FrameworkShape
 from syft.generic.object_storage import ObjectStore
@@ -1273,3 +1273,12 @@ class BaseWorker(AbstractWorker):
                 worker.object_store.rm_obj(obj.id)
 
         return result
+
+    @classmethod
+    def is_framework_supported(cls, framework: str) -> bool:
+        """
+        Returns True if framework is supported, else returns False.
+        :param framework: string
+        :return: True/False
+        """
+        return framework.lower() in framework_packages

--- a/test/workers/test_base.py
+++ b/test/workers/test_base.py
@@ -130,3 +130,10 @@ def test_send_command_not_whitelisted(hook, workers):
 
             with pytest.raises(AttributeError):
                 getattr(attr, method_not_exist)
+
+
+def test_is_framework_supported(hook):
+    worker = sy.VirtualWorker(hook, id="worker")
+    assert worker.is_framework_supported("torch") == True
+    assert sy.VirtualWorker.is_framework_supported("torch") == True
+    assert worker.is_framework_supported("mock_framework") == False


### PR DESCRIPTION


## Description

Added method to return support for framework in BaseWorker.
Issue: #3523

Thank you for your contribution to the PySyft repository.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If your pull request closes a GitHub issue, then set its number below.

Resolves #3523 


## Checklist:
* [ ] My changes are covered by tests.
* [x ] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
* [ x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

(See the [the contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md) for additional tips.)
