### PR TITLE
Solve webrtc notebook async calls

### DIFF
--- a/syft/grid/webrtc_connection.py
+++ b/syft/grid/webrtc_connection.py
@@ -51,7 +51,7 @@ class WebRTCConnection(threading.Thread, BaseWorker):
         self.available = True
         self.connections = connections
 
-    async def _send_msg(self, message: bin, location=None):
+    def _send_msg(self, message: bin, location=None):
         """ Add a new syft operation on the request_pool to be processed asynchronously.
             
             Args:
@@ -66,7 +66,7 @@ class WebRTCConnection(threading.Thread, BaseWorker):
         # Wait
         # PySyft is a sync library and should wait for this response.
         while self._response_pool.empty():
-            await asyncio.sleep(0)
+            time.sleep(0)
         return self._response_pool.get()
 
     def _recv_msg(self, message: bin):
@@ -80,7 +80,7 @@ class WebRTCConnection(threading.Thread, BaseWorker):
                 response_message : Binary syft response message.
         """
         if self.available:
-            return asyncio.run(self._send_msg(message))
+            return self._send_msg(message)
         else:  # PySyft's GC delete commands
             return self._worker._recv_msg(message)
 
@@ -126,7 +126,7 @@ class WebRTCConnection(threading.Thread, BaseWorker):
         """
         message = SearchMessage(query)
         serialized_message = sy.serde.serialize(message)
-        response = asyncio.run(self._send_msg(serialized_message))
+        response = self._send_msg(serialized_message)
         return sy.serde.deserialize(response)
 
     # Main


### PR DESCRIPTION
## Description

Apparently, the jupyter notebook has some limitations for running code asynchronously using the asyncio lib _(more details below)_. This PR aims to replace `asyncio.run()` calls to solve event loop issues during async calls inside of a notebook environment.

Issue details:
_"Unlike terminal IPython, all code runs on asyncio eventloop, so creating a loop by hand will not work, including with magics like %run or other frameworks that create the eventloop themselves."_ , [IPython Docs](https://ipython.readthedocs.io/en/stable/interactive/autoawait.html?highlight=nest#using-autoawait-in-a-notebook-ipykernel)

Related issues on jupyter notebook repository:
[Can't invoke asyncio event_loop after tornado 5.0 update](https://github.com/jupyter/notebook/issues/3397)
[asyncio.run() fails in the notebook](https://github.com/jupyter/notebook/issues/3397) 