### PR TITLE
Fix grid model hosting for large models

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -10,6 +10,7 @@ phe~=1.4.0
 Pillow~=6.2.2
 psutil==5.7.0
 requests~=2.22.0
+requests-toolbelt==0.9.1
 scipy~=1.4.1
 syft-proto==0.4.7
 tblib~=1.6.0

--- a/syft/workers/node_client.py
+++ b/syft/workers/node_client.py
@@ -1,4 +1,6 @@
 import json
+import requests
+from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
 from typing import Union
 from urllib.parse import urlparse
@@ -239,7 +241,7 @@ class NodeClient(WebsocketClientWorker):
         else:
             res_model = model
 
-        serialized_model = serialize(res_model)
+        serialized_model = serialize(res_model).decode(self.encoding)
 
         message = {
             REQUEST_MSG.TYPE_FIELD: REQUEST_MSG.HOST_MODEL,
@@ -248,10 +250,31 @@ class NodeClient(WebsocketClientWorker):
             "allow_download": str(allow_download),
             "mpc": str(mpc),
             "allow_remote_inference": str(allow_remote_inference),
-            "model": serialized_model.decode(self.encoding),
+            "model": serialized_model,
         }
-        response = self._forward_json_to_websocket_server_worker(message)
-        return self._return_bool_result(response)
+
+        url = self.address.replace("ws", "http") + "/serve-model/"
+
+        # Multipart encoding
+        form = MultipartEncoder(message)
+        upload_size = form.len
+
+        # Callback that shows upload progress
+        def progress_callback(monitor):
+            upload_progress = "{} / {} ({:.2f} %)".format(
+                monitor.bytes_read, upload_size, (monitor.bytes_read / upload_size) * 100
+            )
+            print(upload_progress, end="\r")
+            if monitor.bytes_read == upload_size:
+                print()
+
+        monitor = MultipartEncoderMonitor(form, progress_callback)
+        headers = {"Prefer": "respond-async", "Content-Type": monitor.content_type}
+
+        session = requests.Session()
+        response = session.post(url, headers=headers, data=monitor).content
+        session.close()
+        return self._return_bool_result(json.loads(response))
 
     def run_remote_inference(self, model_id, data):
         """ Run a dataset inference using a remote model.


### PR DESCRIPTION
## Description
Due to the need to support uploads for large models **_(>=200MB)_**, the approach used by the `serve_model` method has been modified. We changed the use of standard WebSockets messages to a well-known solution used for uploading large files on HTTP servers.

Fix [#23](https://github.com/OpenMined/PyGridNode/issues/23) 

## Affected Dependencies
- **requests_toolbelt**

## How has this been tested?
```
import syft as sy
import torch as th
from syft.workers.node_client import NodeClient
hook = sy.TorchHook(th)

node = NodeClient("ws://<node_address>")

traced_model = th.jit.load('large_traced_model.jit')

node.serve_model(traced_model,
                 model_id="myCustomModel",
                 allow_download=True,
                 allow_remote_inference=True)
```

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented on my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
