### PR TITLE
Update `syft-proto` to 0.4.7

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -9,7 +9,7 @@ Pillow~=6.2.2
 psutil==5.7.0
 requests~=2.22.0
 scipy~=1.4.1
-git+https://github.com/tudorcebere/syft-proto.git@arg_fix
+syft-proto==0.4.7
 tblib~=1.6.0
 torchvision~=0.5.0
 torch~=1.4.0


### PR DESCRIPTION
## Description
Update to pull in Protobuf support for `BaseDataset`, `FixedPrecisionTensor`, and a fix for integer `Action` arguments.

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes