### PR TITLE
Update AbstractSendable's send() method

### DIFF
--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -1,11 +1,23 @@
 from syft.serde.syft_serializable import SyftSerializable
 from syft.generic.abstract.object import AbstractObject
+from syft.workers.base import BaseWorker
+from syft.generic.pointers.object_pointer import ObjectPointer
 
 
 class AbstractSendable(AbstractObject, SyftSerializable):
-    """
-    This layers functionality for sending objects between workers on top of AbstractObject.
+    """This layers functionality for sending objects between workers on top of AbstractObject.
     """
 
-    def send(self, destination):
-        return self.owner.send_obj(self, destination)
+    def send(self, destination: BaseWorker) -> ObjectPointer:
+        """Send the current object to the worker `destination`.
+
+        Args:
+            destination: The worker where the current object is sent.
+ 
+        Returns:
+            A pointer to the send object.
+        """
+
+        ptr = self.owner.send(self, destination)
+
+        return ptr

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -11,10 +11,11 @@ class AbstractSendable(AbstractObject, SyftSerializable):
 
         Args:
             destination (BaseWorker): The worker where the current object is sent.
- 
+
         Returns:
             An  object of type ObjectPointer pointing to the sent object.
         """
+
         ptr = self.owner.send(self, destination)
 
         return ptr

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -6,14 +6,14 @@ class AbstractSendable(AbstractObject, SyftSerializable):
     """This layers functionality for sending objects between workers on top of AbstractObject.
     """
 
-    def send(self, destination: "BaseWorker") -> "ObjectPointer":
+    def send(self, destination):
         """Send the current object to the worker `destination`.
 
         Args:
-            destination: The worker where the current object is sent.
+            destination (BaseWorker): The worker where the current object is sent.
  
         Returns:
-            A pointer to the send object.
+            An  object of type ObjectPointer pointing to the sent object.
         """
 
         ptr = self.owner.send(self, destination)

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -1,14 +1,12 @@
 from syft.serde.syft_serializable import SyftSerializable
 from syft.generic.abstract.object import AbstractObject
-from syft.workers.base import BaseWorker
-from syft.generic.pointers.object_pointer import ObjectPointer
 
 
 class AbstractSendable(AbstractObject, SyftSerializable):
     """This layers functionality for sending objects between workers on top of AbstractObject.
     """
 
-    def send(self, destination: BaseWorker) -> ObjectPointer:
+    def send(self, destination: "BaseWorker") -> "ObjectPointer":
         """Send the current object to the worker `destination`.
 
         Args:

--- a/syft/generic/abstract/sendable.py
+++ b/syft/generic/abstract/sendable.py
@@ -15,7 +15,6 @@ class AbstractSendable(AbstractObject, SyftSerializable):
         Returns:
             An  object of type ObjectPointer pointing to the sent object.
         """
-
         ptr = self.owner.send(self, destination)
 
         return ptr


### PR DESCRIPTION
# Pull Request

## Description
the `send()` method of `AbstractSendable` used the `send_obj` of `BaseWorker` instead of `send()`. The former does not return a pointer while the latter does.

## Affected Dependencies
List any dependencies that are required for this change.

## Type of Change
Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [ ] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes

## Additional Context
Please also include relevant motivation and context.
