### PR TITLE
Clean up `AbstractSendable` to remove extraneous methods

### DIFF
--- a/examples/experimental/Federated Learning Experiment/FL Experiment.ipynb
+++ b/examples/experimental/Federated Learning Experiment/FL Experiment.ipynb
@@ -211,7 +211,7 @@
    "source": [
     "data = th.ones(4,2)\n",
     "ptr = data.create_pointer()\n",
-    "ptr = ptr.ser()"
+    "ptr = sy.serde.serialize(ptr)"
    ]
   },
   {

--- a/examples/experimental/Federated Learning Experiment/server.py
+++ b/examples/experimental/Federated Learning Experiment/server.py
@@ -17,7 +17,8 @@ def get_model():
     global model
     global ptr
     ptr = model.create_pointer()
-    return model.ser()
+
+    return sy.serde.serialize(model)
 
 
 @app.route("/send_data", methods=["POST"])
@@ -25,4 +26,4 @@ def send_data():
     global ptr
     ptr = sy.serde.deserialize(request.data)
 
-    return model.ser()
+    return sy.serde.serialize(model)

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -9,6 +9,9 @@ class AbstractSendable(AbstractObject, SyftSerializable):
     This layers functionality for sending objects between workers on top of AbstractObject.
     """
 
+    def send(self, destination):
+        return self.owner.send_obj(self, destination)
+
     def serialize(self):  # check serde.py to see how to provide compression schemes
         """Serializes the tensor on which it's called.
 

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -1,5 +1,3 @@
-import syft as sy
-
 from syft.serde.syft_serializable import SyftSerializable
 from syft.generic.abstract.object import AbstractObject
 
@@ -11,25 +9,6 @@ class AbstractSendable(AbstractObject, SyftSerializable):
 
     def send(self, destination):
         return self.owner.send_obj(self, destination)
-
-    def serialize(self):  # check serde.py to see how to provide compression schemes
-        """Serializes the tensor on which it's called.
-
-        This is the high level convenience function for serializing torch
-        tensors. It includes three steps, Simplify, Serialize, and Compress as
-        described in serde.py.
-        By default serde is compressing using LZ4
-
-        Returns:
-            The serialized form of the tensor.
-            For example:
-                x = torch.Tensor([1,2,3,4,5])
-                x.serialize() # returns a serialized object
-        """
-        return sy.serde.serialize(self)
-
-    def ser(self, *args, **kwargs):
-        return self.serialize(*args, **kwargs)
 
     def get(self):
         """Just a pass through. This is most commonly used when calling .get() on a

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -9,24 +9,3 @@ class AbstractSendable(AbstractObject, SyftSerializable):
 
     def send(self, destination):
         return self.owner.send_obj(self, destination)
-
-    def get(self):
-        """Just a pass through. This is most commonly used when calling .get() on a
-        Syft tensor which has a child which is a pointer, an additive shared tensor,
-        a multi-pointer, etc."""
-        class_attributes = self.get_class_attributes()
-        return type(self)(
-            **class_attributes,
-            owner=self.owner,
-            tags=self.tags,
-            description=self.description,
-            id=self.id,
-        ).on(self.child.get())
-
-    def mid_get(self):
-        """This method calls .get() on a child pointer and correctly registers the results"""
-
-        child_id = self.id
-        tensor = self.get()
-        tensor.id = child_id
-        self.owner.register_obj(tensor)

--- a/syft/generic/abstract/tensor.py
+++ b/syft/generic/abstract/tensor.py
@@ -126,6 +126,27 @@ class AbstractTensor(AbstractSendable, SyftSerializable):
         else:
             return child_grad.wrap()
 
+    def get(self):
+        """Just a pass through. This is most commonly used when calling .get() on a
+        Syft tensor which has a child which is a pointer, an additive shared tensor,
+        a multi-pointer, etc."""
+        class_attributes = self.get_class_attributes()
+        return type(self)(
+            **class_attributes,
+            owner=self.owner,
+            tags=self.tags,
+            description=self.description,
+            id=self.id,
+        ).on(self.child.get())
+
+    def mid_get(self):
+        """This method calls .get() on a child pointer and correctly registers the results"""
+
+        child_id = self.id
+        tensor = self.get()
+        tensor.id = child_id
+        self.owner.register_obj(tensor)
+
 
 def initialize_tensor(hook, obj, owner=None, id=None, init_args=(), init_kwargs={}):
     """Initializes the tensor.

--- a/test/serde/msgpack/test_msgpack_serde.py
+++ b/test/serde/msgpack/test_msgpack_serde.py
@@ -359,25 +359,6 @@ def test_torch_Tensor(compress):
 
 
 @pytest.mark.parametrize("compress", [True, False])
-def test_torch_Tensor_convenience(compress):
-    """This test evaluates torch.Tensor.serialize()
-
-    As opposed to using syft.serde.serialize(), torch objects
-    have a convenience function which lets you call .serialize()
-    directly on the tensor itself. This tests to makes sure it
-    works correctly."""
-    if compress:
-        compression._apply_compress_scheme = compression.apply_lz4_compression
-    else:
-        compression._apply_compress_scheme = compression.apply_no_compression
-
-    t = Tensor(numpy.random.random((100, 100)))
-    t_serialized = t.serialize()
-    t_serialized_deserialized = syft.serde.deserialize(t_serialized)
-    assert (t == t_serialized_deserialized).all()
-
-
-@pytest.mark.parametrize("compress", [True, False])
 def test_tuple(compress):
     # Test with a simple datatype
     if compress:


### PR DESCRIPTION
## Description
This removes a few rarely used serialization methods and moves some methods that turn out to only make sense on tensors into `AbstractTensor`.

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes
