### PR TITLE
New strategy for storing rank to id translation tables

### DIFF
--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -6,7 +6,10 @@ import crypten
 from syft.workers.base import BaseWorker
 
 
-RANK_TO_WORKER_ID = {}
+RANK_TO_WORKER_ID = {
+    # Contains translation dictionaries for every computation.
+    # cid (computation id): {rank_to_worker_id dictionary for a specific computation}
+}
 CID = None
 
 

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -30,7 +30,7 @@ def get_worker_from_rank(rank: int, cid: int = None) -> BaseWorker:
     if rank_to_worker_id is None:
         raise RuntimeError(
             "CrypTen computation not initiated properly, computation_id doesn't match any rank to"
-            "worker_id transaltion table"
+            "worker_id translation table"
         )
     return syft.local_worker._get_worker_based_on_id(rank_to_worker_id[rank])
 

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -3,10 +3,38 @@ import syft
 import crypten.communicator as comm
 import crypten
 
+from syft.workers.base import BaseWorker
+
+
+RANK_TO_WORKER_ID = {}
+CID = None
+
+
+def get_worker_from_rank(cid: int, rank: int) -> BaseWorker:
+    """Find the worker running CrypTen party with specific rank in a certain computation.
+
+    Args:
+        cid: CrypTen computation id.
+        rank: rank of the CrypTen party.
+
+    Returns:
+        BaseWorker corresponding to cid and rank.
+    """
+    rank_to_worker_id = RANK_TO_WORKER_ID.get(cid, None)
+    if rank_to_worker_id is None:
+        raise RuntimeError(
+            "CrypTen computation not initiated properly, computation_id doesn't match any rank to"
+            "worker_id transaltion table"
+        )
+    return syft.local_worker._get_worker_based_on_id(rank_to_worker_id[rank])
+
 
 def load(tag: str, src: int, **kwargs):
     if src == comm.get().get_rank():
-        worker = syft.local_worker.get_worker_from_rank(src)
+        if CID is None:
+            raise RuntimeError("CrypTen computation id is not set.")
+
+        worker = get_worker_from_rank(CID, src)
         results = worker.search(tag)
 
         # Make sure there is only one result

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -10,16 +10,22 @@ RANK_TO_WORKER_ID = {}
 CID = None
 
 
-def get_worker_from_rank(cid: int, rank: int) -> BaseWorker:
+def get_worker_from_rank(rank: int, cid: int = None) -> BaseWorker:
     """Find the worker running CrypTen party with specific rank in a certain computation.
 
     Args:
-        cid: CrypTen computation id.
         rank: rank of the CrypTen party.
+        cid: CrypTen computation id.
 
     Returns:
         BaseWorker corresponding to cid and rank.
     """
+    if cid is None:
+        if CID is None:
+            # Neither CID have been set appropriately nor cid have been passed
+            raise ValueError("cid must be set.")
+        cid = CID
+
     rank_to_worker_id = RANK_TO_WORKER_ID.get(cid, None)
     if rank_to_worker_id is None:
         raise RuntimeError(
@@ -34,7 +40,7 @@ def load(tag: str, src: int, **kwargs):
         if CID is None:
             raise RuntimeError("CrypTen computation id is not set.")
 
-        worker = get_worker_from_rank(CID, src)
+        worker = get_worker_from_rank(src)
         results = worker.search(tag)
 
         # Make sure there is only one result

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -135,8 +135,6 @@ def run_multiworkers(
 
             rank_to_worker_id = dict(zip(range(0, len(workers)), [worker.id for worker in workers]))
 
-            sy.local_worker.rank_to_worker_id = rank_to_worker_id
-
             # TODO: run ttp in a specified worker
             # if crypten.mpc.ttp_required():
             #     ttp_process, _ = _new_party(
@@ -193,8 +191,6 @@ def run_multiworkers(
             # wait for workers running the parties return a response
             for thread in threads:
                 thread.join()
-
-            del sy.local_worker.rank_to_worker_id
 
             return return_values
 

--- a/syft/frameworks/crypten/context.py
+++ b/syft/frameworks/crypten/context.py
@@ -13,8 +13,12 @@ from crypten.communicator import DistributedCommunicator
 
 
 def _launch(
-    func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs
+    cid, func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs
 ):  # pragma: no cover
+
+    # set CrypTen computation id
+    sy.frameworks.crypten.CID = cid
+
     communicator_args = {
         "RANK": rank,
         "WORLD_SIZE": world_size,
@@ -34,19 +38,20 @@ def _launch(
     queue.put(return_value)
 
 
-def _new_party(func, rank, world_size, master_addr, master_port, func_args, func_kwargs):
+def _new_party(cid, func, rank, world_size, master_addr, master_port, func_args, func_kwargs):
     queue = multiprocessing.Queue()
     process = multiprocessing.Process(
         target=_launch,
-        args=(func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs),
+        args=(cid, func, rank, world_size, master_addr, master_port, queue, func_args, func_kwargs),
     )
     return process, queue
 
 
-def run_party(func, rank, world_size, master_addr, master_port, func_args, func_kwargs):
+def run_party(cid, func, rank, world_size, master_addr, master_port, func_args, func_kwargs):
     """Start crypten party localy and run computation.
 
     Args:
+        cid (int): CrypTen computation id.
         func (function): computation to be done.
         rank (int): rank of the crypten party.
         world_size (int): number of crypten parties involved in the computation.
@@ -60,7 +65,7 @@ def run_party(func, rank, world_size, master_addr, master_port, func_args, func_
     """
 
     process, queue = _new_party(
-        func, rank, world_size, master_addr, master_port, func_args, func_kwargs
+        cid, func, rank, world_size, master_addr, master_port, func_args, func_kwargs
     )
     was_initialized = DistributedCommunicator.is_initialized()
     if was_initialized:

--- a/syft/frameworks/crypten/message_handler.py
+++ b/syft/frameworks/crypten/message_handler.py
@@ -1,4 +1,4 @@
-from random import randint
+import syft
 
 from syft.messaging.message import CryptenInitPlan
 from syft.messaging.message import CryptenInitJail
@@ -36,7 +36,7 @@ class CryptenMessageHandler(AbstractMessageHandler):
 
         rank_to_worker_id, world_size, master_addr, master_port = msg.crypten_context
 
-        cid = CryptenMessageHandler._get_computation_id()
+        cid = syft.ID_PROVIDER.pop()
         syft_crypten.RANK_TO_WORKER_ID[cid] = rank_to_worker_id
 
         # TODO Change this, we need a way to handle multiple plan definitions
@@ -67,7 +67,7 @@ class CryptenMessageHandler(AbstractMessageHandler):
 
         rank_to_worker_id, world_size, master_addr, master_port = msg.crypten_context
 
-        cid = CryptenMessageHandler._get_computation_id()
+        cid = syft.ID_PROVIDER.pop()
         syft_crypten.RANK_TO_WORKER_ID[cid] = rank_to_worker_id
 
         ser_func = msg.jail_runner
@@ -95,9 +95,3 @@ class CryptenMessageHandler(AbstractMessageHandler):
                 break
         return rank
 
-    @staticmethod
-    def _get_computation_id():
-        cid = randint(0, 2 ** 32)
-        while cid in syft_crypten.RANK_TO_WORKER_ID.keys():
-            cid = randint(0, 2 ** 32)
-        return cid

--- a/syft/frameworks/crypten/message_handler.py
+++ b/syft/frameworks/crypten/message_handler.py
@@ -94,4 +94,3 @@ class CryptenMessageHandler(AbstractMessageHandler):
                 rank = r
                 break
         return rank
-

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -186,7 +186,7 @@ def test_run_party():
         t = crypten.cryptensor(expected)
         return t.get_plain_text()
 
-    t = run_party(party, 0, 1, "127.0.0.1", 15463, (), {})
+    t = run_party(None, party, 0, 1, "127.0.0.1", 15463, (), {})
     result = utils.unpack_values(t)
     assert result == expected
 


### PR DESCRIPTION
## Description

Each CrypTen computation is identified using a CID (computation id), it might be different in different workers. Translation tables are indexed using CIDs. Global table and the CID of the running computation are stored under `syft.frameworks.crypten`, we assume that parties are separate processes and that CID is overwritten after process creation, which means that even if parties are running in the same machine, they won't manipulate the global CID concurrently.

`get_worker_from_rank` was also updated and I assumed that `syft.local_worker` is able to find all other workers using their id, please correct me if that's not the case.

Fixes #3516 
Fixes #3687 

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
