### PR TITLE
Fix syft-proto version

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -16,7 +16,7 @@ RestrictedPython~=5.0
 requests-toolbelt==0.9.1
 shaloop==0.2.1-alpha.11
 scipy~=1.4.1
-git+https://github.com/OpenMined/syft-proto.git@2090357a2247ab1921e2cc73cd7bb076d1067d26#egg=syft-proto
+syft-proto~=0.5.2
 tblib~=1.6.0
 torchvision~=0.5.0
 torch~=1.4.0


### PR DESCRIPTION
## Description
Keep track of the syft-proto version and not the commit.


## How has this been tested?
- There are no error messages when sending stuff to workers.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
