### PR TITLE
Fast FixedPrecisonTensor Reciprocal Method (150x faster)

### DIFF
--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -484,7 +484,7 @@ class FixedPrecisionTensor(AbstractTensor):
 
         Ref: https://github.com/facebookresearch/CrypTen
         """
-        
+
         if method is None:
             ones = self * 0 + 1
             return ones / self

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -468,7 +468,7 @@ class FixedPrecisionTensor(AbstractTensor):
     __matmul__ = matmul
     mm = matmul
 
-    def reciprocal(self, method="NR", nr_iters=10):
+    def reciprocal(self, method="division", nr_iters=10):
         r"""
         Calculate the reciprocal using the algorithm specified in the method args.
         Ref: https://github.com/facebookresearch/CrypTen

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -482,6 +482,9 @@ class FixedPrecisionTensor(AbstractTensor):
                 In general, NR is the fastest and most accurate.
             nr_iters:
                 Number of iterations for `Newton-Raphson`
+        
+        Returns:
+            Reciprocal of `self`
 
         Ref: https://github.com/facebookresearch/CrypTen
         """

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -488,7 +488,7 @@ class FixedPrecisionTensor(AbstractTensor):
         """
 
         if method.lower() == "nr":
-            print('hello')
+            print("hello")
             result = 3 * (0.5 - self).exp() + 0.003
             for i in range(nr_iters):
                 result = 2 * result - result * result * self

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -468,9 +468,19 @@ class FixedPrecisionTensor(AbstractTensor):
     __matmul__ = matmul
     mm = matmul
 
-    def reciprocal(self):
-        ones = self * 0 + 1
-        return ones / self
+    def reciprocal(self, method=None, nr_iters=10):
+        if method is None:
+            ones = self * 0 + 1
+            return ones / self
+        elif method.lower() == "nr":
+            result = 3 * (0.5 - self).exp() + 0.003
+            for i in range(nr_iters):
+                result = 2 * result - result * result * self
+            return result
+        elif method.lower() == "log":
+            return (-self.log()).exp()
+        else:
+            raise ValueError(f"Invalid method {method} given for reciprocal function")
 
     # Approximations:
     def inverse(self, iterations=8):

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -475,7 +475,7 @@ class FixedPrecisionTensor(AbstractTensor):
 
         Args:
             method:
-                None, 'NR' and 'log' can be entered.
+                None, 'NR', 'Log' and 'Division' can be entered.
                 In general, NR is the fastest and most accurate.
             nr_iters:
                 Number of iterations for `Newton-Raphson`
@@ -483,14 +483,14 @@ class FixedPrecisionTensor(AbstractTensor):
             Reciprocal of `self`
         """
 
-        if method is None:
-            ones = self * 0 + 1
-            return ones / self
-        elif method.lower() == "nr":
+        if method is None or method.lower() == "nr":
             result = 3 * (0.5 - self).exp() + 0.003
             for i in range(nr_iters):
                 result = 2 * result - result * result * self
             return result
+        elif method.lower() == "division":
+            ones = self * 0 + 1
+            return ones / self
         elif method.lower() == "log":
             return (-self.log()).exp()
         else:

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -471,6 +471,7 @@ class FixedPrecisionTensor(AbstractTensor):
     def reciprocal(self, method=None, nr_iters=10):
         r"""
         Calculate the reciprocal using the algorithm specified in the method args.
+        Ref: https://github.com/facebookresearch/CrypTen
 
         Args:
             method:
@@ -478,11 +479,8 @@ class FixedPrecisionTensor(AbstractTensor):
                 In general, NR is the fastest and most accurate.
             nr_iters:
                 Number of iterations for `Newton-Raphson`
-        
         Returns:
             Reciprocal of `self`
-
-        Ref: https://github.com/facebookresearch/CrypTen
         """
 
         if method is None:

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -468,7 +468,7 @@ class FixedPrecisionTensor(AbstractTensor):
     __matmul__ = matmul
     mm = matmul
 
-    def reciprocal(self, method=None, nr_iters=10):
+    def reciprocal(self, method="NR", nr_iters=10):
         r"""
         Calculate the reciprocal using the algorithm specified in the method args.
         Ref: https://github.com/facebookresearch/CrypTen

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -471,10 +471,6 @@ class FixedPrecisionTensor(AbstractTensor):
     def reciprocal(self, nr_iters=10):
         r"""
         Calculate the reciprocal using the algorithm specified in the method args.
-        exp(x) = \lim_{n -> infty} (1 + x / n) ^ n
-
-        Here we compute exp by choosing n = 2 ** d for some large d equal to
-        iterations. We then compute (1 + x / n) once and square `d` times.
 
         Args:
             method:

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -559,7 +559,7 @@ class FixedPrecisionTensor(AbstractTensor):
         x = tensor * sign
         ones = tensor * 0 + 1
         half = ones.div(2)
-        result = (ones + (-ones * x).exp()).reciprocal(method="division")
+        result = (ones + (-ones * x).exp()).reciprocal()
         return (result - half) * sign + half
 
     @staticmethod
@@ -606,7 +606,7 @@ class FixedPrecisionTensor(AbstractTensor):
 
         return tanh_approx.div(2) + 0.5
 
-    def sigmoid(tensor, method="exp"):
+    def sigmoid(tensor, method="chebyshev"):
         """
         Approximates the sigmoid function using a given method
 

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -468,7 +468,7 @@ class FixedPrecisionTensor(AbstractTensor):
     __matmul__ = matmul
     mm = matmul
 
-    def reciprocal(self, nr_iters=10):
+    def reciprocal(self, method=None, nr_iters=10):
         r"""
         Calculate the reciprocal using the algorithm specified in the method args.
 

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -468,7 +468,7 @@ class FixedPrecisionTensor(AbstractTensor):
     __matmul__ = matmul
     mm = matmul
 
-    def reciprocal(self, method="division", nr_iters=10):
+    def reciprocal(self, method="NR", nr_iters=10):
         r"""
         Calculate the reciprocal using the algorithm specified in the method args.
         Ref: https://github.com/facebookresearch/CrypTen
@@ -559,7 +559,7 @@ class FixedPrecisionTensor(AbstractTensor):
         x = tensor * sign
         ones = tensor * 0 + 1
         half = ones.div(2)
-        result = (ones + (-ones * x).exp()).reciprocal()
+        result = (ones + (-ones * x).exp()).reciprocal(method="division")
         return (result - half) * sign + half
 
     @staticmethod

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -475,15 +475,20 @@ class FixedPrecisionTensor(AbstractTensor):
 
         Args:
             method:
-                None, 'NR', 'Log' and 'Division' can be entered.
-                In general, NR is the fastest and most accurate.
+            'NR' : `Newton-Raphson`_ method computes the reciprocal using iterations
+                    of :math:`x_{i+1} = (2x_i - self * x_i^2)` and uses
+                    :math:`3*exp(-(x-.5)) + 0.003` as an initial guess by default
+            'log' : Computes the reciprocal of the input from the observation that:
+                    :math:`x^{-1} = exp(-log(x))`
+
             nr_iters:
                 Number of iterations for `Newton-Raphson`
         Returns:
             Reciprocal of `self`
         """
 
-        if method is None or method.lower() == "nr":
+        if method.lower() == "nr":
+            print('hello')
             result = 3 * (0.5 - self).exp() + 0.003
             for i in range(nr_iters):
                 result = 2 * result - result * result * self

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -468,7 +468,24 @@ class FixedPrecisionTensor(AbstractTensor):
     __matmul__ = matmul
     mm = matmul
 
-    def reciprocal(self, method=None, nr_iters=10):
+    def reciprocal(self, nr_iters=10):
+        r"""
+        Calculate the reciprocal using the algorithm specified in the method args.
+        exp(x) = \lim_{n -> infty} (1 + x / n) ^ n
+
+        Here we compute exp by choosing n = 2 ** d for some large d equal to
+        iterations. We then compute (1 + x / n) once and square `d` times.
+
+        Args:
+            method:
+                None, 'NR' and 'log' can be entered.
+                In general, NR is the fastest and most accurate.
+            nr_iters:
+                Number of iterations for `Newton-Raphson`
+
+        Ref: https://github.com/facebookresearch/CrypTen
+        """
+        
         if method is None:
             ones = self * 0 + 1
             return ones / self

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -488,7 +488,6 @@ class FixedPrecisionTensor(AbstractTensor):
         """
 
         if method.lower() == "nr":
-            print("hello")
             result = 3 * (0.5 - self).exp() + 0.003
             for i in range(nr_iters):
                 result = 2 * result - result * result * self

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -108,7 +108,6 @@ def test_reciprocal(workers):
 
     tensor = torch.tensor([1.0, 2.0, 3.0])
     x = tensor.fix_prec()
-    real_result = torch.tensor([1.0, 2.0, 3.0]).reciprocal()
 
     result = x.reciprocal().float_prec()
     assert torch.isclose(result, tensor.reciprocal()).all()

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -106,17 +106,17 @@ def test_methods_for_linear_module(method, parameter):
 def test_reciprocal(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
 
-    x = torch.tensor([1.0, 2.0, 3.0]).fix_prec()
+    tensor = torch.tensor([1.0, 2.0, 3.0])
+    x = tensor.fix_prec()
     real_result = torch.tensor([1.0, 2.0, 3.0]).reciprocal()
 
     result = x.reciprocal().float_prec()
-    assert (result == torch.tensor([1.0, 0.5, 0.333])).all()
-    assert ((real_result - result).abs() <= 0.001).all()
+    assert torch.isclose(result, tensor.reciprocal()).all()
 
     x = torch.tensor([1.0, 2.0, 3.0]).fix_prec()
     result = x.share(bob, alice, crypto_provider=james)
     result = result.reciprocal(method="NR").get().float_prec()
-    assert ((real_result - result).abs() <= 0.001).all()
+    assert torch.isclose(result, tensor.reciprocal()).all()
 
 
 def test_torch_add(workers):

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -102,6 +102,25 @@ def test_methods_for_linear_module(method, parameter):
 
     assert (result == fp_result.float_precision()).all()
 
+def test_reciprocal(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+
+    x = torch.tensor([1., 2., 3.]).fix_prec()
+    real_result = torch.tensor([1., 2., 3.]).reciprocal()
+
+    result = x.reciprocal().float_prec()
+    assert (result == torch.tensor([1., 0.5, 0.333])).all()
+    assert ((real_result - result).abs() <= 0.001).all()
+
+    x = torch.tensor([1., 2., 3.]).fix_prec()
+    result = x.share(bob, alice, crypto_provider=james)
+    result = result.reciprocal(method="NR").get().float_prec()
+    assert ((real_result - result).abs() <= 0.001).all()
+
+    x = torch.tensor([1., 2., 3.]).fix_prec()
+    result = x.share(bob, alice, crypto_provider=james)
+    result = result.reciprocal(method="LOG").get().float_prec()
+    assert ((real_result - result).abs() <= 0.5).all()
 
 def test_torch_add(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -102,25 +102,27 @@ def test_methods_for_linear_module(method, parameter):
 
     assert (result == fp_result.float_precision()).all()
 
+
 def test_reciprocal(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
 
-    x = torch.tensor([1., 2., 3.]).fix_prec()
-    real_result = torch.tensor([1., 2., 3.]).reciprocal()
+    x = torch.tensor([1.0, 2.0, 3.0]).fix_prec()
+    real_result = torch.tensor([1.0, 2.0, 3.0]).reciprocal()
 
     result = x.reciprocal().float_prec()
-    assert (result == torch.tensor([1., 0.5, 0.333])).all()
+    assert (result == torch.tensor([1.0, 0.5, 0.333])).all()
     assert ((real_result - result).abs() <= 0.001).all()
 
-    x = torch.tensor([1., 2., 3.]).fix_prec()
+    x = torch.tensor([1.0, 2.0, 3.0]).fix_prec()
     result = x.share(bob, alice, crypto_provider=james)
     result = result.reciprocal(method="NR").get().float_prec()
     assert ((real_result - result).abs() <= 0.001).all()
 
-    x = torch.tensor([1., 2., 3.]).fix_prec()
+    x = torch.tensor([1.0, 2.0, 3.0]).fix_prec()
     result = x.share(bob, alice, crypto_provider=james)
     result = result.reciprocal(method="LOG").get().float_prec()
     assert ((real_result - result).abs() <= 0.5).all()
+
 
 def test_torch_add(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -108,7 +108,7 @@ def test_reciprocal(workers):
 
     tensor = torch.tensor([1.0, 2.0, 3.0])
     x = tensor.fix_prec()
-    result = x.reciprocal().float_prec()
+    result = x.reciprocal(method="NR").float_prec()
     assert torch.isclose(tensor.reciprocal(), result, rtol=1e-2).all()
 
     x = tensor.fix_prec()

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -113,7 +113,7 @@ def test_reciprocal(workers):
 
     x = tensor.fix_prec()
     result = x.share(bob, alice, crypto_provider=james)
-    result = result.reciprocal(method="NR").get().float_prec()
+    result = result.reciprocal(method="division").get().float_prec()
     assert torch.isclose(tensor.reciprocal(), result, atol=1e-2).all()
 
     x = tensor.fix_prec()

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -108,12 +108,12 @@ def test_reciprocal(workers):
 
     tensor = torch.tensor([1.0, 2.0, 3.0])
     x = tensor.fix_prec()
-    result = x.reciprocal(method="NR").float_prec()
+    result = x.reciprocal(method="division").float_prec()
     assert torch.isclose(tensor.reciprocal(), result, rtol=1e-2).all()
 
     x = tensor.fix_prec()
     result = x.share(bob, alice, crypto_provider=james)
-    result = result.reciprocal(method="division").get().float_prec()
+    result = result.reciprocal(method="NR").get().float_prec()
     assert torch.isclose(tensor.reciprocal(), result, atol=1e-2).all()
 
     x = tensor.fix_prec()

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -108,14 +108,18 @@ def test_reciprocal(workers):
 
     tensor = torch.tensor([1.0, 2.0, 3.0])
     x = tensor.fix_prec()
-
     result = x.reciprocal().float_prec()
-    assert torch.isclose(result, tensor.reciprocal()).all()
+    assert torch.isclose(tensor.reciprocal(), result, rtol=1e-2).all()
 
-    x = torch.tensor([1.0, 2.0, 3.0]).fix_prec()
+    x = tensor.fix_prec()
     result = x.share(bob, alice, crypto_provider=james)
     result = result.reciprocal(method="NR").get().float_prec()
-    assert torch.isclose(result, tensor.reciprocal()).all()
+    assert torch.isclose(tensor.reciprocal(), result, atol=1e-2).all()
+
+    x = tensor.fix_prec()
+    result = x.share(bob, alice, crypto_provider=james)
+    result = result.reciprocal(method="Log").get().float_prec()
+    assert torch.isclose(tensor.reciprocal(), result, atol=5e-1).all()
 
 
 def test_torch_add(workers):

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -118,11 +118,6 @@ def test_reciprocal(workers):
     result = result.reciprocal(method="NR").get().float_prec()
     assert ((real_result - result).abs() <= 0.001).all()
 
-    x = torch.tensor([1.0, 2.0, 3.0]).fix_prec()
-    result = x.share(bob, alice, crypto_provider=james)
-    result = result.reciprocal(method="LOG").get().float_prec()
-    assert ((real_result - result).abs() <= 0.5).all()
-
 
 def test_torch_add(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])


### PR DESCRIPTION
## Description

issue: https://github.com/OpenMined/PySyft/issues/3993

We can use reciprocal 150 times faster on average. Implementing division of AST with reciprocal can make existing very slow division much faster. In addition, many slow operations can be made very quickly.

This implementation referred to the implementation of CrypTen.

https://github.com/facebookresearch/CrypTen/blob/3c4e53aa4910117e4e136691cb09ea7a7e001029/crypten/mpc/mpc.py#L1029

```python
x = torch.tensor([1., 2., 3.]).fix_prec().share(bob, alice, crypto_provider=theo)

# Existing method (using division)
x.reciprocal().get().float_prec() # 27 seconds
# tensor([1.0000, 0.5000, 0.3330])

# New Method (using NR)
x.reciprocal(method="nr").get().float_prec() # 0.18 seconds
# tensor([1.0000, 0.5000, 0.3330])

# New Method (using LOG) / Approximation
x.reciprocal(method="log").get().float_prec() # 0.31 seconds
#  tensor([1.0000, 0.4650, 0.3530])
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
