### PR TITLE
[WIP] fixed the precision issue

### DIFF
--- a/syft/generic/abstract/tensor.py
+++ b/syft/generic/abstract/tensor.py
@@ -75,7 +75,6 @@ class AbstractTensor(AbstractSendable):
             # We usually call .on() on newly created tensor so it's not a sacrilege
             # to rewrite its id
             self.id = tensor.id
-
             self.child = tensor.child
             tensor.child = self
             return tensor

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -158,7 +158,6 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
                         from syft import FixedPrecisionTensor
                         if isinstance(_, FixedPrecisionTensor):
                             self = self.fix_prec()
-                            print("whee")
                         else:
                             self = _.on(self, wrap=True)
                         args = [args[0]]

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -154,7 +154,13 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
                     # that we could accidentally serialize and send a tensor in the
                     # arguments
                     if not isinstance(args[0].child, PointerTensor):
-                        self = type(args[0].child)().on(self, wrap=True)
+                        _ = type(args[0].child)()
+                        from syft import FixedPrecisionTensor
+                        if isinstance(_, FixedPrecisionTensor):
+                            self = self.fix_prec()
+                            print("whee")
+                        else:
+                            self = _.on(self, wrap=True)
                         args = [args[0]]
                         return overloaded_native_method(self, *args, **kwargs)
 

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -195,6 +195,12 @@ def test_torch_add_():
 
     assert (y == torch.tensor([0.15, 0.3, 0.45])).all()
 
+def test_torch_add2():
+    a = torch.tensor(5).fix_prec()
+    b = torch.tensor(2)
+    c = b + a
+    expected = torch.tensor(7)
+    assert c.float_prec() == expected
 
 def test_torch_sub(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
@@ -271,6 +277,13 @@ def test_torch_sub_():
 
     assert (y == torch.tensor([0.05, 0.1, 0.15])).all()
 
+def test_torch_sub2():
+    a = torch.tensor(2).fix_prec()
+    b = torch.tensor(5)
+    c = b - a
+    expected = torch.tensor(3)
+    assert c.float_prec() == expected
+
 
 def test_torch_mul(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
@@ -331,6 +344,13 @@ def test_torch_mul(workers):
     z = x * y
     assert (z.float_prec() == torch.tensor([0.1, 0.4, 0.9])).all()
 
+def test_torch_mul2():
+    a = torch.tensor(5).fix_prec()
+    b = torch.tensor(5)
+    c = b * a
+    expected = torch.tensor(25)
+    assert c.float_prec() == expected
+
 
 def test_torch_div(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
@@ -365,6 +385,13 @@ def test_torch_div(workers):
 
     z = torch.div(x, y)
     assert (z.float_prec() == torch.tensor([[-3.0, -4.1], [1.0, 0.0]])).all()
+
+def test_torch_div2():
+    a = torch.tensor(5).fix_prec()
+    b = torch.tensor(5)
+    c = b / a
+    expected = torch.tensor(1)
+    assert c.float_prec() == expected
 
 
 def test_inplace_operations():

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -198,9 +198,10 @@ def test_torch_add_():
 def test_torch_add2():
     a = torch.tensor(5).fix_prec()
     b = torch.tensor(2)
-    c = b + a
+    c = a + b
     expected = torch.tensor(7)
     assert c.float_prec() == expected
+
 
 def test_torch_sub(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])


### PR DESCRIPTION
## Description

Resolves #3950 

Aims to solve 

- [x] math operations between fixed-precision and non-specified fix precision. The wrapper to convert from non-fixed precision to fixed-precision casted the type but did not actually change the tensor value

- [ ] `PureFrameworkTensorFoundError` which seems to be an issue when the first arg is not a fixed precision but the second one is (does not happen if both are fixed precision)

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Unit tests

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
