### PR TITLE
Raise RuntimeError when negative integers is entered in the `pow`

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -604,6 +604,8 @@ class AdditiveSharingTensor(AbstractTensor):
          - Divide power by 2 and multiply base to itself (if the power is even)
          - Decrement power by 1 to make it even and then follow the first step
         """
+        if power < 0:
+            raise RuntimeError("Integers to negative integer powers are not allowed.")
         base = self
 
         result = 1

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -605,7 +605,7 @@ class AdditiveSharingTensor(AbstractTensor):
          - Decrement power by 1 to make it even and then follow the first step
         """
         if power < 0:
-            raise RuntimeError("Integers to negative integer powers are not allowed.")
+            raise RuntimeError("Negative integer powers are not allowed.")
 
         base = self
 

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -606,6 +606,7 @@ class AdditiveSharingTensor(AbstractTensor):
         """
         if power < 0:
             raise RuntimeError("Integers to negative integer powers are not allowed.")
+
         base = self
 
         result = 1

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -382,7 +382,8 @@ class FixedPrecisionTensor(AbstractTensor):
             power (int): the exponent supposed to be an integer > 0
         """
         if power < 0:
-            raise RuntimeError("Integers to negative integer powers are not allowed.")
+            raise RuntimeError("Negative integer powers are not allowed.")
+
         base = self
 
         result = None

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -381,6 +381,8 @@ class FixedPrecisionTensor(AbstractTensor):
         Args:
             power (int): the exponent supposed to be an integer > 0
         """
+        if power < 0:
+            raise RuntimeError("Integers to negative integer powers are not allowed.")
         base = self
 
         result = None


### PR DESCRIPTION
## Description

RuntimeError raised when a negative interger is entered in the `pow` as in pytorch.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
