### PR TITLE
Remove test_spinup_time

### DIFF
--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -225,19 +225,6 @@ def test_get_not_permitted(workers):
         mock_allowed_to_get.assert_called_once()
 
 
-def test_spinup_time(hook):
-    """Tests to ensure that virtual workers intialized with 10000 data points
-    load in under 1 seconds. This is needed to ensure that virtual workers
-    spun up inside web frameworks are created quickly enough to not cause timeout errors"""
-    data = []
-    for i in range(10000):
-        data.append(torch.Tensor(5, 5).random_(100))
-    start_time = time()
-    dummy = sy.VirtualWorker(hook, id="dummy", data=data)
-    end_time = time()
-    assert (end_time - start_time) < 1
-
-
 def test_send_jit_scriptmodule(hook, workers):  # pragma: no cover
     bob = workers["bob"]
 


### PR DESCRIPTION
## Description
Time based tests are inherently flaky based off of hardware. The original idea
of this test was to make sure that virtual workers were created quickly since
we were concerned about virtual workers taking too long to be created (since
data had to be copied) and wanted to make sure that we didn't regress to a point
where they were so slow that they caused timeout errors. The timings and amount
of data used to test were arbitrary. By removing this test we can reduce test
flakiness and add allow for more freedom to add something similar back when the
requirements are better understood.


Resolves #3503 


## Checklist:
* [x] My changes are covered by tests.
(This change deletes a test so i guess?)
* [x] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
Actually completely forgot to set these up since I wrote this pr on a fresh fork. That being said, the change I made should not break formatting so I'm not going to go back and rerun them
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

(See the [the contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md) for additional tips.)
