### PR TITLE
Paillier testing

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/paillier.py
+++ b/syft/frameworks/torch/tensors/interpreters/paillier.py
@@ -14,7 +14,8 @@ from syft.generic.frameworks.hook.hook_args import (
 from syft.generic.frameworks.overload import overloaded
 from syft.workers.abstract import AbstractWorker
 
-from phe.paillier import EncryptedNumber, PaillierPublicKey
+from phe.paillier import EncryptedNumber
+from phe.paillier import PaillierPublicKey
 
 
 class PaillierTensor(AbstractTensor):

--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -1994,23 +1994,26 @@ def make_gradfn(**kwargs):
 
 
 def make_paillier(**kwargs):
-    # TODO: Add proper testing for paillier tensor
+    PaillierTensor = syft.frameworks.torch.tensors.interpreters.paillier.PaillierTensor
+    pub, pri = syft.keygen()
+    tensor = torch.randn(4, 3)
+    tensor = tensor.encrypt(protocol="paillier", public_key=pub)
+    simplified = PaillierTensor.simplify(kwargs["workers"]["serde_worker"], tensor)
 
-    def compare(original, detailed):
+    def compare(detailed, original):
+        assert isinstance(detailed, PaillierTensor)
+        assert isinstance(original, PaillierTensor)
+        for i in range(len(detailed)):
+            for j in range(len(detailed[0])):
+                assert detailed[i][j].public_key == original[i][j].public_key
+                assert detailed[i][j].exponent == original[i][j].exponent
+
         return True
-
-    tensor = syft.frameworks.torch.tensors.interpreters.paillier.PaillierTensor()
-    simplfied = syft.frameworks.torch.tensors.interpreters.paillier.PaillierTensor.simplify(
-        kwargs["workers"]["serde_worker"], tensor
-    )
 
     return [
         {
             "value": tensor,
-            "simplified": (
-                CODE[syft.frameworks.torch.tensors.interpreters.paillier.PaillierTensor],
-                simplfied,
-            ),
+            "simplified": (CODE[PaillierTensor], simplified,),
             "cmp_detailed": compare,
         }
     ]

--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -2003,10 +2003,16 @@ def make_paillier(**kwargs):
     def compare(detailed, original):
         assert isinstance(detailed, PaillierTensor)
         assert isinstance(original, PaillierTensor)
-        for i in range(len(detailed)):
-            for j in range(len(detailed[0])):
-                assert detailed[i][j].public_key == original[i][j].public_key
-                assert detailed[i][j].exponent == original[i][j].exponent
+
+        if isinstance(detailed, numpy.ndarray):
+            for i in range(len(detailed)):
+                for j in range(len(detailed[0])):
+                    assert detailed[i][j].public_key == original[i][j].public_key
+                    assert detailed[i][j].exponent == original[i][j].exponent
+        else:
+            for i in range(len(detailed)):
+                assert detailed[i].public_key == original[i].public_key
+                assert detailed[i].exponent == original[i].exponent
 
         return True
 


### PR DESCRIPTION
#3510 
#3478
# Description
The [simplify](https://github.com/OpenMined/PySyft/blob/master/syft/frameworks/torch/tensors/interpreters/paillier.py#L265-L282) and [detail](https://github.com/OpenMined/PySyft/blob/master/syft/frameworks/torch/tensors/interpreters/paillier.py#L282-L304) functions of the Paillier tensor have been modified in order to accept tensors of any dimmension.

Proper testing has been added to the [make_paillier()](https://github.com/OpenMined/PySyft/blob/master/test/serde/serde_helpers.py#L2015-L2036) function.

## Affected Dependencies
New dependencies are not required. I am using the following modules:
In [paillier.py](https://github.com/OpenMined/PySyft/blob/master/syft/frameworks/torch/tensors/interpreters/paillier.py):
``` python
from phe.paillier import EncryptedNumber
from phe.paillier import PaillierPublicKey
```
In [serde_helpers.py](https://github.com/OpenMined/PySyft/blob/master/test/serde/serde_helpers.py):
``` python
import numpy
```

## How has this been tested?
The [make_paillier()](https://github.com/OpenMined/PySyft/blob/master/test/serde/serde_helpers.py#L2015-L2036) function in the test directory should show how testing have been performed. For additional testing, you can use this script:
``` python
import torch
import numpy as np
import syft as sy
from syft.serde.msgpack.serde import _simplify

if __name__ == '__main__':

    hook = sy.TorchHook(torch)
    bob = sy.VirtualWorker(hook, id="bob")


    array1 = np.array([1,4]) # 1 dimension array
    array2 = np.array([[5,2,3],[1,4,4],[2,4,4],[2,4,4]]) # 3 or n dimension array

    # Declaring a tensor
    x_tensor1 = torch.Tensor(array1)
    x_tensor2 = torch.Tensor(array2)

    # Encrypting the tensor
    pub, pri = sy.keygen()
    x_encrypted1 = x_tensor1.encrypt(protocol="paillier", public_key=pub)
    x_encrypted2 = x_tensor2.encrypt(protocol="paillier", public_key=pub)

    # Simplify and detail
    simplified_1 = sy.frameworks.torch.tensors.interpreters.paillier.PaillierTensor.simplify(bob, x_encrypted1)
    detailed_1 = sy.frameworks.torch.tensors.interpreters.paillier.PaillierTensor.detail(bob, simplified_1)
    simplified_2 = sy.frameworks.torch.tensors.interpreters.paillier.PaillierTensor.simplify(bob, x_encrypted2)
    detailed_2 = sy.frameworks.torch.tensors.interpreters.paillier.PaillierTensor.detail(bob, simplified_2)

    # Decryption
    decrypted_1 = detailed_1.decrypt(private_key=pri)
    decrypted_2 = detailed_2.decrypt(private_key=pri)

    # Testing
    assert (decrypted_1 == x_tensor1).all()
    assert (decrypted_2 == x_tensor2).all()

    for i in range(len(detailed_1)):
        assert (detailed_1[i].public_key == x_encrypted1[i].public_key)
        assert (detailed_1[i].exponent == x_encrypted1[i].exponent)

    for i in range(len(detailed_2)):
        for j in range(len(detailed_2[0])):
            assert (detailed_2[i][j].public_key == x_encrypted2[i][j].public_key)
            assert (detailed_2[i][j].exponent == x_encrypted2[i][j].exponent)
```

## Checklist
- [ x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ x] My changes are covered by tests
