### PR TITLE
Fixed bug in set_model_params() in test_translation.py

### DIFF
--- a/test/execution/test_translation.py
+++ b/test/execution/test_translation.py
@@ -266,7 +266,7 @@ def test_fl_mnist_example_training_can_be_translated(hook, workers):
 
         for name, child in module._modules.items():
             if child is not None:
-                param_idx += set_model_params(child, params_list, param_idx)
+                param_idx = set_model_params(child, params_list, param_idx)
 
         return param_idx
 


### PR DESCRIPTION
## Description
Fixed bug in implementation of `set_model_params()` in `test/exection/test_translation.py`. See #3780 

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
