### PR TITLE
Add iterable behavior for PointerTensor

### DIFF
--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -216,7 +216,7 @@ def hook_response(attr, response, wrap_type, wrap_args={}, new_self=None):
     """
 
     # inline methods should just return new_self
-    if "__i" == attr[0:3]:
+    if "__i" == attr[0:3] and attr != "__iter__":
         return new_self
 
     # TODO: Why do we need to cast it in a tuple? this is a (small) time waste

--- a/syft/generic/object_storage.py
+++ b/syft/generic/object_storage.py
@@ -161,3 +161,9 @@ class ObjectStore:
 
         for tag in obj.tags:
             self._tag_to_object_ids[tag].add(obj.id)
+
+    def __len__(self):
+        """
+        Return the number of objects in the store
+        """
+        return len(self._objects)

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -407,6 +407,9 @@ class PointerTensor(ObjectPointer, AbstractTensor):
     def __eq__(self, other):
         return self.eq(other)
 
+    def __iter__(self):
+        return (self[idx] for idx in range(self.shape[0]))
+
     @staticmethod
     def simplify(worker: AbstractWorker, ptr: "PointerTensor") -> tuple:
         """


### PR DESCRIPTION
# Pull Request
Fixes #3543

## Description
Add the possibility to do:
```
for tensor in ptr:
     print(tensor) # should return a new pointer tensor
```

## Affected Dependencies
List any dependencies that are required for this change.

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Test if the number of tensors alice has 
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have added tests for my changes

## Additional Context
Add a new method to the storage object such that we can call ```len(alice.object_store``` and will return the number of objects from the worker.
