### PR TITLE
Simplify encrypted aggregation in the tutorials

### DIFF
--- a/examples/tutorials/Part 10 - Federated Learning with Secure Aggregation.ipynb
+++ b/examples/tutorials/Part 10 - Federated Learning with Secure Aggregation.ipynb
@@ -386,13 +386,10 @@
     "    spdz_params = list()\n",
     "    for remote_index in range(len(compute_nodes)):\n",
     "        \n",
-    "        # select the identical parameter from each worker and copy it\n",
-    "        copy_of_parameter = params[remote_index][param_i].copy()\n",
-    "        \n",
     "        # since SMPC can only work with integers (not floats), we need\n",
     "        # to use Integers to store decimal information. In other words,\n",
     "        # we need to use \"Fixed Precision\" encoding.\n",
-    "        fixed_precision_param = copy_of_parameter.fix_precision()\n",
+    "        fixed_precision_param = params[remote_index][param_i].fix_precision()\n",
     "        \n",
     "        # now we encrypt it on the remote machine. Note that \n",
     "        # fixed_precision_param is ALREADY a pointer. Thus, when\n",
@@ -469,7 +466,7 @@
     "        for param_i in range(len(params[0])):\n",
     "            spdz_params = list()\n",
     "            for remote_index in range(len(compute_nodes)):\n",
-    "                spdz_params.append(params[remote_index][param_i].copy().fix_precision().share(bob, alice, crypto_provider=james).get())\n",
+    "                spdz_params.append(params[remote_index][param_i].fix_precision().share(bob, alice, crypto_provider=james).get())\n",
     "\n",
     "            new_param = (spdz_params[0] + spdz_params[1]).get().float_precision()/2\n",
     "            new_params.append(new_param)\n",
@@ -580,7 +577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Pull Request

## Description
In [Part 10 - Federated Learning with Secure Aggregation.ipynb](https://github.com/OpenMined/PySyft/blob/master/examples/tutorials/Part%2010%20-%20Federated%20Learning%20with%20Secure%20Aggregation.ipynb), the first step of "encrypted aggregation" is that copying the selected parameter.
Since the **Fixed Precision** and **Encrypt** are not in-place operations.
Without copying the parameters, we can still keep the plain parameters in the local.
Therefore, in my opinion, this step can be omitted.

## Affected Dependencies
No

## Type of Change
Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [x] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have added tests for my changes

## Additional Context
No
