### PR TITLE
Reduced complexity for route_method_exception

### DIFF
--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -360,25 +360,21 @@ class TranslationUnavailableError(Exception):
     pass
 
 
-def route_method_exception(exception, self, args_, kwargs_):  # noqa: C901
+def route_method_exception(exception, self, args_, kwargs_):
     try:
-        if self.is_wrapper:
-            if isinstance(self.child, sy.PointerTensor):
-                if len(args_) > 0:
-                    if not args_[0].is_wrapper:
-                        return TensorsNotCollocatedException(self, args_[0])
-                    elif isinstance(args_[0].child, sy.PointerTensor):
-                        if self.location != args_[0].child.location:
-                            return TensorsNotCollocatedException(self, args_[0])
+        if self.is_wrapper and isinstance(self.child, sy.PointerTensor) and len(args_) > 0:
+            if not args_[0].is_wrapper:
+                return TensorsNotCollocatedException(self, args_[0])
+            elif isinstance(args_[0].child, sy.PointerTensor):
+                if self.location != args_[0].child.location:
+                    return TensorsNotCollocatedException(self, args_[0])
 
         # if self is a normal tensor
-        elif isinstance(self, FrameworkTensor):
-            if len(args_) > 0:
-                if args_[0].is_wrapper:
-                    if isinstance(args_[0].child, sy.PointerTensor):
-                        return TensorsNotCollocatedException(self, args_[0])
-                elif isinstance(args_[0], sy.PointerTensor):
-                    return TensorsNotCollocatedException(self, args_[0])
+        elif isinstance(self, FrameworkTensor) and len(args_) > 0:
+            if args_[0].is_wrapper and isinstance(args_[0].child, sy.PointerTensor):
+                return TensorsNotCollocatedException(self, args_[0])
+            elif isinstance(args_[0], sy.PointerTensor):
+                return TensorsNotCollocatedException(self, args_[0])
     except:  # noqa: E722
         ""
     return exception


### PR DESCRIPTION
## Description
The method route_method_exception was previously having a much higher complexity of conditional statements. Hence, when checking it with Flake8 it was showing a C901 error. To resolve the problem I have simply reduced the use of the conditional statements. Closes #3429 

## How has this been tested?
- Flake8 tests and PyTest were giving positive results for the changes.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
