### PR TITLE
Made tests fault tolerant to missing crypten module for windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,6 @@ omit =
 	syft/workers/websocket_server.py
 	test/efficiency/*
 	test/notebooks/*
+	test/crypten/*
+	test/serde/*
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,10 @@ from syft.generic.frameworks.hook import hook_args
 from syft.workers.websocket_client import WebsocketClientWorker
 from syft.workers.websocket_server import WebsocketServerWorker
 
+collect_ignore = []
+if os.name == "nt":
+    collect_ignore.append("crypten/")
+
 
 def pytest_configure(config):
     config.addinivalue_line(

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -1,5 +1,3 @@
-from os import name as os_name
-
 import pytest
 
 import torch as th
@@ -8,13 +6,11 @@ import torch.nn.functional as F
 
 import syft as sy
 
-if os_name != "nt":
-    import crypten
+import crypten
 
-if os_name != "nt":
-    from syft.frameworks.crypten.context import run_multiworkers, run_party
-    from syft.frameworks.crypten.model import OnnxModel
-    from syft.frameworks.crypten import utils
+from syft.frameworks.crypten.context import run_multiworkers, run_party
+from syft.frameworks.crypten.model import OnnxModel
+from syft.frameworks.crypten import utils
 
 
 th.set_num_threads(1)
@@ -39,7 +35,6 @@ class ExampleNet(nn.Module):
         return out
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_context_plan(workers):
     # alice and bob
     n_workers = 2
@@ -74,7 +69,6 @@ def test_context_plan(workers):
         )
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_context_jail(workers):
     # alice and bob
     n_workers = 2
@@ -108,7 +102,6 @@ def test_context_jail(workers):
         )
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_context_jail_with_model(workers):
     dummy_input = th.empty(1, 1, 28, 28)
     pytorch_model = ExampleNet()
@@ -136,7 +129,6 @@ def test_context_jail_with_model(workers):
     assert th.all(result[0][1] == result[1][1])
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_context_jail_with_model_failures(workers):
     dummy_input = th.empty(1, 1, 28, 28)
     pytorch_model = ExampleNet()
@@ -189,7 +181,6 @@ def test_context_jail_with_model_failures(workers):
         result = run_encrypted_eval()
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_run_party():
     expected = th.tensor(5)
 
@@ -202,7 +193,6 @@ def test_run_party():
     assert result == expected
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_duplicate_ids(workers):
     # alice and bob
     n_workers = 2
@@ -218,7 +208,6 @@ def test_duplicate_ids(workers):
         return_values = jail_func()
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_context_plan_with_model(workers):
     dummy_input = th.empty(1, 1, 28, 28)
     pytorch_model = ExampleNet()
@@ -245,7 +234,6 @@ def test_context_plan_with_model(workers):
     assert th.all(result[0][1] == result[1][1])
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_context_plan_with_model_private(workers):
     """
         Test if we can run remote inference (using data that is not on our local

--- a/test/crypten/test_context.py
+++ b/test/crypten/test_context.py
@@ -1,5 +1,6 @@
+from os import name as os_name
+
 import pytest
-import crypten
 
 import torch as th
 import torch.nn as nn
@@ -7,9 +8,13 @@ import torch.nn.functional as F
 
 import syft as sy
 
-from syft.frameworks.crypten.context import run_multiworkers, run_party
-from syft.frameworks.crypten.model import OnnxModel
-from syft.frameworks.crypten import utils
+if os_name != "nt":
+    import crypten
+
+if os_name != "nt":
+    from syft.frameworks.crypten.context import run_multiworkers, run_party
+    from syft.frameworks.crypten.model import OnnxModel
+    from syft.frameworks.crypten import utils
 
 
 th.set_num_threads(1)
@@ -34,6 +39,7 @@ class ExampleNet(nn.Module):
         return out
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_context_plan(workers):
     # alice and bob
     n_workers = 2
@@ -68,6 +74,7 @@ def test_context_plan(workers):
         )
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_context_jail(workers):
     # alice and bob
     n_workers = 2
@@ -101,6 +108,7 @@ def test_context_jail(workers):
         )
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_context_jail_with_model(workers):
     dummy_input = th.empty(1, 1, 28, 28)
     pytorch_model = ExampleNet()
@@ -128,6 +136,7 @@ def test_context_jail_with_model(workers):
     assert th.all(result[0][1] == result[1][1])
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_context_jail_with_model_failures(workers):
     dummy_input = th.empty(1, 1, 28, 28)
     pytorch_model = ExampleNet()
@@ -180,6 +189,7 @@ def test_context_jail_with_model_failures(workers):
         result = run_encrypted_eval()
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_run_party():
     expected = th.tensor(5)
 
@@ -192,6 +202,7 @@ def test_run_party():
     assert result == expected
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_duplicate_ids(workers):
     # alice and bob
     n_workers = 2
@@ -207,6 +218,7 @@ def test_duplicate_ids(workers):
         return_values = jail_func()
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_context_plan_with_model(workers):
     dummy_input = th.empty(1, 1, 28, 28)
     pytorch_model = ExampleNet()
@@ -233,6 +245,7 @@ def test_context_plan_with_model(workers):
     assert th.all(result[0][1] == result[1][1])
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_context_plan_with_model_private(workers):
     """
         Test if we can run remote inference (using data that is not on our local

--- a/test/crypten/test_hook.py
+++ b/test/crypten/test_hook.py
@@ -1,15 +1,12 @@
 import pytest
-from os import name as os_name
 
 import torch
 import syft
 
-if os_name != "nt":
-    import crypten
+import crypten
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.skipif("os_name == 'nt'")
 def model():
     l_in, l_h, l_out = 32, 16, 2
     model = crypten.nn.Sequential(
@@ -18,7 +15,6 @@ def model():
     return model
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_send_module(workers, model):
     alice = workers["alice"]
     model_cmp = model.copy()
@@ -37,7 +33,6 @@ def test_send_module(workers, model):
         assert torch.all(p.data == p_cmp)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_share_module(workers, model):
     alice = workers["alice"]
     bob = workers["bob"]
@@ -55,7 +50,6 @@ def test_share_module(workers, model):
         assert isinstance(p, torch.Tensor)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_move_module(workers, model):
     alice = workers["alice"]
     bob = workers["bob"]
@@ -69,7 +63,6 @@ def test_move_module(workers, model):
     assert model.location is None
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_copy(model):
     copy_model = model.copy()
     with torch.no_grad():
@@ -81,7 +74,6 @@ def test_copy(model):
             assert not torch.all(p == 0)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_encrypted_model(model):
     crypten.init()
     model.encrypt()

--- a/test/crypten/test_hook.py
+++ b/test/crypten/test_hook.py
@@ -3,6 +3,7 @@ from os import name as os_name
 
 import torch
 import syft
+
 if os_name != "nt":
     import crypten
 

--- a/test/crypten/test_hook.py
+++ b/test/crypten/test_hook.py
@@ -1,10 +1,14 @@
 import pytest
-import crypten
+from os import name as os_name
+
 import torch
 import syft
+if os_name != "nt":
+    import crypten
 
 
 @pytest.fixture(scope="function")
+@pytest.mark.skipif("os_name == 'nt'")
 def model():
     l_in, l_h, l_out = 32, 16, 2
     model = crypten.nn.Sequential(
@@ -13,6 +17,7 @@ def model():
     return model
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_send_module(workers, model):
     alice = workers["alice"]
     model_cmp = model.copy()
@@ -31,6 +36,7 @@ def test_send_module(workers, model):
         assert torch.all(p.data == p_cmp)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_share_module(workers, model):
     alice = workers["alice"]
     bob = workers["bob"]
@@ -48,6 +54,7 @@ def test_share_module(workers, model):
         assert isinstance(p, torch.Tensor)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_move_module(workers, model):
     alice = workers["alice"]
     bob = workers["bob"]
@@ -61,6 +68,7 @@ def test_move_module(workers, model):
     assert model.location is None
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_copy(model):
     copy_model = model.copy()
     with torch.no_grad():
@@ -72,6 +80,7 @@ def test_copy(model):
             assert not torch.all(p == 0)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_encrypted_model(model):
     crypten.init()
     model.encrypt()

--- a/test/crypten/test_jail.py
+++ b/test/crypten/test_jail.py
@@ -1,9 +1,7 @@
 import pytest
 import torch as th
-from os import name as os_name
 
-if os_name != "nt":
-    from syft.frameworks.crypten import jail
+from syft.frameworks.crypten import jail
 
 
 def add_tensors(tensor):  # pragma: no cover
@@ -12,7 +10,6 @@ def add_tensors(tensor):  # pragma: no cover
     return t + tensor
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_simple_func():
     func = jail.JailRunner(func=add_tensors)
     t = th.tensor(2)
@@ -24,14 +21,12 @@ def import_socket():  # pragma: no cover
     import socket  # noqa: F401
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_import():
     func = jail.JailRunner(func=import_socket)
     with pytest.raises(ImportError):
         func()
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_ser_deser():
     func = jail.JailRunner(func=add_tensors, modules=[th])
     func_ser = jail.JailRunner.simplify(func)
@@ -42,7 +37,6 @@ def test_ser_deser():
     assert expected == func_deser(t)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_empty_jail():
     with pytest.raises(ValueError) as e:
         empty_jail = jail.JailRunner()
@@ -60,13 +54,11 @@ s = "not a function"
         """,
     ],
 )
-@pytest.mark.skipif("os_name == 'nt'")
 def test_not_valid_func(src):
     with pytest.raises(ValueError):
         not_valid = jail.JailRunner(func_src=src)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_already_built():
     func = jail.JailRunner(func=add_tensors)
     with pytest.raises(RuntimeWarning):

--- a/test/crypten/test_jail.py
+++ b/test/crypten/test_jail.py
@@ -1,6 +1,9 @@
 import pytest
 import torch as th
-from syft.frameworks.crypten import jail
+from os import name as os_name
+
+if os_name != "nt":
+    from syft.frameworks.crypten import jail
 
 
 def add_tensors(tensor):  # pragma: no cover
@@ -9,6 +12,7 @@ def add_tensors(tensor):  # pragma: no cover
     return t + tensor
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_simple_func():
     func = jail.JailRunner(func=add_tensors)
     t = th.tensor(2)
@@ -20,12 +24,14 @@ def import_socket():  # pragma: no cover
     import socket  # noqa: F401
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_import():
     func = jail.JailRunner(func=import_socket)
     with pytest.raises(ImportError):
         func()
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_ser_deser():
     func = jail.JailRunner(func=add_tensors, modules=[th])
     func_ser = jail.JailRunner.simplify(func)
@@ -36,6 +42,7 @@ def test_ser_deser():
     assert expected == func_deser(t)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_empty_jail():
     with pytest.raises(ValueError) as e:
         empty_jail = jail.JailRunner()
@@ -53,11 +60,13 @@ s = "not a function"
         """,
     ],
 )
+@pytest.mark.skipif("os_name == 'nt'")
 def test_not_valid_func(src):
     with pytest.raises(ValueError):
         not_valid = jail.JailRunner(func_src=src)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_already_built():
     func = jail.JailRunner(func=add_tensors)
     with pytest.raises(RuntimeWarning):

--- a/test/crypten/test_utils.py
+++ b/test/crypten/test_utils.py
@@ -1,7 +1,10 @@
 import pytest
 import torch as th
-import crypten
-from syft.frameworks.crypten import utils
+from os import name as os_name
+
+if os_name != "nt":
+    import crypten
+    from syft.frameworks.crypten import utils
 
 
 class ExampleNet(th.nn.Module):
@@ -23,6 +26,7 @@ class ExampleNet(th.nn.Module):
         (th.tensor([1, 2, 4, 5]), th.tensor([1.0, 2.0, 3.0]), th.tensor([5, 6, 7, 8])),
     ],
 )
+@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_tensors(tensors):
     packed = utils.pack_values(tensors)
     unpacked = utils.unpack_values(packed)
@@ -36,6 +40,7 @@ def test_pack_tensors(tensors):
         assert th.all(unpacked == tensors)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_crypten_model():
     dummy_input = th.rand(1, 28 * 28)
     expected_crypten_model = crypten.nn.from_pytorch(ExampleNet(), dummy_input)
@@ -55,6 +60,7 @@ def test_pack_crypten_model():
     assert th.all(expected_out == out)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_typerror_crypten_model():
     """
         Testing if we throw an error when trying to unpack an encrypted model,
@@ -68,6 +74,7 @@ def test_pack_typerror_crypten_model():
         packed = utils.pack_values(expected_crypten_model)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_unpack_typerror_crypten_model():
     dummy_input = th.rand(1, 28 * 28)
     expected_crypten_model = crypten.nn.from_pytorch(ExampleNet(), dummy_input)
@@ -77,11 +84,13 @@ def test_unpack_typerror_crypten_model():
         utils.unpack_values(packed)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_other():
     expected_value = utils.pack_values(42)
     assert 42 == utils.unpack_values(expected_value)
 
 
+@pytest.mark.skipif("os_name == 'nt'")
 def test_serialize_models():
     class ExampleNet(th.nn.Module):
         def __init__(self):

--- a/test/crypten/test_utils.py
+++ b/test/crypten/test_utils.py
@@ -1,10 +1,8 @@
 import pytest
 import torch as th
-from os import name as os_name
 
-if os_name != "nt":
-    import crypten
-    from syft.frameworks.crypten import utils
+import crypten
+from syft.frameworks.crypten import utils
 
 
 class ExampleNet(th.nn.Module):
@@ -26,7 +24,6 @@ class ExampleNet(th.nn.Module):
         (th.tensor([1, 2, 4, 5]), th.tensor([1.0, 2.0, 3.0]), th.tensor([5, 6, 7, 8])),
     ],
 )
-@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_tensors(tensors):
     packed = utils.pack_values(tensors)
     unpacked = utils.unpack_values(packed)
@@ -40,7 +37,6 @@ def test_pack_tensors(tensors):
         assert th.all(unpacked == tensors)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_crypten_model():
     dummy_input = th.rand(1, 28 * 28)
     expected_crypten_model = crypten.nn.from_pytorch(ExampleNet(), dummy_input)
@@ -60,7 +56,6 @@ def test_pack_crypten_model():
     assert th.all(expected_out == out)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_typerror_crypten_model():
     """
         Testing if we throw an error when trying to unpack an encrypted model,
@@ -74,7 +69,6 @@ def test_pack_typerror_crypten_model():
         packed = utils.pack_values(expected_crypten_model)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_unpack_typerror_crypten_model():
     dummy_input = th.rand(1, 28 * 28)
     expected_crypten_model = crypten.nn.from_pytorch(ExampleNet(), dummy_input)
@@ -84,13 +78,11 @@ def test_unpack_typerror_crypten_model():
         utils.unpack_values(packed)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_pack_other():
     expected_value = utils.pack_values(42)
     assert 42 == utils.unpack_values(expected_value)
 
 
-@pytest.mark.skipif("os_name == 'nt'")
 def test_serialize_models():
     class ExampleNet(th.nn.Module):
         def __init__(self):

--- a/test/serde/msgpack/test_msgpack_serde_full.py
+++ b/test/serde/msgpack/test_msgpack_serde_full.py
@@ -3,6 +3,7 @@ import pytest
 import numpy
 import torch
 from functools import partial
+from os import name as os_name
 
 import syft
 from syft.serde import msgpack
@@ -70,7 +71,8 @@ samples[
 ] = make_fixedprecisiontensor
 samples[syft.frameworks.torch.tensors.interpreters.private.PrivateTensor] = make_privatetensor
 
-samples[syft.frameworks.crypten.model.OnnxModel] = make_onnxmodel
+if os_name != "nt":
+    samples[syft.frameworks.crypten.model.OnnxModel] = make_onnxmodel
 
 samples[syft.generic.pointers.multi_pointer.MultiPointerTensor] = make_multipointertensor
 samples[syft.generic.pointers.object_pointer.ObjectPointer] = make_objectpointer
@@ -98,6 +100,7 @@ samples[syft.workers.virtual.VirtualWorker] = make_virtual_worker
 samples[SerializableDummyClass] = make_serializable_dummy_class
 
 
+@pytest.mark.xfail("os_name == 'nt'")
 def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in msgpack.serde.msgpack_global_state.simplifiers.items():
@@ -106,6 +109,7 @@ def test_serde_coverage():
 
 
 @pytest.mark.parametrize("cls", samples)
+@pytest.mark.xfail("os_name == 'nt'")
 def test_serde_roundtrip(cls, workers, hook, start_remote_worker):
     """Checks that values passed through serialization-deserialization stay same"""
     serde_worker = syft.VirtualWorker(id=f"serde-worker-{cls.__name__}", hook=hook, auto_add=False)
@@ -143,6 +147,7 @@ def test_serde_roundtrip(cls, workers, hook, start_remote_worker):
 
 
 @pytest.mark.parametrize("cls", samples)
+@pytest.mark.xfail("os_name == 'nt'")
 def test_serde_simplify(cls, workers, hook, start_remote_worker):
     """Checks that simplified structures match expected"""
     serde_worker = syft.VirtualWorker(id=f"serde-worker-{cls.__name__}", hook=hook, auto_add=False)

--- a/test/serde/msgpack/test_msgpack_serde_full.py
+++ b/test/serde/msgpack/test_msgpack_serde_full.py
@@ -100,7 +100,7 @@ samples[syft.workers.virtual.VirtualWorker] = make_virtual_worker
 samples[SerializableDummyClass] = make_serializable_dummy_class
 
 
-@pytest.mark.xfail("os_name == 'nt'")
+@pytest.mark.xfail("os_name == 'nt'", reason="Crypten unavailable for Windows")
 def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in msgpack.serde.msgpack_global_state.simplifiers.items():
@@ -109,7 +109,7 @@ def test_serde_coverage():
 
 
 @pytest.mark.parametrize("cls", samples)
-@pytest.mark.xfail("os_name == 'nt'")
+@pytest.mark.xfail("os_name == 'nt'", reason="Crypten unavailable for Windows")
 def test_serde_roundtrip(cls, workers, hook, start_remote_worker):
     """Checks that values passed through serialization-deserialization stay same"""
     serde_worker = syft.VirtualWorker(id=f"serde-worker-{cls.__name__}", hook=hook, auto_add=False)
@@ -147,7 +147,7 @@ def test_serde_roundtrip(cls, workers, hook, start_remote_worker):
 
 
 @pytest.mark.parametrize("cls", samples)
-@pytest.mark.xfail("os_name == 'nt'")
+@pytest.mark.xfail("os_name == 'nt'", reason="Crypten unavailable for Windows")
 def test_serde_simplify(cls, workers, hook, start_remote_worker):
     """Checks that simplified structures match expected"""
     serde_worker = syft.VirtualWorker(id=f"serde-worker-{cls.__name__}", hook=hook, auto_add=False)

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -66,7 +66,7 @@ samples[syft.messaging.message.PlanCommandMessage] = make_plancommandmessage
 # samples[syft.messaging.message.WorkerCommandMessage] = make_workercommandmessage
 
 
-@pytest.mark.xfail("os_name == 'nt'")
+@pytest.mark.xfail("os_name == 'nt'", reason="Crypten unavailable for Windows")
 def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in protobuf.serde.protobuf_global_state.bufferizers.items():
@@ -75,7 +75,7 @@ def test_serde_coverage():
 
 
 @pytest.mark.parametrize("cls", samples)
-@pytest.mark.xfail("os_name == 'nt'")
+@pytest.mark.xfail("os_name == 'nt'", reason="Crypten unavailable for Windows")
 def test_serde_roundtrip_protobuf(cls, workers, hook):
     """Checks that values passed through serialization-deserialization stay same"""
     serde_worker = syft.VirtualWorker(id=f"serde-worker-{cls.__name__}", hook=hook, auto_add=False)

--- a/test/serde/protobuf/test_protobuf_serde_full.py
+++ b/test/serde/protobuf/test_protobuf_serde_full.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import pytest
 import torch
+from os import name as os_name
 
 import syft
 from syft.serde import protobuf
@@ -47,7 +48,8 @@ samples[syft.generic.pointers.pointer_dataset.PointerDataset] = make_pointerdata
 samples[syft.generic.string.String] = make_string
 
 # OnnxModel
-samples[syft.frameworks.crypten.model.OnnxModel] = make_onnxmodel
+if os_name != "nt":
+    samples[syft.frameworks.crypten.model.OnnxModel] = make_onnxmodel
 
 
 # Syft Messages
@@ -64,6 +66,7 @@ samples[syft.messaging.message.PlanCommandMessage] = make_plancommandmessage
 # samples[syft.messaging.message.WorkerCommandMessage] = make_workercommandmessage
 
 
+@pytest.mark.xfail("os_name == 'nt'")
 def test_serde_coverage():
     """Checks all types in serde are tested"""
     for cls, _ in protobuf.serde.protobuf_global_state.bufferizers.items():
@@ -72,6 +75,7 @@ def test_serde_coverage():
 
 
 @pytest.mark.parametrize("cls", samples)
+@pytest.mark.xfail("os_name == 'nt'")
 def test_serde_roundtrip_protobuf(cls, workers, hook):
     """Checks that values passed through serialization-deserialization stay same"""
     serde_worker = syft.VirtualWorker(id=f"serde-worker-{cls.__name__}", hook=hook, auto_add=False)


### PR DESCRIPTION
## Description
Resolves #4025 by skipping crypten test files and adding expected to fail in serde tests if operating system is Windows.

## How has this been tested?
My own system was failing some tests and `test_inv_sym` goes on forever, so I ran only crypten and serde tests by temporarily moving other test files to another destination.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
