### PR TITLE
requirements.txt updated with tornado compatible notebook version

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -16,3 +16,4 @@ torch~=1.4.0
 tornado==4.5.3
 websocket_client~=0.57.0
 websockets~=8.1.0
+notebook==5.7.8


### PR DESCRIPTION
## Description

Thank you for your contribution to the PySyft repository.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
There was a version conflict with the installation of jupyter notebook with tornado version.
In order to overcome the problem, the requirements.txt is updated with a notebook <6 version so that it is compatible tornado version <5
If your pull request closes a GitHub issue, then set its number below.

Resolves # (issue)
3546

## Checklist:
* [x] My changes are covered by tests.
* [x] I have run [the pre-commit hooks](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md#setting-up-pre-commit-hook) to format and check my code for style issues.
* [x] I have commented my code following [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

(See the [the contribution guidelines](https://github.com/OpenMined/PySyft/blob/master/CONTRIBUTING.md) for additional tips.)
