### PR TITLE
Convert all `create_pointer()` methods to instance methods

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -447,8 +447,8 @@ class TorchTensor(AbstractTensor):
             garbage_collect_data: argument passed down to create_pointer()
 
         Returns:
-            A PointerTensor pointer to self. Note that this
-            object will likely be wrapped by a torch.Tensor wrapper.
+            A PointerTensor pointer to self. Note that this object will likely
+            be wrapped a torch.Tensor wrapper.
 
         Raises:
                 SendNotPermittedError: Raised if send is not permitted on this tensor.

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -593,6 +593,14 @@ class TorchTensor(AbstractTensor):
         if shape is None:
             shape = self.shape
 
+        # ptr = syft.PointerTensor(
+        #     location=location,
+        #     id_at_location=id_at_location,
+        #     owner=owner,
+        #     id=ptr_id,
+        #     garbage_collect_data=garbage_collect_data,
+        #     shape=shape)
+
         ptr = syft.PointerTensor.create_pointer(
             self, location, id_at_location, owner, ptr_id, garbage_collect_data, shape
         )

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -447,7 +447,7 @@ class TorchTensor(AbstractTensor):
             garbage_collect_data: argument passed down to create_pointer()
 
         Returns:
-            A torch.Tensor[PointerTensor] pointer to self. Note that this
+            A PointerTensor pointer to self. Note that this
             object will likely be wrapped by a torch.Tensor wrapper.
 
         Raises:

--- a/syft/generic/abstract/pointer.py
+++ b/syft/generic/abstract/pointer.py
@@ -2,8 +2,8 @@ from abc import abstractmethod
 from typing import List
 from typing import Union
 
-from syft.generic.abstract.sendable import AbstractSendable
 from syft.serde.syft_serializable import SyftSerializable
+from syft.generic.abstract.sendable import AbstractSendable
 from syft.workers.abstract import AbstractWorker
 
 

--- a/syft/generic/abstract/pointer.py
+++ b/syft/generic/abstract/pointer.py
@@ -1,0 +1,62 @@
+from abc import abstractmethod
+from typing import List
+from typing import Union
+
+from syft.generic.abstract.sendable import AbstractSendable
+from syft.serde.syft_serializable import SyftSerializable
+from syft.workers.abstract import AbstractWorker
+
+
+class AbstractPointer(AbstractSendable, SyftSerializable):
+    """A pointer to a remote object."""
+
+    def __init__(
+        self,
+        location: AbstractWorker = None,
+        id_at_location: Union[str, int] = None,
+        owner: AbstractWorker = None,
+        id: Union[str, int] = None,
+        garbage_collect_data: bool = True,
+        point_to_attr: str = None,
+        tags: List[str] = None,
+        description: str = None,
+    ):
+        """Initializes a pointer
+
+        Args:
+            location: An optional AbstractWorker object which points to the worker
+                on which this pointer's object can be found.
+            id_at_location: An optional string or integer id of the object
+                being pointed to.
+            owner: An optional AbstractWorker object to specify the worker on which
+                the pointer is located. It is also where the pointer is
+                registered if register is set to True. Note that this is
+                different from the location parameter that specifies where the
+                pointer points to.
+            id: An optional string or integer id of the pointer.
+            garbage_collect_data: If true (default), delete the remote object when the
+                pointer is deleted.
+            point_to_attr: string which can tell a pointer to not point directly to\
+                an object, but to point to an attribute of that object such as .child or
+                .grad. Note the string can be a chain (i.e., .child.child.child or
+                .grad.child.child). Defaults to None, which means don't point to any attr,
+                just point to then object corresponding to the id_at_location.
+        """
+        super().__init__(id=id, owner=owner, tags=tags, description=description)
+
+        self.location = location
+        self.id_at_location = id_at_location
+        self.garbage_collect_data = garbage_collect_data
+        self.point_to_attr = point_to_attr
+
+    @abstractmethod
+    def get(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def attr(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def setattr(self, *args, **kwargs):
+        pass

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -53,4 +53,4 @@ class AbstractSendable(AbstractObject, SyftSerializable):
         garbage_collect_data: bool = True,
         **kwargs,
     ) -> "AbstractPointer":
-        pass
+        raise NotImplementedError

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -1,5 +1,17 @@
+# from abc import abstractmethod
+from typing import TYPE_CHECKING
+from typing import Union
+
+import syft as sy
 from syft.serde.syft_serializable import SyftSerializable
 from syft.generic.abstract.object import AbstractObject
+
+# from syft.generic.abstract.pointer import AbstractPointer
+from syft.workers.abstract import AbstractWorker
+
+# this if statement avoids circular imports between base.py and pointer.py
+if TYPE_CHECKING:
+    from syft.generic.abstract.pointer import AbstractPointer
 
 
 class AbstractSendable(AbstractObject, SyftSerializable):
@@ -7,5 +19,38 @@ class AbstractSendable(AbstractObject, SyftSerializable):
     This layers functionality for sending objects between workers on top of AbstractObject.
     """
 
-    def send(self, destination):
-        return self.owner.send_obj(self, destination)
+    def send(
+        self, destination: Union[AbstractWorker, str], garbage_collect_data=None
+    ) -> "AbstractPointer":
+        ptr_id = sy.ID_PROVIDER.pop()
+
+        destination = self.owner.get_worker(destination)
+
+        pointer = self.create_pointer(
+            location=destination,
+            id_at_location=self.id,
+            owner=self.owner,
+            ptr_id=ptr_id,
+            garbage_collect_data=garbage_collect_data,
+        )
+
+        self.owner.send_obj(self, destination)
+
+        return pointer
+
+    # TODO: Make the `create_pointer` method below an abstract method. We can't do this yet, because
+    # we're relying on the wrapper tensors to provide the functionality of creating pointers, which
+    # means that many of the custom tensor types don't yet have pointer types or ways to create
+    # pointers.
+
+    # @abstractmethod
+    def create_pointer(
+        self,
+        location: AbstractWorker = None,
+        id_at_location: (str or int) = None,
+        owner: AbstractWorker = None,
+        ptr_id: (str or int) = None,
+        garbage_collect_data: bool = True,
+        **kwargs,
+    ) -> "AbstractPointer":
+        pass

--- a/syft/generic/pointers/object_pointer.py
+++ b/syft/generic/pointers/object_pointer.py
@@ -1,5 +1,3 @@
-from typing import List
-from typing import Union
 from typing import TYPE_CHECKING
 import weakref
 
@@ -11,20 +9,18 @@ from syft.generic.frameworks.hook.hook_args import register_forward_func
 from syft.generic.frameworks.hook.hook_args import register_backward_func
 from syft.generic.frameworks.hook import hook_args
 from syft.generic.frameworks.types import FrameworkTensor
-from syft.generic.abstract.sendable import AbstractSendable
+from syft.generic.abstract.pointer import AbstractPointer
 from syft.messaging.message import ForceObjectDeleteMessage
 from syft.workers.abstract import AbstractWorker
 
 from syft.exceptions import RemoteObjectFoundError
-from syft.serde.syft_serializable import SyftSerializable
 
 # this if statement avoids circular imports between base.py and pointer.py
 if TYPE_CHECKING:
     from syft.workers.abstract import AbstractWorker
-    from syft.workers.base import BaseWorker
 
 
-class ObjectPointer(AbstractSendable, SyftSerializable):
+class ObjectPointer(AbstractPointer):
     """A pointer to a remote object.
 
     An ObjectPointer forwards all API calls to the remote. ObjectPointer objects
@@ -40,45 +36,6 @@ class ObjectPointer(AbstractSendable, SyftSerializable):
     socket, http, or some other protocol) as that functionality is abstracted
     in the BaseWorker object in self.location.
     """
-
-    def __init__(
-        self,
-        location: "BaseWorker" = None,
-        id_at_location: Union[str, int] = None,
-        owner: "BaseWorker" = None,
-        id: Union[str, int] = None,
-        garbage_collect_data: bool = True,
-        point_to_attr: str = None,
-        tags: List[str] = None,
-        description: str = None,
-    ):
-        """Initializes a ObjectPointer.
-
-        Args:
-            location: An optional BaseWorker object which points to the worker
-                on which this pointer's object can be found.
-            id_at_location: An optional string or integer id of the object
-                being pointed to.
-            owner: An optional BaseWorker object to specify the worker on which
-                the pointer is located. It is also where the pointer is
-                registered if register is set to True. Note that this is
-                different from the location parameter that specifies where the
-                pointer points to.
-            id: An optional string or integer id of the ObjectPointer.
-            garbage_collect_data: If true (default), delete the remote object when the
-                pointer is deleted.
-            point_to_attr: string which can tell a pointer to not point directly to\
-                an object, but to point to an attribute of that object such as .child or
-                .grad. Note the string can be a chain (i.e., .child.child.child or
-                .grad.child.child). Defaults to None, which means don't point to any attr,
-                just point to then object corresponding to the id_at_location.
-        """
-        super().__init__(id=id, owner=owner, tags=tags, description=description)
-
-        self.location = location
-        self.id_at_location = id_at_location
-        self.garbage_collect_data = garbage_collect_data
-        self.point_to_attr = point_to_attr
 
     @staticmethod
     def create_pointer(

--- a/syft/generic/pointers/object_wrapper.py
+++ b/syft/generic/pointers/object_wrapper.py
@@ -48,9 +48,8 @@ class ObjectWrapper(SyftSerializable):
     def obj(self):
         return self._obj
 
-    @staticmethod
     def create_pointer(
-        object,
+        self,
         owner: "BaseWorker",
         location: "BaseWorker",
         ptr_id: Union[int, str],
@@ -89,9 +88,9 @@ class ObjectWrapper(SyftSerializable):
             owner=owner,
             location=location,
             id=ptr_id,
-            id_at_location=id_at_location if id_at_location is not None else object.id,
-            tags=object.tags,
-            description=object.description,
+            id_at_location=id_at_location if id_at_location is not None else self.id,
+            tags=self.tags,
+            description=self.description,
             garbage_collect_data=False if garbage_collect_data is None else garbage_collect_data,
         )
         return pointer

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -2,7 +2,6 @@ from typing import List, Union
 
 import syft
 
-from syft.generic.abstract.hookable import hookable
 from syft.generic.abstract.tensor import AbstractTensor
 from syft.generic.frameworks.hook.hook_args import one
 from syft.generic.frameworks.hook.hook_args import register_type_rule
@@ -176,71 +175,6 @@ class PointerTensor(ObjectPointer, AbstractTensor):
             "id_at_location": self.id_at_location,
             "garbage_collect_data": self.garbage_collect_data,
         }
-
-    @staticmethod
-    @hookable
-    def create_pointer(
-        tensor,
-        location: AbstractWorker = None,
-        id_at_location: (str or int) = None,
-        owner: AbstractWorker = None,
-        ptr_id: (str or int) = None,
-        garbage_collect_data=None,
-        shape=None,
-    ) -> "PointerTensor":
-        """Creates a pointer to the "self" FrameworkTensor object.
-
-        This method is called on a FrameworkTensor object, returning a pointer
-        to that object. This method is the CORRECT way to create a pointer,
-        and the parameters of this method give all possible attributes that
-        a pointer can be created with.
-
-        Args:
-            location: The AbstractWorker object which points to the worker on which
-                this pointer's object can be found. In nearly all cases, this
-                is self.owner and so this attribute can usually be left blank.
-                Very rarely you may know that you are about to move the Tensor
-                to another worker so you can pre-initialize the location
-                attribute of the pointer to some other worker, but this is a
-                rare exception.
-            id_at_location: A string or integer id of the tensor being pointed
-                to. Similar to location, this parameter is almost always
-                self.id and so you can leave this parameter to None. The only
-                exception is if you happen to know that the ID is going to be
-                something different than self.id, but again this is very rare
-                and most of the time, setting this means that you are probably
-                doing something you shouldn't.
-            owner: A AbstractWorker parameter to specify the worker on which the
-                pointer is located. It is also where the pointer is registered
-                if register is set to True.
-            ptr_id: A string or integer parameter to specify the id of the pointer
-                in case you wish to set it manually for any special reason.
-                Otherwise, it will be set randomly.
-            garbage_collect_data: If true (default), delete the remote tensor when the
-                pointer is deleted.
-
-        Returns:
-            A FrameworkTensor[PointerTensor] pointer to self. Note that this
-            object itself will likely be wrapped by a FrameworkTensor wrapper.
-        """
-        if owner is None:
-            owner = tensor.owner
-
-        if location is None:
-            location = tensor.owner
-
-        ptr = PointerTensor(
-            location=location,
-            id_at_location=id_at_location,
-            owner=owner,
-            id=ptr_id,
-            garbage_collect_data=True if garbage_collect_data is None else garbage_collect_data,
-            shape=shape,
-            tags=tensor.tags,
-            description=tensor.description,
-        )
-
-        return ptr
 
     def move(self, destination: AbstractWorker, requires_grad: bool = False):
         """

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -1,13 +1,15 @@
 from typing import List, Union
 
 import syft
+
+from syft.generic.abstract.hookable import hookable
+from syft.generic.abstract.tensor import AbstractTensor
 from syft.generic.frameworks.hook.hook_args import one
 from syft.generic.frameworks.hook.hook_args import register_type_rule
 from syft.generic.frameworks.hook.hook_args import register_forward_func
 from syft.generic.frameworks.hook.hook_args import register_backward_func
 from syft.generic.frameworks.types import FrameworkShapeType
 from syft.generic.frameworks.types import FrameworkTensor
-from syft.generic.abstract.tensor import AbstractTensor
 from syft.generic.pointers.object_pointer import ObjectPointer
 from syft.messaging.message import TensorCommandMessage
 from syft.workers.abstract import AbstractWorker
@@ -176,11 +178,12 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         }
 
     @staticmethod
+    @hookable
     def create_pointer(
         tensor,
-        location: Union[AbstractWorker, str] = None,
+        location: AbstractWorker = None,
         id_at_location: (str or int) = None,
-        owner: Union[AbstractWorker, str] = None,
+        owner: AbstractWorker = None,
         ptr_id: (str or int) = None,
         garbage_collect_data=None,
         shape=None,
@@ -226,23 +229,16 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         if location is None:
             location = tensor.owner
 
-        owner = tensor.owner.get_worker(owner)
-        location = tensor.owner.get_worker(location)
-
-        # previous_pointer = owner.get_pointer_to(location, id_at_location)
-        previous_pointer = None
-
-        if previous_pointer is None:
-            ptr = PointerTensor(
-                location=location,
-                id_at_location=id_at_location,
-                owner=owner,
-                id=ptr_id,
-                garbage_collect_data=True if garbage_collect_data is None else garbage_collect_data,
-                shape=shape,
-                tags=tensor.tags,
-                description=tensor.description,
-            )
+        ptr = PointerTensor(
+            location=location,
+            id_at_location=id_at_location,
+            owner=owner,
+            id=ptr_id,
+            garbage_collect_data=True if garbage_collect_data is None else garbage_collect_data,
+            shape=shape,
+            tags=tensor.tags,
+            description=tensor.description,
+        )
 
         return ptr
 

--- a/syft/generic/string.py
+++ b/syft/generic/string.py
@@ -228,9 +228,8 @@ class String(AbstractSendable):
 
         return _self + other
 
-    @staticmethod
     def create_pointer(
-        obj,
+        self,
         location: BaseWorker = None,
         id_at_location: (str or int) = None,
         register: bool = False,
@@ -247,10 +246,10 @@ class String(AbstractSendable):
         """
 
         if id_at_location is None:
-            id_at_location = obj.id
+            id_at_location = self.id
 
         if owner is None:
-            owner = obj.owner
+            owner = self.owner
 
         string_pointer = StringPointer(
             location=location,

--- a/syft/workers/abstract.py
+++ b/syft/workers/abstract.py
@@ -1,5 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
+from typing import Union
+
 from syft.serde.syft_serializable import SyftSerializable
 
 
@@ -34,5 +36,33 @@ class AbstractWorker(ABC, SyftSerializable):
 
         Args:
             message: The binary message being received.
+        """
+        pass
+
+    @abstractmethod
+    def send_obj(self, obj: object, location: "AbstractWorker"):
+        """Send a torch object to a worker.
+
+        Args:
+            obj: An object to be sent.
+            location: An AbstractWorker instance indicating the worker which should
+                receive the object.
+        """
+        pass
+
+    @abstractmethod
+    def request_obj(
+        self, obj_id: Union[str, int], location: "AbstractWorker", *args, **kwargs
+    ) -> object:
+        """Returns the requested object from specified location.
+
+        Args:
+            obj_id (int or string):  A string or integer id of an object to look up.
+            location (BaseWorker): A BaseWorker instance that lets you provide the lookup
+                location.
+            user (object, optional): user credentials to perform user authentication.
+            reason (string, optional): a description of why the data scientist wants to see it.
+        Returns:
+            A torch Tensor or Variable object.
         """
         pass


### PR DESCRIPTION
## Description
This PR converts all `create_pointer()` methods in PySyft to instance methods, in order to both make them consistent and make them easier to hook for prep/clean-up actions provided by the members of a tensor chain.

## Checklist
- [X] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [X] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes