### PR TITLE
fixing threepio import bug

### DIFF
--- a/syft/execution/translation/threepio.py
+++ b/syft/execution/translation/threepio.py
@@ -17,12 +17,12 @@ class PlanTranslatorThreepio(AbstractPlanTranslator):
         threepio = Threepio(self.plan.base_framework, to_framework, None)
         function_name = action.name.split(".")[-1]
         args = action.args if action.target is None else (action.target, *action.args)
-        cmd = threepio.translate(Command(function_name, args, action.kwargs))
+        cmd = threepio.translate(Command(function_name, args, action.kwargs))[0]
 
         new_action = action.copy()
-        new_action.name = ".".join(cmd[0].attrs)
-        new_action.args = tuple(cmd[0].args)
-        new_action.kwargs = cmd[0].kwargs
+        new_action.name = ".".join(cmd.attrs)
+        new_action.args = tuple(cmd.args)
+        new_action.kwargs = cmd.kwargs
         new_action.target = None
         return new_action
 

--- a/syft/execution/translation/threepio.py
+++ b/syft/execution/translation/threepio.py
@@ -18,11 +18,12 @@ class PlanTranslatorThreepio(AbstractPlanTranslator):
         function_name = action.name.split(".")[-1]
         args = action.args if action.target is None else (action.target, *action.args)
         cmd = threepio.translate(Command(function_name, args, action.kwargs))
+        
 
         new_action = action.copy()
-        new_action.name = ".".join(cmd.attrs)
-        new_action.args = tuple(cmd.args)
-        new_action.kwargs = cmd.kwargs
+        new_action.name = ".".join(cmd[0].attrs)
+        new_action.args = tuple(cmd[0].args)
+        new_action.kwargs = cmd[0].kwargs
         new_action.target = None
         return new_action
 

--- a/syft/execution/translation/threepio.py
+++ b/syft/execution/translation/threepio.py
@@ -1,5 +1,5 @@
 from pythreepio.threepio import Threepio
-from pythreepio.utils import Command
+from pythreepio.command import Command
 from syft.execution.action import Action
 from syft.execution.role import Role
 from syft.execution.translation import TranslationTarget

--- a/syft/execution/translation/threepio.py
+++ b/syft/execution/translation/threepio.py
@@ -18,7 +18,6 @@ class PlanTranslatorThreepio(AbstractPlanTranslator):
         function_name = action.name.split(".")[-1]
         args = action.args if action.target is None else (action.target, *action.args)
         cmd = threepio.translate(Command(function_name, args, action.kwargs))
-        
 
         new_action = action.copy()
         new_action.name = ".".join(cmd[0].attrs)


### PR DESCRIPTION
## Description
This Pull request fix an import bug when `Command` from threepio is called. Command is no longer in threepio, now `command` contain that class. It solves #3712 

## How has this been tested?
- Before I was not able to install and import from master branch, now it works fine!

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
