### PR TITLE
Create toy workers, actions, and messages to experiment with async

### DIFF
--- a/syft/workers/async_toy.py
+++ b/syft/workers/async_toy.py
@@ -1,0 +1,131 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+import asyncio
+
+
+@dataclass
+class ToyAction:
+    command: str
+    value: str = field(default_factory=str)
+    dependencies: list = field(default_factory=list)
+
+
+@dataclass
+class ToyMessage:
+    destination: str
+    command: str
+    value: str
+
+    def to_action(self):
+        return ToyAction(dependencies=[], command=self.command, value=self.value)
+
+
+class AbstractToyWorker:
+    counter = 0
+
+    def __init__(self, name: str, actions: list = [], all_workers: dict = {}):
+        self.name = name
+        self.actions = actions
+        self.known_workers = all_workers
+        self.store = {}
+        self.next_action_index = 0
+        self.executed = []
+
+    @property
+    def _name_counter(self):
+        return str(self.name) + str(AbstractToyWorker.counter)
+
+    def receive_msg(self, message: ToyMessage):
+        self._execute_action(message.to_action())
+        # Try to execute anything that is now unlocked by received values
+        self.execute()
+
+    def send_msg(self, message: ToyMessage):
+        self.known_workers[message.destination].receive_msg(message)
+
+    def execute(self):
+        while not self.finished:
+            action = self.actions[self.next_action_index]
+
+            # Check dependencies and return if not satisfied
+            for dep in action.dependencies:
+                if dep not in self.store.keys():
+                    return
+
+            # Run the command if dependencies are satisfied
+            self.next_action_index += 1
+            self._execute_action(action)
+
+    def _execute_action(self, action):
+        # Record the action being executed
+        self.executed.append(action)
+
+        # Set a flag in the store and execute any further actions now unlocked
+        if action.command == "set" or action.command == "receive":
+            self.store[action.value] = True
+        # Send a message that sets a flag on a remote worker
+        elif action.command == "send":
+            msg = ToyMessage(destination=action.value, command="receive", value=self._name_counter)
+            return self.send_msg(msg)
+        # Do a local "computation"
+        elif action.command == "compute":
+            self.store[self._name_counter] = True
+        else:
+            raise ValueError("action.command value not supported.")
+
+        # Increment the global counter of actions executed
+        AbstractToyWorker.counter += 1
+
+        return None
+
+    @property
+    def finished(self):
+        return self.next_action_index >= len(self.actions)
+
+    @classmethod
+    def reset_counter(cls):
+        cls.counter = 0
+
+    @staticmethod
+    def introduce(*args):
+        # Build map of all the workers
+        workers = {}
+        for worker in args:
+            workers[worker.name] = worker
+
+        # Introduce them to each other
+        for worker in args:
+            worker.known_workers = workers
+
+
+class SingleThreadedSynchronousWorker(AbstractToyWorker):
+    pass
+
+
+class SingleThreadedAsynchronousWorker(AbstractToyWorker):
+    async def receive_msg(self, message: ToyMessage):
+        await self._execute_action(message.to_action())
+        # Try to execute anything that is now unlocked by received values
+        await self.execute()
+
+    async def send_msg(self, message: ToyMessage):
+        await self.known_workers[message.destination].receive_msg(message)
+
+    async def execute(self):
+        while not self.finished:
+            action = self.actions[self.next_action_index]
+
+            # Check dependencies and return if not satisfied
+            for dep in action.dependencies:
+                if dep not in self.store.keys():
+                    return
+
+            # Run the command if dependencies are satisfied
+            self.next_action_index += 1
+            await self._execute_action(action)
+
+    async def _execute_action(self, action):
+        awaitable = super()._execute_action(action)
+        if awaitable:
+            await awaitable

--- a/syft/workers/async_toy.py
+++ b/syft/workers/async_toy.py
@@ -99,11 +99,11 @@ class AbstractToyWorker:
             worker.known_workers = workers
 
 
-class SingleThreadedSynchronousWorker(AbstractToyWorker):
+class SynchronousWorker(AbstractToyWorker):
     pass
 
 
-class SingleThreadedAsynchronousWorker(AbstractToyWorker):
+class AsynchronousWorker(AbstractToyWorker):
     async def receive_msg(self, message: ToyMessage):
         await self._execute_action(message.to_action())
         # Try to execute anything that is now unlocked by received values

--- a/syft/workers/async_toy.py
+++ b/syft/workers/async_toy.py
@@ -21,7 +21,7 @@ class ToyMessage:
         return ToyAction(dependencies=[], command=self.command, value=self.value)
 
 
-class AbstractToyWorker:
+class ToyWorker:
     counter = 0
 
     def __init__(self, name: str, actions: list = [], all_workers: dict = {}):
@@ -34,7 +34,7 @@ class AbstractToyWorker:
 
     @property
     def _name_counter(self):
-        return str(self.name) + str(AbstractToyWorker.counter)
+        return str(self.name) + str(ToyWorker.counter)
 
     def receive_msg(self, message: ToyMessage):
         self._execute_action(message.to_action())
@@ -75,7 +75,7 @@ class AbstractToyWorker:
             raise ValueError("action.command value not supported.")
 
         # Increment the global counter of actions executed
-        AbstractToyWorker.counter += 1
+        ToyWorker.counter += 1
 
         return None
 
@@ -99,11 +99,11 @@ class AbstractToyWorker:
             worker.known_workers = workers
 
 
-class SynchronousWorker(AbstractToyWorker):
+class SynchronousWorker(ToyWorker):
     pass
 
 
-class AsynchronousWorker(AbstractToyWorker):
+class AsynchronousWorker(ToyWorker):
     async def receive_msg(self, message: ToyMessage):
         await self._execute_action(message.to_action())
         # Try to execute anything that is now unlocked by received values

--- a/test/workers/test_async_toy.py
+++ b/test/workers/test_async_toy.py
@@ -1,0 +1,166 @@
+import pytest
+import asyncio
+
+from syft.workers.async_toy import AbstractToyWorker
+from syft.workers.async_toy import SingleThreadedSynchronousWorker
+from syft.workers.async_toy import SingleThreadedAsynchronousWorker
+from syft.workers.async_toy import ToyAction
+from syft.workers.async_toy import ToyMessage
+
+
+def test_set():
+    AbstractToyWorker.reset_counter()
+
+    alice = AbstractToyWorker(name="alice")
+    action = ToyAction("set", "test")
+
+    alice._execute_action(action)
+    assert alice.store["test"] is True
+
+
+def test_compute():
+    AbstractToyWorker.reset_counter()
+
+    alice = AbstractToyWorker(name="alice")
+    action = ToyAction("compute", "test")
+
+    alice._execute_action(action)
+
+    assert alice.store == {"alice0": True}
+
+
+def test_send():
+    AbstractToyWorker.reset_counter()
+
+    alice = AbstractToyWorker(name="alice")
+    bob = AbstractToyWorker(name="bob")
+    AbstractToyWorker.introduce(alice, bob)
+
+    action = ToyAction("send", "bob")
+
+    alice._execute_action(action)
+    assert bob.store["alice0"] is True
+
+
+def test_unknown_action():
+    AbstractToyWorker.reset_counter()
+
+    alice = AbstractToyWorker(name="alice")
+    action = ToyAction("flarble", "garb")
+
+    with pytest.raises(ValueError):
+        alice._execute_action(action)
+
+
+def test_action_counter():
+    AbstractToyWorker.reset_counter()
+
+    alice = AbstractToyWorker(name="alice")
+    bob = AbstractToyWorker(name="bob")
+    AbstractToyWorker.introduce(alice, bob)
+
+    # Counter increments by one every time an action is executed
+    action = ToyAction("set", "test1")
+    alice._execute_action(action)
+
+    assert alice.store["test1"] is True
+    assert AbstractToyWorker.counter == 1
+
+    action = ToyAction("set", "test2")
+    alice._execute_action(action)
+
+    assert alice.store["test2"] is True
+    assert AbstractToyWorker.counter == 2
+
+    # Counter increments regardless of which worker executes the action
+    action = ToyAction("set", "test3")
+    bob._execute_action(action)
+
+    assert bob.store["test3"] is True
+    assert AbstractToyWorker.counter == 3
+
+    # Send actions increment the counter only for send
+    action = ToyAction("send", "bob")
+    alice._execute_action(action)
+
+    assert bob.store["alice3"] is True
+    assert AbstractToyWorker.counter == 4
+
+
+def test_single_threaded_synchronous_comms():
+    AbstractToyWorker.reset_counter()
+
+    alice = SingleThreadedSynchronousWorker(name="alice")
+    bob = SingleThreadedSynchronousWorker(name="bob")
+    AbstractToyWorker.introduce(alice, bob)
+
+    # Create a potential deadlock
+    alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
+
+    bob.actions = [ToyAction("compute", dependencies=["alice0"]), ToyAction("send", "alice")]
+
+    # Take turns executing synchronously
+    while not (alice.finished and bob.finished):
+        alice.execute()
+        bob.execute()
+
+    assert len(alice.executed) == 3
+    assert len(bob.executed) == 3
+
+    assert bob.store["alice0"] is True
+    assert bob.store["bob1"] is True
+    assert alice.store["bob2"] is True
+    assert alice.store["alice3"] is True
+
+
+@pytest.mark.asyncio
+async def test_single_threaded_async_comms():
+    AbstractToyWorker.reset_counter()
+
+    alice = SingleThreadedAsynchronousWorker(name="alice")
+    bob = SingleThreadedAsynchronousWorker(name="bob")
+    AbstractToyWorker.introduce(alice, bob)
+
+    # Create a potential deadlock
+    alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
+
+    bob.actions = [ToyAction("compute", dependencies=["alice0"]), ToyAction("send", "alice")]
+
+    # Take turns executing asynchronously
+    while not (alice.finished and bob.finished):
+        await alice.execute()
+        await bob.execute()
+
+    assert len(alice.executed) == 3
+    assert len(bob.executed) == 3
+
+    assert bob.store["alice0"] is True
+    assert bob.store["bob1"] is True
+    assert alice.store["bob2"] is True
+    assert alice.store["alice3"] is True
+
+
+@pytest.mark.asyncio
+async def test_single_threaded_async_comms_concurrent():
+    AbstractToyWorker.reset_counter()
+
+    alice = SingleThreadedAsynchronousWorker(name="alice")
+    bob = SingleThreadedAsynchronousWorker(name="bob")
+    AbstractToyWorker.introduce(alice, bob)
+
+    # Create a potential deadlock
+    alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
+
+    bob.actions = [ToyAction("compute", dependencies=["alice0"]), ToyAction("send", "alice")]
+
+    # Execute asynchronously AND concurrently
+    while not (alice.finished and bob.finished):
+        await asyncio.gather(alice.execute(), bob.execute())
+
+    assert len(alice.executed) == 3
+    assert len(bob.executed) == 3
+
+    assert bob.store["alice0"] is True
+    assert bob.store["bob1"] is True
+    assert alice.store["bob2"] is True
+    assert alice.store["alice3"] is True

--- a/test/workers/test_async_toy.py
+++ b/test/workers/test_async_toy.py
@@ -1,7 +1,7 @@
 import pytest
 import asyncio
 
-from syft.workers.async_toy import AbstractToyWorker
+from syft.workers.async_toy import ToyWorker
 from syft.workers.async_toy import SynchronousWorker
 from syft.workers.async_toy import AsynchronousWorker
 from syft.workers.async_toy import ToyAction
@@ -9,9 +9,9 @@ from syft.workers.async_toy import ToyMessage
 
 
 def test_set():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
-    alice = AbstractToyWorker(name="alice")
+    alice = ToyWorker(name="alice")
     action = ToyAction("set", "test")
 
     alice._execute_action(action)
@@ -19,9 +19,9 @@ def test_set():
 
 
 def test_compute():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
-    alice = AbstractToyWorker(name="alice")
+    alice = ToyWorker(name="alice")
     action = ToyAction("compute", "test")
 
     alice._execute_action(action)
@@ -30,11 +30,11 @@ def test_compute():
 
 
 def test_send():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
-    alice = AbstractToyWorker(name="alice")
-    bob = AbstractToyWorker(name="bob")
-    AbstractToyWorker.introduce(alice, bob)
+    alice = ToyWorker(name="alice")
+    bob = ToyWorker(name="bob")
+    ToyWorker.introduce(alice, bob)
 
     action = ToyAction("send", "bob")
 
@@ -43,9 +43,9 @@ def test_send():
 
 
 def test_unknown_action():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
-    alice = AbstractToyWorker(name="alice")
+    alice = ToyWorker(name="alice")
     action = ToyAction("flarble", "garb")
 
     with pytest.raises(ValueError):
@@ -53,46 +53,46 @@ def test_unknown_action():
 
 
 def test_action_counter():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
-    alice = AbstractToyWorker(name="alice")
-    bob = AbstractToyWorker(name="bob")
-    AbstractToyWorker.introduce(alice, bob)
+    alice = ToyWorker(name="alice")
+    bob = ToyWorker(name="bob")
+    ToyWorker.introduce(alice, bob)
 
     # Counter increments by one every time an action is executed
     action = ToyAction("set", "test1")
     alice._execute_action(action)
 
     assert alice.store["test1"] is True
-    assert AbstractToyWorker.counter == 1
+    assert ToyWorker.counter == 1
 
     action = ToyAction("set", "test2")
     alice._execute_action(action)
 
     assert alice.store["test2"] is True
-    assert AbstractToyWorker.counter == 2
+    assert ToyWorker.counter == 2
 
     # Counter increments regardless of which worker executes the action
     action = ToyAction("set", "test3")
     bob._execute_action(action)
 
     assert bob.store["test3"] is True
-    assert AbstractToyWorker.counter == 3
+    assert ToyWorker.counter == 3
 
     # Send actions increment the counter only for send
     action = ToyAction("send", "bob")
     alice._execute_action(action)
 
     assert bob.store["alice3"] is True
-    assert AbstractToyWorker.counter == 4
+    assert ToyWorker.counter == 4
 
 
 def test_single_threaded_synchronous_comms():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
     alice = SynchronousWorker(name="alice")
     bob = SynchronousWorker(name="bob")
-    AbstractToyWorker.introduce(alice, bob)
+    ToyWorker.introduce(alice, bob)
 
     # Create a potential deadlock
     alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
@@ -115,11 +115,11 @@ def test_single_threaded_synchronous_comms():
 
 @pytest.mark.asyncio
 async def test_single_threaded_async_comms():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
     alice = AsynchronousWorker(name="alice")
     bob = AsynchronousWorker(name="bob")
-    AbstractToyWorker.introduce(alice, bob)
+    ToyWorker.introduce(alice, bob)
 
     # Create a potential deadlock
     alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
@@ -142,11 +142,11 @@ async def test_single_threaded_async_comms():
 
 @pytest.mark.asyncio
 async def test_single_threaded_async_comms_concurrent():
-    AbstractToyWorker.reset_counter()
+    ToyWorker.reset_counter()
 
     alice = AsynchronousWorker(name="alice")
     bob = AsynchronousWorker(name="bob")
-    AbstractToyWorker.introduce(alice, bob)
+    ToyWorker.introduce(alice, bob)
 
     # Create a potential deadlock
     alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]

--- a/test/workers/test_async_toy.py
+++ b/test/workers/test_async_toy.py
@@ -2,8 +2,8 @@ import pytest
 import asyncio
 
 from syft.workers.async_toy import AbstractToyWorker
-from syft.workers.async_toy import SingleThreadedSynchronousWorker
-from syft.workers.async_toy import SingleThreadedAsynchronousWorker
+from syft.workers.async_toy import SynchronousWorker
+from syft.workers.async_toy import AsynchronousWorker
 from syft.workers.async_toy import ToyAction
 from syft.workers.async_toy import ToyMessage
 
@@ -90,8 +90,8 @@ def test_action_counter():
 def test_single_threaded_synchronous_comms():
     AbstractToyWorker.reset_counter()
 
-    alice = SingleThreadedSynchronousWorker(name="alice")
-    bob = SingleThreadedSynchronousWorker(name="bob")
+    alice = SynchronousWorker(name="alice")
+    bob = SynchronousWorker(name="bob")
     AbstractToyWorker.introduce(alice, bob)
 
     # Create a potential deadlock
@@ -117,8 +117,8 @@ def test_single_threaded_synchronous_comms():
 async def test_single_threaded_async_comms():
     AbstractToyWorker.reset_counter()
 
-    alice = SingleThreadedAsynchronousWorker(name="alice")
-    bob = SingleThreadedAsynchronousWorker(name="bob")
+    alice = AsynchronousWorker(name="alice")
+    bob = AsynchronousWorker(name="bob")
     AbstractToyWorker.introduce(alice, bob)
 
     # Create a potential deadlock
@@ -144,8 +144,8 @@ async def test_single_threaded_async_comms():
 async def test_single_threaded_async_comms_concurrent():
     AbstractToyWorker.reset_counter()
 
-    alice = SingleThreadedAsynchronousWorker(name="alice")
-    bob = SingleThreadedAsynchronousWorker(name="bob")
+    alice = AsynchronousWorker(name="alice")
+    bob = AsynchronousWorker(name="bob")
     AbstractToyWorker.introduce(alice, bob)
 
     # Create a potential deadlock

--- a/test/workers/test_async_toy.py
+++ b/test/workers/test_async_toy.py
@@ -1,9 +1,11 @@
-import pytest
 import asyncio
+import pytest
+import threading
 
 from syft.workers.async_toy import ToyWorker
-from syft.workers.async_toy import SynchronousWorker
 from syft.workers.async_toy import AsynchronousWorker
+from syft.workers.async_toy import SynchronousWorker
+from syft.workers.async_toy import ThreadedSynchronousWorker
 from syft.workers.async_toy import ToyAction
 from syft.workers.async_toy import ToyMessage
 
@@ -96,7 +98,6 @@ def test_single_threaded_synchronous_comms():
 
     # Create a potential deadlock
     alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
-
     bob.actions = [ToyAction("compute", dependencies=["alice0"]), ToyAction("send", "alice")]
 
     # Take turns executing synchronously
@@ -123,7 +124,6 @@ async def test_single_threaded_async_comms():
 
     # Create a potential deadlock
     alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
-
     bob.actions = [ToyAction("compute", dependencies=["alice0"]), ToyAction("send", "alice")]
 
     # Take turns executing asynchronously
@@ -150,12 +150,61 @@ async def test_single_threaded_async_comms_concurrent():
 
     # Create a potential deadlock
     alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
-
     bob.actions = [ToyAction("compute", dependencies=["alice0"]), ToyAction("send", "alice")]
 
     # Execute asynchronously AND concurrently
     while not (alice.finished and bob.finished):
         await asyncio.gather(alice.execute(), bob.execute())
+
+    assert len(alice.executed) == 3
+    assert len(bob.executed) == 3
+
+    assert bob.store["alice0"] is True
+    assert bob.store["bob1"] is True
+    assert alice.store["bob2"] is True
+    assert alice.store["alice3"] is True
+
+
+# The first set of parameters should pass, because the blocking communication methods will wait for
+# 1 second before timing out, and the whole execution is 10 seconds long, leaving plenty of time for
+# retries after timeouts happen.
+
+# The second set of parameters should fail, because the blocking communication methods will wait for
+# 10 seconds before timing out, and the whole execution is only 5 seconds long, creating a deadlock
+# that doesn't resolve before the execution is terminated. (If there were no timeouts, this would
+# block forever and the test would hang instead of failing.
+
+
+@pytest.mark.parametrize("timeout,ratio", [(1, 10), (10, 0.5)])
+def test_multi_threaded_parallel_synchronous_comms(timeout, ratio):
+    ToyWorker.reset_counter()
+
+    alice = ThreadedSynchronousWorker(name="alice")
+    bob = ThreadedSynchronousWorker(name="bob")
+    ThreadedSynchronousWorker.introduce(alice, bob)
+
+    # Create a potential deadlock
+    alice.actions = [ToyAction("send", "bob"), ToyAction("compute", dependencies=["bob2"])]
+    bob.actions = [ToyAction("compute", dependencies=["alice0"]), ToyAction("send", "alice")]
+
+    # Run each worker in a thread
+    def run_until_finished(worker, stop_event, timeout):
+        while not (worker.finished or stop_event.is_set()):
+            worker.execute(timeout)
+
+    stop_event = threading.Event()
+
+    alice_thread = threading.Thread(target=run_until_finished, args=(alice, stop_event, timeout))
+    bob_thread = threading.Thread(target=run_until_finished, args=(bob, stop_event, timeout))
+
+    alice_thread.start()
+    bob_thread.start()
+
+    # Wait for the threads to finish
+    alice_thread.join(timeout=timeout * ratio)
+    bob_thread.join(timeout=timeout * ratio)
+
+    stop_event.set()
 
     assert len(alice.executed) == 3
     assert len(bob.executed) == 3


### PR DESCRIPTION
## Description

This experimental code demonstrates running multiple workers simultaneously in a single thread with `asyncio`, and shows how remote execution primitives (along the lines of `Plans/Protocols`) necessarily become `async`-aware if they contain `async` cross-worker communication methods.

## Checklist:
* [X] My changes are covered by tests.
* [X] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
* [X] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).