### PR TITLE
Support Python <3.8 #3826

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.7, 3.6]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,9 +41,7 @@ jobs:
 
     - name: Install lint, formatter, security checker
       run: |
-            pip3 install flake8
-            pip3 install black
-            pip3 install bandit
+            pip3 install flake8 black bandit
 
     - name: Lint and format
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,4 +54,5 @@ jobs:
 
     - name: Run tests with coverage
       run: |
+            pip install typing-extensions dataclasses
             python setup.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ pyscaffold[all]
 sqlitedict
 torch>=1.5
 typeguard
+sqlitedict
+typing-extensions # backport to older python 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ torch>=1.5
 typeguard
 sqlitedict
 typing-extensions # backport to older python 3
+dataclasses # backport to python 3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@
 #
 bandit
 black
+dataclasses # backport to python 3.6
 flake8
 flask
 forbiddenfruit>=0.1.3
@@ -24,8 +25,7 @@ isort
 pyjwt
 pyscaffold[all]
 sqlitedict
+sqlitedict
 torch>=1.5
 typeguard
-sqlitedict
 typing-extensions # backport to older python 3
-dataclasses # backport to python 3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ testing =
     protobuf
     sqlitedict
     typing-extensions
+    dataclasses
 
 [options.entry_points]
 # Add here console scripts like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ testing =
     pytest-cov
     protobuf
     sqlitedict
+    typing-extensions
 
 [options.entry_points]
 # Add here console scripts like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ install_requires =
     forbiddenfruit>=0.1.3
     dpcontracts
     typeguard
+    typing-extensions
+    dataclasses
 
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov

--- a/src/syft/core/common/uid.py
+++ b/src/syft/core/common/uid.py
@@ -3,7 +3,7 @@ import uuid
 
 # external class/method imports
 from syft.core.common.serde.serializable import Serializable
-from typing import final
+from typing_extensions import final
 
 # syft imports
 from ...proto.core.common.common_object_pb2 import UID as UID_PB

--- a/src/syft/core/io/address.py
+++ b/src/syft/core/io/address.py
@@ -1,4 +1,4 @@
-from typing import final
+from typing_extensions import final
 
 from syft.core.common.uid import UID
 

--- a/src/syft/core/io/connection.py
+++ b/src/syft/core/io/connection.py
@@ -1,4 +1,4 @@
-from typing import final
+from typing_extensions import final
 
 from syft.core.common.message import (
     EventualSyftMessageWithoutReply,

--- a/src/syft/core/io/virtual.py
+++ b/src/syft/core/io/virtual.py
@@ -4,7 +4,7 @@ Replacing this object with an actual network connection object
 (such as one powered by P2P tech, web sockets, or HTTP) should
 execute the exact same functionality but do so over a network"""
 
-from typing import final
+from typing_extensions import final
 
 from syft.core.common.message import (
     EventualSyftMessageWithoutReply,

--- a/src/syft/core/node/common/node.py
+++ b/src/syft/core/node/common/node.py
@@ -3,8 +3,6 @@
 stuff
 """
 
-from __future__ import annotations
-
 from typing import List
 
 from syft.core.common.message import (

--- a/src/syft/core/node/common/service/child_node_lifecycle_service.py
+++ b/src/syft/core/node/common/service/child_node_lifecycle_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List
 
 from syft.core.common.message import ImmediateSyftMessageWithoutReply

--- a/src/syft/core/node/common/service/heritage_update_service.py
+++ b/src/syft/core/node/common/service/heritage_update_service.py
@@ -4,9 +4,6 @@ registers within a new Network or if a Device registers within
 a new Domain, all the other child node will need to know this
 information to populate complete addresses into their clients."""
 
-
-from __future__ import annotations
-
 from typing import List
 
 from syft.core.common.message import ImmediateSyftMessageWithoutReply

--- a/src/syft/core/node/common/service/msg_forwarding_service.py
+++ b/src/syft/core/node/common/service/msg_forwarding_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List
 
 from syft.core.common.message import (

--- a/src/syft/core/node/common/service/node_service.py
+++ b/src/syft/core/node/common/service/node_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List
 
 from syft.core.common.message import (

--- a/src/syft/core/node/common/service/obj_action_service.py
+++ b/src/syft/core/node/common/service/obj_action_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List
 
 from syft.core.common.message import ImmediateSyftMessageWithoutReply

--- a/src/syft/core/node/common/service/repr_service.py
+++ b/src/syft/core/node/common/service/repr_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List
 from typing_extensions import final
 

--- a/src/syft/core/node/common/service/repr_service.py
+++ b/src/syft/core/node/common/service/repr_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import List, final
+from typing import List
+from typing_extensions import final
 
 from syft.decorators import type_hints
 from syft.core.common.message import ImmediateSyftMessageWithoutReply

--- a/src/syft/core/node/device/client.py
+++ b/src/syft/core/node/device/client.py
@@ -1,4 +1,5 @@
-from typing import List, final
+from typing import List
+from typing_extensions import final
 
 from syft.core.common.uid import UID
 

--- a/src/syft/core/node/device/device.py
+++ b/src/syft/core/node/device/device.py
@@ -1,4 +1,5 @@
-from typing import Dict, final
+from typing import Dict
+from typing_extensions import final
 
 from syft.core.common.message import SyftMessage
 from syft.core.common.uid import UID

--- a/src/syft/core/node/network/client.py
+++ b/src/syft/core/node/network/client.py
@@ -1,4 +1,5 @@
-from typing import List, final
+from typing import List
+from typing_extensions import final
 
 from syft.core.common.uid import UID
 

--- a/src/syft/core/node/vm/client.py
+++ b/src/syft/core/node/vm/client.py
@@ -1,4 +1,5 @@
-from typing import List, final
+from typing import List
+from typing_extensions import final
 
 from ....decorators import syft_decorator
 from ...io.address import Address

--- a/src/syft/core/node/vm/vm.py
+++ b/src/syft/core/node/vm/vm.py
@@ -1,4 +1,4 @@
-from typing import final
+from typing_extensions import final
 
 from syft.core.common.message import SyftMessage
 

--- a/src/syft/core/store/store_disk.py
+++ b/src/syft/core/store/store_disk.py
@@ -1,4 +1,5 @@
-from typing import Final, Optional
+from typing import Optional
+from typing_extensions import Final
 
 from sqlitedict import SqliteDict
 

--- a/src/syft/core/store/store_disk.py
+++ b/src/syft/core/store/store_disk.py
@@ -1,6 +1,9 @@
 from typing import Optional
 from typing_extensions import Final
 
+import tempfile
+from pathlib import Path
+
 from sqlitedict import SqliteDict
 
 from ...decorators import syft_decorator
@@ -16,7 +19,7 @@ class DiskObjectStore(ObjectStore):
         super().__init__(as_wrapper=False)
 
         if db_path is None:
-            db_path = "/tmp/test.sqlite"
+            db_path = str(Path(f"{tempfile.gettempdir()}") / "test.sqlite")
 
         self.db: Final = SqliteDict(db_path)
         self.search_engine = None

--- a/src/syft/decorators/syft_decorator_impl.py
+++ b/src/syft/decorators/syft_decorator_impl.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 
 from .typecheck import type_hints


### PR DESCRIPTION
## Description
This PR fixes some minor flake8 issues re-introduced allowing CI to pass, and adds support for both Python 3.7 and Python 3.6 with minimal changes.

The issue was discussed here:
https://github.com/OpenMined/PySyft/issues/3826

Changes required for each version are separated into their own commits.

## Affected Dependencies
None

## How has this been tested?
This has been tested on MacOS with Python 3.8.5, Python 3.7.8 and Python 3.6.11, and additionally GitHub Actions CI.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
