### PR TITLE
 [WIP] Make `BaseWorker` comms methods async 

### DIFF
--- a/pip-dep/requirements_dev.txt
+++ b/pip-dep/requirements_dev.txt
@@ -8,6 +8,7 @@ mypy>=0.711
 pre-commit>=1.16.1
 pyopenssl>=19.0.0
 pyshark>=0.4.2.4
+pytest-asyncio
 pytest-randomly~=3.2.1
 pytest>=5.4.1
 setuptools>=41.0.0

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -287,8 +287,9 @@ class TorchHook(FrameworkHook):
 
     def _get_hooked_base_worker_method(hook_self, attr):
         @wraps(attr)
-        def overloaded_attr(self_torch, *args, **kwargs):
-            ptr = hook_self.local_worker.send_command(
+        async def overloaded_attr(self_torch, *args, **kwargs):
+            # TODO: See if we can avoid sending a command here
+            ptr = await hook_self.local_worker.send_command(
                 recipient=self_torch.worker(),
                 cmd_name=f"{'torch'}.{attr}",
                 args_=args,

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -413,7 +413,7 @@ class TorchTensor(AbstractTensor):
             cmd = cmd.replace("_C._nn", "nn.functional")
         return cmd
 
-    def send(
+    async def send(
         self,
         *location,
         inplace: bool = False,
@@ -471,7 +471,7 @@ class TorchTensor(AbstractTensor):
                 if self._is_parameter():
                     self.data.child.garbage_collect_data = False
 
-            ptr = self.owner.send(
+            ptr = await self.owner.send(
                 self,
                 location,
                 local_autograd=local_autograd,

--- a/syft/generic/pointers/callable_pointer.py
+++ b/syft/generic/pointers/callable_pointer.py
@@ -60,10 +60,10 @@ class CallablePointer(ObjectPointer):
             description=description,
         )
 
-    def __call__(self, *args, **kwargs):
+    async def __call__(self, *args, **kwargs):
 
         return_ids = (sy.ID_PROVIDER.pop(),)
-        response = self.owner.send_command(
+        response = await self.owner.send_command(
             cmd_name="__call__",
             target=self.id_at_location,
             args_=args,

--- a/syft/generic/pointers/object_pointer.py
+++ b/syft/generic/pointers/object_pointer.py
@@ -228,7 +228,7 @@ class ObjectPointer(AbstractObject, SyftSerializable):
             pointer = err.pointer
             return pointer
 
-    def get(self, user=None, reason: str = "", deregister_ptr: bool = True):
+    async def get(self, user=None, reason: str = "", deregister_ptr: bool = True):
         """Requests the object being pointed to.
 
         The object to which the pointer points will be requested, serialized and returned.
@@ -264,12 +264,12 @@ class ObjectPointer(AbstractObject, SyftSerializable):
         # if the pointer happens to be pointing to a local object,
         # just return that object (this is an edge case)
         if self.location == self.owner:
-            obj = self.owner.get_obj(self.id_at_location)
+            obj = await self.owner.get_obj(self.id_at_location)
             if hasattr(obj, "child"):
                 obj = obj.child
         else:
             # get tensor from location
-            obj = self.owner.request_obj(self.id_at_location, self.location, user, reason)
+            obj = await self.owner.request_obj(self.id_at_location, self.location, user, reason)
 
         # Remove this pointer by default
         if deregister_ptr:

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -294,7 +294,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         self.owner.send_command(cmd_name="mid_get", target=self, recipient=self.location)
         return self
 
-    def get(self, user=None, reason: str = "", deregister_ptr: bool = True):
+    async def get(self, user=None, reason: str = "", deregister_ptr: bool = True):
         """Requests the tensor/chain being pointed to, be serialized and return
 
         Since PointerTensor objects always point to a remote tensor (or chain
@@ -321,7 +321,9 @@ class PointerTensor(ObjectPointer, AbstractTensor):
             An AbstractTensor object which is the tensor (or chain) that this
             object used to point to #on a remote machine.
         """
-        tensor = ObjectPointer.get(self, user=user, reason=reason, deregister_ptr=deregister_ptr)
+        tensor = await ObjectPointer.get(
+            self, user=user, reason=reason, deregister_ptr=deregister_ptr
+        )
 
         # TODO: remove these 3 lines
         # The fact we have to check this means

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -715,7 +715,7 @@ class BaseWorker(AbstractWorker):
         """
         return self.send_msg(ObjectMessage(obj), location)
 
-    def request_obj(
+    async def request_obj(
         self, obj_id: Union[str, int], location: "BaseWorker", user=None, reason: str = ""
     ) -> object:
         """Returns the requested object from specified location.
@@ -729,7 +729,7 @@ class BaseWorker(AbstractWorker):
         Returns:
             A torch Tensor or Variable object.
         """
-        obj = self.send_msg(ObjectRequestMessage(obj_id, user, reason), location)
+        obj = await self.send_msg(ObjectRequestMessage(obj_id, user, reason), location)
         return obj
 
     # SECTION: Manage the workers network

--- a/syft/workers/virtual.py
+++ b/syft/workers/virtual.py
@@ -7,18 +7,18 @@ from syft.federated.federated_client import FederatedClient
 
 
 class VirtualWorker(BaseWorker, FederatedClient):
-    def _send_msg(self, message: bin, location: BaseWorker) -> bin:
+    async def _send_msg(self, message: bin, location: BaseWorker) -> bin:
         """send message to worker location"""
         if self.message_pending_time > 0:
             if self.verbose:
                 print(f"pending time of {self.message_pending_time} seconds to send message...")
             sleep(self.message_pending_time)
 
-        return location._recv_msg(message)
+        return await location._recv_msg(message)
 
-    def _recv_msg(self, message: bin) -> bin:
+    async def _recv_msg(self, message: bin) -> bin:
         """receive message"""
-        return self.recv_msg(message)
+        return await self.recv_msg(message)
 
     # For backwards compatibility with Udacity course
     @property

--- a/test/workers/test_base.py
+++ b/test/workers/test_base.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import time
 
@@ -10,29 +11,31 @@ from syft.workers.websocket_client import WebsocketClientWorker
 from syft.workers.websocket_server import WebsocketServerWorker
 
 
-def test_create_already_existing_worker(hook):
+@pytest.mark.asyncio
+async def test_create_already_existing_worker(hook):
     # Shares tensor with bob
     bob = sy.VirtualWorker(hook, "bob")
-    x = th.tensor([1, 2, 3]).send(bob)
+    x = await th.tensor([1, 2, 3]).send(bob)
 
     # Recreates bob and shares a new tensor
     bob = sy.VirtualWorker(hook, "bob")
-    y = th.tensor([2, 2, 2]).send(bob)
+    y = await th.tensor([2, 2, 2]).send(bob)
 
     # Recreates bob and shares a new tensor
     bob = sy.VirtualWorker(hook, "bob")
-    z = th.tensor([2, 2, 10]).send(bob)
+    z = await th.tensor([2, 2, 10]).send(bob)
 
     # Both workers should be the same, so the following operation should be valid
     _ = x + y * z
 
 
-def test_clear_object_for_worker_created_with_pre_existing_id(hook):
+@pytest.mark.asyncio
+async def test_clear_object_for_worker_created_with_pre_existing_id(hook):
 
     worker = sy.VirtualWorker(hook, id="worker")
     worker.clear_objects()
 
-    ptr = th.tensor([1, 2, 3]).send(worker)
+    ptr = await th.tensor([1, 2, 3]).send(worker)
 
     assert len(worker._known_workers[worker.id].object_store._objects) == len(
         worker.object_store._objects
@@ -48,7 +51,7 @@ def test_clear_object_for_worker_created_with_pre_existing_id(hook):
     )
     assert len(worker.object_store._objects) == 0
 
-    ptr = th.tensor([1, 2, 3]).send(worker)
+    ptr = await th.tensor([1, 2, 3]).send(worker)
 
     assert len(worker._known_workers[worker.id].object_store._objects) == len(
         worker.object_store._objects
@@ -56,10 +59,11 @@ def test_clear_object_for_worker_created_with_pre_existing_id(hook):
     assert len(worker.object_store._objects) == 1
 
 
-def test_create_already_existing_worker_with_different_type(hook, start_proc):
+@pytest.mark.asyncio
+async def test_create_already_existing_worker_with_different_type(hook, start_proc):
     # Shares tensor with bob
     bob = sy.VirtualWorker(hook, "bob")
-    _ = th.tensor([1, 2, 3]).send(bob)
+    _ = await th.tensor([1, 2, 3]).send(bob)
 
     kwargs = {"id": "fed1", "host": "localhost", "port": 8765, "hook": hook}
     server = start_proc(WebsocketServerWorker, **kwargs)
@@ -74,13 +78,14 @@ def test_create_already_existing_worker_with_different_type(hook, start_proc):
     server.terminate()
 
 
-def test_execute_worker_function(hook):
+@pytest.mark.asyncio
+async def test_execute_worker_function(hook):
     sy.VirtualWorker.mocked_function = MethodType(
         mock.Mock(return_value="bob_mocked_function"), sy.VirtualWorker
     )
 
     bob = sy.VirtualWorker(hook, "bob")
-    x = th.tensor([1, 2, 3]).send(bob)
+    x = await th.tensor([1, 2, 3]).send(bob)
 
     message = bob.create_worker_command_message(
         command_name="mocked_function", command_owner="self"
@@ -88,7 +93,7 @@ def test_execute_worker_function(hook):
 
     serialized_message = sy.serde.serialize(message)
 
-    response = bob._recv_msg(serialized_message)
+    response = await bob._recv_msg(serialized_message)
     response = sy.serde.deserialize(response)
 
     assert response == "bob_mocked_function"
@@ -103,20 +108,24 @@ def test_enable_registration_with_ctx(hook):
     assert hook.local_worker.is_client_worker == True
 
 
-def test_send_command_whitelist(hook, workers):
+@pytest.mark.asyncio
+async def test_send_command_whitelist(hook, workers):
     bob = workers["bob"]
     whitelisted_methods = {
         "torch": {"tensor": [1, 2, 3], "rand": (2, 3), "randn": (2, 3), "zeros": (2, 3)}
     }
 
-    for framework, methods in whitelisted_methods.items():
-        attr = getattr(bob.remote, framework)
+    for framework_name, methods in whitelisted_methods.items():
+        framework = getattr(bob.remote, framework_name)
 
         for method, inp in methods.items():
-            x = getattr(attr, method)(inp)
+            attr_method = getattr(framework, method)
+            x = await attr_method(inp)
 
             if "rand" not in method:
-                assert (x.get() == getattr(th, method)(inp)).all()
+                output = await x.get()
+                method = getattr(th, method)
+                assert (output == method(inp)).all()
 
 
 def test_send_command_not_whitelisted(hook, workers):


### PR DESCRIPTION
## Description

This is an ultra-rough spike to learn how to make workers capable of running asynchronously, which would be super-useful for testing `Protocols` without needing to incur the additional complexity of websockets.

## Checklist:
* [X] My changes are covered by tests.
* [X] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
* [X] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

(See the [the contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md) for additional tips.)
