### PR TITLE
Namespace dynamic_fl_client route

### DIFF
--- a/syft/grid/clients/dynamic_fl_client.py
+++ b/syft/grid/clients/dynamic_fl_client.py
@@ -226,7 +226,7 @@ class DynamicFLClient(WebsocketClientWorker):
             "model": serialized_model,
         }
 
-        url = self.address.replace("ws", "http") + "/serve-model/"
+        url = self.address.replace("ws", "http") + "dynamic/serve-model/"
 
         # Multipart encoding
         form = MultipartEncoder(message)

--- a/syft/grid/clients/dynamic_fl_client.py
+++ b/syft/grid/clients/dynamic_fl_client.py
@@ -226,7 +226,7 @@ class DynamicFLClient(WebsocketClientWorker):
             "model": serialized_model,
         }
 
-        url = self.address.replace("ws", "http") + "dynamic/serve-model/"
+        url = self.address.replace("ws", "http") + "/dynamic/serve-model/"
 
         # Multipart encoding
         form = MultipartEncoder(message)


### PR DESCRIPTION
## Description
Namespace dynamic FL client routes. Added url prefix `dynamic` to the Dynamic FL client url.
Fixes https://github.com/OpenMined/PyGrid/issues/600

## How has this been tested?
- Existing tests.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
