### PR TITLE
Negate operation of FV scheme

### DIFF
--- a/syft/frameworks/torch/he/fv/evaluator.py
+++ b/syft/frameworks/torch/he/fv/evaluator.py
@@ -1,6 +1,7 @@
 import copy
 
 from syft.frameworks.torch.he.fv.util.operations import poly_add_mod
+from syft.frameworks.torch.he.fv.util.operations import negate_mod
 from syft.frameworks.torch.he.fv.util.operations import multiply_add_plain_with_delta
 from syft.frameworks.torch.he.fv.ciphertext import CipherText
 from syft.frameworks.torch.he.fv.plaintext import PlainText
@@ -38,6 +39,24 @@ class Evaluator:
 
         else:
             raise TypeError(f"Addition Operation not supported between {type(op1)} and {type(op2)}")
+
+    def negate(self, ct):
+        """Negate a cipher i.e -(ct_value)
+
+        Args:
+            ct (Ciphertext): Ciphertext to be negated.
+
+        Returns:
+            A Ciphertext object with value equivalent to result of -(ct_value).
+        """
+        result = copy.deepcopy(ct.data)
+
+        for i in range(len(result)):
+            for j in range(len(result[i])):
+                for k in range(len(result[i][j])):
+                    result[i][j][k] = negate_mod(ct.data[i][j][k], self.coeff_modulus[j])
+
+        return CipherText(result)
 
     def _add_cipher_cipher(self, ct1, ct2):
         """Adds two ciphertexts.

--- a/test/torch/tensors/test_fv.py
+++ b/test/torch/tensors/test_fv.py
@@ -441,3 +441,15 @@ def test_fv_add_plain_plain(int1, int2):
         == encoder.decode(evaluator.add(op1, op2))
         == encoder.decode(evaluator.add(op2, op1))
     )
+
+
+@pytest.mark.parametrize("val", [(0), (-1), (100), (-1000), (-123), (99), (0xFFF), (0xFFFFFF)])
+def test_fv_negate_cipher(val):
+    ctx = Context(EncryptionParams(1024, CoeffModulus().create(1024, [30, 30]), 1024))
+    keys = KeyGenerator(ctx).keygen()
+    encoder = IntegerEncoder(ctx)
+    evaluator = Evaluator(ctx)
+    encryptor = Encryptor(ctx, keys[1])  # keys[1] = public_key
+    decryptor = Decryptor(ctx, keys[0])  # keys[0] = secret_key
+    op = encryptor.encrypt(encoder.encode(val))
+    assert -val == encoder.decode(decryptor.decrypt(evaluator.negate(op)))


### PR DESCRIPTION
## Description
closes #3701  
Implemented negation operation of the FV scheme.

Accepts Ciphertext and returns negated value Ciphertext.

## Affected Dependencies
None

## How has this been tested?
- Added tests which check the negated values from the operation.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
