### PR TITLE
[WIP] Implement Relinearization key and opertation of FV Scheme

### DIFF
--- a/examples/experimental/FV HE Experimentation.ipynb
+++ b/examples/experimental/FV HE Experimentation.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 81,
    "metadata": {
     "tags": []
    },
@@ -26,7 +26,8 @@
     "from syft.frameworks.torch.he.fv.decryptor import Decryptor\n",
     "from syft.frameworks.torch.he.fv.integer_encoder import IntegerEncoder\n",
     "from syft.frameworks.torch.he.fv.modulus import SeqLevelType\n",
-    "from syft.frameworks.torch.he.fv.evaluator import Evaluator"
+    "from syft.frameworks.torch.he.fv.evaluator import Evaluator\n",
+    "from syft.frameworks.torch.he.fv.relin_keys import RelinKeys"
    ]
   },
   {
@@ -38,12 +39,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
-    "poly_modulus = 64\n",
-    "bit_sizes= [40]\n",
+    "poly_modulus = 128\n",
+    "bit_sizes= [30]\n",
     "plain_modulus = 64\n",
     "ctx = Context(EncryptionParams(poly_modulus, CoeffModulus().create(poly_modulus, bit_sizes), plain_modulus))\n",
     "keygenerator = KeyGenerator(ctx)\n",
@@ -52,42 +53,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 83,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "[1099511623297]\n"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(ctx.param.coeff_modulus)"
+    "# print(ctx.param.coeff_modulus)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "secret key values :  [[0, 1099511623296, 1, 1, 1099511623296, 1, 0, 1099511623296, 1, 1099511623296, 1099511623296, 1099511623296, 1099511623296, 1099511623296, 0, 0, 1, 1099511623296, 0, 0, 0, 1099511623296, 1, 1099511623296, 1, 1, 1, 0, 1099511623296, 1099511623296, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1099511623296, 1099511623296, 1, 1, 1, 1, 1099511623296, 1099511623296, 0, 0, 1099511623296, 1, 1, 0, 1, 1099511623296, 1, 0, 1, 1099511623296, 0, 0, 1099511623296, 0, 1099511623296]]\n"
-    }
-   ],
-   "source": [
-    "# print(len(sk.data))\n",
-    "print('secret key values : ', sk.data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,17 +82,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 85,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "[0, 1]     [0, 1, 0, 1]     [0, 0, 1]\n"
-    }
-   ],
+   "outputs": [],
    "source": [
     "int_encoder = IntegerEncoder(ctx)\n",
     "ri1 = random.randint(0,10)\n",
@@ -124,7 +95,7 @@
     "pt1 = int_encoder.encode(ri1)\n",
     "pt2 = int_encoder.encode(ri2)\n",
     "pt3 = int_encoder.encode(ri3)\n",
-    "print(pt1.data,\"   \", pt2.data, \"   \", pt3.data)\n",
+    "# print(pt1.data,\"   \", pt2.data, \"   \", pt3.data)\n",
     "# print('plaintext data',plaintext.data)"
    ]
   },
@@ -137,21 +108,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 86,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "2\n10\n4\n"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(int_encoder.decode(pt1))\n",
-    "print(int_encoder.decode(pt2))\n",
-    "print(int_encoder.decode(pt3))"
+    "# print(int_encoder.decode(pt1))\n",
+    "# print(int_encoder.decode(pt2))\n",
+    "# print(int_encoder.decode(pt3))"
    ]
   },
   {
@@ -164,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 90,
    "metadata": {
     "tags": []
    },
@@ -221,19 +186,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 91,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "2     10     4\n"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(int_encoder.decode(dec1), \"   \", int_encoder.decode(dec2), \"   \", int_encoder.decode(dec3))"
+    "# print(int_encoder.decode(dec1), \"   \", int_encoder.decode(dec2), \"   \", int_encoder.decode(dec3))"
    ]
   },
   {
@@ -245,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,58 +213,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 93,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "12\n"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cc12 = eval.add(ct1, ct2)\n",
     "cc12 = decrypter.decrypt(cc12)\n",
-    "print(int_encoder.decode(cc12))"
+    "# print(int_encoder.decode(cc12))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 94,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "12\n"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pc12 = eval.add(pt1, ct2)\n",
     "pc12 = decrypter.decrypt(pc12)\n",
-    "print(int_encoder.decode(pc12))"
+    "# print(int_encoder.decode(pc12))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 95,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "12\n"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pp12 = eval.add(pt1, pt2)\n",
-    "print(int_encoder.decode(pp12))"
+    "# print(int_encoder.decode(pp12))"
    ]
   },
   {
@@ -317,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,53 +267,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 97,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "\n\nct1 : [[[1042665945075, 916558144260, 1044174421481, 210629152726, 847821787156, 534894345004, 763475050322, 1033922928488, 532772495248, 351443634171, 1093570136397, 1006841470961, 377936268283, 147046430775, 970183333355, 847329897793, 667471202702, 176662347509, 919648546066, 796441831579, 275081728359, 407687223886, 344513077501, 899118994863, 860389120643, 467753443738, 119725953496, 894760788805, 851090554632, 823548090674, 351534884471, 50687760242, 595463970022, 434506787772, 586276619829, 337725279644, 735579946766, 511011770164, 450013503941, 542766713743, 311432052482, 979771104334, 194974774539, 760908664549, 229372331842, 437253620955, 435574411594, 937959646039, 982777761329, 770521129800, 6214731693, 76094852900, 131833917135, 649660765117, 1200241420, 428350364244, 920846207780, 192005048959, 603237170, 574887659510, 310476840958, 316729173050, 720651025894, 57302224595]], [[787708916333, 612305453753, 503055916075, 265330060304, 967037136757, 1084209027336, 852537584879, 596009293454, 545315984284, 89629478514, 500310893722, 913635272488, 295331741414, 343170521360, 440884132924, 581218043564, 33460522930, 74158105179, 323823980986, 146114471480, 676087278909, 243911193038, 413021988266, 955351839796, 840461138011, 961133130920, 528311773385, 265522350713, 321109105178, 206248972455, 174064935921, 1050332569006, 260899814482, 545123058910, 843199852499, 777269994295, 927317252133, 817358300955, 644149364338, 262915863359, 864407703940, 315167079979, 239198950163, 100585200786, 602519089033, 763797387073, 114190291157, 859475750349, 599593877147, 172868742508, 430120457778, 948660869026, 721632921867, 373424760414, 92045226725, 439108553694, 584669091328, 631410978903, 479865998565, 41996167970, 504676203801, 437975668245, 41317672422, 282897743591]]]\n\n\nct2 : [[[536821766082, 585811519751, 713117807512, 453910120189, 969782634823, 293602305066, 370327689694, 837251947672, 169966145043, 159057006308, 82219478630, 286841273088, 961884851812, 3524731701, 797779128802, 54029609253, 534388427994, 1035671716795, 971032879986, 760615459955, 1755712634, 171301454914, 855481318547, 651222568531, 591671179453, 880891842782, 694051268864, 242920355771, 315336614397, 355443273823, 145024819419, 384022590009, 465400970283, 132693141744, 81818035682, 215064320534, 145249611055, 84790849906, 360503870492, 689102571563, 349174364279, 904676445732, 672964706925, 82994202862, 728243985058, 747888667666, 673653640163, 109076520616, 420053159630, 807540689048, 708044469947, 717614098683, 528977486448, 948673843337, 6079372932, 485253989853, 455715362950, 814740225456, 370859807274, 643568687552, 955701725154, 291551477531, 718813946401, 588437535526]], [[533010224687, 545383495441, 567709192381, 108165556120, 516900927372, 826625739072, 448875783417, 1010286501280, 1094291450416, 136336175112, 970283543233, 352556949223, 184667360906, 572879480837, 699238808805, 844649364977, 863359915496, 502254584510, 524456402942, 75401951875, 858542782966, 219260635339, 2349901207, 695534318514, 1098827426359, 696786848670, 828761711538, 755624847980, 719268865331, 889182616769, 528286361623, 1005874934372, 301866186353, 938306569271, 544536703895, 157408270177, 722598784808, 905145409821, 990123723941, 1021179204412, 597535556990, 733745366742, 302706460432, 372047210407, 42526756666, 246250422418, 904656658054, 697399941349, 306536731809, 1008246605183, 440125592694, 308403793977, 738710884420, 215660228580, 292162081725, 468929778278, 676106983643, 704007234379, 634889958724, 252886483649, 320637080231, 683654774225, 1069805043714, 519601686952]]]\n\n\n\nfinal result:  20\n"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "result = eval._mul_cipher_cipher(ct1, ct2)\n",
-    "print(\"\\n\\nct1 :\",ct1.data)\n",
-    "print(\"\\n\\nct2 :\",ct2.data)\n",
-    "print('\\n\\n')\n",
-    "\n",
-    "result = decrypter.decrypt(result)\n",
-    "result = int_encoder.decode(result)\n",
-    "\n",
-    "print('final result: ', result)"
+    "first_prod = eval._mul_cipher_cipher(ct1, ct2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 98,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "20      20\n"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(ri1 * ri2, \"    \", result)\n",
-    "assert ri1 * ri2 == result"
+    "\n",
+    "relin_prod = eval.relin(first_prod, keygenerator.get_relin_keys())\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "final_prod = eval._mul_cipher_cipher(relin_prod, ct3)\n",
+    "result = decrypter.decrypt(final_prod)\n",
+    "result = int_encoder.decode(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "0      -4313233534013225645650638308439700547724\n"
+    },
+    {
+     "output_type": "error",
+     "ename": "AssertionError",
+     "evalue": "",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-100-e1c951fc4c6a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mri1\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mri2\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mri3\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"    \"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0mri1\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mri2\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "print(ri1 * ri2 * ri3, \"    \", result)\n",
+    "assert ri1 * ri2 == result"
+   ]
   },
   {
    "cell_type": "code",

--- a/syft/frameworks/torch/he/fv/evaluator.py
+++ b/syft/frameworks/torch/he/fv/evaluator.py
@@ -337,3 +337,41 @@ class Evaluator:
         """
         pt1, pt2 = pt1.data, pt2.data
         return PlainText(poly_mul_mod(pt1, pt2, self.plain_modulus, self.poly_modulus))
+
+    def relin(self, ct, rlk):
+        ct0, ct1, ct2 = copy.deepcopy(ct.data)
+
+        mul_rlk0_c2 = [0] * len(self.coeff_modulus)
+        mul_rlk1_c2 = [0] * len(self.coeff_modulus)
+        for i in range(len(self.coeff_modulus)):
+            mul_rlk0_c2[i] = [0] * len(self.coeff_modulus)
+            mul_rlk1_c2[i] = [0] * len(self.coeff_modulus)
+
+        for i in range(len(self.coeff_modulus)):
+            for j in range(len(self.coeff_modulus)):
+                mul_rlk0_c2[i][j] = poly_mul_mod(
+                    rlk[i][0][j], ct2[j], self.coeff_modulus[j], self.poly_modulus
+                )
+                mul_rlk1_c2[i][j] = poly_mul_mod(
+                    rlk[i][1][j], ct2[j], self.coeff_modulus[j], self.poly_modulus
+                )
+
+        temp0 = [0] * len(self.coeff_modulus)
+        temp1 = [0] * len(self.coeff_modulus)
+        for i in range(len(self.coeff_modulus)):
+            temp0[i] = [0] * self.poly_modulus
+            temp1[i] = [0] * self.poly_modulus
+
+        for i in range(len(self.coeff_modulus)):
+            for j in range(len(self.coeff_modulus)):
+                temp0[i] = poly_add(mul_rlk0_c2[j][i], temp0[i], self.poly_modulus)
+                temp1[i] = poly_add(mul_rlk1_c2[j][i], temp1[i], self.poly_modulus)
+
+        ct0_final = [0] * len(self.coeff_modulus)
+        ct1_final = [0] * len(self.coeff_modulus)
+
+        for i in range(len(self.coeff_modulus)):
+            ct0_final[i] = poly_add_mod(ct0[i], temp0[i], self.coeff_modulus[i], self.poly_modulus)
+            ct1_final[i] = poly_add_mod(ct1[i], temp1[i], self.coeff_modulus[i], self.poly_modulus)
+
+        return CipherText([ct0_final, ct1_final])

--- a/syft/frameworks/torch/he/fv/relin_keys.py
+++ b/syft/frameworks/torch/he/fv/relin_keys.py
@@ -1,0 +1,35 @@
+from syft.frameworks.torch.he.fv.util.operations import poly_mul_mod
+from syft.frameworks.torch.he.fv.util.rlwe import encrypt_symmetric
+from syft.frameworks.torch.he.fv.util.operations import poly_add_mod
+
+
+class RelinKeys:
+    def __init__(self, context, sk):
+        self._context = context
+        self._coeff_modulus = context.param.coeff_modulus
+        self._poly_modulus = context.param.poly_modulus
+        self._secret_key = sk.data
+        self._secret_key_power_2 = self._get_sk_power_2(sk.data)
+
+    def _generate_relin_key(self):
+        return self._generate_one_kswitch_key(self._secret_key_power_2)
+
+    def _generate_one_kswitch_key(self, sk_power_2):
+        result = [0] * len(self._coeff_modulus)
+        for i in range(len(self._coeff_modulus)):
+            result[i] = encrypt_symmetric(self._context, self._secret_key).data
+            factor = self._coeff_modulus[-1] % self._coeff_modulus[i]
+
+            temp = [(x * factor) for x in sk_power_2[i]]
+
+            for j in range(len(self._coeff_modulus)):
+                result[i][0][j] = poly_add_mod(
+                    result[i][0][j], temp, self._coeff_modulus[j], self._poly_modulus
+                )
+        return result
+
+    def _get_sk_power_2(self, sk):
+        sk_power_2 = None
+        for i in range(len(self._coeff_modulus)):
+            sk_power_2 = poly_mul_mod(sk[i], sk[i], self._coeff_modulus[i], self._poly_modulus,)
+        return sk_power_2

--- a/syft/frameworks/torch/he/fv/util/operations.py
+++ b/syft/frameworks/torch/he/fv/util/operations.py
@@ -70,7 +70,7 @@ def poly_add(op1, op2, poly_mod):
     return np.polyadd(np.array(op1, dtype="object"), np.array(op2, dtype="object")).tolist()
 
 
-def poly_add_mod(op1, op2, coeff_mod, poly_mod):
+def poly_add_mod(op1, op2, coeff_mod, poly_mod, debug=False):
     """Add two polynomials and modulo every coefficient with coeff_mod.
 
     Args:
@@ -87,7 +87,8 @@ def poly_add_mod(op1, op2, coeff_mod, poly_mod):
         op1 += [0] * (poly_mod - len(op1))
     if len(op2) != poly_mod:
         op2 += [0] * (poly_mod - len(op2))
-
+    if debug:
+        print("arguments for poly_add_mod : ", op1, "\n\nsecond arg : ", op2)
     return np.mod(
         np.polyadd(np.array(op1, dtype="object"), np.array(op2, dtype="object")), coeff_mod
     ).tolist()

--- a/test/torch/tensors/test_fv.py
+++ b/test/torch/tensors/test_fv.py
@@ -666,3 +666,23 @@ def test_fv_mul_plain_plain(int1, int2):
         == encoder.decode(evaluator.mul(op1, op2))
         == encoder.decode(evaluator._mul_plain_plain(op2, op1))
     )
+
+
+@pytest.mark.parametrize(
+    "val", [(0), (1), (-1), (100), (1000), (-1000), (-99)],
+)
+def test_fv_relin(val):
+    ctx = Context(EncryptionParams(128, CoeffModulus().create(128, [40]), 64))
+    keygenerator = KeyGenerator(ctx)
+    keys = keygenerator.keygen()
+    relin_key = keygenerator.get_relin_keys()
+    encoder = IntegerEncoder(ctx)
+    encryptor = Encryptor(ctx, keys[1])  # keys[1] = public_key
+    decryptor = Decryptor(ctx, keys[0])  # keys[0] = secret_key
+    evaluator = Evaluator(ctx)
+
+    op = encryptor.encrypt(encoder.encode(val))
+    temp_prod = evaluator.mul(op, op)
+    relin_prod = evaluator.relin(temp_prod, relin_key)
+
+    assert val * val == encoder.decode(decryptor.decrypt(relin_prod))


### PR DESCRIPTION
## Description
Closes #3662  #3791 
Implementing relin_keys and Relinearization operation for the FV scheme. So that we can decrement the size of ciphertexts if needed. Mainly required after multiplication operation.

## Affected Dependencies
TODO

## How has this been tested?
TODO

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
