### PR TITLE
Increase key-size to 2048-bit keys in test_websocket_worker.py

### DIFF
--- a/test/workers/test_websocket_worker.py
+++ b/test/workers/test_websocket_worker.py
@@ -19,7 +19,7 @@ def test_websocket_worker_basic(hook, start_proc, secure, tmpdir):
     def create_self_signed_cert(cert_path, key_path):
         # create a key pair
         k = crypto.PKey()
-        k.generate_key(crypto.TYPE_RSA, 1024)
+        k.generate_key(crypto.TYPE_RSA, 2048)
 
         # create a self-signed cert
         cert = crypto.X509()


### PR DESCRIPTION
## Description
Key-size value is changed to 2048 to deal with issues raised by [tighter default security values in openssl configuration](https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1).

Closes https://github.com/OpenMined/PySyft/issues/3787

## How has this been tested?
`test_websocket_worker.py` run OK with `CipherString = DEFAULT@SECLEVEL=2`.
