### PR TITLE
Fix for Nodeclient serialization error

### DIFF
--- a/syft/workers/websocket_client.py
+++ b/syft/workers/websocket_client.py
@@ -20,14 +20,14 @@ from syft.messaging.message import SearchMessage
 from syft.messaging.message import TensorCommandMessage
 from syft.generic.tensor import AbstractTensor
 from syft.generic.pointers.pointer_tensor import PointerTensor
-from syft.workers.base import BaseWorker
+from syft.workers.virtual import VirtualWorker
 
 logger = logging.getLogger(__name__)
 
 TIMEOUT_INTERVAL = 60
 
 
-class WebsocketClientWorker(BaseWorker):
+class WebsocketClientWorker(VirtualWorker):
     def __init__(
         self,
         hook,


### PR DESCRIPTION
1. Fix for "Cannot serialize Nodeclient Object" 

## Description
**_pysyft: v2.6.0_**

While running this:

input_value = th.tensor([1.0, 2])
result = grid.run_remote_inference("convnet", input_value, mpc=True)

**_Error Occurs_**
"TypeError: can not serialize 'NodeClient' object"
While debugging and comparing with pysyft(0.2.5):
this function is not returning the right value for NodeClient (in file serde.py line no 337 )
Function: _serialize_msgpack_simple

The main reason for this is:
1. The code wouldn't find any simplifiers for NodeClient (Function: _simplify, file serde.py line no 393).
for inheritance_type in **_classes_inheritance_**:
   if inheritance_type in _**msgpack_global_state.simplifiers:**_

2. Main Cause: It is because WebSocketClientWorker(websocket_client.py) extends from BaseWorker. And the getmro response below doesn't include 'VirtualWorker'.
classes_inheritance = inspect.getmro(type(obj))[1:]

3. Extending this class (WebSocketClientWorker) from VirtualWorker fixes the problem. 
in line:
cloud_grid_service.serve_model(model,id=model.id,allow_remote_inference=True, mpc=True)
closes #3648

## How has this been tested?
- Function: _simplify, file serde.py line no 393, returns the correct simplified value instead of returning unprocessed 'NodeClient' object
- cloud_grid_service.serve_model(model,id=model.id,allow_remote_inference=True, mpc=True) runs without error. And it returns the correct inference result without error 

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests (Does not Apply)