### PR TITLE
Detecting duplicate worker IDs in crypten computation

### DIFF
--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -108,7 +108,7 @@ def run_multiworkers(
             # - check if workers are reachable / they can handle the computation
             # - check return code of processes for possible failure
 
-            if len(workers) != len(set(worker.id for worker in workers)):
+            if len(workers) != len(set(worker.id for worker in workers)):  # noqa: C401
                 raise RuntimeError("found workers with same ID but IDs must be unique")
 
             if model is not None:

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -108,6 +108,9 @@ def run_multiworkers(
             # - check if workers are reachable / they can handle the computation
             # - check return code of processes for possible failure
 
+            if len(workers) != len(set([worker.id for worker in workers])):
+                raise RuntimeError("found workers with same ID but IDs must be unique")
+
             if model is not None:
                 if not isinstance(model, th.nn.Module):
                     raise TypeError("model must be a torch.nn.Module")

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -108,7 +108,7 @@ def run_multiworkers(
             # - check if workers are reachable / they can handle the computation
             # - check return code of processes for possible failure
 
-            if len(workers) != len(set([worker.id for worker in workers])):
+            if len(workers) != len(set(worker.id for worker in workers)):
                 raise RuntimeError("found workers with same ID but IDs must be unique")
 
             if model is not None:

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -201,6 +201,6 @@ def test_duplicate_ids(workers):
     @run_multiworkers([alice, alice2], master_addr="127.0.0.1")
     def jail_func(crypten=crypten):  # pragma: no cover
         pass
-    
+
     with pytest.raises(RuntimeError):
         return_values = jail_func()

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -189,3 +189,18 @@ def test_run_party():
     t = run_party(party, 0, 1, "127.0.0.1", 15463, (), {})
     result = utils.unpack_values(t)
     assert result == expected
+
+
+def test_duplicate_ids(workers):
+    # alice and bob
+    n_workers = 2
+
+    alice = workers["alice"]
+    alice2 = workers["alice"]
+
+    @run_multiworkers([alice, alice2], master_addr="127.0.0.1")
+    def jail_func(crypten=crypten):  # pragma: no cover
+        pass
+    
+    with pytest.raises(RuntimeError):
+        return_values = jail_func()


### PR DESCRIPTION
## Description
To refer to crypten parties running on specific workers, we can do whether with the rank (int) of the party or the id (str) of the worker running the party, thus we needed a kind of translation mechanism between worker id and rank, but when workers involved in the computation happen to have duplicate ids, ranks get translated badly and the computation will fail badly. This PR raise an error when a computation is about to start with duplicates ids.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
