### PR TITLE
Update static FL get-model route to retrieve-model

### DIFF
--- a/syft/grid/clients/static_fl_client.py
+++ b/syft/grid/clients/static_fl_client.py
@@ -126,5 +126,5 @@ class StaticFLClient:
             "version": version,
             "checkpoint": checkpoint,
         }
-        serialized_model = self._send_http_req("GET", "/get-model", params)
+        serialized_model = self._send_http_req("GET", "/model_centric/retrieve-model", params)
         return self._unserialize(serialized_model, StatePB)


### PR DESCRIPTION
## Description
PyGrid route is updated:
https://github.com/OpenMined/PyGrid/pull/668
Client is updated accordingly.

## Affected Dependencies
n/a

## How has this been tested?
E2e run of static FL notebooks.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
