### PR TITLE
fix TensorsNotCollocatedException message formatting

### DIFF
--- a/syft/exceptions.py
+++ b/syft/exceptions.py
@@ -98,7 +98,7 @@ class TensorsNotCollocatedException(Exception):
         if isinstance(tensor_a, sy.PointerTensor) and isinstance(tensor_b, sy.PointerTensor):
             message = (
                 f"You tried to call {attr} involving two tensors which are not on the same machine!"
-                " One tensor is on {tensor_a.location} while the other is on {tensor_b.location}."
+                f" One tensor is on {tensor_a.location} while the other is on {tensor_b.location}."
                 " Use a combination of .move(), .get(), and/or .send()"
                 " to co-locate them to the same machine."
             )
@@ -106,17 +106,17 @@ class TensorsNotCollocatedException(Exception):
             message = (
                 f"You tried to call {attr} involving two tensors where one tensor is actually"
                 " located on another machine (is a PointerTensor). Call .get() on a"
-                " the PointerTensor or .send({tensor_b.location.id}) on the other tensor.\n"
-                "Tensor A: {tensor_a}\n"
-                "Tensor B: {tensor_b}"
+                f" the PointerTensor or .send({tensor_b.location.id}) on the other tensor.\n"
+                f"Tensor A: {tensor_a}\n"
+                f"Tensor B: {tensor_b}"
             )
         elif isinstance(tensor_b, sy.PointerTensor):
             message = (
                 f"You tried to call {attr} involving two tensors where one tensor is actually"
                 " located on another machine (is a PointerTensor). Call .get() on a"
-                " the PointerTensor or .send({tensor_a.location.id}) on the other tensor.\n"
-                "Tensor A: {tensor_a}\n"
-                "Tensor B: {tensor_b}"
+                f" the PointerTensor or .send({tensor_a.location.id}) on the other tensor.\n"
+                f"Tensor A: {tensor_a}\n"
+                f"Tensor B: {tensor_b}"
             )
         else:
             message = (


### PR DESCRIPTION
## Description
TensorsNotCollocatedExceptions's message was not formatted to correctly display tensor locations because of missing `f`'s in front of formatted string literals. 

This was a simple fix yet the incorrect behavior was making debugging troublesome.
## Affected Dependencies
None.

## How has this been tested?
A later invocation of the exception displayed the correct values. (Exception is raised when a command is executed on two tensors that are on different machines, e.g. `a.backward(b)` when `a` and `b` are tensors on different machines.)
## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
