### PR TITLE
Bump Pillow version in requirements.txt

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -9,7 +9,7 @@ lz4~=3.0.2
 msgpack~=1.0.0
 numpy~=1.18.1
 phe~=1.4.0
-Pillow~=6.2.2
+Pillow>=7.1.0
 psutil==5.7.0
 requests~=2.22.0
 RestrictedPython~=5.0


### PR DESCRIPTION
## Description

**4 Pillow vulnerabilities found in pip-dep/requirements.txt 2 days ago**
Remediation
Upgrade Pillow to version 7.1.0 or later. For example:

```
Pillow>=7.1.0
```
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2020-11538
moderate severity
Vulnerable versions: < 7.1.0
Patched version: 7.1.0
In libImaging/SgiRleDecode.c in Pillow through 7.0.0, a number of out-of-bounds reads exist in the parsing of SGI image files, a different issue than CVE-2020-5311.

CVE-2020-10177
moderate severity
Vulnerable versions: < 7.1.0
Patched version: 7.1.0
Pillow before 6.2.3 and 7.x before 7.0.1 has multiple out-of-bounds reads in libImaging/FliDecode.c.

CVE-2020-10379
moderate severity
Vulnerable versions: < 7.1.0
Patched version: 7.1.0
In Pillow before 6.2.3 and 7.x before 7.0.1, there are two Buffer Overflows in libImaging/TiffDecode.c.

CVE-2020-10994
moderate severity
Vulnerable versions: < 7.1.0
Patched version: 7.1.0
In libImaging/Jpeg2KDecode.c in Pillow before 7.0.0, there are multiple out-of-bounds reads via a crafted JP2 file.