### PR TITLE
Improve `@hookable` decorator to allow modifying return values after

### DIFF
--- a/syft/generic/abstract/hookable.py
+++ b/syft/generic/abstract/hookable.py
@@ -1,7 +1,8 @@
 from functools import wraps
 
 
-def chain_call(obj, method_name, *args, **kwargs):
+def map_chain_call(obj, method_name, *args, **kwargs):
+    """Calls each hook method in sequence and creates a list of the return values"""
     results = []
     current = obj
     while current is not None:
@@ -10,6 +11,18 @@ def chain_call(obj, method_name, *args, **kwargs):
             results.append(method(*args, **kwargs))
         current = getattr(current, "child", None)
     return results
+
+
+def reduce_chain_call(obj, method_name, initial_val, *args, **kwargs):
+    """Calls each hook method in sequence, passing return values from one to the next"""
+    result = initial_val
+    current = obj
+    while current is not None:
+        method = getattr(current, method_name, None)
+        if method:
+            result = method(result, *args, **kwargs)
+        current = getattr(current, "child", None)
+    return result
 
 
 def hookable(hookable_method):
@@ -24,9 +37,9 @@ def hookable(hookable_method):
 
     @wraps(hookable_method)
     def hooked_method(self, *args, **kwargs):
-        chain_call(self, f"_before_{method_name}", *args, **kwargs)
+        map_chain_call(self, f"_before_{method_name}", *args, **kwargs)
         return_val = hookable_method(self, *args, **kwargs)
-        chain_call(self, f"_after_{method_name}", *args, **kwargs)
+        return_val = reduce_chain_call(self, f"_after_{method_name}", return_val, *args, **kwargs)
         return return_val
 
     return hooked_method

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -12,7 +12,7 @@ from syft.frameworks.torch.mpc.primitives import PrimitiveStorage
 from syft.execution.computation import ComputationAction
 from syft.execution.communication import CommunicationAction
 
-from syft.generic.abstract.hookable import chain_call
+from syft.generic.abstract.hookable import map_chain_call
 from syft.generic.abstract.tensor import AbstractTensor
 from syft.generic.frameworks.hook import hook_args
 from syft.generic.frameworks.remote import Remote
@@ -679,7 +679,7 @@ class BaseWorker(AbstractWorker):
 
         obj = self.get_obj(obj_id)
 
-        permitted = all(chain_call(obj, "allow", user=user))
+        permitted = all(map_chain_call(obj, "allow", user=user))
         if not permitted:
             raise GetNotPermittedError()
         else:

--- a/test/generic/test_hookable.py
+++ b/test/generic/test_hookable.py
@@ -1,26 +1,45 @@
-from syft.generic.abstract.hookable import chain_call
+from syft.generic.abstract.hookable import map_chain_call
+from syft.generic.abstract.hookable import reduce_chain_call
 from syft.generic.abstract.hookable import hookable
 
 
-def test_chain_call():
-    class Chainable:
+def test_reduce_chain_call():
+    class Reduceable:
         def __init__(self, value):
             self.child = None
             self.value = value
 
-        def chainable(self):
+        def reduceable(self, value):
+            return value + self.value
+
+    c1 = Reduceable(1)
+    c1.child = Reduceable(2)
+    c1.child.child = Reduceable(3)
+
+    return_val = reduce_chain_call(c1, "reduceable", 0)
+
+    assert return_val == 6
+
+
+def test_map_chain_call():
+    class Mappable:
+        def __init__(self, value):
+            self.child = None
+            self.value = value
+
+        def mappable(self):
             return self.value
 
-    c1 = Chainable(1)
-    c1.child = Chainable(2)
-    c1.child.child = Chainable(3)
+    c1 = Mappable(1)
+    c1.child = Mappable(2)
+    c1.child.child = Mappable(3)
 
-    return_val = chain_call(c1, "chainable")
+    return_val = map_chain_call(c1, "mappable")
 
     assert return_val == [1, 2, 3]
 
 
-def test_hookable():
+def test_hooks_get_called():
     class Hookable:
         def __init__(self):
             self.child = None
@@ -33,7 +52,7 @@ def test_hookable():
         def set_flag(self, flag):
             self.flags[flag] = True
 
-        def _after_set_flag(self, flag):
+        def _after_set_flag(self, obj, flag):
             self.flags[f"after_{flag}"] = True
 
     h = Hookable()
@@ -43,3 +62,28 @@ def test_hookable():
     assert h.flags["flag"] is True
     assert h.flags["before_flag"] is True
     assert h.flags["after_flag"] is True
+
+
+def test_hooks_propagate_return_val():
+    class Alterable:
+        def __init__(self, value, after):
+            self.child = None
+            self.value = value
+            self.after = after
+
+        @hookable
+        def get_value(self):
+            return self.value
+
+        def _after_get_value(self, return_val):
+            # Merge dictionaries
+            return_val = {**return_val, **self.after}
+            return return_val
+
+    a = Alterable({"a": 1}, {"after_a": 1})
+    a.child = Alterable({"b": 2}, {"after_b": 2})
+    a.child.child = Alterable({"c": 3}, {"after_c": 3})
+
+    result = a.get_value()
+
+    assert result == {"a": 1, "after_a": 1, "after_b": 2, "after_c": 3}


### PR DESCRIPTION
## Description
This renames `chain_call` to `map_chain_call` and introduces a method
called `reduce_chain_call`. `map_chain_call` still gathers the values
returned from each hook method that's called on a tensor chain, resulting
in a list of values. `reduce_chain_call` passes the output value from
each hook method into the next one, resulting in a single value.

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have added tests for my changes
