### PR TITLE
Fixed bug in set_model_params() in Create Plan

### DIFF
--- a/examples/experimental/FL Training Plan/Create Plan.ipynb
+++ b/examples/experimental/FL Training Plan/Create Plan.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "    for name, child in module._modules.items():\n",
     "        if child is not None:\n",
-    "            param_idx += set_model_params(child, params_list, param_idx)\n",
+    "            param_idx = set_model_params(child, params_list, param_idx)\n",
     "\n",
     "    return param_idx"
    ],

--- a/examples/experimental/FL Training Plan/Create Plan.ipynb
+++ b/examples/experimental/FL Training Plan/Create Plan.ipynb
@@ -61,7 +61,6 @@
     "\n",
     "import syft as sy\n",
     "import torch as th\n",
-    "from torch import jit\n",
     "from torch import nn\n",
     "from syft.serde import protobuf\n",
     "import os\n",


### PR DESCRIPTION
## Description
Fixes #3780 

```python
def set_model_params(module, params_list, start_param_idx=0):
    """ Set params list into model recursively
    """
    param_idx = start_param_idx

    for name, param in module._parameters.items():
        print('\t','name:', name, '\tparam_idx:', param_idx)
        module._parameters[name] = params_list[param_idx]
        param_idx += 1

    for name, child in module._modules.items():
        print(child, param_idx)
        if child is not None:
            param_idx = set_model_params(child, params_list, param_idx)

    return param_idx

class Net(nn.Module):
    def __init__(self):
        super(Net, self).__init__()
        self.fc1 = nn.Linear(784, 392)
        self.fc2 = nn.Linear(392, 64)
        self.fc3 = nn.Linear(64, 10)

    def forward(self, x):
        x = nn.functional.relu(self.fc1(x))
        x = nn.functional.relu(self.fc2(x))
        x = self.fc3(x)
        return x

model = Net()
model_params = list(model.parameters())
set_model_params(model, model_params)
```
### Output
```bash
Linear(in_features=784, out_features=392, bias=True) 0
	 name: weight 	param_idx: 0
	 name: bias 	param_idx: 1
Linear(in_features=392, out_features=64, bias=True) 2
	 name: weight 	param_idx: 2
	 name: bias 	param_idx: 3
Linear(in_features=64, out_features=10, bias=True) 4
	 name: weight 	param_idx: 4
	 name: bias 	param_idx: 5
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
