### PR TITLE
Error message if non integer value used with BFV scheme

### DIFF
--- a/syft/frameworks/torch/he/fv/integer_encoder.py
+++ b/syft/frameworks/torch/he/fv/integer_encoder.py
@@ -41,7 +41,8 @@ class IntegerEncoder:
         Returns:
             A PlainText object containing the integer value.
         """
-
+        if not isinstance(value, int):
+            raise ValueError(f"BFV scheme only works with integer values, whereas provided {value}")
         coeff_index = 0
         if value < 0:
             # negative value.

--- a/syft/frameworks/torch/he/fv/integer_encoder.py
+++ b/syft/frameworks/torch/he/fv/integer_encoder.py
@@ -42,7 +42,9 @@ class IntegerEncoder:
             A PlainText object containing the integer value.
         """
         if not isinstance(value, int):
-            raise ValueError(f"BFV scheme only works with integer values, whereas provided {value}")
+            raise ValueError(
+                f"BFV scheme only works with integer values, whereas provided{type(value).__name__}"
+            )
         coeff_index = 0
         if value < 0:
             # negative value.


### PR DESCRIPTION
## Description
Just added an error message for the case when the bfv scheme is used with non-interger values.

## Affected Dependencies
None

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented on my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labelled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
