### PR TITLE
Update notebook/tornado versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ work from the command line.
 ```bash
 conda create -n pysyft python=3.7
 conda activate pysyft # some older version of conda require "source activate pysyft" instead.
-conda install jupyter notebook
+conda install jupyter notebook==5.7.8 tornado==4.5.3
 ```
 **Note:** Use Python 3.6-3.7. Tensorflow does not support Python 3.8 hence it might lead to installation errors.
 


### PR DESCRIPTION
# Pull Request
Fixes #3508.

## Description
When you install the ```jupyter notebook``` it will install the latest version, but there are some issues regarding this that are detailed [here](https://github.com/jupyter/notebook/issues/3397)

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Check the #3508 and validate that the notebook can be seen.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes

## Additional Context
This PR should solve the problem with the notebooks.