### PR TITLE
Add utilities for hooking and chaining methods calls along tensor chains

### DIFF
--- a/syft/generic/abstract/hookable.py
+++ b/syft/generic/abstract/hookable.py
@@ -1,0 +1,32 @@
+from functools import wraps
+
+
+def chain_call(obj, method_name, *args, **kwargs):
+    results = []
+    current = obj
+    while current is not None:
+        method = getattr(current, method_name, None)
+        if method:
+            results.append(method(*args, **kwargs))
+        current = current.child
+    return results
+
+
+def hookable(hookable_method):
+    """Decorator which checks for corresponding hooks and calls them if they exist
+
+    When this decorator is applied to a method, it checks for the existence of `_before_method()`
+    and `_after_method()` hooks, and calls them before/after the correspdoning method if they do.
+
+    This function should be used only as a decorator.
+    """
+    method_name = hookable_method.__name__
+
+    @wraps(hookable_method)
+    def hooked_method(self, *args, **kwargs):
+        chain_call(self, f"_before_{method_name}", *args, **kwargs)
+        return_val = hookable_method(self, *args, **kwargs)
+        chain_call(self, f"_after_{method_name}", *args, **kwargs)
+        return return_val
+
+    return hooked_method

--- a/test/generic/test_hookable.py
+++ b/test/generic/test_hookable.py
@@ -1,0 +1,45 @@
+from syft.generic.abstract.hookable import chain_call
+from syft.generic.abstract.hookable import hookable
+
+
+def test_chain_call():
+    class Chainable:
+        def __init__(self, value):
+            self.child = None
+            self.value = value
+
+        def chainable(self):
+            return self.value
+
+    c1 = Chainable(1)
+    c1.child = Chainable(2)
+    c1.child.child = Chainable(3)
+
+    return_val = chain_call(c1, "chainable")
+
+    assert return_val == [1, 2, 3]
+
+
+def test_hookable():
+    class Hookable:
+        def __init__(self):
+            self.child = None
+            self.flags = {}
+
+        def _before_set_flag(self, flag):
+            self.flags[f"before_{flag}"] = True
+
+        @hookable
+        def set_flag(self, flag):
+            self.flags[flag] = True
+
+        def _after_set_flag(self, flag):
+            self.flags[f"after_{flag}"] = True
+
+    h = Hookable()
+
+    h.set_flag("flag")
+
+    assert h.flags["flag"] is True
+    assert h.flags["before_flag"] is True
+    assert h.flags["after_flag"] is True


### PR DESCRIPTION
## Description

Adds utilities for inserting optional `_before_method()`/`_after_method()` hooks on a method decorated with `@hookable`, which allows custom tensor types to insert any functionality they individually require before or after a generic tensor method like `send`. This should help clean up the copious `if isinstance(self, TensorClass)` code in `AbstractTensor` and beyond.

In order to make sure that all custom functionality for types in the tensor chain gets called, this also creates a `chain_call()` function, which accepts a method name with args/kwargs, and calls that method (if it exists) on every tensor in the chain from outermost to innermost, returning the results in an ordered list.

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have added tests for my changes