### PR TITLE
Overload mod operator for the fixed precision tensor

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -78,12 +78,12 @@ class FixedPrecisionTensor(AbstractTensor):
         """
         Define the modulo operation over object instances.
         """
-        result = self.copy()
+        result = FixedPrecisionTensor()
         if isinstance(divisor, int):
             scaled_divisor = divisor * (self.base ** self.precision_fractional)
-            result.child %= scaled_divisor
+            result.child = self.child % scaled_divisor
         elif isinstance(divisor, FixedPrecisionTensor):
-            result.child %= divisor.child
+            result.child = self.child % divisor.child
         else:
             raise TypeError("Unsupported type for modulo operation")
         return result

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -81,9 +81,9 @@ class FixedPrecisionTensor(AbstractTensor):
         result = self.copy()
         if isinstance(divisor, int):
             scaled_divisor = divisor * (self.base ** self.precision_fractional)
-            result.child = result.child % scaled_divisor
+            result.child %= scaled_divisor
         elif isinstance(divisor, FixedPrecisionTensor):
-            result.child = result.child % divisor.child
+            result.child %= divisor.child
         else:
             raise TypeError("Unsupported type for modulo operation")
         return result

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -75,7 +75,7 @@ class FixedPrecisionTensor(AbstractTensor):
 
     def __mod__(self, other):
         """
-        Define the module operation over object instances.
+        Define the modulo operation over object instances.
         """
         result = self.copy()
         scaled_divisor = other * (self.base ** self.precision_fractional)

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -73,12 +73,12 @@ class FixedPrecisionTensor(AbstractTensor):
                     "Unsupported arg value for dtype. Use dtype='long' or dtype='int'."
                 )
 
-    def __mod__(self, other):
+    def __mod__(self, divisor):
         """
         Define the modulo operation over object instances.
         """
         result = self.copy()
-        scaled_divisor = other * (self.base ** self.precision_fractional)
+        scaled_divisor = divisor * (self.base ** self.precision_fractional)
         result.child = result.child % scaled_divisor
         return result
 

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -73,6 +73,15 @@ class FixedPrecisionTensor(AbstractTensor):
                     "Unsupported arg value for dtype. Use dtype='long' or dtype='int'."
                 )
 
+    def __mod__(self, other):
+        """
+        Define the module operation over object instances.
+        """
+        result = self.copy()
+        scaled_divisor = other * (self.base ** self.precision_fractional)
+        result.child = result.child % scaled_divisor
+        return result
+
     def get_class_attributes(self):
         """
         Specify all the attributes need to build a wrapper correctly when returning a response,

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -166,7 +166,10 @@ class FixedPrecisionTensor(AbstractTensor):
         """
         if isinstance(divisor, (int, float)):
             scaled_divisor = int(divisor * self.base ** self.precision_fractional)
-            return getattr(_self, "fmod")(scaled_divisor)
+            if isinstance(_self, AdditiveSharingTensor):
+                return getattr(_self, "mod")(scaled_divisor)
+            else:
+                return getattr(_self, "fmod")(scaled_divisor)
 
         response = getattr(_self, "fmod")(divisor)
 

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -37,10 +37,18 @@ def test_fix_prec_registration(hook):
         assert hook.local_worker.get_obj(x.id) == x
 
 
-def test_fixed_precision_mod_operation():
-    # Test mod operation with scalar
+def test_fixed_precision_mod_operation(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+
+    # Test mod operation with scalar (method syntax)
     x = torch.tensor([1, 2, 3]).fix_prec()
     y = x % 3
+    y = y.float_prec()
+    assert (y == torch.tensor([1.0, 2.0, 0.0])).all()
+
+    # Test mod operation with scalar (function syntax)
+    x = torch.tensor([1, 2, 3]).fix_prec()
+    y = torch.fmod(x, 3)
     y = y.float_prec()
     assert (y == torch.tensor([1.0, 2.0, 0.0])).all()
 

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -41,10 +41,7 @@ def test_fixed_precision_mod_operation():
     x = torch.tensor([1, 2, 3]).fix_prec()
     y = x % 3
     y = y.float_prec()
-    z = torch.tensor([1.0, 2.0, 0.0])
-    print(z)
-    print(y)
-    assert (x == z).all()
+    assert (y == torch.tensor([1.0, 2.0, 0.0])).all()
 
 
 def test_inplace_encode_decode(workers):

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -37,6 +37,16 @@ def test_fix_prec_registration(hook):
         assert hook.local_worker.get_obj(x.id) == x
 
 
+def test_fixed_precision_mod_operation():
+    x = torch.tensor([1, 2, 3]).fix_prec()
+    y = x % 3
+    y = y.float_prec()
+    z = torch.tensor([1.0, 2.0, 0.0])
+    print(z)
+    print(y)
+    assert (x == z).all()
+
+
 def test_inplace_encode_decode(workers):
 
     x = torch.tensor([0.1, 0.2, 0.3])

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -37,8 +37,7 @@ def test_fix_prec_registration(hook):
         assert hook.local_worker.get_obj(x.id) == x
 
 
-def test_fixed_precision_mod_operation(workers):
-    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+def test_fixed_precision_mod_operation():
 
     # Test mod operation with scalar (method syntax)
     x = torch.tensor([1, 2, 3]).fix_prec()

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -37,7 +37,8 @@ def test_fix_prec_registration(hook):
         assert hook.local_worker.get_obj(x.id) == x
 
 
-def test_fixed_precision_mod_operation():
+def test_fixed_precision_mod_operation(workers):
+    alice, bob, james = workers["alice"], workers["bob"], workers["james"]
 
     # Test mod operation with scalar (method syntax)
     x = torch.tensor([1, 2, 3]).fix_prec()
@@ -56,6 +57,11 @@ def test_fixed_precision_mod_operation():
     y = torch.tensor([3]).fix_prec()
     z = (x % y).float_prec()
     assert (z == torch.tensor([1.0, 2.0, 0.0])).all()
+
+    # Test mod operation AST-on-scalar
+    x = torch.tensor([1, 2, 3]).fix_prec().share(bob, alice, crypto_provider=james)
+    y = x % 3  # Moded shares
+    assert ((y.get() % 3).float_prec() == torch.tensor([1.0, 2.0, 0.0])).all()
 
 
 def test_inplace_encode_decode(workers):

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -38,10 +38,17 @@ def test_fix_prec_registration(hook):
 
 
 def test_fixed_precision_mod_operation():
+    # Test mod operation with scalar
     x = torch.tensor([1, 2, 3]).fix_prec()
     y = x % 3
     y = y.float_prec()
     assert (y == torch.tensor([1.0, 2.0, 0.0])).all()
+
+    # Test mod operation with another FPT
+    x = torch.tensor([1, 2, 3]).fix_prec()
+    y = torch.tensor([3]).fix_prec()
+    z = (x % y).float_prec()
+    assert (z == torch.tensor([1.0, 2.0, 0.0])).all()
 
 
 def test_inplace_encode_decode(workers):


### PR DESCRIPTION
As pointed out in https://github.com/OpenMined/PySyft/issues/3958 modular operations over fixed precision tensors are broken. This PR overloads the mod operation over fixed precision tensors in [`syft/frameworks/torch/tensors/interpreters/precision.py`](https://github.com/arturomf94/PySyft/blob/d75a2ba0d4542faf1e5d019c00a9d77868f4d723/syft/frameworks/torch/tensors/interpreters/precision.py#L76) and adds a corresponding test in [`test/torch/tensors/test_precision.py`](https://github.com/arturomf94/PySyft/blob/d75a2ba0d4542faf1e5d019c00a9d77868f4d723/test/torch/tensors/test_precision.py#L40)

Closes: https://github.com/OpenMined/PySyft/issues/3958