### PR TITLE
Introduce an experimental mechanism for remote exec on Python workers

### DIFF
--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -121,7 +121,7 @@ class TorchAttributes(FrameworkAttributes):
             self.guard[f"syft.{key}"] = self.guard[key]
 
         # Concatenate torch functions
-        self.allowed_commands = self._torch_functions
+        self.allowed_commands = self.allowed_commands.union(self._torch_functions)
 
         # The equivalent concatenation of native torch function names and native torch method names
         self.native_commands = {

--- a/syft/generic/frameworks/attributes.py
+++ b/syft/generic/frameworks/attributes.py
@@ -7,11 +7,25 @@ from typing import Any
 
 from syft.generic.frameworks.hook.hook import FrameworkHook
 
+allowed_commands = set()
+
 
 class FrameworkAttributes(ABC):
+    _allowed_commands = None
+
     @abstractmethod
     def __init__(self, framework: ModuleType, hook: FrameworkHook):
         pass
+
+    @property
+    def allowed_commands(self):
+        if self._allowed_commands is None:
+            self._allowed_commands = allowed_commands
+        return self._allowed_commands
+
+    @allowed_commands.setter
+    def allowed_commands(self, new_commands):
+        self._allowed_commands = new_commands
 
     # Forcing subclasses to define a class-level constant; see
     # https://stackoverflow.com/a/53417582 for nuance

--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -722,7 +722,7 @@ def register_tensor(tensor: FrameworkTensorType, owner: AbstractWorker, response
     owner.de_register_obj(tensor)  # Doesn't raise Exceptions if absent on owner
     tensor.owner = owner
     try:
-        tensor.id = response_ids.pop(-1)
+        tensor.id = response_ids.pop(0)
     except IndexError:
         raise exceptions.ResponseSignatureError
 

--- a/syft/generic/utils.py
+++ b/syft/generic/utils.py
@@ -22,13 +22,15 @@ class memorize(dict):
 
 
 def allow_command(func):
-    func_name = f"{func.__module__}.{func.__name__}"
+    module = func.__module__
+    func_name = f"{module}{'.' if module else ''}{func.__name__}"
     allowed_commands.update({func_name})
     return func
 
 
 def remote(func, location):
-    command_name = f"{func.__module__}.{func.__name__}"
+    module = func.__module__
+    command_name = f"{module}{'.' if module else ''}{func.__name__}"
 
     worker = sy.local_worker
 

--- a/syft/generic/utils.py
+++ b/syft/generic/utils.py
@@ -1,3 +1,7 @@
+from syft.generic.frameworks.attributes import allowed_commands
+import syft as sy
+
+
 class memorize(dict):
     """
     This is a decorator to cache a function output when the function is
@@ -15,3 +19,32 @@ class memorize(dict):
     def __missing__(self, key):
         result = self[key] = self.func(*key)
         return result
+
+
+def allow_command(func):
+    func_name = f"{func.__module__}.{func.__name__}"
+    allowed_commands.update({func_name})
+    return func
+
+
+def remote(func, location):
+    command_name = f"{func.__module__}.{func.__name__}"
+
+    worker = sy.local_worker
+
+    if isinstance(location, str):
+        location = worker.get_worker(location)
+
+    def remote_exec(*args, return_value=False, return_arity=1, multiprocessing=False, **kwargs):
+
+        response_ids = tuple(sy.ID_PROVIDER.pop() for _ in range(return_arity))
+
+        command = (command_name, None, args, kwargs)
+
+        response = worker.send_command(
+            location, *command, return_ids=response_ids, return_value=return_value
+        )
+
+        return response
+
+    return remote_exec

--- a/syft/test/__init__.py
+++ b/syft/test/__init__.py
@@ -1,0 +1,10 @@
+from syft.generic.utils import allow_command
+
+
+@allow_command
+def my_awesome_computation(x):
+    x = x + 1
+    x = x * 2
+    x = x - 1
+    y = x * 2
+    return x, y

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -501,8 +501,13 @@ class BaseWorker(AbstractWorker):
                 )
                 responses.append(response)
 
+            if return_value:
+                responses = [response.get() for response in responses]
+
             if len(return_ids) == 1:
                 responses = responses[0]
+            else:
+                responses = tuple(responses)
         else:
             responses = ret_val
         return responses

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -166,6 +166,8 @@ class BaseWorker(AbstractWorker):
         # storage object for crypto primitives
         self.crypto_store = PrimitiveStorage(owner=self)
 
+        self.syft = sy
+
     def get_obj(self, obj_id: Union[str, int]) -> object:
         """Returns the object from registry.
 

--- a/test/generic/frameworks/test_attributes.py
+++ b/test/generic/frameworks/test_attributes.py
@@ -22,3 +22,27 @@ def test_remote(workers, return_value):
         results = tuple(result.get() for result in results)
 
     assert results == expected
+
+
+@pytest.mark.parametrize("return_value", [True, False])
+def test_remote_wrong_arity(workers, return_value):
+    """
+    Identical to test_remote except the use didn't set return_arity to
+    be the correct number of return values.
+    Here it should be 2, not 1.
+    """
+    alice = workers["alice"]
+
+    x = th.tensor([1.0])
+    expected = my_awesome_computation(x)
+
+    p = x.send(alice)
+    args = (p,)
+    results = remote(my_awesome_computation, location=alice)(
+        *args, return_value=return_value, return_arity=1
+    )
+
+    if not return_value:
+        results = tuple(result.get() for result in results)
+
+    assert results == expected

--- a/test/generic/frameworks/test_attributes.py
+++ b/test/generic/frameworks/test_attributes.py
@@ -1,0 +1,24 @@
+import pytest
+import torch as th
+
+from syft.test import my_awesome_computation
+from syft.generic.utils import remote
+
+
+@pytest.mark.parametrize("return_value", [True, False])
+def test_remote(workers, return_value):
+    alice = workers["alice"]
+
+    x = th.tensor([1.0])
+    expected = my_awesome_computation(x)
+
+    p = x.send(alice)
+    args = (p,)
+    results = remote(my_awesome_computation, location=alice)(
+        *args, return_value=return_value, return_arity=2
+    )
+
+    if not return_value:
+        results = tuple(result.get() for result in results)
+
+    assert results == expected


### PR DESCRIPTION
## Description
This is an experimental tool which really helps reducing communication rounds. It doesn't use Plans and is only compatible with Python workers, which is a limitation for PySyft.

However it is very useful for the moment for crypto protocols, as it highly reduces the number of communication and doesn't require to contain only pytorch operations (for example I can make a call to a custom library or use numpy code)

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
