### PR TITLE
Fix some typos in docstring

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,7 +179,7 @@ pygments_style = "sphinx"
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 
-# If true, keep warnings as "system old_message" paragraphs in the built documents.
+# If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
 

--- a/src/syft/__init__.py
+++ b/src/syft/__init__.py
@@ -16,7 +16,7 @@ truly polyglot. Syft "core" functionality includes the following modules:
 
 * :py:mod:`syft.core.node` - APIs for interacting with remote machines you do not directly
 control.
-* :py:mod:`syft.core.old_message` - APIs for serializing messages sent between Client and Node
+* :py:mod:`syft.core.message` - APIs for serializing messages sent between Client and Node
 classes.
 * :py:mod:`syft.core.pointer` - Client side API for referring to objects on a Node
 * :py:mod:`syft.core.store` - Server side API for referring to object storage on a node

--- a/src/syft/ast/klass.py
+++ b/src/syft/ast/klass.py
@@ -93,12 +93,12 @@ class Class(Callable):
                 description=self.description if hasattr(self, "description") else "",
             )
 
-            # Step 2: create old_message which contains object to send
+            # Step 2: create message which contains object to send
             obj_msg = SaveObjectAction(
                 obj_id=ptr.id_at_location, obj=self, address=client.address
             )
 
-            # Step 3: send old_message
+            # Step 3: send message
             client.send_immediate_msg_without_reply(msg=obj_msg)
 
             # STep 4: return pointer

--- a/src/syft/core/io/location/group/registry.py
+++ b/src/syft/core/io/location/group/registry.py
@@ -9,7 +9,7 @@ class RegistryBackedLocationGroup(LocationGroup):
     determined by an official owner who has an official list. The
     best and most practical example of this is a Node and its group
     of children (or grand children, etc.). Sending messages to this
-    group requires sending a old_message to its owner and asking it
+    group requires sending a message to its owner and asking it
     to redistribute to the group. However, we can still maintain a list
     of workers which we believe to be in the group which allows us
     to logically reason about the group itself."""

--- a/src/syft/core/io/route.py
+++ b/src/syft/core/io/route.py
@@ -110,7 +110,7 @@ class RouteSchema(ObjectWithID):
     two groups of functionality:
 
     1) Discovering new routes
-    2) Comparing known routes to find the best one for a old_message
+    2) Comparing known routes to find the best one for a message
     """
 
     def __init__(self, destination: Location):

--- a/src/syft/core/io/route.py
+++ b/src/syft/core/io/route.py
@@ -4,13 +4,13 @@ a particular type at a specific location. We assume that
 a Client may have multiple ways of interacting with a node
 (such as multiple protocols, http, websockets, broadcast server
 , etc.). We assume that a Client also has knowledge of the
-full variety of messages and old_message types which can be sent
+full variety of messages and message types which can be sent
 to a Node. It is the highest level of abstraction.
 
 A connection is the lowest level of abstraction, representing
 a real network interface to a single destination. Importantly,
 this destination may not even be the ultimate destination
-for a old_message. In this sense, a connection is just a single "hop"
+for a message. In this sense, a connection is just a single "hop"
 in a potentially long series of hops between a Client and
 a Node.
 
@@ -26,7 +26,7 @@ an intentional information bottleneck.
 
 This might beg the question, what is the point of Route if
 the right combination of Clients and Connections can always
-get a old_message to where it needs to go?
+get a message to where it needs to go?
 
 The answer is that neither a Connection, Client, or Node are
 appropriate for the nature of four combined constraints.
@@ -41,7 +41,7 @@ cloud networking costs being the biggest)
 
 We need the ability for an arbitrary client (which represents
 an abstract, indirect connection to a specific remote node of
-a specific type) to be able to consider a old_message, it's address
+a specific type) to be able to consider a message, its address
 , and other metadata, and make a logical decision on which connection
 should be used. (For example, some messages block for a reply)
 
@@ -57,13 +57,13 @@ know about.
 This abstraction is called a "Route" and each hop is called a "Hop"
 where any collection of hops within the route is called a
 "RouteSegment". Note that a Route need only be initialized with
-it's source and destination(s).
+its source and destination(s).
 
 When a route is used by a client, it is used to decide which route
-would be best to take for a particular old_message.
+would be best to take for a particular message.
 
-When a route is attached to a old_message, it implies the expected
-journey the old_message is to take to the address. A node may or may
+When a route is attached to a message, it implies the expected
+journey the message is to take to the address. A node may or may
 not actually respect this journey.
 
 Routes can be created locally, but they are best created by asking

--- a/src/syft/core/node/common/node.py
+++ b/src/syft/core/node/common/node.py
@@ -123,7 +123,7 @@ class Node(AbstractNode):
 
         # ABOUT SERVICES AND MESSAGES
 
-        # Each service corresponds to one or more old_message types which
+        # Each service corresponds to one or more message types which
         # the service processes. There are two kinds of messages, those
         # which require a reply and those which do not. Thus, there
         # are two kinds of services, service which generate a reply
@@ -141,15 +141,15 @@ class Node(AbstractNode):
         # which reply with some amount of information.
 
         # for messages which need a reply, this uses the type
-        # of the old_message to look up the service which
-        # addresses that old_message.
+        # of the message to look up the service which
+        # addresses that message.
         self.immediate_msg_with_reply_router: Dict[
             Type[ImmediateSyftMessageWithReply], ImmediateNodeServiceWithReply
         ] = {}
 
         # for messages which don't lead to a reply, this uses
-        # the type of the old_message to look up the service
-        # which addresses that old_message
+        # the type of the message to look up the service
+        # which addresses that message
         self.immediate_msg_without_reply_router: Dict[
             Type[ImmediateSyftMessageWithoutReply], Any
         ] = {}
@@ -191,9 +191,9 @@ class Node(AbstractNode):
 
         # This is a special service which cannot be listed in any
         # of the other services because it handles messages of all types.
-        # Thus, it does not live in a old_message router since
+        # Thus, it does not live in a message router since
         # routers only exist to decide which messages go to which
-        # services, and they require that every old_message only correspond
+        # services, and they require that every message only correspond
         # to only one service type. If we have more messages like
         # these we'll make a special category for "services that
         # all messages are applied to" but for now this will do.
@@ -393,17 +393,17 @@ class Node(AbstractNode):
 
     @syft_decorator(typechecking=True)
     def _register_services(self) -> None:
-        """In this method, we set each old_message type to the appropriate
-        service for this node. It's important to note that one old_message type
+        """In this method, we set each message type to the appropriate
+        service for this node. It's important to note that one message type
         cannot map to multiple services on any given node type. If you want to
-        send information to a different service, create a new old_message type for that
-        service. Put another way, a service can have multiple old_message types which
-        correspond to it, but each old_message type can only have one service (per node
+        send information to a different service, create a new message type for that
+        service. Put another way, a service can have multiple message types which
+        correspond to it, but each message type can only have one service (per node
         subclass) which corresponds to it."""
 
         for isr in self.immediate_services_with_reply:
             # Create a single instance of the service to cache in the router corresponding
-            # to one or more old_message types.
+            # to one or more message types.
             isr_instance = isr()
             for handler_type in isr.message_handler_types():
                 # for each explicitly supported type, add it to the router
@@ -418,7 +418,7 @@ class Node(AbstractNode):
 
         for iswr in self.immediate_services_without_reply:
             # Create a single instance of the service to cache in the router corresponding
-            # to one or more old_message types.
+            # to one or more message types.
             iswr_instance = iswr()
             for handler_type in iswr.message_handler_types():
 
@@ -434,7 +434,7 @@ class Node(AbstractNode):
 
         for eswr in self.eventual_services_without_reply:
             # Create a single instance of the service to cache in the router corresponding
-            # to one or more old_message types.
+            # to one or more message types.
             eswr_instance = eswr()
             for handler_type in eswr.message_handler_types():
 

--- a/src/syft/core/node/common/service/heritage_update_service.py
+++ b/src/syft/core/node/common/service/heritage_update_service.py
@@ -24,7 +24,7 @@ from ...abstract.node import AbstractNode
 from .node_service import ImmediateNodeServiceWithoutReply
 from ....common.serde.deserialize import _deserialize
 
-# TODO: change all old_message names in syft to have "WithReply" or "WithoutReply"
+# TODO: change all message names in syft to have "WithReply" or "WithoutReply"
 # at the end of the name
 
 

--- a/src/syft/core/node/common/service/msg_forwarding_service.py
+++ b/src/syft/core/node/common/service/msg_forwarding_service.py
@@ -61,7 +61,7 @@ class SignedMessageWithoutReplyForwardingService(SignedNodeServiceWithoutReply):
         if sy.VERBOSE:
             print(f"> ❌ {node.pprint} 🤷🏾‍♀️ {addr.target_emoji()}")
         raise Exception(
-            "Address unknown - cannot forward old_message. Throwing it away."
+            "Address unknown - cannot forward message. Throwing it away."
         )
 
     @staticmethod
@@ -118,7 +118,7 @@ class SignedMessageWithReplyForwardingService(SignedNodeServiceWithReply):
         if sy.VERBOSE:
             print(f"> ❌ {node.pprint} 🤷🏾‍♀️ {addr.target_emoji()}")
         raise Exception(
-            "Address unknown - cannot forward old_message. Throwing it away."
+            "Address unknown - cannot forward message. Throwing it away."
         )
 
     @staticmethod

--- a/src/syft/core/node/device/client.py
+++ b/src/syft/core/node/device/client.py
@@ -47,20 +47,20 @@ class DeviceClient(Client):
 
     # def create_vm(self, name:str):
     #
-    #     # Step 1: create a old_message which will request for a VM to be created.
-    #     # we can set route=None because we know the old_message is just going directly
+    #     # Step 1: create a message which will request for a VM to be created.
+    #     # we can set route=None because we know the message is just going directly
     #     # to the device.
     #     msg = CreateVirtualMachineMessage(vm_name=name, address=self.node_address)
     #
-    #     # Step 2: Send the old_message to the device this client points to.
+    #     # Step 2: Send the message to the device this client points to.
     #     # Receive a reply_msg and save it in a variable.
     #     reply_msg = self.send_msg(msg=msg)
     #
-    #     # Step 3: Unpack the vm client from the reply old_message
+    #     # Step 3: Unpack the vm client from the reply message
     #     vm_client = reply_msg.client
     #
     #     # Step 4: Return the client object directly. We assume that the
-    #     # client object knows how to send old_message to the VM no matter
+    #     # client object knows how to send message to the VM no matter
     #     # where it exists. Aka, we don't need to save the client in any
     #     # particular kind of context to know how to use it. We should be
     #     # able to "just use it" anywhere and it should "just work"... finding

--- a/src/syft/decorators/typecheck.py
+++ b/src/syft/decorators/typecheck.py
@@ -56,7 +56,7 @@ def type_hints(
         """In this method, we want to check to see if all arguments (except self) are passed in as
         kwargs. Additionally, we want to have an informative error for when args are passed in
         incorrectly. The requirement to only use kwargs is a bit of an exotic one and some Python
-        users might not be used to it. Thus, a good error old_message is important."""
+        users might not be used to it. Thus, a good error message is important."""
 
         # We begin by initializing the maximum number of args we will allow at 0. We will iterate
         # this if by chance we see an argument whose name is "self".

--- a/src/syft/lib/generic.py
+++ b/src/syft/lib/generic.py
@@ -53,14 +53,14 @@ class ObjectConstructor(object):
         - arbitrary functionality before the underlying (original) object constructor is called
         - arbitrary functionality after the underlying (original) object constructor is called.
 
-    Thus, if any object has it's functionality extended or overridden by PySyft, it should be created using
+    Thus, if any object has its functionality extended or overridden by PySyft, it should be created using
     an extension of this class.
 
     GARBAGE COLLECTION NOTES:
 
     There is a special case in codebases which wrap C++ functionality wherein an object can be created on the
     C++ side, a Python wrapper is created (calling our constructor above). However, some methods can destroy
-    and then re-create the Python wrappr without destroying or re-creating the underlying tensor. This can be very
+    and then re-create the Python wrapper without destroying or re-creating the underlying tensor. This can be very
     tricky to deal with for a variety of reasons. However, we have observed that we can override this ability by:
 
     - caching the Python object somewhere so that the original python object doesn't get destroyed until it should be
@@ -295,14 +295,14 @@ class ObjectConstructor(object):
             raise AttributeError(
                 f"Syft's custom object constructor {type(self)} "
                 f"cannot find the original constructor"
-                f"to initialize '{self.constructor_name}'' "
+                f"to initialize '{self.constructor_name}' "
                 f"objects, which should have been stored at "
                 f"'{self.original_constructor_name}'. Either "
-                f"you're doing active development and forgot"
-                f" to cache the original constructor in the "
-                f"right place before installing Syft's custom"
+                f"you're doing active development and forgot "
+                f"to cache the original constructor in the "
+                f"right place before installing Syft's custom "
                 f"constructor or something is very broken and "
-                f"you should file a Github Issue. See"
+                f"you should file a Github Issue. See "
                 f"the documentation for ObjectConstructor for "
                 f"more information on this functionality."
             )


### PR DESCRIPTION
## Description
Especially, "message" had been replaced by "old_message" at different places.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
