### PR TITLE
Remove the hook from Crypten MPC Tensor

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -141,7 +141,6 @@ class TorchHook(FrameworkHook):
 
         if dependency_check.crypten_available:
             self.to_auto_overload[crypten.mpc.MPCTensor] = ["get_plain_text"]
-            self._hook_native_tensor(crypten.mpc.MPCTensor, TorchTensor)
             self._hook_syft_placeholder_methods(crypten.mpc.MPCTensor, PlaceHolder)
 
         # Add all hooked tensor methods to pointer but change behaviour to have the cmd sent

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -30,8 +30,8 @@ def test_add_crypten_support(workers):
 
 
 def test_context(workers):
-    # self, alice and bob
-    n_workers = 3
+    # alice and bob
+    n_workers = 2
 
     alice = workers["alice"]
     bob = workers["bob"]
@@ -45,8 +45,8 @@ def test_context(workers):
     @run_multiworkers([alice, bob], master_addr="127.0.0.1")
     @sy.func2plan()
     def plan_func(crypten=crypten):
-        alice_tensor = crypten.load("crypten_data", 1)
-        bob_tensor = crypten.load("crypten_data", 2)
+        alice_tensor = crypten.load("crypten_data", 0)
+        bob_tensor = crypten.load("crypten_data", 1)
 
         crypt = alice_tensor + bob_tensor
         result = crypt.get_plain_text()


### PR DESCRIPTION
# Pull Request

## Description
Remove the hooking for the MPCTensor since currently the PlaceHolder class is used to track the operations on an MPCTensor (in a plan)

## Affected Dependencies
List any dependencies that are required for this change.

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have added tests for my changes

## Additional Context
Please also include relevant motivation and context.
