### PR TITLE
Create `has_child` method

### DIFF
--- a/syft/execution/placeholder.py
+++ b/syft/execution/placeholder.py
@@ -131,7 +131,7 @@ class PlaceHolder(AbstractTensor):
 
         out = f"{type(self).__name__ }[Id:{self.id.value}]"
 
-        if hasattr(self, "child") and self.child is not None:
+        if self.has_child() and self.child is not None:
             out += f">{self.child}"
 
         return out

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -58,9 +58,6 @@ class TorchTensor(AbstractTensor):
     origin = None
     id_at_origin = None
 
-    def has_child(self):
-        return hasattr(self, "child")
-
     def trigger_origin_backward_hook(self, origin: str, id_at_origin: int):
         """
         This hook is triggered when a tensor which was received from a sender has
@@ -480,7 +477,7 @@ class TorchTensor(AbstractTensor):
 
             location = location[0]
 
-            if hasattr(self, "child") and isinstance(self.child, PointerTensor):
+            if self.has_child() and isinstance(self.child, PointerTensor):
                 self.child.garbage_collect_data = False
                 if self._is_parameter():
                     self.data.child.garbage_collect_data = False
@@ -617,7 +614,7 @@ class TorchTensor(AbstractTensor):
 
     def mid_get(self):
         """This method calls .get() on a child pointer and correctly registers the results"""
-        if not hasattr(self, "child"):
+        if not self.has_child():
             raise InvalidTensorForRemoteGet(self)
 
         self.child.mid_get()
@@ -628,7 +625,7 @@ class TorchTensor(AbstractTensor):
 
         TODO: make this kind of message forwarding generic?
         """
-        if not hasattr(self, "child"):
+        if not self.has_child():
             raise InvalidTensorForRemoteGet(self)
 
         self.child.remote_get()

--- a/syft/generic/abstract/object.py
+++ b/syft/generic/abstract/object.py
@@ -41,16 +41,19 @@ class AbstractObject(ABC):
         self.child = child
 
     def __str__(self) -> str:
-        if hasattr(self, "child"):
+        if self.has_child():
             return type(self).__name__ + ">" + self.child.__str__()
         else:
             return type(self).__name__
 
     def __repr__(self) -> str:
-        if hasattr(self, "child"):
+        if self.has_child():
             return type(self).__name__ + ">" + self.child.__repr__()
         else:
             return type(self).__name__
+
+    def has_child(self):
+        return hasattr(self, "child")
 
     def describe(self, description: str) -> "AbstractObject":
         self.description = description

--- a/syft/generic/abstract/object.py
+++ b/syft/generic/abstract/object.py
@@ -41,19 +41,16 @@ class AbstractObject(ABC):
         self.child = child
 
     def __str__(self) -> str:
-        if self.has_child():
+        if hasattr(self, "child"):
             return type(self).__name__ + ">" + self.child.__str__()
         else:
             return type(self).__name__
 
     def __repr__(self) -> str:
-        if self.has_child():
+        if hasattr(self, "child"):
             return type(self).__name__ + ">" + self.child.__repr__()
         else:
             return type(self).__name__
-
-    def has_child(self):
-        return hasattr(self, "child")
 
     def describe(self, description: str) -> "AbstractObject":
         self.description = description

--- a/syft/generic/abstract/tensor.py
+++ b/syft/generic/abstract/tensor.py
@@ -19,6 +19,9 @@ class AbstractTensor(AbstractSendable, SyftSerializable):
     ):
         super(AbstractTensor, self).__init__(id, owner, tags, description, child)
 
+    def has_child(self):
+        return hasattr(self, "child")
+
     def wrap(self, register=True, type=None, **kwargs):
         """Wraps the class inside an empty object of class `type`.
 

--- a/syft/generic/abstract/tensor.py
+++ b/syft/generic/abstract/tensor.py
@@ -89,7 +89,7 @@ class AbstractTensor(AbstractSendable, SyftSerializable):
         cloned_tensor.id = self.id
         cloned_tensor.owner = self.owner
 
-        if hasattr(self, "child") and self.child is not None:
+        if self.has_child() and self.child is not None:
             cloned_tensor.child = self.child.clone()
 
         return cloned_tensor
@@ -98,7 +98,7 @@ class AbstractTensor(AbstractSendable, SyftSerializable):
         """
         Forward to Additive Shared Tensor the call to refresh shares
         """
-        if hasattr(self, "child"):
+        if self.has_child():
             self.child = self.child.refresh()
             return self
         else:
@@ -111,7 +111,7 @@ class AbstractTensor(AbstractSendable, SyftSerializable):
     def __len__(self) -> int:
         """Alias .shape[0] with len(), helpful for pointers"""
         try:
-            if hasattr(self, "child") and not isinstance(self.child, dict):
+            if self.has_child() and not isinstance(self.child, dict):
                 return self.child.shape[0]
             else:
                 return self.shape[0]


### PR DESCRIPTION
## Description

Classes that inherit `TensorObject` often use `hasattr(self, "child")`. So, I think it's good to abstract this.

Thank You!

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
