### PR TITLE
Add RNG for workers

### DIFF
--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -65,6 +65,9 @@ from syft.workers.virtual import VirtualWorker  # noqa: E402,F401
 from syft.workers.websocket_client import WebsocketClientWorker  # noqa: E402,F401
 from syft.workers.websocket_server import WebsocketServerWorker  # noqa: E402,F401
 
+# Register PRZS in PrimitiveStorage
+import syft.frameworks.torch.mpc.przs  # noqa: E402,F401
+
 # Import Syft's Public Tensor Types
 from syft.frameworks.torch.tensors.decorators.logging import LoggingTensor  # noqa: E402,F401
 from syft.frameworks.torch.tensors.interpreters.additive_shared import (  # noqa: E402,F401

--- a/syft/__init__.py
+++ b/syft/__init__.py
@@ -65,7 +65,7 @@ from syft.workers.virtual import VirtualWorker  # noqa: E402,F401
 from syft.workers.websocket_client import WebsocketClientWorker  # noqa: E402,F401
 from syft.workers.websocket_server import WebsocketServerWorker  # noqa: E402,F401
 
-# Register PRZS in PrimitiveStorage
+# Register PRZS such that all workers have the allowed commands from the przs file
 import syft.frameworks.torch.mpc.przs  # noqa: E402,F401
 
 # Import Syft's Public Tensor Types

--- a/syft/frameworks/torch/mpc/__init__.py
+++ b/syft/frameworks/torch/mpc/__init__.py
@@ -10,6 +10,7 @@ def crypto_protocol(protocol_name):
         protocol_name: the name of the protocol. Currently supported:
             - snn: SecureNN
             - fss: Function Secret Sharing
+            - falcon (WIP): Falcon
 
     Example in a tensor file:
         ```

--- a/syft/frameworks/torch/mpc/primitives.py
+++ b/syft/frameworks/torch/mpc/primitives.py
@@ -30,6 +30,7 @@ class PrimitiveStorage:
         self.fss_comp: list = []
         self.mul: dict = defaultdict(list)
         self.matmul: dict = defaultdict(list)
+        self.generators = {}
 
         self._owner: AbstractWorker = owner
         self._builders: dict = {
@@ -264,3 +265,34 @@ class PrimitiveStorage:
             return primitives_worker
 
         return build_separate_triples
+
+    def __get_next_elem(self, generator, shape=(1,), size=2 ** 32):
+        tensor = th.empty(shape, dtype=th.long)
+        worker = tensor.owner
+
+        return tensor.random_(-size // 2, (size - 1) // 2, generator=generator)
+
+    def generate_alpha_3of3(self):
+        assert (
+            "przs" in self.generators
+        ), "You must call setup_przs because the seeds where not shared between workers"
+
+        generators = self.generators["przs"]
+        cur_gen = generators["cur"]
+        prev_gen = generators["prev"]
+
+        share = self.__get_next_elem(cur_gen) - self.__get_next_elem(prev_gen)
+        return share
+
+    def generate_alpha_2of3(self):
+        assert (
+            "przs" in self.generators
+        ), "You must call setup_przs because the seeds where not shared between workers"
+
+        generators = self.generators["przs"]
+        cur_gen = generators["cur"]
+        prev_gen = generators["prev"]
+
+        share_cur, share_prev = (self.__get_next_elem(cur_gen), self.__get_next_elem(prev_gen))
+        print(share_cur, share_prev)
+        return share_cur, share_prev

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -1,31 +1,95 @@
 from collections import defaultdict
+from syft.frameworks.torch.mpc.primitives import PrimitiveStorage
+from syft.generic.utils import remote, allow_command
 
 import torch
-
 import syft
-from syft.generic.utils import allow_command, remote
 
 RING_SIZE = 2 ** 64
+ERR_MSG = "You must call PRZS.setup because the seeds where not shared between workers"
 
 
-def przs_setup(workers):
-    seed_max = 2 ** 32
-    shifted_workers = [workers.pop()]+[workers]
-    cycle_workers = zip(workers, shifted_workers)
+class PRZS:
+    def __init__(self):
+        self.generators = {}
 
-    workers_ptr = defaultdict(dict)
+    @property
+    def generators(self):
+        return self.__generators
 
-    for cur_worker, next_worker in cycle_workers:
-        ptr = cur_worker.remote.torch.randint(-seed_max, seed_max - 1, size=(1,))
-        ptr_next = ptr.copy().move(next_worker)
+    @generators.setter
+    def generators(self, generators):
+        self.__generators = generators
 
-        workers_ptr[cur_worker]["cur_seed"] = ptr
-        workers_ptr[next_worker]["prev_seed"] = ptr_next
+    @staticmethod
+    def setup(workers):
+        seed_max = 2 ** 32
+        paired_workers = list(zip(workers, workers[1:]))
+        paired_workers.append((workers[-1], workers[0]))
 
-    for worker, seeds in workers_ptr.items():
-        cur_seed = seeds["cur_seed"]
-        prev_seed = seeds["prev_seed"]
-        remote(_initialize_generators, location=worker)(cur_seed, prev_seed)
+        workers_ptr = defaultdict(dict)
+
+        for cur_worker, next_worker in paired_workers:
+            ptr = cur_worker.remote.torch.randint(-seed_max, seed_max - 1, size=(1,))
+            ptr_next = ptr.copy().move(next_worker)
+
+            workers_ptr[cur_worker]["cur_seed"] = ptr
+            workers_ptr[next_worker]["prev_seed"] = ptr_next
+
+        for worker, seeds in workers_ptr.items():
+            cur_seed = seeds["cur_seed"]
+            prev_seed = seeds["prev_seed"]
+            func_remote = remote(_initialize_generators, location=worker)
+            func_remote(cur_seed, prev_seed)
+
+    def generate_alpha_3of3(self):
+        """
+            This function should be called only on a local worker
+            Generate a random number (alpha) using the two generators
+            * generator cur - represents a generator initialized with this worker (i) seed
+            * generator prev - represents a generator initialized with
+                        the previous worker (i-1) seed
+        """
+        assert self.generators, ERR_MSG
+        cur_gen = self.generators["cur"]
+        prev_gen = self.generators["prev"]
+
+        alpha = self.__get_next_elem(cur_gen) - self.__get_next_elem(prev_gen)
+        return alpha
+
+    def generate_alpha_2of3(self):
+        """
+            This function should be called only on a local worker
+            Generate 2 random numbers (alpha_i, alpha_i-1) using the two generators
+            * generator cur - represents a generator initialized with this worker (i) seed
+                        and it generates alpha_i
+            * generator prev - represents a generator initialized with
+                        the previous worker (i-1) seed and it generates alpha_i-1
+        """
+
+        assert self.generators, ERR_MSG
+
+        cur_gen = self.generators["cur"]
+        prev_gen = self.generators["prev"]
+
+        alpha_cur, alpha_prev = (self.__get_next_elem(cur_gen), self.__get_next_elem(prev_gen))
+        return alpha_cur, alpha_prev
+
+    def __get_next_elem(self, generator, shape=(1,), ring_size=2 ** 32):
+        tensor = torch.empty(shape, dtype=torch.long)
+        worker = tensor.owner
+
+        return tensor.random_(-ring_size // 2, (ring_size - 1) // 2, generator=generator)
+
+
+def get_random(name_generator, shape, worker):
+    func = None
+    if worker == syft.local_worker:
+        func = _get_random_tensor(name_generator, shape, worker.id)
+    else:
+        func = remote(_get_random_tensor, location=worker)
+
+    return func(name_generator, shape, worker.id)
 
 
 @allow_command
@@ -37,20 +101,22 @@ def _initialize_generators(cur_seed, prev_seed):
     cur_generator.manual_seed(cur_seed.item())
     prev_generator.manual_seed(prev_seed.item())
 
-    generators = {"przs": {"cur": cur_generator, "prev": prev_generator}}
-    setattr(worker.crypto_store, "generators", generators)
+    worker.crypto_store.przs.generators = {"cur": cur_generator, "prev": prev_generator}
 
 
 @allow_command
-def przs_get_random_number(name_generator, shape, id_worker):
-    worker = syft.local_worker.get_worker(id_worker)
-    generators = getattr(worker.crypto_store, "generators")
-    gen = generators["przs"][name_generator]
+def _get_random_tensor(name_generator, shape, worker_id):
+    worker = syft.local_worker.get_worker(worker_id)
+
+    assert worker.crypto_store.przs.generators, ERR_MSG
+
+    generators = worker.crypto_store.przs.generators
+
+    gen = generators[name_generator]
     rand_elem = torch.randint(
         -(RING_SIZE // 2), (RING_SIZE - 1) // 2, shape, dtype=torch.long, generator=gen
     )
     return rand_elem
 
 
-def przs_get_random(name_generator, shape, worker):
-    return remote(przs_get_random_number, location=worker)(name_generator, shape, worker.id)
+PrimitiveStorage.register_component("przs", PRZS)

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -1,0 +1,55 @@
+from collections import defaultdict
+
+import torch
+
+import syft
+from syft.generic.utils import allow_command, remote
+
+RING_SIZE = 2 ** 64
+
+
+def przs_setup(workers):
+    seed_max = 2 ** 32
+    cycle_workers = zip(workers, [*workers[1:], workers[0]])
+
+    workers_ptr = defaultdict(dict)
+
+    for cur_worker, next_worker in cycle_workers:
+        ptr = cur_worker.remote.torch.randint(-seed_max, seed_max - 1, size=(1,))
+        ptr_next = ptr.copy().move(next_worker)
+
+        workers_ptr[cur_worker]["cur_seed"] = ptr
+        workers_ptr[next_worker]["prev_seed"] = ptr_next
+
+    for worker, seeds in workers_ptr.items():
+        cur_seed = seeds["cur_seed"]
+        prev_seed = seeds["prev_seed"]
+        remote(_initialize_generators, location=worker)(cur_seed, prev_seed)
+
+
+@allow_command
+def _initialize_generators(cur_seed, prev_seed):
+    worker = cur_seed.owner
+    cur_generator = torch.Generator()
+    prev_generator = torch.Generator()
+
+    cur_generator.manual_seed(cur_seed.item())
+    prev_generator.manual_seed(prev_seed.item())
+
+    generators = {"przs": {"cur": cur_generator, "prev": prev_generator}}
+    setattr(worker.crypto_store, "generators", generators)
+
+
+@allow_command
+def przs_get_random_number(name_generator, shape, id_worker):
+    worker = syft.local_worker.get_worker(id_worker)
+    generators = getattr(worker.crypto_store, "generators")
+    gen = generators["przs"][name_generator]
+    rand_elem = torch.randint(
+        -(RING_SIZE // 2), (RING_SIZE - 1) // 2, shape, dtype=torch.long, generator=gen
+    )
+    return rand_elem
+
+
+def przs_get_random(name_generator, shape, worker):
+    return remote(przs_get_random_number, location=worker)(name_generator, shape, worker.id)

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -43,8 +43,11 @@ class PRZS:
         for worker, seeds in workers_ptr.items():
             cur_seed = seeds["cur_seed"]
             prev_seed = seeds["prev_seed"]
-            func_remote = remote(_initialize_generators, location=worker)
-            func_remote(cur_seed, prev_seed)
+            if worker == syft.local_worker:
+                func = _initialize_generators
+            else:
+                func = remote(_initialize_generators, location=worker)
+            func(cur_seed, prev_seed)
 
 
 def get_random(name_generator, shape, worker):

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -10,7 +10,8 @@ RING_SIZE = 2 ** 64
 
 def przs_setup(workers):
     seed_max = 2 ** 32
-    cycle_workers = zip(workers, [*workers[1:], workers[0]])
+    shifted_workers = [workers.pop()]+[workers]
+    cycle_workers = zip(workers, shifted_workers)
 
     workers_ptr = defaultdict(dict)
 

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -96,7 +96,7 @@ def gen_alpha_3of3(worker):
 def gen_alpha_2of3(worker):
     func = None
     if worker == syft.local_worker:
-        func = _generate_alpha_3of3
+        func = _generate_alpha_2of3
     else:
         func = remote(_generate_alpha_2of3, location=worker)
 

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -420,7 +420,7 @@ class TorchTensor(AbstractTensor):
 
     def _fix_torch_library(cmd):
         """
-        Change the cmd string parameter to use nn.functional path to avoid erros.
+        Change the cmd string parameter to use nn.functional path to avoid errors.
         """
         if "_C._nn" in cmd:
             cmd = cmd.replace("_C._nn", "nn.functional")

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -97,7 +97,13 @@ class TorchAttributes(FrameworkAttributes):
             "typename",
         ]
 
-        self.worker_methods = ["tensor", "rand", "zeros", "randn", "randint"]
+        self.worker_methods = [
+            "tensor",
+            "rand",
+            "zeros",
+            "randn",
+            "randint",
+        ]
 
         # SECTION: Build the guard, that define which functions or methods can be safely called by
         # external or local workers

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -163,11 +163,10 @@ class BaseWorker(AbstractWorker):
             self.framework = hook.framework
             if hasattr(hook, "torch"):
                 self.torch = self.framework
-                self.remote = Remote(self, "torch")
             elif hasattr(hook, "tensorflow"):
                 self.tensorflow = self.framework
-                self.remote = Remote(self, "tensorflow")
 
+        self.remote = Remote(self, sy.framework.ALIAS)
         # storage object for crypto primitives
         self.crypto_store = PrimitiveStorage(owner=self)
 

--- a/test/torch/mpc/test_crypto_store.py
+++ b/test/torch/mpc/test_crypto_store.py
@@ -53,7 +53,6 @@ def test_przs_alpha_2of3(workers):
     PRZS.setup(workers_vals)
 
     values = [gen_alpha_2of3(worker).get() for worker in workers_vals]
-    print(values)
 
     """
         Worker i holds (alpha_i, and alpha_i-1)

--- a/test/torch/mpc/test_crypto_store.py
+++ b/test/torch/mpc/test_crypto_store.py
@@ -60,8 +60,8 @@ def test_przs_alpha_2of3(workers):
         Here we do:
         ((alpha_i, alpha_i-1), (alpha_i+1, alpha_i))
     """
-    cycle_values = zip(values, [*values[1:], values[0]])
-    for alphas_worker_cur, alphas_worker_next in cycle_values:
+    paired_values = zip(values, [*values[1:], values[0]])
+    for alphas_worker_cur, alphas_worker_next in paired_values:
         alpha_cur, _ = alphas_worker_cur
         _, alpha_prev = alphas_worker_next
 

--- a/test/torch/mpc/test_crypto_store.py
+++ b/test/torch/mpc/test_crypto_store.py
@@ -1,7 +1,7 @@
 import pytest
 
 from syft.exceptions import EmptyCryptoPrimitiveStoreError
-from syft.frameworks.torch.mpc.przs import RING_SIZE, PRZS
+from syft.frameworks.torch.mpc.przs import RING_SIZE, PRZS, gen_alpha_3of3, gen_alpha_2of3
 
 
 def test_primitives_usage(workers):
@@ -35,8 +35,7 @@ def test_przs_alpha_3of3(workers):
     workers_vals = [alice, bob, james]
     PRZS.setup(workers_vals)
 
-    """Carefull! This works because we have virtual workers"""
-    values = [worker.crypto_store.przs.generate_alpha_3of3() for worker in workers_vals]
+    values = [gen_alpha_3of3(worker).get() for worker in workers_vals]
 
     sum_values = sum(values)
 
@@ -53,7 +52,8 @@ def test_przs_alpha_2of3(workers):
     workers_vals = [alice, bob, james]
     PRZS.setup(workers_vals)
 
-    values = [worker.crypto_store.przs.generate_alpha_2of3() for worker in workers_vals]
+    values = [gen_alpha_2of3(worker).get() for worker in workers_vals]
+    print(values)
 
     """
         Worker i holds (alpha_i, and alpha_i-1)

--- a/test/torch/mpc/test_crypto_store.py
+++ b/test/torch/mpc/test_crypto_store.py
@@ -55,7 +55,8 @@ def test_przs_alpha_2of3(workers):
 
     values = [worker.crypto_store.przs.generate_alpha_2of3() for worker in workers_vals]
 
-    """Worker i holds (alpha_i, and alpha_i-1)
+    """
+        Worker i holds (alpha_i, and alpha_i-1)
         Here we do:
         ((alpha_i, alpha_i-1), (alpha_i+1, alpha_i))
     """

--- a/test/torch/mpc/test_crypto_store.py
+++ b/test/torch/mpc/test_crypto_store.py
@@ -1,7 +1,7 @@
 import pytest
 
 from syft.exceptions import EmptyCryptoPrimitiveStoreError
-from syft.frameworks.torch.mpc.przs import przs_setup, RING_SIZE
+from syft.frameworks.torch.mpc.przs import RING_SIZE, PRZS
 
 
 def test_primitives_usage(workers):
@@ -33,10 +33,10 @@ def test_przs_alpha_3of3(workers):
     )
 
     workers_vals = [alice, bob, james]
-    przs_setup(workers_vals)
+    PRZS.setup(workers_vals)
 
     """Carefull! This works because we have virtual workers"""
-    values = [worker.crypto_store.generate_alpha_3of3() for worker in workers_vals]
+    values = [worker.crypto_store.przs.generate_alpha_3of3() for worker in workers_vals]
 
     sum_values = sum(values)
 
@@ -51,9 +51,9 @@ def test_przs_alpha_2of3(workers):
     )
 
     workers_vals = [alice, bob, james]
-    przs_setup(workers_vals)
+    PRZS.setup(workers_vals)
 
-    values = [worker.crypto_store.generate_alpha_2of3() for worker in workers_vals]
+    values = [worker.crypto_store.przs.generate_alpha_2of3() for worker in workers_vals]
 
     """Worker i holds (alpha_i, and alpha_i-1)
         Here we do:

--- a/test/torch/mpc/test_crypto_store.py
+++ b/test/torch/mpc/test_crypto_store.py
@@ -1,6 +1,7 @@
 import pytest
 
 from syft.exceptions import EmptyCryptoPrimitiveStoreError
+from syft.frameworks.torch.mpc.przs import przs_setup, RING_SIZE
 
 
 def test_primitives_usage(workers):
@@ -22,3 +23,45 @@ def test_primitives_usage(workers):
 
     with pytest.raises(EmptyCryptoPrimitiveStoreError):
         _ = alice.crypto_store.get_keys("fss_eq", 4, remove=True)
+
+
+def test_przs_alpha_3of3(workers):
+    alice, bob, james = (
+        workers["alice"],
+        workers["bob"],
+        workers["james"],
+    )
+
+    workers_vals = [alice, bob, james]
+    przs_setup(workers_vals)
+
+    """Carefull! This works because we have virtual workers"""
+    values = [worker.crypto_store.generate_alpha_3of3() for worker in workers_vals]
+
+    sum_values = sum(values)
+
+    assert sum_values.item() % RING_SIZE == 0
+
+
+def test_przs_alpha_2of3(workers):
+    alice, bob, james = (
+        workers["alice"],
+        workers["bob"],
+        workers["james"],
+    )
+
+    workers_vals = [alice, bob, james]
+    przs_setup(workers_vals)
+
+    values = [worker.crypto_store.generate_alpha_2of3() for worker in workers_vals]
+
+    """Worker i holds (alpha_i, and alpha_i-1)
+        Here we do:
+        ((alpha_i, alpha_i-1), (alpha_i+1, alpha_i))
+    """
+    cycle_values = zip(values, [*values[1:], values[0]])
+    for alphas_worker_cur, alphas_worker_next in cycle_values:
+        alpha_cur, _ = alphas_worker_cur
+        _, alpha_prev = alphas_worker_next
+
+        assert alpha_cur == alpha_prev

--- a/test/torch/mpc/test_przs.py
+++ b/test/torch/mpc/test_przs.py
@@ -1,0 +1,21 @@
+from syft.frameworks.torch.mpc.przs import przs_setup, przs_get_random
+
+
+def test_get_random_number(workers):
+    alice, bob, james = (
+        workers["alice"],
+        workers["bob"],
+        workers["james"],
+    )
+
+    workers = [alice, bob, james]
+
+    przs_setup(workers)
+    cycle_workers = zip(workers, [*workers[1:], workers[0]])
+    shape = (3, 2)
+
+    for worker_cur, worker_next in cycle_workers:
+        t1 = przs_get_random("cur", shape, worker_cur)
+        t2 = przs_get_random("prev", shape, worker_next)
+
+        assert (t1.get() == t2.get()).all()

--- a/test/torch/mpc/test_przs.py
+++ b/test/torch/mpc/test_przs.py
@@ -11,6 +11,7 @@ def test_get_random_number(workers):
     workers = [alice, bob, james]
 
     PRZS.setup(workers)
+
     paired_workers = list(zip(workers, workers[1:]))
     paired_workers.append((workers[-1], workers[0]))
 

--- a/test/torch/mpc/test_przs.py
+++ b/test/torch/mpc/test_przs.py
@@ -1,4 +1,4 @@
-from syft.frameworks.torch.mpc.przs import przs_setup, przs_get_random
+from syft.frameworks.torch.mpc.przs import PRZS, get_random
 
 
 def test_get_random_number(workers):
@@ -10,12 +10,14 @@ def test_get_random_number(workers):
 
     workers = [alice, bob, james]
 
-    przs_setup(workers)
-    cycle_workers = zip(workers, [*workers[1:], workers[0]])
+    PRZS.setup(workers)
+    paired_workers = list(zip(workers, workers[1:]))
+    paired_workers.append((workers[-1], workers[0]))
+
     shape = (3, 2)
 
-    for worker_cur, worker_next in cycle_workers:
-        t1 = przs_get_random("cur", shape, worker_cur)
-        t2 = przs_get_random("prev", shape, worker_next)
+    for worker_cur, worker_next in paired_workers:
+        t1 = get_random("cur", shape, worker_cur)
+        t2 = get_random("prev", shape, worker_next)
 
         assert (t1.get() == t2.get()).all()


### PR DESCRIPTION
## Description
In the Correlated Randomness scenario, each worker will have 2 seeds (one generated locally, and one received from another worker).

For the moment this PR is WIP because I am thinking on an interface/best approach to generate random numbers remote using those generators.

Fixes #3898

## Affected Dependencies
- Running remote execution on the workers

## How has this been tested?
- Added tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
