### PR TITLE
Move permissions from `TorchTensor.send()` to `PrivateTensor._before_send()` hook

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -18,7 +18,6 @@ from syft.workers.base import BaseWorker
 
 from syft.exceptions import PureFrameworkTensorFoundError
 from syft.exceptions import InvalidTensorForRemoteGet
-from syft.exceptions import SendNotPermittedError
 
 
 def _get_maximum_precision():
@@ -454,9 +453,6 @@ class TorchTensor(AbstractTensor):
         Raises:
                 SendNotPermittedError: Raised if send is not permitted on this tensor.
         """
-
-        if not self.allow(user=user):
-            raise SendNotPermittedError()
 
         # If you send a pointer p1, you want the pointer to pointer p2 to control
         # the garbage collection and not the remaining old p1 (here self). Because if

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -11,6 +11,7 @@ from syft.frameworks.torch.tensors.interpreters.paillier import PaillierTensor
 from syft.messaging.message import TensorCommandMessage
 from syft.generic.frameworks.types import FrameworkTensor
 from syft.generic.abstract.tensor import AbstractTensor
+from syft.generic.abstract.hookable import hookable
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.generic.utils import memorize
 from syft.workers.base import BaseWorker
@@ -413,6 +414,7 @@ class TorchTensor(AbstractTensor):
             cmd = cmd.replace("_C._nn", "nn.functional")
         return cmd
 
+    @hookable
     def send(
         self,
         *location,

--- a/syft/frameworks/torch/tensors/interpreters/private.py
+++ b/syft/frameworks/torch/tensors/interpreters/private.py
@@ -3,12 +3,11 @@ import syft
 
 from typing import List, Tuple
 
+from syft.exceptions import SendNotPermittedError
+from syft.generic.abstract.tensor import AbstractTensor
 from syft.generic.frameworks.hook import hook_args
 from syft.generic.frameworks.overload import overloaded
-
-
 from syft.workers.abstract import AbstractWorker
-from syft.generic.abstract.tensor import AbstractTensor
 
 
 class PrivateTensor(AbstractTensor):
@@ -60,6 +59,10 @@ class PrivateTensor(AbstractTensor):
             bool : A boolean value (True if the user is allowed and false if it isn't).
         """
         return user in self.allowed_users
+
+    def _before_send(self, *location, user: object = None, **kwargs):
+        if not self.allow(user):
+            raise SendNotPermittedError()
 
     def register_credentials(self, users: List[str]) -> "PrivateTensor":
         """ Register a new user credential(s) into the list of allowed users to get this tensor.

--- a/syft/generic/abstract/hookable.py
+++ b/syft/generic/abstract/hookable.py
@@ -8,7 +8,7 @@ def chain_call(obj, method_name, *args, **kwargs):
         method = getattr(current, method_name, None)
         if method:
             results.append(method(*args, **kwargs))
-        current = current.child
+        current = getattr(current, "child", None)
     return results
 
 


### PR DESCRIPTION
## Description
This extracts permission checking into a `_before_send()` hook on the relevant class (`PrivateTensor`), so that `TorchTensor` doesn't have to know as much about the functionality of custom types. This is the first of many similar refactors to move knowledge of custom tensor types out of `TorchTensor`.

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have added tests for my changes

