### PR TITLE
updating the websocket client's timeout

### DIFF
--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -17,7 +17,7 @@ from syft.workers.base import BaseWorker
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT_INTERVAL = 60
+TIMEOUT_INTERVAL = 360
 
 
 class WebsocketClientWorker(BaseWorker):


### PR DESCRIPTION

## Description
Increasing the timeout will help in solving a lot of timeout issues especially with tensor.send() when the tensor is large and model.send() when the model is big.
This should solve issue #3813 and some other timeout issues.