### PR TITLE
Register the `translation` mark with PyTest to suppress warnings

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,12 @@ from syft.workers.websocket_client import WebsocketClientWorker
 from syft.workers.websocket_server import WebsocketServerWorker
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "translation: mark test to run only as part of the translation test suite"
+    )
+
+
 def pytest_sessionstart(session):
     session.failed_tests = set()
 
@@ -27,7 +33,7 @@ def pytest_runtest_makereport(item, call):  # pragma: no cover
 
 def pytest_runtest_setup(item):  # pragma: no cover
     if item.originalname in item.session.failed_tests:
-        pytest.skip("previous test failed (%s)" % item.name)
+        pytest.skip(f"previous test failed ({item.name})")
 
 
 def _start_proc(participant, dataset: str = None, **kwargs):  # pragma: no cover


### PR DESCRIPTION


# Pull Request

## Description
This mark is used in the test suite to designate tests that should only
run during the translation tests and not as part of the regular notebook
tests. It works fine now, but results in warnings from PyTest at the end
of the test suite output about an unregistered mark. This change makes
the warnings go away, but otherwise doesn't change anything about the
functionality of the test suite.

## Type of Change
Please mark options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes
