### PR TITLE
Add optimized versions of AvgPool, MaxPool and adaptive pooling

### DIFF
--- a/syft/frameworks/torch/mpc/securenn.py
+++ b/syft/frameworks/torch/mpc/securenn.py
@@ -283,7 +283,7 @@ def msb(a_sh):
     L = a_sh.field + 1  # field of a is L - 1
     dtype = get_dtype(L)
     input_shape = a_sh.shape
-    a_sh = a_sh.view(-1)
+    a_sh = a_sh.reshape(-1)
 
     # the commented out numbers below correspond to the
     # line numbers in Table 5 of the SecureNN paper

--- a/syft/frameworks/torch/nn/__init__.py
+++ b/syft/frameworks/torch/nn/__init__.py
@@ -1,7 +1,8 @@
 from syft.frameworks.torch.nn.conv import Conv2d
 from syft.frameworks.torch.nn.functional import conv2d
-from syft.frameworks.torch.nn.functional import maxpool2d
-from syft.frameworks.torch.nn.functional import avgpool2d
+from syft.frameworks.torch.nn.functional import max_pool2d
+from syft.frameworks.torch.nn.functional import avg_pool2d
+from syft.frameworks.torch.nn.functional import adaptive_avg_pool2d
 from syft.frameworks.torch.nn.functional import dropout
 from syft.frameworks.torch.nn.functional import linear
 from syft.frameworks.torch.nn.pool import AvgPool2d
@@ -28,8 +29,9 @@ def nn(module):
         module.conv2d = conv2d
         module.dropout = dropout
         module.linear = linear
-        module.max_pool2d = maxpool2d
-        module.avg_pool2d = avgpool2d
+        module.max_pool2d = max_pool2d
+        module.avg_pool2d = avg_pool2d
+        module.adaptive_avg_pool2d = adaptive_avg_pool2d
 
     module.functional = functional
 

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -1,5 +1,9 @@
 import torch
 
+import syft as sy
+from syft.generic.utils import allow_command
+from syft.generic.utils import remote
+
 
 def linear(*args):
     """
@@ -35,23 +39,16 @@ def dropout(input, p=0.5, training=True, inplace=False):
     return input
 
 
-def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):  # noqa: C901
+@allow_command
+def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     """
-    Overloads torch.nn.functional.conv2d to be able to use MPC on convolutional networks.
-    The idea is to build new tensors from input and weight to compute a
-    matrix multiplication equivalent to the convolution.
-    Args:
-        input: input image
-        weight: convolution kernels
-        bias: optional additive bias
-        stride: stride of the convolution kernels
-        padding:  implicit paddings on both sides of the input.
-        dilation: spacing between kernel elements
-        groups: split input into groups, in_channels should be divisible by the number of groups
-    Returns:
-        the result of the convolution (FixedPrecision Tensor)
-    """
+    This is a block of local computation done at the beginning of the convolution. It
+    basically does the matrix unrolling to be able to do the convolution as a simple
+    matrix multiplication.
 
+    Because all the computation are local, we add the @allow_command and run it directly
+    on each share of the additive sharing tensor, when running mpc computations
+    """
     assert len(input.shape) == 4
     assert len(weight.shape) == 4
 
@@ -106,7 +103,7 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     #                       [in values to compute out value 1],
     #                       ...
     #                       [in values to compute out value nb_rows_out*nb_cols_out]]
-    im_flat = input.view(batch_size, -1)
+    im_flat = input.reshape(batch_size, -1)
     im_reshaped = []
     for cur_row_out in range(nb_rows_out):
         for cur_col_out in range(nb_cols_out):
@@ -121,20 +118,34 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     #                       [weights for out channel 1],
     #                       ...
     #                       [weights for out channel nb_channels_out]].TRANSPOSE()
-    weight_reshaped = weight.view(nb_channels_out // groups, -1).t()
+    weight_reshaped = weight.reshape(nb_channels_out // groups, -1).t()
 
-    # Now that everything is set up, we can compute the result
-    if groups > 1:
-        res = []
-        chunks_im = torch.chunk(im_reshaped, groups, dim=2)
-        chunks_weights = torch.chunk(weight_reshaped, groups, dim=0)
-        for g in range(groups):
-            tmp = chunks_im[g].matmul(chunks_weights[g])
-            res.append(tmp)
-        res = torch.cat(res, dim=2)
-    else:
-        res = im_reshaped.matmul(weight_reshaped)
+    return (
+        im_reshaped,
+        weight_reshaped,
+        torch.tensor(batch_size),
+        torch.tensor(nb_channels_out),
+        torch.tensor(nb_rows_out),
+        torch.tensor(nb_cols_out),
+    )
 
+
+@allow_command
+def _post_conv(bias, res, batch_size, nb_channels_out, nb_rows_out, nb_cols_out):
+    """
+    This is a block of local computation done at the end of the convolution. It
+    basically reshape the matrix back to the shape it should have with a regular
+    convolution.
+
+    Because all the computation are local, we add the @allow_command and run it directly
+    on each share of the additive sharing tensor, when running mpc computations
+    """
+    batch_size, nb_channels_out, nb_rows_out, nb_cols_out = (
+        batch_size.item(),
+        nb_channels_out.item(),
+        nb_rows_out.item(),
+        nb_cols_out.item(),
+    )
     # Add a bias if needed
     if bias is not None:
         if bias.is_wrapper and res.is_wrapper:
@@ -147,65 +158,320 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     # ... And reshape it back to an image
     res = (
         res.permute(0, 2, 1)
-        .view(batch_size, nb_channels_out, nb_rows_out, nb_cols_out)
+        .reshape(batch_size, nb_channels_out, nb_rows_out, nb_cols_out)
         .contiguous()
     )
+
     return res
 
 
-def _pool(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
-    output_shape = (
-        (tensor.shape[0] - kernel_size) // stride + 1,
-        (tensor.shape[1] - kernel_size) // stride + 1,
+def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+    """
+    Overloads torch.nn.functional.conv2d to be able to use MPC on convolutional networks.
+    The idea is to unroll the input and weight matrices to compute a
+    matrix multiplication equivalent to the convolution.
+    Args:
+        input: input image
+        weight: convolution kernels
+        bias: optional additive bias
+        stride: stride of the convolution kernels
+        padding:  implicit paddings on both sides of the input.
+        dilation: spacing between kernel elements
+        groups: split input into groups, in_channels should be divisible by the number of groups
+    Returns:
+        the result of the convolution as a fixed precision tensor.
+    """
+    input_fp, weight_fp = input, weight
+    input, weight = input.child, weight.child
+    if bias is not None:
+        bias = bias.child
+
+    locations = input.locations
+
+    im_reshaped_shares = {}
+    weight_reshaped_shares = {}
+    params = {}
+    for location in locations:
+        input_share = input.child[location.id]
+        weight_share = weight.child[location.id]
+        bias_share = bias.child[location.id] if bias is not None else None
+        r = remote(_pre_conv, location=location)(
+            input_share,
+            weight_share,
+            bias_share,
+            stride,
+            padding,
+            dilation,
+            groups,
+            return_value=False,
+            return_arity=6,
+        )
+        (
+            im_reshaped_share,
+            weight_reshaped_share,
+            batch_size,
+            nb_channels_out,
+            nb_rows_out,
+            nb_cols_out,
+        ) = r
+        params[location.id] = (batch_size, nb_channels_out, nb_rows_out, nb_cols_out)
+
+        im_reshaped_shares[location.id] = im_reshaped_share
+        weight_reshaped_shares[location.id] = weight_reshaped_share
+
+    im_reshaped = sy.FixedPrecisionTensor(**input_fp.get_class_attributes()).on(
+        sy.AdditiveSharingTensor(im_reshaped_shares, **input.get_class_attributes()), wrap=False
     )
-    kernel_size = (kernel_size, kernel_size)
-    b = torch.ones(tensor.shape)  # when torch.Tensor.stride() is supported: replace with A.stride()
-    a_strides = b.stride()
-    a_w = torch.as_strided(
-        tensor,
-        size=output_shape + kernel_size,
-        stride=(stride * a_strides[0], stride * a_strides[1]) + a_strides,
+    weight_reshaped = sy.FixedPrecisionTensor(**weight_fp.get_class_attributes()).on(
+        sy.AdditiveSharingTensor(weight_reshaped_shares, **input.get_class_attributes()), wrap=False
     )
-    a_w = a_w.reshape(-1, *kernel_size)
-    result = []
-    if mode == "max":
-        for channel in range(a_w.shape[0]):
-            result.append(a_w[channel].max())
-    elif mode == "mean":
-        for channel in range(a_w.shape[0]):
-            result.append(torch.mean(a_w[channel]))
+
+    # Now that everything is set up, we can compute the convolution as a simple matmul
+    if groups > 1:
+        res = []
+        chunks_im = torch.chunk(im_reshaped, groups, dim=2)
+        chunks_weights = torch.chunk(weight_reshaped, groups, dim=0)
+        for g in range(groups):
+            tmp = chunks_im[g].matmul(chunks_weights[g])
+            res.append(tmp)
+        res = torch.cat(res, dim=2)
+        raise NotImplementedError
     else:
-        raise ValueError("unknown pooling mode")
+        res_fp = im_reshaped.matmul(weight_reshaped)
+        res = res_fp.child
 
-    result = torch.stack(result).reshape(output_shape)
-    return result
+    # and then we reshape the result
+    res_shares = {}
+    for location in locations:
+        bias_share = bias.child[location.id] if bias is not None else None
+        res_share = res.child[location.id]
+        res_share = remote(_post_conv, location=location)(
+            bias_share, res_share, *params[location.id]
+        )
+        res_shares[location.id] = res_share
 
-
-def pool2d(tensor, kernel_size: int = 2, stride: int = 2, mode="max"):
-    assert len(tensor.shape) < 5
-    if len(tensor.shape) == 2:
-        return _pool(tensor, kernel_size, stride, mode)
-    if len(tensor.shape) == 3:
-        return torch.squeeze(pool2d(torch.unsqueeze(tensor, dim=0), kernel_size, stride, mode))
-    batches = tensor.shape[0]
-    channels = tensor.shape[1]
-    out_shape = (
-        batches,
-        channels,
-        (tensor.shape[2] - kernel_size) // stride + 1,
-        (tensor.shape[3] - kernel_size) // stride + 1,
+    result_fp = sy.FixedPrecisionTensor(**res_fp.get_class_attributes()).on(
+        sy.AdditiveSharingTensor(res_shares, **res.get_class_attributes()), wrap=False
     )
-    result = []
-    for batch in range(batches):
-        for channel in range(channels):
-            result.append(_pool(tensor[batch][channel], kernel_size, stride, mode))
-    result = torch.stack(result).reshape(out_shape)
-    return result
+    return result_fp
 
 
-def maxpool2d(tensor, kernel_size: int = 2, stride: int = 2):
-    return pool2d(tensor, kernel_size, stride)
+@allow_command
+def _pre_pool(input, kernel_size, stride=1, padding=0, dilation=1, groups=1):
+    """
+    This is a block of local computation done at the beginning of the pool. It
+    basically does the matrix unrolling to be able to do the pooling as a single
+    max or average operation
+    """
+    assert len(input.shape) == 4
+
+    # Change to tuple if not one
+    stride = torch.nn.modules.utils._pair(stride)
+    padding = torch.nn.modules.utils._pair(padding)
+    dilation = torch.nn.modules.utils._pair(dilation)
+
+    # Extract a few useful values
+    batch_size, nb_channels_in, nb_rows_in, nb_cols_in = input.shape
+    nb_channels_out, nb_channels_kernel, nb_rows_kernel, nb_cols_kernel = (
+        nb_channels_in,
+        1,
+        kernel_size,
+        kernel_size,
+    )
+
+    # Check if inputs are coherent
+    # assert nb_channels_in == nb_channels_kernel * groups
+    assert nb_channels_in % groups == 0
+    assert nb_channels_out % groups == 0
+
+    # Compute output shape
+    nb_rows_out = int(
+        ((nb_rows_in + 2 * padding[0] - dilation[0] * (nb_rows_kernel - 1) - 1) / stride[0]) + 1
+    )
+    nb_cols_out = int(
+        ((nb_cols_in + 2 * padding[1] - dilation[1] * (nb_cols_kernel - 1) - 1) / stride[1]) + 1
+    )
+
+    # Apply padding to the input
+    if padding != (0, 0):
+        padding_mode = "constant"
+        input = torch.nn.functional.pad(
+            input, (padding[1], padding[1], padding[0], padding[0]), padding_mode
+        )
+        # Update shape after padding
+        nb_rows_in += 2 * padding[0]
+        nb_cols_in += 2 * padding[1]
+
+    # We want to get relative positions of values in the input tensor that are used by one filter convolution.
+    # It basically is the position of the values used for the top left convolution.
+    pattern_ind = []
+    for r in range(nb_rows_kernel):
+        for c in range(nb_cols_kernel):
+            pixel = r * nb_cols_in * dilation[0] + c * dilation[1]
+            pattern_ind.append(pixel)
+
+    # The image tensor is reshaped for the matrix multiplication:
+    # on each row of the new tensor will be the input values used for each filter convolution
+    # We will get a matrix [[in values to compute out value 0],
+    #                       [in values to compute out value 1],
+    #                       ...
+    #                       [in values to compute out value nb_rows_out*nb_cols_out]]
+    im_flat = input.reshape(batch_size, nb_channels_in, -1)
+    im_reshaped = []
+    for cur_row_out in range(nb_rows_out):
+        for cur_col_out in range(nb_cols_out):
+            # For each new output value, we just need to shift the receptive field
+            offset = cur_row_out * stride[0] * nb_cols_in + cur_col_out * stride[1]
+            tmp = [ind + offset for ind in pattern_ind]
+            im_reshaped.append(im_flat[:, :, tmp])
+    im_reshaped = torch.stack(im_reshaped).permute(1, 2, 0, 3)
+
+    return (
+        im_reshaped,
+        torch.tensor(batch_size),
+        torch.tensor(nb_channels_out),
+        torch.tensor(nb_rows_out),
+        torch.tensor(nb_cols_out),
+    )
 
 
-def avgpool2d(tensor, kernel_size: int = 2, stride: int = 2):
-    return pool2d(tensor, kernel_size, stride, mode="mean")
+@allow_command
+def _post_pool(res, batch_size, nb_channels_out, nb_rows_out, nb_cols_out):
+    """
+    This is a block of local computation done at the end of the pool. It reshapes
+    the output to the expected shape
+    """
+    batch_size, nb_channels_out, nb_rows_out, nb_cols_out = (
+        batch_size.item(),
+        nb_channels_out.item(),
+        nb_rows_out.item(),
+        nb_cols_out.item(),
+    )
+
+    # ... And reshape it back to an image
+    res = res.reshape(  # .permute(0, 2, 1)
+        batch_size, nb_channels_out, nb_rows_out, nb_cols_out
+    ).contiguous()
+
+    return res
+
+
+def max_pool2d(
+    input,
+    kernel_size: int = 2,
+    stride: int = 2,
+    padding=0,
+    dilation=1,
+    ceil_mode=None,
+    return_indices=None,
+):
+    return _pool2d(
+        input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        mode="max",
+    )
+
+
+def avg_pool2d(
+    input,
+    kernel_size: int = 2,
+    stride: int = 2,
+    padding=0,
+    ceil_mode=False,
+    count_include_pad=True,
+    divisor_override=None,
+):
+    return _pool2d(
+        input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=1,
+        ceil_mode=ceil_mode,
+        mode="avg",
+    )
+
+
+def _pool2d(
+    input, kernel_size: int = 2, stride: int = 2, padding=0, dilation=1, ceil_mode=None, mode="avg"
+):
+    if isinstance(kernel_size, tuple):
+        assert kernel_size[0] == kernel_size[1]
+        kernel_size = kernel_size[0]
+    if isinstance(stride, tuple):
+        assert stride[0] == stride[1]
+        stride = stride[0]
+
+    input_fp = input
+    input = input.child
+
+    locations = input.locations
+
+    im_reshaped_shares = {}
+    params = {}
+    for location in locations:
+        input_share = input.child[location.id]
+        r = remote(_pre_pool, location=location)(
+            input_share, kernel_size, stride, padding, dilation, return_value=False, return_arity=5,
+        )
+        (im_reshaped_share, batch_size, nb_channels_out, nb_rows_out, nb_cols_out,) = r
+        params[location.id] = (batch_size, nb_channels_out, nb_rows_out, nb_cols_out)
+
+        im_reshaped_shares[location.id] = im_reshaped_share
+
+    im_reshaped = sy.AdditiveSharingTensor(im_reshaped_shares, **input.get_class_attributes())
+
+    if mode == "max":
+        # We have optimisations when the kernel is small, namely a square of size 2 or 3
+        # to reduce the number of rounds and the total number of comparisons.
+        # See more in Appendice C.3 https://arxiv.org/pdf/2006.04593.pdf
+        if im_reshaped.shape[-1] == 4:
+            ab, cd = im_reshaped[:, :, :, :2], im_reshaped[:, :, :, 2:]
+            max1 = ab + (cd >= ab) * (cd - ab)
+            e, f = max1[:, :, :, 0], max1[:, :, :, 1]
+            max2 = e + (f >= e) * (f - e)
+            res = max2
+        elif im_reshaped.shape[-1] == 9:
+            abcd, efgh = im_reshaped[:, :, :, :4], im_reshaped[:, :, :, 4:8]
+            ABCD = abcd + (efgh >= abcd) * (efgh - abcd)
+            AB, CD = ABCD[:, :, :, :2], ABCD[:, :, :, 2:]
+            _AB = AB + (CD >= AB) * (CD - AB)
+            _A, _B = _AB[:, :, :, 0], _AB[:, :, :, 1]
+            _A_ = _A + (_B >= _A) * (_B - _A)
+            _B_ = im_reshaped[:, :, :, 8]
+            max4 = _A_ + (_B_ >= _A_) * (_B_ - _A_)
+            res = max4
+        else:
+            res = im_reshaped.max(dim=-1)
+    elif mode == "avg":
+        res = im_reshaped.mean(dim=-1)
+    else:
+        raise ValueError(f"In pool2d, mode should be avg or max, not {mode}.")
+
+    res_shares = {}
+    for location in locations:
+        res_share = res.child[location.id]
+        res_share = remote(_post_pool, location=location)(res_share, *params[location.id])
+        res_shares[location.id] = res_share
+
+    result_fp = sy.FixedPrecisionTensor(**input_fp.get_class_attributes()).on(
+        sy.AdditiveSharingTensor(res_shares, **res.get_class_attributes()), wrap=False
+    )
+    return result_fp
+
+
+def adaptive_avg_pool2d(tensor, output_size):
+    if isinstance(output_size, tuple):
+        assert output_size[0] == output_size[1]
+        output_size = output_size[0]
+    assert tensor.shape[2] == tensor.shape[3]
+    input_size = tensor.shape[2]
+    assert input_size >= output_size
+    stride = input_size // output_size
+    kernel_size = input_size - (output_size - 1) * stride
+    padding = 0
+    return avg_pool2d(tensor, kernel_size, stride, padding)

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -302,7 +302,8 @@ def _pre_pool(input, kernel_size, stride=1, padding=0, dilation=1, groups=1):
         nb_rows_in += 2 * padding[0]
         nb_cols_in += 2 * padding[1]
 
-    # We want to get relative positions of values in the input tensor that are used by one filter convolution.
+    # We want to get relative positions of values in the input tensor that are used by
+    # one filter convolution.
     # It basically is the position of the values used for the top left convolution.
     pattern_ind = []
     for r in range(nb_rows_kernel):

--- a/test/torch/nn/test_functional.py
+++ b/test/torch/nn/test_functional.py
@@ -1,9 +1,12 @@
+import pytest
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 
-def test_torch_nn_functional_linear():
+@pytest.mark.parametrize("protocol", ["snn", "fss"])
+def test_torch_nn_functional_linear(protocol):
     tensor = nn.Parameter(torch.tensor([[1.0, 2], [3, 4]]), requires_grad=False).fix_prec()
     weight = nn.Parameter(torch.tensor([[1.0, 2], [3, 4]]), requires_grad=True).fix_prec()
 
@@ -36,7 +39,8 @@ def test_torch_nn_functional_linear():
     assert (result == expected).all()
 
 
-def test_torch_nn_functional_dropout(workers):
+@pytest.mark.parametrize("protocol", ["snn", "fss"])
+def test_torch_nn_functional_dropout(workers, protocol):
 
     # Test for fixed precision tensor
     a = torch.rand((20, 20))
@@ -61,7 +65,8 @@ def test_torch_nn_functional_dropout(workers):
     assert ((test_output == x).get().float_prec() == 1).all()
 
 
-def test_torch_nn_functional_conv2d(workers):
+@pytest.mark.parametrize("protocol", ["snn", "fss"])
+def test_torch_nn_functional_conv2d(workers, protocol):
     # Test with FixedPrecision tensors
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     im = torch.tensor(
@@ -84,14 +89,14 @@ def test_torch_nn_functional_conv2d(workers):
     w_fp = w.fix_prec()
     bias_fp = bias.fix_prec()
 
-    res0 = F.conv2d(im_fp, w_fp, bias=bias_fp, stride=1).float_prec()
+    res0 = F.conv2d(im_fp, w_fp, bias_fp, stride=1).float_prec()
     res1 = F.conv2d(
-        im_fp, w_fp[:, 0:1].contiguous(), bias=bias_fp, stride=2, padding=3, dilation=2, groups=2
+        im_fp, w_fp[:, 0:1].contiguous(), bias_fp, stride=2, padding=3, dilation=2, groups=2
     ).float_prec()
 
-    expected0 = torch.conv2d(im, w, bias=bias, stride=1)
+    expected0 = torch.conv2d(im, w, bias, stride=1)
     expected1 = torch.conv2d(
-        im, w[:, 0:1].contiguous(), bias=bias, stride=2, padding=3, dilation=2, groups=2
+        im, w[:, 0:1].contiguous(), bias, stride=2, padding=3, dilation=2, groups=2
     )
 
     assert (res0 == expected0).all()
@@ -102,12 +107,12 @@ def test_torch_nn_functional_conv2d(workers):
     w_shared = w.fix_prec().share(bob, alice, crypto_provider=james)
     bias_shared = bias.fix_prec().share(bob, alice, crypto_provider=james)
 
-    res0 = F.conv2d(im_shared, w_shared, bias=bias_shared, stride=1).get().float_precision()
+    res0 = F.conv2d(im_shared, w_shared, bias_shared, stride=1).get().float_precision()
     res1 = (
         F.conv2d(
             im_shared,
             w_shared[:, 0:1].contiguous(),
-            bias=bias_shared,
+            bias_shared,
             stride=2,
             padding=3,
             dilation=2,
@@ -117,16 +122,17 @@ def test_torch_nn_functional_conv2d(workers):
         .float_precision()
     )
 
-    expected0 = torch.conv2d(im, w, bias=bias, stride=1)
+    expected0 = torch.conv2d(im, w, bias, stride=1)
     expected1 = torch.conv2d(
-        im, w[:, 0:1].contiguous(), bias=bias, stride=2, padding=3, dilation=2, groups=2
+        im, w[:, 0:1].contiguous(), bias, stride=2, padding=3, dilation=2, groups=2
     )
 
     assert (res0 == expected0).all()
     assert (res1 == expected1).all()
 
 
-def test_torch_nn_functional_maxpool(workers):
+@pytest.mark.parametrize("protocol", ["snn", "fss"])
+def test_torch_nn_functional_maxpool(workers, protocol):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     enc_tensor = torch.tensor(
         [[[[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]]]], dtype=torch.float
@@ -156,7 +162,8 @@ def test_torch_nn_functional_maxpool(workers):
     assert (r_max == exp_max).all()
 
 
-def test_torch_nn_functional_avgpool(workers):
+@pytest.mark.parametrize("protocol", ["snn", "fss"])
+def test_torch_nn_functional_avgpool(workers, protocol):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     enc_tensor = torch.tensor(
         [[[[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]]]], dtype=torch.float

--- a/test/torch/nn/test_functional.py
+++ b/test/torch/nn/test_functional.py
@@ -134,6 +134,7 @@ def test_torch_nn_functional_conv2d(workers, protocol):
 @pytest.mark.parametrize("protocol", ["snn", "fss"])
 def test_torch_nn_functional_maxpool(workers, protocol):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+    # 4d
     enc_tensor = torch.tensor(
         [[[[1, 1, 2, 4], [5, 6, 7, 8], [3, 2, 1, 0], [1, 2, 3, 4]]]], dtype=torch.float
     )
@@ -141,6 +142,11 @@ def test_torch_nn_functional_maxpool(workers, protocol):
     r_max = F.max_pool2d(enc_tensor, kernel_size=2)
     r_max = r_max.get().float_prec()
     exp_max = torch.tensor([[[[6.0, 8.0], [3.0, 4.0]]]])
+    assert (r_max == exp_max).all()
+    # 4d kernel_size = 3
+    r_max = F.max_pool2d(enc_tensor, kernel_size=3, stride=1)
+    r_max = r_max.get().float_prec()
+    exp_max = torch.tensor([[[[7.0, 8.0], [7.0, 8.0]]]])
     assert (r_max == exp_max).all()
     # 3d
     enc_tensor = torch.tensor(

--- a/test/torch/nn/test_nn.py
+++ b/test/torch/nn/test_nn.py
@@ -35,33 +35,25 @@ def test_conv2d(workers):
     mkldnn_enabled_init = torch._C._get_mkldnn_enabled()
     torch._C._set_mkldnn_enabled(False)
 
-    # Direct Import from Syft
-    model = syft_nn.Conv2d(1, 2, 3, bias=True)
-    model_1 = nn.Conv2d(1, 2, 3, bias=True)
-    model.weight = model_1.weight.fix_prec()
-    model.bias = model_1.bias.fix_prec()
-    data = torch.rand(10, 1, 28, 28)  # eg. mnist data
-
-    out = model(data.fix_prec()).float_prec()
-    out_1 = model_1(data)
-
-    assert torch.allclose(out, out_1, atol=1e-2)
+    model = nn.Conv2d(1, 2, 3, bias=True)
+    data = torch.rand(5, 1, 7, 7)
+    expected = model(data)
 
     # Fixed Precision Tensor
-    model_2 = model_1.copy().fix_prec()
-    out_2 = model_2(data.fix_prec()).float_prec()
+    model_2 = model.copy().fix_prec()
+    out = model_2(data.fix_prec()).float_prec()
 
     # Note: absolute tolerance can be reduced by increasing precision_fractional of fix_prec()
-    assert torch.allclose(out_1, out_2, atol=1e-2)
+    assert torch.allclose(out, expected, atol=1e-2)
 
     # Additive Shared Tensor
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     shared_data = data.fix_prec().share(bob, alice, crypto_provider=james)
 
-    mode_3 = model_2.share(bob, alice, crypto_provider=james)
-    out_3 = mode_3(shared_data).get().float_prec()
+    model_3 = model_2.share(bob, alice, crypto_provider=james)
+    out = model_3(shared_data).get().float_prec()
 
-    assert torch.allclose(out_1, out_3, atol=1e-2)
+    assert torch.allclose(out, expected, atol=1e-2)
 
     # Reset mkldnn to the original state
     torch._C._set_mkldnn_enabled(mkldnn_enabled_init)

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -1,6 +1,8 @@
 import pytest
 
 import torch
+import torch.nn as nn
+import torch.nn.functional as F
 
 import syft
 from syft.frameworks.torch.tensors.interpreters.additive_shared import AdditiveSharingTensor
@@ -843,6 +845,96 @@ def test_argmax(workers, protocol):
     x = t.fix_prec().share(*args, **kwargs)
     ids = x.argmax(dim=1).get().float_prec()
     assert (ids.long() == torch.argmax(t, dim=1)).all()
+
+
+@pytest.mark.parametrize("protocol", ["snn", "fss"])
+def test_max_pool2d(workers, protocol):
+    me, alice, bob, crypto_provider = (
+        workers["me"],
+        workers["alice"],
+        workers["bob"],
+        workers["james"],
+    )
+
+    if protocol == "fss":
+        for worker in workers.values():
+            syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
+        me.crypto_store.provide_primitives(
+            ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=32
+        )
+
+    args = (alice, bob)
+    kwargs = dict(crypto_provider=crypto_provider, protocol=protocol)
+
+    if protocol == "fss":
+        me.crypto_store.provide_primitives(
+            ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=1000
+        )
+        # me.crypto_store.provide_primitives(["fss_comp"], [alice, bob], n_instances=2000)
+        # me.crypto_store.provide_primitives(
+        #     ["beaver"],
+        #     [alice, bob],
+        #     n_instances=2,
+        #     beaver={
+        #         "op_shapes": [
+        #             ("mul", torch.Size([3, 7, 4, 2]), torch.Size([3, 7, 4, 2])),
+        #             ("mul", torch.Size([3, 7, 4]), torch.Size([3, 7, 4])),
+        #             ("mul", torch.Size([3, 7, 1, 9]), torch.Size([3, 7, 1, 9])),
+        #         ]
+        #     },
+        # )
+
+    m = 4
+    t = torch.tensor(list(range(3 * 7 * m * m))).float().reshape(3, 7, m, m)
+    x = t.fix_prec().share(*args, **kwargs)
+
+    # using maxpool optimization for kernel_size=2
+    expected = F.max_pool2d(t, kernel_size=2)
+    result = F.max_pool2d(x, kernel_size=2).get().float_prec()
+
+    assert (result == expected).all()
+
+    # without
+    expected = F.max_pool2d(t, kernel_size=3)
+    result = F.max_pool2d(x, kernel_size=3).get().float_prec()
+
+    assert (result == expected).all()
+
+
+@pytest.mark.parametrize("protocol", ["snn", "fss"])
+def test_avg_pool2d(workers, protocol):
+    me, alice, bob, crypto_provider = (
+        workers["me"],
+        workers["alice"],
+        workers["bob"],
+        workers["james"],
+    )
+
+    if protocol == "fss":
+        for worker in workers.values():
+            syft.frameworks.torch.mpc.fss.initialize_crypto_plans(worker)
+        me.crypto_store.provide_primitives(
+            ["xor_add_couple", "fss_eq", "fss_comp"], [alice, bob], n_instances=32
+        )
+
+    args = (alice, bob)
+    kwargs = dict(crypto_provider=crypto_provider, protocol="fss")
+
+    m = 4
+    t = torch.tensor(list(range(3 * 7 * m * m))).float().reshape(3, 7, m, m)
+    x = t.fix_prec().share(*args, **kwargs)
+
+    # using maxpool optimization for kernel_size=2
+    expected = F.avg_pool2d(t, kernel_size=2)
+    result = F.avg_pool2d(x, kernel_size=2).get().float_prec()
+
+    assert (result == expected).all()
+
+    # without
+    expected = F.avg_pool2d(t, kernel_size=3)
+    result = F.avg_pool2d(x, kernel_size=3).get().float_prec()
+
+    assert (result == expected).all()
 
 
 def test_mod(workers):

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -1,7 +1,6 @@
 import pytest
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 
 import syft


### PR DESCRIPTION
## Description
This is an optimisation of pooling and convolution layers which uses #3689. Basically it consists of decomposing conv & pool in 3 phases: a "pre" phase where all workers compute local stuff, a phase with communication, and a "post" phase where all workers compute local stuff.

## Affected Dependencies
List any dependencies that are required for this change.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
