### PR TITLE
Throw error if protoc not found

### DIFF
--- a/scripts/build_proto.sh
+++ b/scripts/build_proto.sh
@@ -3,6 +3,12 @@ CLEAN="src/syft/proto"
 PYTHON_OUT="src/syft"
 PROTO_IN="proto"
 
+command -v protoc &> /dev/null
+if [ $? -ne 0 ]; then
+    echo -ne "Install protobuf\n"
+    exit 1
+fi
+
 rm -rf "${CLEAN}"
 find ${PROTO_IN} -name "*.proto" -print0 | xargs -0 protoc --python_out=${PYTHON_OUT}
 


### PR DESCRIPTION
## Description
Could not find an issue to link this to.
Give a message if the ```protoc``` file is not found on the system.

## Affected Dependencies
No dependencies are affected

## How has this been tested?
- Running ```pre_commit.sh``` without ```protoc``` installed.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests - manually tested
