### PR TITLE
Full Demo: Training an Encrypted Neural Network across Workers using Crypten (with jails)

### DIFF
--- a/examples/experimental/Training an Encrypted Neural Network across Workers using Crypten.ipynb
+++ b/examples/experimental/Training an Encrypted Neural Network across Workers using Crypten.ipynb
@@ -1,0 +1,325 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before running this notebook, you should first run `./mnist_utils.py --option features --reduced 100 --binary` using the [mnist_utils.py from CrypTen](https://github.com/facebookresearch/CrypTen/blob/b1466440bde4db3e6e1fcb1740584d35a16eda9e/tutorials/mnist_utils.py) to prepare the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow. Fix this by compiling custom ops. Missing file was '/home/youben/anaconda3/envs/pysyft-dev-py37/lib/python3.7/site-packages/tf_encrypted/operations/secure_random/secure_random_module_tf_1.15.0.so'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/youben/anaconda3/envs/pysyft-dev-py37/lib/python3.7/site-packages/tf_encrypted/session.py:24: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import crypten\n",
+    "import syft\n",
+    "from time import time\n",
+    "from syft import WebsocketClientWorker\n",
+    "from syft.frameworks.crypten.context import run_multiworkers\n",
+    "\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "torch.set_num_threads(1)\n",
+    "hook = syft.TorchHook(torch)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define an example network\n",
+    "class ExampleNet(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(ExampleNet, self).__init__()\n",
+    "        self.conv1 = nn.Conv2d(1, 16, kernel_size=5, padding=0)\n",
+    "        self.fc1 = nn.Linear(16 * 12 * 12, 100)\n",
+    "        self.fc2 = nn.Linear(100, 2)  # For binary classification, final layer needs only 2 outputs\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        out = self.conv1(x)\n",
+    "        out = F.relu(out)\n",
+    "        out = F.max_pool2d(out, 2)\n",
+    "        out = out.view(out.size(0), -1)\n",
+    "        out = self.fc1(out)\n",
+    "        out = F.relu(out)\n",
+    "        out = self.fc2(out)\n",
+    "        return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[%] Connecting to workers ...\n",
+      "[+] Connected to workers\n",
+      "[%] Sending labels and training data ...\n",
+      "[+] Data ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Syft workers\n",
+    "print(\"[%] Connecting to workers ...\")\n",
+    "ALICE = syft.VirtualWorker(hook=hook, id=\"alice\")\n",
+    "BOB = syft.VirtualWorker(hook=hook, id=\"bob\")\n",
+    "print(\"[+] Connected to workers\")\n",
+    "\n",
+    "# Add crypten support to the worker\n",
+    "ALICE.add_crypten_support()\n",
+    "BOB.add_crypten_support()\n",
+    "\n",
+    "print(\"[%] Sending labels and training data ...\")\n",
+    "# Prepare and send labels\n",
+    "label_eye = torch.eye(2)\n",
+    "labels = torch.load(\"/tmp/train_labels.pth\")\n",
+    "labels = labels.long()\n",
+    "labels_one_hot = label_eye[labels]\n",
+    "labels_one_hot.tag(\"labels\")\n",
+    "al_ptr = labels_one_hot.send(ALICE)\n",
+    "bl_ptr = labels_one_hot.send(BOB)\n",
+    "\n",
+    "# Prepare and send training data\n",
+    "alice_train = torch.load(\"/tmp/alice_train.pth\").tag(\"alice_train\")\n",
+    "at_ptr = alice_train.send(ALICE)\n",
+    "bob_train = torch.load(\"/tmp/bob_train.pth\").tag(\"bob_train\")\n",
+    "bt_ptr = bob_train.send(BOB)\n",
+    "\n",
+    "print(\"[+] Data ready\")\n",
+    "\n",
+    "# Initialize model\n",
+    "dummy_input = torch.empty(1, 1, 28, 28)\n",
+    "pytorch_model = ExampleNet()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@run_multiworkers([ALICE, BOB], master_addr=\"127.0.0.1\", model=pytorch_model, dummy_input=dummy_input)\n",
+    "def run_encrypted_training():\n",
+    "    rank = crypten.communicator.get().get_rank()\n",
+    "    \n",
+    "    worker_id = syft.local_worker.rank_to_worker_id[rank]\n",
+    "    worker = syft.local_worker.get_worker(worker_id)\n",
+    "    labels_one_hot = worker.search(\"labels\")[0]\n",
+    "\n",
+    "    # Load data:\n",
+    "    x_alice_enc = crypten.load(\"alice_train\", 0)\n",
+    "    x_bob_enc = crypten.load(\"bob_train\", 1)\n",
+    "\n",
+    "    # Combine the feature sets: identical to Tutorial 3\n",
+    "    x_combined_enc = crypten.cat([x_alice_enc, x_bob_enc], dim=2)\n",
+    "\n",
+    "    # Reshape to match the network architecture\n",
+    "    x_combined_enc = x_combined_enc.unsqueeze(1)\n",
+    "\n",
+    "    # model is sent from the master worker\n",
+    "    model.encrypt()\n",
+    "    # Set train mode\n",
+    "    model.train()\n",
+    "\n",
+    "    # Define a loss function\n",
+    "    loss = crypten.nn.MSELoss()\n",
+    "\n",
+    "    # Define training parameters\n",
+    "    learning_rate = 0.001\n",
+    "    num_epochs = 2\n",
+    "    batch_size = 10\n",
+    "    num_batches = x_combined_enc.size(0) // batch_size\n",
+    "\n",
+    "    for i in range(num_epochs):\n",
+    "        # Print once for readability\n",
+    "        if rank == 0:\n",
+    "            print(f\"Epoch {i} in progress:\")\n",
+    "            pass\n",
+    "\n",
+    "        for batch in range(num_batches):\n",
+    "            # define the start and end of the training mini-batch\n",
+    "            start, end = batch * batch_size, (batch + 1) * batch_size\n",
+    "\n",
+    "            # construct AutogradCrypTensors out of training examples / labels\n",
+    "            x_train = x_combined_enc[start:end]\n",
+    "            y_batch = labels_one_hot[start:end]\n",
+    "            y_train = crypten.cryptensor(y_batch, requires_grad=True)\n",
+    "\n",
+    "            # perform forward pass:\n",
+    "            output = model(x_train)\n",
+    "\n",
+    "            loss_value = loss(output, y_train)\n",
+    "\n",
+    "            # set gradients to \"zero\"\n",
+    "            model.zero_grad()\n",
+    "\n",
+    "            # perform backward pass:\n",
+    "            loss_value.backward()\n",
+    "\n",
+    "            # update parameters\n",
+    "            model.update_parameters(learning_rate)\n",
+    "\n",
+    "            # Print progress every batch:\n",
+    "            batch_loss = loss_value.get_plain_text()\n",
+    "            if rank == 0:\n",
+    "                print(f\"\\tBatch {(batch + 1)} of {num_batches} Loss {batch_loss.item():.4f}\")\n",
+    "\n",
+    "    model.decrypt()\n",
+    "    # printed contain all the printed strings during training\n",
+    "    return printed, model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[%] Starting computation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/pytorch/torch/csrc/utils/tensor_numpy.cpp:141: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program.\n",
+      "/home/youben/anaconda3/envs/pysyft-dev-py37/lib/python3.7/site-packages/torch/storage.py:34: FutureWarning: pickle support for Storage will be removed in 1.5. Use `torch.save` instead\n",
+      "  warnings.warn(\"pickle support for Storage will be removed in 1.5. Use `torch.save` instead\", FutureWarning)\n",
+      "/home/youben/anaconda3/envs/pysyft-dev-py37/lib/python3.7/site-packages/torch/storage.py:34: FutureWarning: pickle support for Storage will be removed in 1.5. Use `torch.save` instead\n",
+      "  warnings.warn(\"pickle support for Storage will be removed in 1.5. Use `torch.save` instead\", FutureWarning)\n",
+      "/pytorch/aten/src/ATen/native/BinaryOps.cpp:66: UserWarning: Integer division of tensors using div or / is deprecated, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.\n",
+      "/pytorch/aten/src/ATen/native/BinaryOps.cpp:66: UserWarning: Integer division of tensors using div or / is deprecated, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.\n",
+      "/pytorch/aten/src/ATen/native/BinaryOps.cpp:81: UserWarning: Integer division of tensors using div or / is deprecated, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.\n",
+      "/pytorch/aten/src/ATen/native/BinaryOps.cpp:81: UserWarning: Integer division of tensors using div or / is deprecated, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[+] run_encrypted_training() took 50s\n",
+      "Epoch 0 in progress:\n",
+      "\tBatch 1 of 10 Loss 0.4638\n",
+      "\tBatch 2 of 10 Loss 0.4665\n",
+      "\tBatch 3 of 10 Loss 0.4065\n",
+      "\tBatch 4 of 10 Loss 0.3489\n",
+      "\tBatch 5 of 10 Loss 0.3312\n",
+      "\tBatch 6 of 10 Loss 0.2796\n",
+      "\tBatch 7 of 10 Loss 0.2767\n",
+      "\tBatch 8 of 10 Loss 0.2430\n",
+      "\tBatch 9 of 10 Loss 0.2457\n",
+      "\tBatch 10 of 10 Loss 0.2002\n",
+      "Epoch 1 in progress:\n",
+      "\tBatch 1 of 10 Loss 0.1624\n",
+      "\tBatch 2 of 10 Loss 0.1516\n",
+      "\tBatch 3 of 10 Loss 0.1549\n",
+      "\tBatch 4 of 10 Loss 0.1922\n",
+      "\tBatch 5 of 10 Loss 0.1319\n",
+      "\tBatch 6 of 10 Loss 0.1634\n",
+      "\tBatch 7 of 10 Loss 0.2243\n",
+      "\tBatch 8 of 10 Loss 0.1454\n",
+      "\tBatch 9 of 10 Loss 0.1717\n",
+      "\tBatch 10 of 10 Loss 0.1334\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"[%] Starting computation\")\n",
+    "func_ts = time()\n",
+    "result = run_encrypted_training()\n",
+    "func_te = time()\n",
+    "print(f\"[+] run_encrypted_training() took {int(func_te - func_ts)}s\")\n",
+    "printed = result[0][0]\n",
+    "model = result[0][1]\n",
+    "print(printed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<crypten.nn.module.Graph object at 0x7f5f91672e10>\n",
+      "(Wrapper)>FixedPrecisionTensor>[AdditiveSharingTensor]\n",
+      "\t-> [PointerTensor | me:70320103064 -> alice:76402485570]\n",
+      "\t-> [PointerTensor | me:99473637600 -> bob:24884125725]\n",
+      "\t*crypto provider: cp*\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/youben/git-repo/PySyft/syft/frameworks/torch/tensors/interpreters/additive_shared.py:79: UserWarning: Use dtype instead of field\n",
+      "  warnings.warn(\"Use dtype instead of field\")\n",
+      "/home/youben/git-repo/PySyft/syft/frameworks/torch/tensors/interpreters/additive_shared.py:91: UserWarning: Default args selected\n",
+      "  warnings.warn(\"Default args selected\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "cp = syft.VirtualWorker(hook=hook, id=\"cp\")\n",
+    "model.fix_prec()\n",
+    "model.share(ALICE, BOB, crypto_provider=cp)\n",
+    "print(model)\n",
+    "print(list(model.parameters())[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -120,7 +120,8 @@ def run_multiworkers(
             crypten_model = None if onnx_model is None else utils.onnx_to_crypten(onnx_model)
 
             world_size = len(workers)
-            return_values = {rank: None for rank in range(world_size)}
+            manager = multiprocessing.Manager()
+            return_values = manager.dict({rank: None for rank in range(world_size)})
 
             if isinstance(func, sy.Plan):
                 using_plan = True
@@ -175,7 +176,7 @@ def run_multiworkers(
                         ser_jail_runner,
                         onnx_model,
                     )
-                thread = threading.Thread(
+                thread = multiprocessing.Process(
                     target=_send_party_info,
                     args=(workers[i], rank, msg, return_values, crypten_model),
                 )

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -13,7 +13,9 @@ from syft.frameworks.crypten.hook.hook import hook_plan_building, unhook_plan_bu
 from crypten.communicator import DistributedCommunicator
 
 
-def _launch(func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs):
+def _launch(
+    func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs
+):  # pragma: no cover
     communicator_args = {
         "RANK": rank,
         "WORLD_SIZE": world_size,
@@ -72,7 +74,7 @@ def run_party(func, rank, world_size, master_addr, master_port, func_args, func_
     return res
 
 
-def _send_party_info(worker, rank, msg, return_values, model=None):
+def _send_party_info(worker, rank, msg, return_values, model=None):  # pragma: no cover
     """Send message to worker with necessary information to run a crypten party.
     Add response to return_values dictionary.
 

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -150,19 +150,18 @@ def run_multiworkers(
             sy.local_worker.add_crypten_support()
             sy.local_worker._set_rank_to_worker_id(rank_to_worker_id)
 
-            # Run TTP if required
             # TODO: run ttp in a specified worker
-            if crypten.mpc.ttp_required():
-                ttp_process, _ = _new_party(
-                    crypten.mpc.provider.TTPServer,
-                    world_size,
-                    world_size,
-                    master_addr,
-                    master_port,
-                    (),
-                    {},
-                )
-                ttp_process.start()
+            # if crypten.mpc.ttp_required():
+            #     ttp_process, _ = _new_party(
+            #         crypten.mpc.provider.TTPServer,
+            #         world_size,
+            #         world_size,
+            #         master_addr,
+            #         master_port,
+            #         (),
+            #         {},
+            #     )
+            #     ttp_process.start()
 
             # Send messages to other workers so they start their parties
             threads = []

--- a/syft/frameworks/crypten/jail.py
+++ b/syft/frameworks/crypten/jail.py
@@ -51,6 +51,16 @@ class JailRunner:
             # Remove decorator if any
             func_src = re.sub(r"@[^\(]+\([^\)]*\)", "", func_src)
 
+        # remove base indent
+        lines = func_src.split("\n")
+        if len(lines) and re.match(r"^ *", lines[0]):
+            base_re = "^" + re.match(r"^ *", lines[0]).group(0)
+            new_lines = []
+            for l in lines:
+                l = re.sub(base_re, "", l)
+                new_lines.append(l)
+            func_src = "\n".join(new_lines)
+
         is_func, self._func_name = JailRunner._check_func_def(func_src)
         if not is_func:
             raise ValueError("Not a valid function definition")

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -141,7 +141,7 @@ class TorchHook(FrameworkHook):
 
         if dependency_check.crypten_available:
             self.to_auto_overload[crypten.mpc.MPCTensor] = ["get_plain_text"]
-            self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
+            # self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
             self._hook_syft_placeholder_methods(crypten.mpc.MPCTensor, PlaceHolder)
 
         # Add all hooked tensor methods to pointer but change behaviour to have the cmd sent

--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -141,7 +141,6 @@ class TorchHook(FrameworkHook):
 
         if dependency_check.crypten_available:
             self.to_auto_overload[crypten.mpc.MPCTensor] = ["get_plain_text"]
-            # self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
             self._hook_syft_placeholder_methods(crypten.mpc.MPCTensor, PlaceHolder)
 
         # Add all hooked tensor methods to pointer but change behaviour to have the cmd sent

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -7,8 +7,9 @@ import torch.nn.functional as F
 
 import syft as sy
 
-from syft.frameworks.crypten.context import run_multiworkers
+from syft.frameworks.crypten.context import run_multiworkers, run_party
 from syft.frameworks.crypten.worker_support import methods_to_add
+from syft.frameworks.crypten import utils
 
 
 th.set_num_threads(1)
@@ -161,3 +162,15 @@ def test_context_jail_with_model(workers):
     result = run_encrypted_eval()
     # compare out
     assert th.all(result[0][1] == result[1][1])
+
+
+def test_run_party():
+    expected = th.tensor(5)
+
+    def party():
+        t = crypten.cryptensor(expected)
+        return t.get_plain_text()
+
+    t = run_party(party, 0, 1, "127.0.0.1", 15463, (), {})
+    result = utils.unpack_values(t)
+    assert result == expected

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -2,10 +2,35 @@ import pytest
 import crypten
 
 import torch as th
+import torch.nn as nn
+import torch.nn.functional as F
+
 import syft as sy
 
 from syft.frameworks.crypten.context import run_multiworkers
 from syft.frameworks.crypten.worker_support import methods_to_add
+
+
+th.set_num_threads(1)
+
+
+# Define an example network
+class ExampleNet(nn.Module):
+    def __init__(self):
+        super(ExampleNet, self).__init__()
+        self.conv1 = nn.Conv2d(1, 16, kernel_size=5, padding=0)
+        self.fc1 = nn.Linear(16 * 12 * 12, 100)
+        self.fc2 = nn.Linear(100, 2)
+
+    def forward(self, x):
+        out = self.conv1(x)
+        out = F.relu(out)
+        out = F.max_pool2d(out, 2)
+        out = out.view(out.size(0), -1)
+        out = self.fc1(out)
+        out = F.relu(out)
+        out = self.fc2(out)
+        return out
 
 
 def test_add_crypten_support(workers):
@@ -67,3 +92,72 @@ def test_context(workers):
         ), "Crypten party with rank {} don't match expected value {} != {}".format(
             rank, return_values[rank], expected_value
         )
+
+
+def test_context_jail(workers):
+    # alice and bob
+    n_workers = 2
+
+    alice = workers["alice"]
+    bob = workers["bob"]
+
+    alice_tensor_ptr = th.tensor([42, 53, 3, 2]).tag("crypten_data").send(alice)
+    bob_tensor_ptr = th.tensor([101, 32, 29, 2]).tag("crypten_data").send(bob)
+
+    alice.add_crypten_support()
+    bob.add_crypten_support()
+
+    @run_multiworkers([alice, bob], master_addr="127.0.0.1")
+    def jail_func(crypten=crypten):
+        alice_tensor = crypten.load("crypten_data", 0)
+        bob_tensor = crypten.load("crypten_data", 1)
+
+        crypt = alice_tensor + bob_tensor
+        result = crypt.get_plain_text()
+        return result
+
+    return_values = jail_func()
+
+    expected_value = th.tensor([143, 85, 32, 4])
+
+    alice.remove_crypten_support()
+    bob.remove_crypten_support()
+
+    # A toy function is ran at each party, and they should all decrypt
+    # a tensor with value [143, 85]
+    for rank in range(n_workers):
+        assert th.all(
+            return_values[rank] == expected_value
+        ), "Crypten party with rank {} don't match expected value {} != {}".format(
+            rank, return_values[rank], expected_value
+        )
+
+
+def test_context_jail_with_model(workers):
+    dummy_input = th.empty(1, 1, 28, 28)
+    pytorch_model = ExampleNet()
+
+    alice = workers["alice"]
+    bob = workers["bob"]
+
+    alice_tensor_ptr = th.tensor(dummy_input).tag("crypten_data").send(alice)
+
+    alice.add_crypten_support()
+    bob.add_crypten_support()
+
+    @run_multiworkers(
+        [alice, bob], master_addr="127.0.0.1", model=pytorch_model, dummy_input=dummy_input
+    )
+    def run_encrypted_eval():
+        rank = crypten.communicator.get().get_rank()
+        t = crypten.load("crypten_data", 0)
+
+        model.encrypt()  # noqa: F821
+        out = model(t)  # noqa: F821
+        model.decrypt()  # noqa: F821
+        out = out.get_plain_text()
+        return model, out  # noqa: F821
+
+    result = run_encrypted_eval()
+    # compare out
+    assert th.all(result[0][1] == result[1][1])

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -70,7 +70,7 @@ def test_context(workers):
 
     @run_multiworkers([alice, bob], master_addr="127.0.0.1")
     @sy.func2plan()
-    def plan_func(crypten=crypten):
+    def plan_func(crypten=crypten):  # pragma: no cover
         alice_tensor = crypten.load("crypten_data", 0)
         bob_tensor = crypten.load("crypten_data", 1)
 
@@ -109,7 +109,7 @@ def test_context_jail(workers):
     bob.add_crypten_support()
 
     @run_multiworkers([alice, bob], master_addr="127.0.0.1")
-    def jail_func(crypten=crypten):
+    def jail_func(crypten=crypten):  # pragma: no cover
         alice_tensor = crypten.load("crypten_data", 0)
         bob_tensor = crypten.load("crypten_data", 1)
 
@@ -149,7 +149,7 @@ def test_context_jail_with_model(workers):
     @run_multiworkers(
         [alice, bob], master_addr="127.0.0.1", model=pytorch_model, dummy_input=dummy_input
     )
-    def run_encrypted_eval():
+    def run_encrypted_eval():  # pragma: no cover
         rank = crypten.communicator.get().get_rank()
         t = crypten.load("crypten_data", 0)
 
@@ -177,7 +177,7 @@ def test_context_jail_with_model_failures(workers):
     bob.add_crypten_support()
 
     @run_multiworkers([alice, bob], master_addr="127.0.0.1", model=pytorch_model)
-    def run_encrypted_eval():
+    def run_encrypted_eval():  # pragma: no cover
         rank = crypten.communicator.get().get_rank()
         t = crypten.load("crypten_data", 0)
 
@@ -191,7 +191,7 @@ def test_context_jail_with_model_failures(workers):
         result = run_encrypted_eval()
 
     @run_multiworkers([alice, bob], master_addr="127.0.0.1", model=5)
-    def run_encrypted_eval():
+    def run_encrypted_eval():  # pragma: no cover
         rank = crypten.communicator.get().get_rank()
         t = crypten.load("crypten_data", 0)
 
@@ -205,7 +205,7 @@ def test_context_jail_with_model_failures(workers):
         result = run_encrypted_eval()
 
     @run_multiworkers([alice, bob], master_addr="127.0.0.1", model=pytorch_model, dummy_input=73)
-    def run_encrypted_eval():
+    def run_encrypted_eval():  # pragma: no cover
         rank = crypten.communicator.get().get_rank()
         t = crypten.load("crypten_data", 0)
 
@@ -222,7 +222,7 @@ def test_context_jail_with_model_failures(workers):
 def test_run_party():
     expected = th.tensor(5)
 
-    def party():
+    def party():  # pragma: no cover
         t = crypten.cryptensor(expected)
         return t.get_plain_text()
 

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -30,8 +30,8 @@ def test_add_crypten_support(workers):
 
 
 def test_context(workers):
-    # self, alice and bob
-    n_workers = 3
+    # alice and bob
+    n_workers = 2
 
     alice = workers["alice"]
     bob = workers["bob"]
@@ -45,8 +45,8 @@ def test_context(workers):
     @run_multiworkers([alice, bob], master_addr="127.0.0.1")
     @sy.func2plan()
     def plan_func(crypten=crypten):
-        alice_tensor = crypten.load("crypten_data", 1)
-        bob_tensor = crypten.load("crypten_data", 2)
+        alice_tensor = crypten.load("crypten_data", 0)
+        bob_tensor = crypten.load("crypten_data", 1)
 
         crypt = alice_tensor + bob_tensor
         result = crypt.get_plain_text()

--- a/test/crypten/test_hook.py
+++ b/test/crypten/test_hook.py
@@ -31,6 +31,23 @@ def test_send_module(workers, model):
         assert torch.all(p.data == p_cmp)
 
 
+def test_share_module(workers, model):
+    alice = workers["alice"]
+    bob = workers["bob"]
+    cp = workers["charlie"]
+
+    model.fix_prec()
+    model.share(alice, bob, crypto_provider=cp)
+    for p in model.parameters():
+        assert isinstance(p.child, syft.FixedPrecisionTensor)
+        assert isinstance(p.child.child, syft.AdditiveSharingTensor)
+
+    model.get()
+    model.float_prec()
+    for p in model.parameters():
+        assert isinstance(p, torch.Tensor)
+
+
 def test_move_module(workers, model):
     alice = workers["alice"]
     bob = workers["bob"]
@@ -53,3 +70,11 @@ def test_copy(model):
 
         for p in copy_model.parameters():
             assert not torch.all(p == 0)
+
+
+def test_encrypted_model(model):
+    crypten.init()
+    model.encrypt()
+    with pytest.raises(RuntimeError):
+        model._check_encrypted()
+    crypten.uninit()

--- a/test/crypten/test_jail.py
+++ b/test/crypten/test_jail.py
@@ -34,3 +34,31 @@ def test_ser_deser():
     t = th.tensor(2)
     expected = th.tensor(7)
     assert expected == func_deser(t)
+
+
+def test_empty_jail():
+    with pytest.raises(ValueError) as e:
+        empty_jail = jail.JailRunner()
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """
+s = "not a function"
+print(s)
+        """,
+        """
+s = "not a function"
+        """,
+    ],
+)
+def test_not_valid_func(src):
+    with pytest.raises(ValueError):
+        not_valid = jail.JailRunner(func_src=src)
+
+
+def test_already_built():
+    func = jail.JailRunner(func=add_tensors)
+    with pytest.raises(RuntimeWarning):
+        func._build()


### PR DESCRIPTION
## Description

This PR add an experimental notebook showing how to train an encrypted neural network using crypten, it's based on [Tutorial7 of CrypTen](https://github.com/facebookresearch/CrypTen/blob/master/tutorials/Tutorial_7_Training_an_Encrypted_Neural_Network.ipynb).

Two issues were also solved to implement the demo correctly. First an issue regarding how the crypten computation is initiated in the syft context, and a second regarding how virtual workers are used.

### First issue

CrypTen computation is started from a master worker that will be responsible of running the master party which needs to bind and listen to a port for synchronizing between distributed parties, our initial design start a party (rank 0) on the local worker to be the master that will do the previous job, this introduced some complication with the API as users will list workers in the `run_multiworker` decorator and doesn't expect an additional party to be running on the local worker. We solved this by removing the need to start a local party, but the ip address and port referred on the decorator would be the one used by the first worker in the list (more work on this need to be done).

### Second issue

Using virtual workers doesn't parallelize the computation as calling send will just call recv and the execution of the commands sent to the VirtualWorker will just run sequentially on the main thread. Using threads to call operations on VirtualWorker (which was our case) doesn't solve the issue as well as most computation is cpu-bound, and python doesn't support threads as expected because of the Global Interpreter Lock. So we switched to using processes instead, this introduces some extra cost for creating these processes, but this shouldn't be a big deal if the memory is shared using copy-on-write, a deeper analysis of this may be required only if this start popping up issues.

### Results
With the previous changes, we were able to reproduce the same training as in the CrypTen tutorial with little changes, the running time is almost the same even for VirtualWorker due to the parallelism using processes.


## Checklist:
* [x] My changes are covered by tests.
* [x] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

(See the [the contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md) for additional tips.)
