### PR TITLE
Documentation/plan and protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ docs/_modules
 .coverage
 .vscode/
 **/pip-wheel-metadata
-
+.ropeproject/

--- a/syft/execution/plan.py
+++ b/syft/execution/plan.py
@@ -86,6 +86,9 @@ class Plan(AbstractSendable):
     input referenced through pointers, instead of sending multiple messages you need now to send a
     single message with the references of the plan and the pointers.
 
+    Specifically, a Plan contains only ComputationAction and does not concern itself with
+    operations covered by CommunicationAction. Use Protocol to cover both types of actions.
+
     All arguments are optional.
 
     Args:

--- a/syft/execution/protocol.py
+++ b/syft/execution/protocol.py
@@ -70,6 +70,9 @@ class Protocol(AbstractSendable):
     input referenced through pointers, instead of sending multiple messages you need now to send a
     single message with the references of the protocol and the pointers.
 
+    Specifically, a Protocol can contain a mix of ComputationAction and CommunicationAction and
+    acts as a cross-worker. Use Plan for pure mathematical operations.
+
     All arguments are optional.
 
     Args:


### PR DESCRIPTION
## Description
When a first-timer encounters `Plan` and `Protocol`, they tend to be confused as to how the two classes differentiate from each other or when to use which class.

This PR adds additional explanations to `Plan` and `Protocol`, which currently contain identical class-level docstring. When new contributors read the documentation of both classes now, they should have a better idea about the similarity as well as the differences between the classes.

Credit: The added lines are taken from explanations by @LaRiffle :pray: 

## Affected Dependencies
N/A

## How has this been tested?
N/A

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
