### PR TITLE
The `__repr__` on the `Network` class must return a `repr_str`

### DIFF
--- a/syft/grid/rtc/network.py
+++ b/syft/grid/rtc/network.py
@@ -175,7 +175,7 @@ class Network(threading.Thread):
 
     def __repr__(self):
         """Default String representation"""
-        repr_str = (
+        return (
             f"< Peer ID: {self.id}, "
             f"hosted datasets: {list(self._worker.object_store._tag_to_object_ids.keys())}, "
             f"hosted_models: {list(self._worker.models.keys())}, "


### PR DESCRIPTION
## Description

The `__repr__` method only generated a string and did not return it. I fixed it 😄 

Thank You!

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
