### PR TITLE
Use OnnxModels for private inference

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -12,7 +12,7 @@ psutil==5.7.0
 requests~=2.22.0
 RestrictedPython~=5.0
 scipy~=1.4.1
-git+https://github.com/gmuraru/syft-proto.git@d8a4069457f65891ff02ad7e565dace8cd7b9a3f#egg=syft-proto
+syft-proto==0.4.10
 tblib~=1.6.0
 torchvision~=0.5.0
 torch~=1.4.0

--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -12,7 +12,7 @@ psutil==5.7.0
 requests~=2.22.0
 RestrictedPython~=5.0
 scipy~=1.4.1
-syft-proto==0.4.7
+git+https://github.com/gmuraru/syft-proto.git@d8a4069457f65891ff02ad7e565dace8cd7b9a3f#egg=syft-proto
 tblib~=1.6.0
 torchvision~=0.5.0
 torch~=1.4.0

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -76,9 +76,9 @@ def load(tag: str, src: int, **kwargs):
 
 def load_model(tag: str):
     """
-    ATTENTION: All the workers that are part of the CrypTen computation
+    WARNING: All the workers that are part of the CrypTen computation
     should have the model
-    This method should dissapear once CrypTen has support to load models
+    This method should disappear once CrypTen has support to load models
     that are available only at one party (by using the crypten.load function)
     """
     src = comm.get().get_rank()

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -1,5 +1,7 @@
 import syft
 
+from syft.frameworks.crypten.model import OnnxModel  # noqa: F401
+
 import crypten.communicator as comm
 import crypten
 
@@ -69,4 +71,22 @@ def load(tag: str, src: int, **kwargs):
     else:
         result = crypten.load_from_party(preloaded=-1, src=src, **kwargs)
 
+    return result
+
+
+def load_model(tag: str):
+    """
+    ATTENTION: All the workers that are part of the CrypTen computation
+    should have the model
+    This method should dissapear once CrypTen has support to load models
+    that are available only at one party (by using the crypten.load function)
+    """
+    src = comm.get().get_rank()
+    worker = get_worker_from_rank(src)
+    results = worker.search(tag)
+
+    # Make sure there is only one result
+    assert len(results) == 1
+
+    result = results[0].to_crypten()
     return result

--- a/syft/frameworks/crypten/hook/hook.py
+++ b/syft/frameworks/crypten/hook/hook.py
@@ -11,12 +11,12 @@ class CrypTenPlanBuild(object):
     TODO: When the problem converting Onnx serialized models to PyTorch is solved
     we can have serialized models on a SINGLE worker.
 
-    Those model will be known by a single party and when the party will call
-    the crypten.load function it will deserialize the model to a Torch one
+    This model will be known by a single party and when the party will call
+    the crypten.load function it will deserialize the model to a PyTorch one
     and share it with the other parties.
 
     In this scenario, the worker that started the computation will not know about the
-    instrinsics of the architecture and ONLY ONE worker can have knowledge about the
+    instrinsics of the architecture and *only one* worker can have knowledge about the
     model
     """
 

--- a/syft/frameworks/crypten/hook/hook.py
+++ b/syft/frameworks/crypten/hook/hook.py
@@ -7,19 +7,6 @@ import torch as th
 
 
 class CrypTenPlanBuild(object):
-    """
-    TODO: When the problem converting Onnx serialized models to PyTorch is solved
-    we can have serialized models on a SINGLE worker.
-
-    This model will be known by a single party and when the party will call
-    the crypten.load function it will deserialize the model to a PyTorch one
-    and share it with the other parties.
-
-    In this scenario, the worker that started the computation will not know about the
-    instrinsics of the architecture and *only one* worker can have knowledge about the
-    model
-    """
-
     @staticmethod
     def f_return_none(*args, **kwargs):
         return None

--- a/syft/frameworks/crypten/model.py
+++ b/syft/frameworks/crypten/model.py
@@ -4,12 +4,11 @@ import torch
 
 import syft
 
-from syft.workers.abstract import AbstractWorker
-from syft.workers.base import BaseWorker
 from syft.frameworks.crypten import utils
-
 from syft.generic.pointers.object_pointer import ObjectPointer
 from syft.generic.abstract.sendable import AbstractSendable
+from syft.workers.abstract import AbstractWorker
+from syft.workers.base import BaseWorker
 
 from syft_proto.frameworks.crypten.onnx_model_pb2 import OnnxModel as OnnxModelPB
 

--- a/syft/frameworks/crypten/model.py
+++ b/syft/frameworks/crypten/model.py
@@ -1,0 +1,179 @@
+from typing import List
+
+import torch
+
+import syft
+
+from syft.workers.abstract import AbstractWorker
+from syft.workers.base import BaseWorker
+from syft.frameworks.crypten import utils
+
+from syft.generic.pointers.object_pointer import ObjectPointer
+from syft.generic.abstract.sendable import AbstractSendable
+
+from syft_proto.frameworks.crypten.onnx_model_pb2 import OnnxModel as OnnxModelPB
+
+
+class OnnxModel(AbstractSendable):
+    def __init__(
+        self,
+        serialized_model: bytes = None,
+        id: int = None,
+        owner: "syft.workers.AbstractWorker" = None,
+        tags: List[str] = None,
+        description: str = None,
+    ):
+        super(OnnxModel, self).__init__(id, owner, tags, description, None)
+        self.serialized_model = serialized_model
+
+    @classmethod
+    def fromModel(
+        cls,
+        model: torch.nn.Module,
+        dummy_input: torch.Tensor,
+        id: int = None,
+        owner: "syft.workers.AbstractWorker" = None,
+        tags: List[str] = None,
+        description: str = None,
+    ):
+        serialized_model = utils.pytorch_to_onnx(model, dummy_input)
+
+        return cls(serialized_model, id, owner, tags, description)
+
+    def get_class_attributes(self):
+        return {"serialized_model": self.serialized_model}
+
+    def create_pointer(
+        self,
+        location: BaseWorker = None,
+        id_at_location: (str or int) = None,
+        register: bool = False,
+        owner: BaseWorker = None,
+        ptr_id: (str or int) = None,
+        garbage_collect_data: bool = True,
+        **kwargs,
+    ) -> ObjectPointer:
+        """Creates a pointer to the "self" OnnxModel object.
+
+        Returns:
+            An ObjectPointer pointer to self.
+        """
+
+        if id_at_location is None:
+            id_at_location = self.id
+
+        if ptr_id is None:
+            if location is not None and location.id != self.owner.id:
+                ptr_id = self.id
+            else:
+                ptr_id = syft.ID_PROVIDER.pop()
+
+        ptr = ObjectPointer.create_pointer(
+            self, location, id_at_location, register, owner, ptr_id, garbage_collect_data, **kwargs
+        )
+
+        return ptr
+
+    def to_crypten(self):
+        return utils.onnx_to_crypten(self.serialized_model)
+
+    def send(
+        self, location, garbage_collect_data: bool = True,
+    ):
+        ptr = self.owner.send(self, location, garbage_collect_data=garbage_collect_data,)
+
+        ptr.description = self.description
+        ptr.tags = self.tags
+
+        return ptr
+
+    @staticmethod
+    def simplify(worker: AbstractWorker, model: "OnnxModel") -> tuple:
+        """
+        Takes the attributes of a FixedPrecisionTensor and saves them in a tuple.
+
+        Args:
+            worker: the worker doing the serialization
+            model: an OnnxModel.
+
+        Returns:
+            tuple: a tuple holding the unique attributes of the fixed precision tensor.
+        """
+        return (
+            syft.serde.msgpack.serde._simplify(worker, model.serialized_model),
+            syft.serde.msgpack.serde._simplify(worker, model.id),
+            syft.serde.msgpack.serde._simplify(worker, model.tags),
+            syft.serde.msgpack.serde._simplify(worker, model.description),
+        )
+
+    @staticmethod
+    def detail(worker: AbstractWorker, model: tuple) -> "OnnxModel":
+        """
+        This function reconstructs an OnnxModel given it's attributes in form of a tuple.
+        Args:
+            worker: the worker doing the deserialization
+            model: a tuple holding the attributes of the OnnxModel
+        Returns:
+            OnnxModel: an OnnxModel
+        """
+
+        (serialized_model, id, tags, description) = model
+
+        model = OnnxModel(
+            serialized_model=syft.serde.msgpack.serde._detail(worker, serialized_model),
+            id=syft.serde.msgpack.serde._detail(worker, id),
+            owner=worker,
+            tags=syft.serde.msgpack.serde._detail(worker, tags),
+            description=syft.serde.msgpack.serde._detail(worker, description),
+        )
+
+        return model
+
+    @staticmethod
+    def bufferize(worker, onnx_model):
+        """
+         This method serializes OnnxModel into OnnxModelPB.
+          Args:
+             onnx_model (OnnxModel): input OnnxModel to be serialized.
+          Returns:
+             proto_prec_tensor (FixedPrecisionTensorPB): serialized FixedPrecisionTensor
+         """
+        proto_onnx_model = OnnxModelPB()
+        syft.serde.protobuf.proto.set_protobuf_id(proto_onnx_model.id, onnx_model.id)
+        proto_onnx_model.serialized_model = onnx_model.serialized_model
+        for tag in onnx_model.tags:
+            proto_onnx_model.tags.append(tag)
+        proto_onnx_model.description = onnx_model.description
+
+        return proto_onnx_model
+
+    @staticmethod
+    def unbufferize(worker, proto_onnx_model):
+        """
+            This method deserializes OnnxModelPB into OnnxModel.
+            Args:
+                proto_onnx_model (OnnxModelPB): input OnnxModel to be
+                deserialized.
+            Returns:
+                onnx_model (OnnxModel): deserialized OnnxModelPB
+        """
+        proto_id = syft.serde.protobuf.proto.get_protobuf_id(proto_onnx_model.id)
+
+        onnx_model = OnnxModel(
+            proto_onnx_model.serialized_model,
+            owner=worker,
+            id=proto_id,
+            tags=set(proto_onnx_model.tags),
+            description=proto_onnx_model.description,
+        )
+
+        return onnx_model
+
+    @staticmethod
+    def get_protobuf_schema():
+        """
+            Returns the protobuf schema used for OnnxModel.
+            Returns:
+                Protobuf schema for OnnxModel.
+        """
+        return OnnxModelPB

--- a/syft/frameworks/crypten/model.py
+++ b/syft/frameworks/crypten/model.py
@@ -12,6 +12,19 @@ from syft.workers.base import BaseWorker
 
 from syft_proto.frameworks.crypten.onnx_model_pb2 import OnnxModel as OnnxModelPB
 
+"""
+TODO: When the problem converting Onnx serialized models to PyTorch is solved
+we can have serialized models on a SINGLE worker.
+
+This model will be known by a single party and when the party will call
+the crypten.load function it will deserialize the model to a PyTorch one
+and share it with the other parties.
+
+In this scenario, the worker that started the computation will not know about the
+instrinsics of the architecture and *only one* worker can have knowledge about the
+model
+"""
+
 
 class OnnxModel(AbstractSendable):
     def __init__(

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -234,6 +234,10 @@ def test_context_plan_with_model(workers):
 
 
 def test_context_plan_with_model_private(workers):
+    """
+        Test if we can run remote inference (using data that is not on our local
+        paty) using a private model (model that is not known locally)
+    """
     dummy_input = th.empty(1, 1, 28, 28)
     pytorch_model = ExampleNet()
 

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 import syft as sy
 
 from syft.frameworks.crypten.context import run_multiworkers, run_party
+from syft.frameworks.crypten.model import OnnxModel
 from syft.frameworks.crypten import utils
 
 
@@ -219,14 +220,46 @@ def test_context_plan_with_model(workers):
         [alice, bob], master_addr="127.0.0.1", model=pytorch_model, dummy_input=dummy_input
     )
     @sy.func2plan()
-    def plan_func_model(model=None, crypten=crypten):
+    def plan_func_model(model=None, crypten=crypten):  # noqa: F821
         t = crypten.load("crypten_data", 0)
 
-        model.encrypt()  # noqa: F821
-        out = model(t)  # noqa: F821
-        model.decrypt()  # noqa: F821
+        model.encrypt()
+        out = model(t)
+        model.decrypt()
         out = out.get_plain_text()
-        return model, out  # noqa: F821
+        return model, out
 
     result = plan_func_model()
     assert th.all(result[0][1] == result[1][1])
+
+
+def test_context_plan_with_model_private(workers):
+    dummy_input = th.empty(1, 1, 28, 28)
+    pytorch_model = ExampleNet()
+
+    alice = workers["alice"]
+    bob = workers["bob"]
+
+    data_alice = th.tensor(dummy_input).tag("crypten_data").send(alice)
+    model = OnnxModel.fromModel(pytorch_model, dummy_input).tag("crypten_model")
+
+    # Model is known only by Bob and Alice and the data is at the local party
+    alice_model_ptr = model.send(alice)
+    bob_model_ptr = model.send(bob)
+
+    @run_multiworkers([alice, bob], master_addr="127.0.0.1")
+    @sy.func2plan()
+    def plan_func_model(crypten=crypten):  # noqa: F821
+        data = crypten.load("crypten_data", 0)
+
+        # This should load the crypten model that is found at all parties
+        model = crypten.load_model("crypten_model")
+
+        model.encrypt()
+        out = model(data)
+        model.decrypt()
+        out = out.get_plain_text()
+        return out
+
+    result = plan_func_model()
+    assert th.all(result[0] == result[1])

--- a/test/serde/msgpack/test_msgpack_serde_full.py
+++ b/test/serde/msgpack/test_msgpack_serde_full.py
@@ -69,6 +69,8 @@ samples[
 ] = make_fixedprecisiontensor
 samples[syft.frameworks.torch.tensors.interpreters.private.PrivateTensor] = make_privatetensor
 
+samples[syft.frameworks.crypten.model.OnnxModel] = make_onnxmodel
+
 samples[syft.generic.pointers.multi_pointer.MultiPointerTensor] = make_multipointertensor
 samples[syft.generic.pointers.object_pointer.ObjectPointer] = make_objectpointer
 samples[syft.generic.pointers.object_wrapper.ObjectWrapper] = make_objectwrapper

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -46,6 +46,10 @@ samples[syft.generic.pointers.pointer_tensor.PointerTensor] = make_pointertensor
 samples[syft.generic.pointers.pointer_dataset.PointerDataset] = make_pointerdataset
 samples[syft.generic.string.String] = make_string
 
+# OnnxModel
+samples[syft.frameworks.crypten.model.OnnxModel] = make_onnxmodel
+
+
 # Syft Messages
 samples[syft.messaging.message.ObjectMessage] = make_objectmessage
 samples[syft.messaging.message.TensorCommandMessage] = make_tensor_command_message


### PR DESCRIPTION
## Description
Define and use ```OnnxModels``` serialized models.
The parties know the model architecture and one of the parties has data that should be run through the model.
The local party does not have any idea about the architecture or the data.

The local party would only receive the result for the inference step.


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Added test to check the functionality

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
