### PR TITLE
Add BatchNorm to AdditiveSharingTensor

### DIFF
--- a/syft/frameworks/torch/nn/__init__.py
+++ b/syft/frameworks/torch/nn/__init__.py
@@ -5,6 +5,7 @@ from syft.frameworks.torch.nn.functional import avg_pool2d
 from syft.frameworks.torch.nn.functional import adaptive_avg_pool2d
 from syft.frameworks.torch.nn.functional import dropout
 from syft.frameworks.torch.nn.functional import linear
+from syft.frameworks.torch.nn.functional import batch_norm
 from syft.frameworks.torch.nn.pool import AvgPool2d
 from syft.frameworks.torch.nn.rnn import GRU
 from syft.frameworks.torch.nn.rnn import GRUCell
@@ -32,6 +33,7 @@ def nn(module):
         module.max_pool2d = max_pool2d
         module.avg_pool2d = avg_pool2d
         module.adaptive_avg_pool2d = adaptive_avg_pool2d
+        module.batch_norm = batch_norm
 
     module.functional = functional
 

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -692,7 +692,11 @@ class FixedPrecisionTensor(AbstractTensor):
         unbiased_self = self - mu
         mean = (unbiased_self * unbiased_self).mean(**kwargs)
         if unbiased:
-            numel = self.numel()
+            if kwargs.get("dim"):
+                dim = kwargs["dim"]
+                numel = self.shape[dim]
+            else:
+                numel = self.numel()
             return mean * numel / (numel - 1)
         else:
             return mean

--- a/test/torch/tensors/test_additive_shared.py
+++ b/test/torch/tensors/test_additive_shared.py
@@ -1,6 +1,7 @@
 import pytest
 
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 
 import syft


### PR DESCRIPTION
## Description
Add Batchnorm and tests
Fix a bug in .var() for  evaluation on a specific dim

**NOTE** This implem will be improved with the current work on FALCON

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
