### PR TITLE
Move comms methods upstream from `TorchTensor` into abstract classes

### DIFF
--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -1,7 +1,8 @@
 import syft as sy
 
-from syft.serde.syft_serializable import SyftSerializable
 from syft.generic.abstract.object import AbstractObject
+from syft.serde.syft_serializable import SyftSerializable
+from syft.workers.abstract import AbstractWorker
 
 
 class AbstractSendable(AbstractObject, SyftSerializable):
@@ -28,6 +29,34 @@ class AbstractSendable(AbstractObject, SyftSerializable):
     def ser(self, *args, **kwargs):
         return self.serialize(*args, **kwargs)
 
+    def create_pointer(
+        self,
+        location: AbstractWorker = None,
+        id_at_location: (str or int) = None,
+        owner: AbstractWorker = None,
+        ptr_id: (str or int) = None,
+        garbage_collect_data: bool = True,
+        shape=None,
+        **kwargs,
+    ):
+        pass
+
+    def send(
+        self,
+        *location,
+        inplace: bool = False,
+        user: object = None,
+        local_autograd: bool = False,
+        requires_grad: bool = False,
+        preinitialize_grad: bool = False,
+        no_wrap: bool = False,
+        garbage_collect_data: bool = True,
+    ):
+        pass
+
+    def send_(self, *location, **kwargs):
+        pass
+
     def get(self):
         """Just a pass through. This is most commonly used when calling .get() on a
         Syft tensor which has a child which is a pointer, an additive shared tensor,
@@ -41,10 +70,27 @@ class AbstractSendable(AbstractObject, SyftSerializable):
             id=self.id,
         ).on(self.child.get())
 
+    def get_(self, *args, **kwargs):
+        pass
+
     def mid_get(self):
         """This method calls .get() on a child pointer and correctly registers the results"""
-
         child_id = self.id
         tensor = self.get()
         tensor.id = child_id
         self.owner.register_obj(tensor)
+
+    def remote_get(self):
+        pass
+
+    def allow(self, user=None) -> bool:
+        pass
+
+    def move(self, location: AbstractWorker):
+        pass
+
+    def move_(self, location: AbstractWorker):
+        pass
+
+    def remote_send(self, location):
+        pass

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+
 import syft as sy
 
 from syft.generic.abstract.object import AbstractObject
@@ -54,6 +56,7 @@ class AbstractSendable(AbstractObject, SyftSerializable):
     ):
         pass
 
+    @abstractmethod
     def send_(self, *location, **kwargs):
         pass
 
@@ -70,6 +73,7 @@ class AbstractSendable(AbstractObject, SyftSerializable):
             id=self.id,
         ).on(self.child.get())
 
+    @abstractmethod
     def get_(self, *args, **kwargs):
         pass
 
@@ -83,14 +87,17 @@ class AbstractSendable(AbstractObject, SyftSerializable):
     def remote_get(self):
         pass
 
+    @abstractmethod
     def allow(self, user=None) -> bool:
         pass
 
     def move(self, location: AbstractWorker):
         pass
 
+    @abstractmethod
     def move_(self, location: AbstractWorker):
         pass
 
-    def remote_send(self, location):
+    @abstractmethod
+    def remote_send(self, location: AbstractWorker):
         pass


### PR DESCRIPTION
## Description
Another step along the road of providing consistent communication methods to all objects and tensors. (See also #3643.)

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] My changes are covered by tests