### PR TITLE
Removed `wrap()` on non-tensor pointers in `respond_to_search()`

### DIFF
--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -251,7 +251,7 @@ class BaseMessageHandler(AbstractMessageHandler):
             # Wrap only if the pointer points to a tensor.
             # If it points to a generic object, do not wrap.
             if isinstance(obj, torch.Tensor):
-                ptr.wrap()
+                ptr = ptr.wrap()
 
             results.append(ptr)
 

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -245,7 +245,7 @@ class BaseMessageHandler(AbstractMessageHandler):
             # decision to decide when to delete the tensor.
             ptr = obj.create_pointer(
                 garbage_collect_data=False, owner=sy.local_worker, tags=obj.tags
-            ).wrap()
+            )
 
             results.append(ptr)
 

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -249,7 +249,7 @@ class BaseMessageHandler(AbstractMessageHandler):
 
             # Wrap only if the pointer points to a tensor.
             # If it points to a generic object, do not wrap.
-            if isinstance(obj, PointerTensor):
+            if isinstance(ptr, PointerTensor):
                 ptr.wrap()
 
             results.append(ptr)

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -26,6 +26,7 @@ from syft.exceptions import ObjectNotFoundError
 from syft.exceptions import PlanCommandUnknownError
 from syft.exceptions import ResponseSignatureError
 
+import torch
 
 class BaseMessageHandler(AbstractMessageHandler):
     def __init__(self, object_store, worker):
@@ -249,7 +250,7 @@ class BaseMessageHandler(AbstractMessageHandler):
 
             # Wrap only if the pointer points to a tensor.
             # If it points to a generic object, do not wrap.
-            if isinstance(obj, FrameworkTensor):
+            if isinstance(obj, torch.Tensor):
                 ptr.wrap()
 
             results.append(ptr)

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -247,7 +247,6 @@ class BaseMessageHandler(AbstractMessageHandler):
                 garbage_collect_data=False, owner=sy.local_worker, tags=obj.tags
             ).wrap()
 
-
             results.append(ptr)
 
         return results

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -245,7 +245,13 @@ class BaseMessageHandler(AbstractMessageHandler):
             # decision to decide when to delete the tensor.
             ptr = obj.create_pointer(
                 garbage_collect_data=False, owner=sy.local_worker, tags=obj.tags
-            ).wrap()
+            )  # .wrap()
+
+            # Wrap only if the pointer points to a tensor.
+            # If it points to a generic object, do not wrap.
+            if isinstance(obj, PointerTensor):
+                ptr.wrap()
+
             results.append(ptr)
 
         return results

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -245,12 +245,7 @@ class BaseMessageHandler(AbstractMessageHandler):
             # decision to decide when to delete the tensor.
             ptr = obj.create_pointer(
                 garbage_collect_data=False, owner=sy.local_worker, tags=obj.tags
-            )  # .wrap()
-
-            # Wrap only if the pointer points to a tensor.
-            # If it points to a generic object, do not wrap.
-            if isinstance(obj, PointerTensor):
-                ptr.wrap()
+            )
 
             results.append(ptr)
 

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -249,7 +249,7 @@ class BaseMessageHandler(AbstractMessageHandler):
 
             # Wrap only if the pointer points to a tensor.
             # If it points to a generic object, do not wrap.
-            if isinstance(ptr, PointerTensor):
+            if isinstance(obj, FrameworkTensor):
                 ptr.wrap()
 
             results.append(ptr)

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -245,7 +245,8 @@ class BaseMessageHandler(AbstractMessageHandler):
             # decision to decide when to delete the tensor.
             ptr = obj.create_pointer(
                 garbage_collect_data=False, owner=sy.local_worker, tags=obj.tags
-            )
+            ).wrap()
+
 
             results.append(ptr)
 

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -26,7 +26,6 @@ from syft.exceptions import ObjectNotFoundError
 from syft.exceptions import PlanCommandUnknownError
 from syft.exceptions import ResponseSignatureError
 
-import torch
 
 class BaseMessageHandler(AbstractMessageHandler):
     def __init__(self, object_store, worker):
@@ -250,7 +249,7 @@ class BaseMessageHandler(AbstractMessageHandler):
 
             # Wrap only if the pointer points to a tensor.
             # If it points to a generic object, do not wrap.
-            if isinstance(obj, torch.Tensor):
+            if isinstance(ptr, PointerTensor):
                 ptr = ptr.wrap()
 
             results.append(ptr)

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -247,6 +247,11 @@ class BaseMessageHandler(AbstractMessageHandler):
                 garbage_collect_data=False, owner=sy.local_worker, tags=obj.tags
             )
 
+            # Wrap only if the pointer points to a tensor.
+            # If it points to a generic object, do not wrap.
+            if isinstance(obj, PointerTensor):
+                ptr.wrap()
+
             results.append(ptr)
 
         return results


### PR DESCRIPTION
## Description

in `syft/workers/message_handlers:respond_to_search()`, all pointers are wrapped before being returned. This should be the case only on `PointerTensor` objects, not only all pointers.

This causes a fail in SyferText where we need to exchange object pointers that are not tensors.

## Affected Dependencies
None

## How has this been tested?
All existing tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
