### PR TITLE
Update FV scheme to use context chain instead of single context object

### DIFF
--- a/syft/frameworks/torch/he/fv/ciphertext.py
+++ b/syft/frameworks/torch/he/fv/ciphertext.py
@@ -6,7 +6,9 @@ class CipherText:
 
     Attributes:
         data: A 3-dim list representing ciphertext values.
+        param_id: parameter id used in encryption process.
     """
 
-    def __init__(self, data):
+    def __init__(self, data, param_id):
         self.data = data
+        self.param_id = param_id

--- a/syft/frameworks/torch/he/fv/context.py
+++ b/syft/frameworks/torch/he/fv/context.py
@@ -61,23 +61,22 @@ class Context:
 
 
 class ContextData:
-    """A class used to hold parameters and perform parameters validation.
-
-    Args:
-        param: An EncryptionParams object with polynomial modulus, coefficient modulus and
-        plain modulus set.
-        prev_context_id: Id of the previous ContextData object in context chain.
-        next_context_id: Id of the next ContextData object in context chain.
-
-    Attributes:
-        prev_context_id: Id of the previous ContextData object in context chain.
-        next_context_id: Id of the next ContextData object in context chain.
-        coeff_div_plain_modulus: A list of float values equal to (q[i]/t),
-            In research papers denoted by delta.
-        rns_tool: A RNSTool class instance.
-    """
-
     def __init__(self, param, prev_context_id=None, next_context_id=None):
+        """A class used to hold parameters and perform parameters validation.
+
+        Args:
+            param: An EncryptionParams object with polynomial modulus, coefficient modulus and
+            plain modulus set.
+            prev_context_id: Id of the previous ContextData object in context chain.
+            next_context_id: Id of the next ContextData object in context chain.
+
+        Attributes:
+            prev_context_id: Id of the previous ContextData object in context chain.
+            next_context_id: Id of the next ContextData object in context chain.
+            coeff_div_plain_modulus: A list of float values equal to (q[i]/t),
+                In research papers denoted by delta.
+            rns_tool: A RNSTool class instance.
+        """
         self.validate(param)
         self.param = param
         self.prev_context_id = prev_context_id

--- a/syft/frameworks/torch/he/fv/context.py
+++ b/syft/frameworks/torch/he/fv/context.py
@@ -1,3 +1,4 @@
+import copy
 import math
 from functools import reduce
 
@@ -13,27 +14,88 @@ from syft.frameworks.torch.he.fv.util.global_variable import POLY_MOD_DEGREE_MIN
 
 
 class Context:
-    """A class used as for holding and easily supplying of all the general
-    parameters required throughout the implementation.
+    def __init__(self, params):
+        """A class used as for holding and easily supplying of all the general
+        parameters required throughout the implementation.
+
+        Args:
+            An EncryptionParams object with polynomial modulus, coefficient modulus and
+            plain modulus set.
+        """
+        # Validation of params provided for the encryption scheme.
+        self.key_param_id = params.param_id
+        self.context_data_map = {}
+        self.context_data_map[self.key_param_id] = ContextData(params)
+
+        if len(params.coeff_modulus) > 1:
+            self.first_param_id = self.create_next_context_data(self.key_param_id)
+        else:
+            self.first_param_id = self.key_param_id
+        self.last_param_id = self.first_param_id
+
+        prev_parms_id = self.first_param_id
+        while len(self.context_data_map[prev_parms_id].param.coeff_modulus) > 1:
+            prev_parms_id = self.create_next_context_data(prev_parms_id)
+            self.last_param_id = prev_parms_id
+
+    def create_next_context_data(self, prev_parms_id):
+        """Generate next context data in context chain by dropping the last coefficient modulus.
+
+        Args:
+            prev_params_id: Id of previous context data in context chain.
+        Returns:
+            Id of newly generated context data in context chain.
+        """
+        next_parms = copy.deepcopy(self.context_data_map[prev_parms_id].param)
+        next_coeff_modulus = next_parms.coeff_modulus[:-1]
+        next_parms.set_coeff_modulus(next_coeff_modulus)
+        next_param_id = next_parms.param_id
+
+        assert next_param_id != prev_parms_id
+
+        next_context_data = ContextData(next_parms)
+        self.context_data_map[next_param_id] = next_context_data
+        self.context_data_map[prev_parms_id].next_context_id = next_param_id
+        self.context_data_map[next_param_id].prev_context_id = prev_parms_id
+        return next_param_id
+
+
+class ContextData:
+    """A class used to hold parameters and perform parameters validation.
+
+    Args:
+        param: An EncryptionParams object with polynomial modulus, coefficient modulus and
+        plain modulus set.
+        prev_context_id: Id of the previous ContextData object in context chain.
+        next_context_id: Id of the next ContextData object in context chain.
 
     Attributes:
-        param: An EncryptionParams object.
+        prev_context_id: Id of the previous ContextData object in context chain.
+        next_context_id: Id of the next ContextData object in context chain.
         coeff_div_plain_modulus: A list of float values equal to (q[i]/t),
             In research papers denoted by delta.
         rns_tool: A RNSTool class instance.
     """
 
-    def __init__(self, params):
+    def __init__(self, param, prev_context_id=None, next_context_id=None):
+        self.validate(param)
+        self.param = param
+        self.prev_context_id = prev_context_id
+        self.next_context_id = next_context_id
 
-        # Validation of params provided for the encryption scheme.
-        self.validate(params)
+        # A list containing values of coeff_mod[i] / plain_mod for one time computation
+        # and useful in encryption process.
+        self.coeff_div_plain_modulus = [x / param.plain_modulus for x in param.coeff_modulus]
 
-        self.param = params
-
-        self.rns_tool = RNSTool(params)
+        self.rns_tool = RNSTool(param)
 
     def validate(self, params):
+        """Performs parameter validation on the provided encryption parameters.
 
+        Args:
+            params: An EncryptionParams object with polynomial modulus, coefficient modulus and
+            plain modulus set.
+        """
         # The number of coeff moduli is restricted to 62
         if (
             len(params.coeff_modulus) > COEFF_MOD_COUNT_MAX
@@ -93,7 +155,3 @@ class Context:
                 raise RuntimeError(
                     "Coefficient modulus are not relatively prime with plain modulus"
                 )
-
-        # A list containing values of coeff_mod[i] / plain_mod for one time computation
-        # and useful in encryption process.
-        self.coeff_div_plain_modulus = [x / params.plain_modulus for x in params.coeff_modulus]

--- a/syft/frameworks/torch/he/fv/decryptor.py
+++ b/syft/frameworks/torch/he/fv/decryptor.py
@@ -11,14 +11,12 @@ class Decryptor:
 
     Args:
         context (Context): Context for extracting encryption parameters.
-        secret_key: A secret key from same pair of keys(secretkey or publickey) used in encryptor.
+        secret_key_list: A list to store secret key powers.
     """
 
     def __init__(self, context, secret_key):
-        self._context = context
-        self._coeff_modulus = context.param.coeff_modulus
-        self._coeff_count = context.param.poly_modulus
-        self._secret_key_array = [secret_key.data]
+        self.context = context
+        self.secret_key_list = [secret_key.data]
 
     def decrypt(self, encrypted):
         """Decrypts the encrypted ciphertext objects.
@@ -29,12 +27,13 @@ class Decryptor:
         Returns:
             A PlainText object containing the decrypted result.
         """
+        context_data = self.context.context_data_map[encrypted.param_id]
 
         # Calculate [c0 + c1 * sk + c2 * sk^2 ...]_q
-        temp_product_modq = self._mul_ct_sk(copy.deepcopy(encrypted.data))
+        temp_product_modq = self._mul_ct_sk(copy.deepcopy(encrypted))
 
         # Divide scaling variant using BEHZ FullRNS techniques
-        result = self._context.rns_tool.decrypt_scale_and_round(temp_product_modq)
+        result = context_data.rns_tool.decrypt_scale_and_round(temp_product_modq)
 
         # removing leading zeroes in plaintext representation.
         plain_coeff_count = get_significant_count(result)
@@ -52,22 +51,23 @@ class Decryptor:
         Returns:
             A 2-dim list containing result of [c0 + c1 * sk + c2 * sk^2 ...]_q.
         """
+        context_data = self.context.context_data_map[encrypted.param_id]
+        coeff_modulus = context_data.param.coeff_modulus
+        coeff_count = context_data.param.poly_modulus
+        encrypted = encrypted.data
         phase = encrypted[0]
 
-        secret_key_array = self._get_sufficient_sk_power(len(encrypted) - 1)
+        secret_key_list = self._get_sufficient_sk_power(len(encrypted) - 1)
 
         for j in range(1, len(encrypted)):
-            for i in range(len(self._coeff_modulus)):
+            for i in range(len(coeff_modulus)):
                 phase[i] = poly_add_mod(
                     poly_mul_mod(
-                        encrypted[j][i],
-                        secret_key_array[j - 1][i],
-                        self._coeff_modulus[i],
-                        self._coeff_count,
+                        encrypted[j][i], secret_key_list[j - 1][i], coeff_modulus[i], coeff_count,
                     ),
                     phase[i],
-                    self._coeff_modulus[i],
-                    self._coeff_count,
+                    coeff_modulus[i],
+                    coeff_count,
                 )
         return phase
 
@@ -80,19 +80,21 @@ class Decryptor:
         Returns:
             A 2-dim list having secretkey powers.
         """
+        param = self.context.context_data_map[self.context.key_param_id].param
+        coeff_modulus = param.coeff_modulus
+        coeff_count = param.poly_modulus
+        if max_power == len(self.secret_key_list):
+            return self.secret_key_list
 
-        if max_power == len(self._secret_key_array):
-            return self._secret_key_array
-
-        while len(self._secret_key_array) < max_power:
-            sk_extra_power = [0] * len(self._coeff_modulus)
-            for i in range(len(self._coeff_modulus)):
+        while len(self.secret_key_list) < max_power:
+            sk_extra_power = [0] * len(coeff_modulus)
+            for i in range(len(coeff_modulus)):
                 sk_extra_power[i] = poly_mul_mod(
-                    self._secret_key_array[-1][i],
-                    self._secret_key_array[0][i],
-                    self._coeff_modulus[i],
-                    self._coeff_count,
+                    self.secret_key_list[-1][i],
+                    self.secret_key_list[0][i],
+                    coeff_modulus[i],
+                    coeff_count,
                 )
-            self._secret_key_array.append(sk_extra_power)
+            self.secret_key_list.append(sk_extra_power)
 
-        return self._secret_key_array
+        return self.secret_key_list

--- a/syft/frameworks/torch/he/fv/encryption_params.py
+++ b/syft/frameworks/torch/he/fv/encryption_params.py
@@ -32,3 +32,14 @@ class EncryptionParams:
         self.coeff_modulus = coeff_modulus
 
         self.plain_modulus = plain_modulus
+        self.param_id = self.compute_parms_id()
+
+    def set_coeff_modulus(self, coeff_mod):
+        """Set coefficient modulus and generate new param_id."""
+        self.coeff_modulus = coeff_mod
+        self.param_id = self.compute_parms_id()
+
+    def compute_parms_id(self):
+        # TODO: use hash function here.
+        param_data = [self.poly_modulus, *self.coeff_modulus, self.plain_modulus]
+        return " ".join(str(x) for x in param_data)

--- a/syft/frameworks/torch/he/fv/encryptor.py
+++ b/syft/frameworks/torch/he/fv/encryptor.py
@@ -48,6 +48,7 @@ class Encryptor:
 
         Args:
             message (Plaintext): An Plaintext object which has to be encrypted.
+            param_id: Parameter id for accessing the correct parameters from the context chain.
             is_asymmetric (bool): Based on the key provided for encryption select
                 the mode of encryption.
 

--- a/syft/frameworks/torch/he/fv/encryptor.py
+++ b/syft/frameworks/torch/he/fv/encryptor.py
@@ -1,5 +1,6 @@
 from syft.frameworks.torch.he.fv.secret_key import SecretKey
 from syft.frameworks.torch.he.fv.public_key import PublicKey
+from syft.frameworks.torch.he.fv.ciphertext import CipherText
 from syft.frameworks.torch.he.fv.util.rlwe import encrypt_symmetric
 from syft.frameworks.torch.he.fv.util.rlwe import encrypt_asymmetric
 from syft.frameworks.torch.he.fv.util.operations import multiply_add_plain_with_delta
@@ -17,8 +18,8 @@ class Encryptor:
     """
 
     def __init__(self, context, key):
-        self._context = context
-        self._key = key
+        self.context = context
+        self.key = key
 
     def encrypt(self, message):
         """Encrypts an Plaintext data using the FV HE Scheme.
@@ -33,16 +34,16 @@ class Encryptor:
             ValueError: Key provided for encryption is not a valid key object.
         """
 
-        if isinstance(self._key, PublicKey):
-            return self._encrypt(message, True)
+        if isinstance(self.key, PublicKey):
+            return self._encrypt(message, self.context.first_param_id, True)
 
-        elif isinstance(self._key, SecretKey):
-            return self._encrypt(message, False)
+        elif isinstance(self.key, SecretKey):
+            return self._encrypt(message, self.context.first_param_id, False)
 
         else:
             raise ValueError("key for encryption is not valid")
 
-    def _encrypt(self, message, is_asymmetric):
+    def _encrypt(self, message, param_id, is_asymmetric):
         """Encrypts the message according to the key provided.
 
         Args:
@@ -56,13 +57,27 @@ class Encryptor:
 
         result = None
         if is_asymmetric:
-            result = encrypt_asymmetric(
-                self._context, self._key.data
-            )  # Public key used for encryption
+            prev_context_id = self.context.context_data_map[param_id].prev_context_id
+
+            if prev_context_id is not None:
+                # Requires modulus switching
+                prev_context_data = self.context.context_data_map[prev_context_id]
+                rns_tool = prev_context_data.rns_tool
+                temp = encrypt_asymmetric(self.context, prev_context_id, self.key.data).data
+
+                for j in range(2):
+                    temp[j] = rns_tool.divide_and_round_q_last_inplace(temp[j])
+                result = CipherText(temp, param_id)
+            else:
+                result = encrypt_asymmetric(
+                    self.context, param_id, self.key.data
+                )  # Public key used for encryption
 
         else:
             result = encrypt_symmetric(
-                self._context, self._key.data
+                self.context, param_id, self.key.data
             )  # Secret key used for encryption
 
-        return multiply_add_plain_with_delta(result, message, self._context)
+        return multiply_add_plain_with_delta(
+            result, message, self.context.context_data_map[self.context.first_param_id]
+        )

--- a/syft/frameworks/torch/he/fv/evaluator.py
+++ b/syft/frameworks/torch/he/fv/evaluator.py
@@ -39,9 +39,9 @@ def _typecheck(op1, op2):
 class Evaluator:
     def __init__(self, context):
         self.context = context
-        self.poly_modulus = context.param.poly_modulus
-        self.coeff_modulus = context.param.coeff_modulus
-        self.plain_modulus = context.param.plain_modulus
+        param = context.context_data_map[context.key_param_id].param
+        self.plain_modulus = param.plain_modulus
+        self.poly_modulus = param.poly_modulus
 
     def add(self, op1, op2):
         """Add two operands using FV scheme.
@@ -109,14 +109,16 @@ class Evaluator:
         Returns:
             A Ciphertext object with value equivalent to result of -(ct_value).
         """
+        context_data = self.context.context_data_map[ct.param_id]
+        coeff_modulus = context_data.param.coeff_modulus
         result = copy.deepcopy(ct.data)
 
         for i in range(len(result)):
-            for j in range(len(result[i])):
+            for j in range(len(coeff_modulus)):
                 for k in range(len(result[i][j])):
-                    result[i][j][k] = negate_mod(ct.data[i][j][k], self.coeff_modulus[j])
+                    result[i][j][k] = negate_mod(result[i][j][k], coeff_modulus[j])
 
-        return CipherText(result)
+        return CipherText(result, ct.param_id)
 
     def mul(self, op1, op2):
         """Multiply two operands using FV scheme.
@@ -159,16 +161,20 @@ class Evaluator:
             A Ciphertext object with value equivalent to result of addition of two provided
                 arguments.
         """
+        param_id = ct1.param_id
+        context_data = self.context.context_data_map[param_id]
+        coeff_modulus = context_data.param.coeff_modulus
+
         ct1, ct2 = copy.deepcopy(ct1.data), copy.deepcopy(ct2.data)
         result = ct2 if len(ct2) > len(ct1) else ct1
 
         for i in range(min(len(ct1), len(ct2))):
-            for j in range(len(self.coeff_modulus)):
+            for j in range(len(coeff_modulus)):
                 result[i][j] = poly_add_mod(
-                    ct1[i][j], ct2[i][j], self.coeff_modulus[j], self.poly_modulus
+                    ct1[i][j], ct2[i][j], coeff_modulus[j], self.poly_modulus
                 )
 
-        return CipherText(result)
+        return CipherText(result, param_id)
 
     def _add_cipher_plain(self, ct, pt):
         """Add a plaintext into a ciphertext.
@@ -182,7 +188,7 @@ class Evaluator:
                 arguments.
         """
         ct = copy.deepcopy(ct)
-        return multiply_add_plain_with_delta(ct, pt, self.context)
+        return multiply_add_plain_with_delta(ct, pt, self.context.context_data_map[ct.param_id])
 
     def _add_plain_plain(self, pt1, pt2):
         """Adds two plaintexts object.
@@ -210,7 +216,7 @@ class Evaluator:
                 arguments.
         """
         ct = copy.deepcopy(ct)
-        return multiply_sub_plain_with_delta(ct, pt, self.context)
+        return multiply_sub_plain_with_delta(ct, pt, self.context.context_data_map[ct.param_id])
 
     def _sub_cipher_cipher(self, ct1, ct2):
         """Subtract two ciphertexts.
@@ -223,21 +229,24 @@ class Evaluator:
             A Ciphertext object with value equivalent to result of subtraction of two provided
                 arguments.
         """
+        param_id = ct1.param_id
+        context_data = self.context.context_data_map[ct1.param_id]
+        coeff_modulus = context_data.param.coeff_modulus
         ct1, ct2 = copy.deepcopy(ct1.data), copy.deepcopy(ct2.data)
         result = ct2 if len(ct2) > len(ct1) else ct1
         min_size, max_size = min(len(ct1), len(ct2)), max(len(ct1), len(ct2))
 
         for i in range(min_size):
-            for j in range(len(self.coeff_modulus)):
+            for j in range(len(coeff_modulus)):
                 result[i][j] = poly_sub_mod(
-                    ct1[i][j], ct2[i][j], self.coeff_modulus[j], self.poly_modulus
+                    ct1[i][j], ct2[i][j], coeff_modulus[j], self.poly_modulus
                 )
 
         for i in range(min_size + 1, max_size):
-            for j in range(len(self.coeff_modulus)):
-                result[i][j] = poly_negate_mod(result[i][j], self.coeff_modulus[j])
+            for j in range(len(coeff_modulus)):
+                result[i][j] = poly_negate_mod(result[i][j], coeff_modulus[j])
 
-        return CipherText(result)
+        return CipherText(result, param_id)
 
     def _mul_cipher_cipher(self, ct1, ct2):
         """Multiply two operands using FV scheme.
@@ -250,13 +259,16 @@ class Evaluator:
             A Ciphertext object with a value equivalent to the result of the product of two
                 operands.
         """
+        param_id = ct1.param_id
+        context_data = self.context.context_data_map[param_id]
+        coeff_modulus = context_data.param.coeff_modulus
         ct1, ct2 = ct1.data, ct2.data
 
         if len(ct1) > 2 or len(ct2) > 2:
             # TODO: perform relinearization operation.
             raise Warning("Multiplying ciphertext of size >2 should be avoided.")
 
-        rns_tool = self.context.rns_tool
+        rns_tool = context_data.rns_tool
         bsk_base_mod = rns_tool.base_Bsk.base
         bsk_base_mod_count = len(bsk_base_mod)
         dest_count = len(ct2) + len(ct1) - 1
@@ -273,9 +285,7 @@ class Evaluator:
         for i in range(len(ct2)):
             tmp_encrypted2_bsk.append(rns_tool.sm_mrq(rns_tool.fastbconv_m_tilde(ct2[i])))
 
-        tmp_des_coeff_base = [
-            [[0] for y in range(len(self.coeff_modulus))] for x in range(dest_count)
-        ]
+        tmp_des_coeff_base = [[[0] for y in range(len(coeff_modulus))] for x in range(dest_count)]
 
         tmp_des_bsk_base = [[[0] for y in range(bsk_base_mod_count)] for x in range(dest_count)]
 
@@ -292,16 +302,16 @@ class Evaluator:
                 if len(ct2) > m - encrypted1_index:
                     encrypted2_index = m - encrypted1_index
 
-                    for i in range(len(self.coeff_modulus)):
+                    for i in range(len(coeff_modulus)):
                         tmp_des_coeff_base[m][i] = poly_add_mod(
                             poly_mul_mod(
                                 ct1[encrypted1_index][i],
                                 ct2[encrypted2_index][i],
-                                self.coeff_modulus[i],
+                                coeff_modulus[i],
                                 self.poly_modulus,
                             ),
                             tmp_des_coeff_base[m][i],
-                            self.coeff_modulus[i],
+                            coeff_modulus[i],
                             self.poly_modulus,
                         )
 
@@ -325,12 +335,9 @@ class Evaluator:
         result = []
         for i in range(dest_count):
             temp = []
-            for j in range(len(self.coeff_modulus)):
+            for j in range(len(coeff_modulus)):
                 temp.append(
-                    [
-                        (x * self.plain_modulus) % self.coeff_modulus[j]
-                        for x in tmp_des_coeff_base[i][j]
-                    ]
+                    [(x * self.plain_modulus) % coeff_modulus[j] for x in tmp_des_coeff_base[i][j]]
                 )
             for j in range(bsk_base_mod_count):
                 temp.append(
@@ -338,27 +345,28 @@ class Evaluator:
                 )
             result.append(rns_tool.fastbconv_sk(rns_tool.fast_floor(temp)))
 
-        return CipherText(result)
+        return CipherText(result, param_id)
 
     def _mul_cipher_plain(self, ct, pt):
         """Multiply two operands using FV scheme.
-
         Args:
             op1 (Ciphertext): First polynomial argument (Multiplicand).
             op2 (Plaintext): Second polynomial argument (Multiplier).
-
         Returns:
             A Ciphertext object with a value equivalent to the result of the product of two
                 operands.
         """
+        param_id = ct.param_id
+        context_data = self.context.context_data_map[param_id]
+        coeff_modulus = context_data.param.coeff_modulus
         ct, pt = ct.data, pt.data
         result = copy.deepcopy(ct)
 
         for i in range(len(result)):
-            for j in range(len(self.coeff_modulus)):
-                result[i][j] = poly_mul_mod(ct[i][0], pt, self.coeff_modulus[j], self.poly_modulus)
+            for j in range(len(coeff_modulus)):
+                result[i][j] = poly_mul_mod(ct[i][0], pt, coeff_modulus[j], self.poly_modulus)
 
-        return CipherText(result)
+        return CipherText(result, param_id)
 
     def _mul_plain_plain(self, pt1, pt2):
         """Multiply two operands using FV scheme.

--- a/syft/frameworks/torch/he/fv/integer_encoder.py
+++ b/syft/frameworks/torch/he/fv/integer_encoder.py
@@ -19,7 +19,7 @@ class IntegerEncoder:
     """
 
     def __init__(self, context):
-        self.plain_modulus = context.param.plain_modulus
+        self.plain_modulus = context.context_data_map[context.first_param_id].param.plain_modulus
 
         if self.plain_modulus <= 1:
             raise ValueError("plain_modulus must be at least 2")

--- a/syft/frameworks/torch/he/fv/key_generator.py
+++ b/syft/frameworks/torch/he/fv/key_generator.py
@@ -18,9 +18,9 @@ class KeyGenerator:
         if not isinstance(context, Context):
             raise ValueError("invalid context")
 
-        self._public_key = None
-        self._secret_key = None
-        self._context = context
+        self.public_key = None
+        self.secret_key = None
+        self.context = context
 
     def keygen(self):
         """Generate the secret key and public key.
@@ -30,17 +30,17 @@ class KeyGenerator:
         """
         self._generate_sk()
         self._generate_pk()
-        return [self._secret_key, self._public_key]
+        return [self.secret_key, self.public_key]
 
-    def _generate_sk(self, is_initialized=False):
-        param = self._context.param
-
-        if not is_initialized:
-            self._secret_key = SecretKey(sample_poly_ternary(param))
+    def _generate_sk(self):
+        param = self.context.context_data_map[self.context.key_param_id].param
+        self.secret_key = SecretKey(sample_poly_ternary(param))
 
     def _generate_pk(self):
-        if self._secret_key is None:
+        if self.secret_key is None:
             raise RuntimeError("cannot generate public key for unspecified secret key")
 
-        public_key = encrypt_symmetric(self._context, self._secret_key.data)
-        self._public_key = PublicKey(public_key.data)
+        public_key = encrypt_symmetric(
+            self.context, self.context.key_param_id, self.secret_key.data
+        )
+        self.public_key = PublicKey(public_key.data)

--- a/syft/frameworks/torch/he/fv/util/operations.py
+++ b/syft/frameworks/torch/he/fv/util/operations.py
@@ -219,7 +219,7 @@ def xgcd(x, y):
     return [x, prev_a, prev_b]
 
 
-def multiply_add_plain_with_delta(ct, pt, context):
+def multiply_add_plain_with_delta(ct, pt, context_data):
     """Add message into phase.
 
     Args:
@@ -230,10 +230,11 @@ def multiply_add_plain_with_delta(ct, pt, context):
     Returns:
         A Ciphertext object with the encrypted result of encryption process.
     """
-    coeff_modulus = context.param.coeff_modulus
+    ct_param_id = ct.param_id
+    coeff_modulus = context_data.param.coeff_modulus
     pt = pt.data
     plain_coeff_count = len(pt)
-    delta = context.coeff_div_plain_modulus
+    delta = context_data.coeff_div_plain_modulus
     ct0, ct1 = ct.data  # here ct = pk * u * e
 
     # Coefficients of plain m multiplied by coeff_modulus q, divided by plain_modulus t,
@@ -243,10 +244,10 @@ def multiply_add_plain_with_delta(ct, pt, context):
             temp = round(delta[j] * pt[i]) % coeff_modulus[j]
             ct0[j][i] = (ct0[j][i] + temp) % coeff_modulus[j]
 
-    return CipherText([ct0, ct1])  # ct0 = pk0 * u * e + delta * pt
+    return CipherText([ct0, ct1], ct_param_id)  # ct0 = pk0 * u * e + delta * pt
 
 
-def multiply_sub_plain_with_delta(ct, pt, context):
+def multiply_sub_plain_with_delta(ct, pt, context_data):
     """Subtract plaintext from ciphertext.
 
     Args:
@@ -257,10 +258,11 @@ def multiply_sub_plain_with_delta(ct, pt, context):
     Returns:
         A Ciphertext object with the encrypted result of encryption process.
     """
-    coeff_modulus = context.param.coeff_modulus
+    ct_param_id = ct.param_id
+    coeff_modulus = context_data.param.coeff_modulus
     pt = pt.data
     plain_coeff_count = len(pt)
-    delta = context.coeff_div_plain_modulus
+    delta = context_data.coeff_div_plain_modulus
     ct0, ct1 = ct.data  # here ct = pk * u * e
 
     # Coefficients of plain m multiplied by coeff_modulus q, divided by plain_modulus t,
@@ -270,4 +272,4 @@ def multiply_sub_plain_with_delta(ct, pt, context):
             temp = round(delta[j] * pt[i]) % coeff_modulus[j]
             ct0[j][i] = (ct0[j][i] - temp) % coeff_modulus[j]
 
-    return CipherText([ct0, ct1])  # ct0 = pk0 * u * e - delta * pt
+    return CipherText([ct0, ct1], ct_param_id)  # ct0 = pk0 * u * e - delta * pt

--- a/syft/frameworks/torch/he/fv/util/rlwe.py
+++ b/syft/frameworks/torch/he/fv/util/rlwe.py
@@ -116,6 +116,7 @@ def encrypt_asymmetric(context, param_id, public_key):
     Args:
         context (Context): A valid context required for extracting the encryption
             parameters.
+        param_id: Parameter id for accessing the correct parameters from the context chain.
         public_key (PublicKey): A public key generated with same encryption parameters.
 
     Returns:
@@ -156,6 +157,7 @@ def encrypt_symmetric(context, param_id, secret_key):
 
     Args:
         context (Context): A valid context required for extracting the encryption parameters.
+        param_id: Parameter id for accessing the correct parameters from the context chain.
         secret_key (SecretKey): A secret key generated with same encryption parameters.
 
     Returns:

--- a/syft/frameworks/torch/he/fv/util/rlwe.py
+++ b/syft/frameworks/torch/he/fv/util/rlwe.py
@@ -109,7 +109,7 @@ def sample_poly_uniform(param):
     return result
 
 
-def encrypt_asymmetric(context, public_key):
+def encrypt_asymmetric(context, param_id, public_key):
     """Create encryption of zero values with a public key which can be used in
     subsequent processes to add a message into it.
 
@@ -121,7 +121,7 @@ def encrypt_asymmetric(context, public_key):
     Returns:
         A ciphertext object containing encryption of zeroes by asymmetric encryption procedure.
     """
-    param = context.param
+    param = context.context_data_map[param_id].param
     poly_mod = param.poly_modulus
     coeff_modulus = param.coeff_modulus
     coeff_mod_size = len(coeff_modulus)
@@ -147,10 +147,10 @@ def encrypt_asymmetric(context, public_key):
                 coeff_modulus[i],
                 poly_mod,
             )
-    return CipherText(result)
+    return CipherText(result, param_id)
 
 
-def encrypt_symmetric(context, secret_key):
+def encrypt_symmetric(context, param_id, secret_key):
     """Create encryption of zero values with a secret key which can be used in subsequent
     processes to add a message into it.
 
@@ -161,15 +161,16 @@ def encrypt_symmetric(context, secret_key):
     Returns:
         A ciphertext object containing encryption of zeroes by symmetric encryption procedure.
     """
-    poly_mod = context.param.poly_modulus
-    coeff_modulus = context.param.coeff_modulus
+    key_param = context.context_data_map[param_id].param
+    poly_mod = key_param.poly_modulus
+    coeff_modulus = key_param.coeff_modulus
     coeff_mod_size = len(coeff_modulus)
 
     # Sample uniformly at random
-    c1 = sample_poly_uniform(context.param)
+    c1 = sample_poly_uniform(key_param)
 
     # Sample e <-- chi
-    e = sample_poly_normal(context.param)
+    e = sample_poly_normal(key_param)
 
     # calculate -(a*s + e) (mod q) and store in c0
 
@@ -186,4 +187,4 @@ def encrypt_symmetric(context, secret_key):
             coeff_modulus[i],
         )
 
-    return CipherText([c0, c1])
+    return CipherText([c0, c1], param_id)

--- a/test/torch/tensors/test_fv.py
+++ b/test/torch/tensors/test_fv.py
@@ -213,45 +213,6 @@ def test_get_sufficient_sk_power(poly_mod, coeff_mod, plain_mod, sk, max_power, 
 
 
 @pytest.mark.parametrize(
-    "poly_mod, coeff_mod, plain_mod, sk, ct, result",
-    [
-        (2, [17], 2, [[1, 1]], [[[1, 1]], [[1, 1]], [[1, 1]]], [[16, 5]]),
-        (2, [17], 2, [[1, 1]], [[[1, 1]], [[2, 3]], [[15, 5]]], [[7, 2]]),
-        (
-            4,
-            [31],
-            4,
-            [[1, 30, 30, 0]],
-            [[[189, 231, 179, 412]], [[12, 10, 0, 11]], [[134, 234, 11, 199]]],
-            [[29, 25, 25, 22]],
-        ),
-        (
-            4,
-            [1031],
-            4,
-            [[0, 1, 1030, 1030]],
-            [[[1, 2, 3, 4]], [[1, 2, 3, 4]], [[1, 2, 3, 4]], [[1, 2, 3, 4]]],
-            [[32, 32, 4, 1019]],
-        ),
-        (
-            4,
-            [1031],
-            4,
-            [[1030, 1, 1, 1030]],
-            [[[1, 1, 1, 1]], [[1, 2, 3, 4]], [[4, 3, 2, 1]], [[0, 0, 0, 0]]],
-            [[1026, 1030, 1028, 13]],
-        ),
-    ],
-)
-def test_mul_ct_sk(poly_mod, coeff_mod, plain_mod, sk, ct, result):
-    ctx = Context(EncryptionParams(poly_mod, coeff_mod, plain_mod))
-    sk = SecretKey(sk)
-    decrypter = Decryptor(ctx, sk)
-    output = decrypter._mul_ct_sk(ct)
-    assert output == result
-
-
-@pytest.mark.parametrize(
     "plain_modulus, value",
     [(128, 1), (64, 2), (32, -3), (256, 64), (128, 0xFFFFFFFFFFFFFFFF), (128, 0x80F02), (128, 64)],
 )
@@ -391,7 +352,6 @@ def test_fv_encryption_decrption_asymmetric(poly_modulus, plain_modulus, coeff_b
         (256, 256, [40, 40, 40], 2),
         (4096, 256, [40, 40, 40], 0x7FFFFFFFFFFFFFFD),
         (1024, 256, [40, 40, 40], 0x7FFFFFFFFFFFFFFE),
-        (64, 256, [40, 40, 40], 0x7FFFFFFFFFFFFFFF),
         (4096, 256, [40, 40, 40], 314159265),
     ],
 )


### PR DESCRIPTION
## Description
For Relinearization operation, we need to perform modulus switching which requires the context chain to have context object with different coefficient modulus value.

## Affected Dependencies
None

## How has this been tested?
All tests for components passing

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
