### PR TITLE
ImportError due to Pillow version in torchvision --problem solved

### DIFF
--- a/examples/tutorials/Part 06 - Federated Learning on MNIST using a CNN.ipynb
+++ b/examples/tutorials/Part 06 - Federated Learning on MNIST using a CNN.ipynb
@@ -1,363 +1,756 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "epochs = 10"
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "celltoolbar": "Tags",
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.9"
+    },
+    "colab": {
+      "name": "Part 06 - Federated Learning on MNIST using a CNN.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "accelerator": "GPU"
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Part 6 - Federated Learning on MNIST using a CNN\n",
-    "\n",
-    "## Upgrade to Federated Learning in 10 Lines of PyTorch + PySyft\n",
-    "\n",
-    "\n",
-    "### Context \n",
-    "\n",
-    "Federated Learning is a very exciting and upsurging Machine Learning technique that aims at building systems that learn on decentralized data. The idea is that the data remains in the hands of its producer (which is also known as the _worker_), which helps improving privacy and ownership, and the model is shared between workers. One immediate application is for example to predict the next word on your mobile phone when you write text: you don't want the data used for training — i.e. your text messages — to be sent to a central server.\n",
-    "\n",
-    "The rise of Federated Learning is therefore tightly connected to the spread of data privacy awareness, and the GDPR in EU which enforces data protection since May 2018 has acted as a catalyst. To anticipate on regulation, large actors like Apple or Google have started investing massively in this technology, especially to protect the mobile users' privacy, but they have not made their tools available. At OpenMined, we believe that anyone willing to conduct a Machine Learning project should be able to implement privacy preserving tools with very little effort. We have built tools for encrypting data in a single line [as mentioned in our blog post](https://blog.openmined.org/training-cnns-using-spdz/) and we now release our Federated Learning framework which leverage the new PyTorch 1.0 version to provide an intuitive interface to building secure and scalable models.\n",
-    "\n",
-    "In this tutorial, we'll use directly [the canonical example of training a CNN on MNIST using PyTorch](https://github.com/pytorch/examples/blob/master/mnist/main.py) and show how simple it is to implement Federated Learning with it using our [PySyft library](https://github.com/OpenMined/PySyft/). We will go through each part of the example and underline the code which is changed.\n",
-    "\n",
-    "You can also find this material in [our blogpost](https://blog.openmined.org/upgrade-to-federated-learning-in-10-lines).\n",
-    "\n",
-    "Authors:\n",
-    "- Théo Ryffel - GitHub: [@LaRiffle](https://github.com/LaRiffle)\n",
-    "\n",
-    "**Ok, let's get started!**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Imports and model specifications\n",
-    "\n",
-    "First we make the official imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torch.nn.functional as F\n",
-    "import torch.optim as optim\n",
-    "from torchvision import datasets, transforms"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And than those specific to PySyft. In particular we define remote workers `alice` and `bob`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import syft as sy  # <-- NEW: import the Pysyft library\n",
-    "hook = sy.TorchHook(torch)  # <-- NEW: hook PyTorch ie add extra functionalities to support Federated Learning\n",
-    "bob = sy.VirtualWorker(hook, id=\"bob\")  # <-- NEW: define remote worker bob\n",
-    "alice = sy.VirtualWorker(hook, id=\"alice\")  # <-- NEW: and alice"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We define the setting of the learning task"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class Arguments():\n",
-    "    def __init__(self):\n",
-    "        self.batch_size = 64\n",
-    "        self.test_batch_size = 1000\n",
-    "        self.epochs = epochs\n",
-    "        self.lr = 0.01\n",
-    "        self.momentum = 0.5\n",
-    "        self.no_cuda = False\n",
-    "        self.seed = 1\n",
-    "        self.log_interval = 30\n",
-    "        self.save_model = False\n",
-    "\n",
-    "args = Arguments()\n",
-    "\n",
-    "use_cuda = not args.no_cuda and torch.cuda.is_available()\n",
-    "\n",
-    "torch.manual_seed(args.seed)\n",
-    "\n",
-    "device = torch.device(\"cuda\" if use_cuda else \"cpu\")\n",
-    "\n",
-    "kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Data loading and sending to workers\n",
-    "We first load the data and transform the training Dataset into a Federated Dataset split across the workers using the `.federate` method. This federated dataset is now given to a Federated DataLoader. The test dataset remains unchanged."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "federated_train_loader = sy.FederatedDataLoader( # <-- this is now a FederatedDataLoader \n",
-    "    datasets.MNIST('../data', train=True, download=True,\n",
-    "                   transform=transforms.Compose([\n",
-    "                       transforms.ToTensor(),\n",
-    "                       transforms.Normalize((0.1307,), (0.3081,))\n",
-    "                   ]))\n",
-    "    .federate((bob, alice)), # <-- NEW: we distribute the dataset across all the workers, it's now a FederatedDataset\n",
-    "    batch_size=args.batch_size, shuffle=True, **kwargs)\n",
-    "\n",
-    "test_loader = torch.utils.data.DataLoader(\n",
-    "    datasets.MNIST('../data', train=False, transform=transforms.Compose([\n",
-    "                       transforms.ToTensor(),\n",
-    "                       transforms.Normalize((0.1307,), (0.3081,))\n",
-    "                   ])),\n",
-    "    batch_size=args.test_batch_size, shuffle=True, **kwargs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### CNN specification\n",
-    "Here we use exactly the same CNN as in the official example."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class Net(nn.Module):\n",
-    "    def __init__(self):\n",
-    "        super(Net, self).__init__()\n",
-    "        self.conv1 = nn.Conv2d(1, 20, 5, 1)\n",
-    "        self.conv2 = nn.Conv2d(20, 50, 5, 1)\n",
-    "        self.fc1 = nn.Linear(4*4*50, 500)\n",
-    "        self.fc2 = nn.Linear(500, 10)\n",
-    "\n",
-    "    def forward(self, x):\n",
-    "        x = F.relu(self.conv1(x))\n",
-    "        x = F.max_pool2d(x, 2, 2)\n",
-    "        x = F.relu(self.conv2(x))\n",
-    "        x = F.max_pool2d(x, 2, 2)\n",
-    "        x = x.view(-1, 4*4*50)\n",
-    "        x = F.relu(self.fc1(x))\n",
-    "        x = self.fc2(x)\n",
-    "        return F.log_softmax(x, dim=1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Define the train and test functions\n",
-    "For the train function, because the data batches are distributed across `alice` and `bob`, you need to send the model to the right location for each batch. Then, you perform all the operations remotely with the same syntax like you're doing local PyTorch. When you're done, you get back the model updated and the loss to look for improvement."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def train(args, model, device, federated_train_loader, optimizer, epoch):\n",
-    "    model.train()\n",
-    "    for batch_idx, (data, target) in enumerate(federated_train_loader): # <-- now it is a distributed dataset\n",
-    "        model.send(data.location) # <-- NEW: send the model to the right location\n",
-    "        data, target = data.to(device), target.to(device)\n",
-    "        optimizer.zero_grad()\n",
-    "        output = model(data)\n",
-    "        loss = F.nll_loss(output, target)\n",
-    "        loss.backward()\n",
-    "        optimizer.step()\n",
-    "        model.get() # <-- NEW: get the model back\n",
-    "        if batch_idx % args.log_interval == 0:\n",
-    "            loss = loss.get() # <-- NEW: get the loss back\n",
-    "            print('Train Epoch: {} [{}/{} ({:.0f}%)]\\tLoss: {:.6f}'.format(\n",
-    "                epoch, batch_idx * args.batch_size, len(federated_train_loader) * args.batch_size,\n",
-    "                100. * batch_idx / len(federated_train_loader), loss.item()))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The test function does not change!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def test(args, model, device, test_loader):\n",
-    "    model.eval()\n",
-    "    test_loss = 0\n",
-    "    correct = 0\n",
-    "    with torch.no_grad():\n",
-    "        for data, target in test_loader:\n",
-    "            data, target = data.to(device), target.to(device)\n",
-    "            output = model(data)\n",
-    "            test_loss += F.nll_loss(output, target, reduction='sum').item() # sum up batch loss\n",
-    "            pred = output.argmax(1, keepdim=True) # get the index of the max log-probability \n",
-    "            correct += pred.eq(target.view_as(pred)).sum().item()\n",
-    "\n",
-    "    test_loss /= len(test_loader.dataset)\n",
-    "\n",
-    "    print('\\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\\n'.format(\n",
-    "        test_loss, correct, len(test_loader.dataset),\n",
-    "        100. * correct / len(test_loader.dataset)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Launch the training !"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "model = Net().to(device)\n",
-    "optimizer = optim.SGD(model.parameters(), lr=args.lr) # TODO momentum is not supported at the moment\n",
-    "\n",
-    "for epoch in range(1, args.epochs + 1):\n",
-    "    train(args, model, device, federated_train_loader, optimizer, epoch)\n",
-    "    test(args, model, device, test_loader)\n",
-    "\n",
-    "if (args.save_model):\n",
-    "    torch.save(model.state_dict(), \"mnist_cnn.pt\")\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Et voilà! Here you are, you have trained a model on remote data using Federated Learning!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## One Last Thing\n",
-    "I know there's a question you're dying to ask: **how long does it takes to do Federated Learning compared to normal PyTorch?**\n",
-    "\n",
-    "The computation time is actually **less than twice the time** used for normal PyTorch execution! More precisely, it takes 1.9 times longer, which is very little compared to the features we were able to add."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "As you observe, we modified 10 lines of code to upgrade the official Pytorch example on MNIST to a real Federated Learning setting!\n",
-    "\n",
-    "Of course, there are dozen of improvements we could think of. We would like the computation to operate in parallel on the workers and to perform federated averaging, to update the central model every `n` batches only, to reduce the number of messages we use to communicate between workers, etc. These are features we're working on to make Federated Learning ready for a production environment and we'll write about them as soon as they are released!\n",
-    "\n",
-    "You should now be able to do Federated Learning by yourself! If you enjoyed this and would like to join the movement toward privacy preserving, decentralized ownership of AI and the AI supply chain (data), you can do so in the following ways! \n",
-    "\n",
-    "### Star PySyft on GitHub\n",
-    "\n",
-    "The easiest way to help our community is just by starring the repositories! This helps raise awareness of the cool tools we're building.\n",
-    "\n",
-    "- [Star PySyft](https://github.com/OpenMined/PySyft)\n",
-    "\n",
-    "### Pick our tutorials on GitHub!\n",
-    "\n",
-    "We made really nice tutorials to get a better understanding of what Federated and Privacy-Preserving Learning should look like and how we are building the bricks for this to happen.\n",
-    "\n",
-    "- [Checkout the PySyft tutorials](https://github.com/OpenMined/PySyft/tree/master/examples/tutorials)\n",
-    "\n",
-    "\n",
-    "### Join our Slack!\n",
-    "\n",
-    "The best way to keep up to date on the latest advancements is to join our community! \n",
-    "\n",
-    "- [Join slack.openmined.org](http://slack.openmined.org)\n",
-    "\n",
-    "### Join a Code Project!\n",
-    "\n",
-    "The best way to contribute to our community is to become a code contributor! If you want to start \"one off\" mini-projects, you can go to PySyft GitHub Issues page and search for issues marked `Good First Issue`.\n",
-    "\n",
-    "- [Good First Issue Tickets](https://github.com/OpenMined/PySyft/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)\n",
-    "\n",
-    "### Donate\n",
-    "\n",
-    "If you don't have time to contribute to our codebase, but would still like to lend support, you can also become a Backer on our Open Collective. All donations go toward our web hosting and other community expenses such as hackathons and meetups!\n",
-    "\n",
-    "- [Donate through OpenMined's Open Collective Page](https://opencollective.com/openmined)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "celltoolbar": "Tags",
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.9"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "parameters"
+        ],
+        "id": "QVZeJBIZoN8P",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "epochs = 10"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "rDcA-NfAoQNw",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "outputId": "b54be575-d1d2-4443-9659-110ab2bd2f34"
+      },
+      "source": [
+        "pip install 'syft[udacity]'\n",
+        "pip install \"pillow>7\""
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Collecting syft[udacity]\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/69/eb/e7ad7f909c53477f9fbe732aaa5cf036122428268e5239b18344604bc8f8/syft-0.2.8-py3-none-any.whl (415kB)\n",
+            "\u001b[K     |████████████████████████████████| 419kB 3.5MB/s \n",
+            "\u001b[?25hRequirement already satisfied: numpy~=1.18.1 in /usr/local/lib/python3.6/dist-packages (from syft[udacity]) (1.18.5)\n",
+            "Requirement already satisfied: dill~=0.3.1 in /usr/local/lib/python3.6/dist-packages (from syft[udacity]) (0.3.2)\n",
+            "Collecting requests-toolbelt==0.9.1\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/60/ef/7681134338fc097acef8d9b2f8abe0458e4d87559c689a8c306d0957ece5/requests_toolbelt-0.9.1-py2.py3-none-any.whl (54kB)\n",
+            "\u001b[K     |████████████████████████████████| 61kB 6.2MB/s \n",
+            "\u001b[?25hCollecting lz4~=3.0.2\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e7/81/011fef8766fb0ef681037ad6fee96168ee03a864464986cbaa23e5357704/lz4-3.0.2-cp36-cp36m-manylinux2010_x86_64.whl (1.8MB)\n",
+            "\u001b[K     |████████████████████████████████| 1.8MB 11.5MB/s \n",
+            "\u001b[?25hCollecting websocket-client~=0.57.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/4c/5f/f61b420143ed1c8dc69f9eaec5ff1ac36109d52c80de49d66e0c36c3dfdf/websocket_client-0.57.0-py2.py3-none-any.whl (200kB)\n",
+            "\u001b[K     |████████████████████████████████| 204kB 26.1MB/s \n",
+            "\u001b[?25hCollecting torchvision~=0.5.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/7e/90/6141bf41f5655c78e24f40f710fdd4f8a8aff6c8b7c6f0328240f649bdbe/torchvision-0.5.0-cp36-cp36m-manylinux1_x86_64.whl (4.0MB)\n",
+            "\u001b[K     |████████████████████████████████| 4.0MB 25.9MB/s \n",
+            "\u001b[?25hCollecting torch~=1.4.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/24/19/4804aea17cd136f1705a5e98a00618cb8f6ccc375ad8bfa437408e09d058/torch-1.4.0-cp36-cp36m-manylinux1_x86_64.whl (753.4MB)\n",
+            "\u001b[K     |████████████████████████████████| 753.4MB 23kB/s \n",
+            "\u001b[?25hCollecting openmined.threepio==0.2.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/0a/38/df6367693c7f3808f076cd8c2647c434a04adda2bbb2435dadefe7258fd4/openmined.threepio-0.2.0.tar.gz (73kB)\n",
+            "\u001b[K     |████████████████████████████████| 81kB 9.2MB/s \n",
+            "\u001b[?25hCollecting syft-proto~=0.5.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/a8/85/fea3668a2da78b02394bd2532e6c8b01f354c664f09db74d7f133b68f938/syft_proto-0.5.2-py3-none-any.whl (63kB)\n",
+            "\u001b[K     |████████████████████████████████| 71kB 7.6MB/s \n",
+            "\u001b[?25hCollecting phe~=1.4.0\n",
+            "  Downloading https://files.pythonhosted.org/packages/32/0e/568e97b014eb14e794a1258a341361e9da351dc6240c63b89e1541e3341c/phe-1.4.0.tar.gz\n",
+            "Collecting psutil==5.7.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/c4/b8/3512f0e93e0db23a71d82485ba256071ebef99b227351f0f5540f744af41/psutil-5.7.0.tar.gz (449kB)\n",
+            "\u001b[K     |████████████████████████████████| 450kB 35.3MB/s \n",
+            "\u001b[?25hCollecting importlib-resources~=1.5.0\n",
+            "  Downloading https://files.pythonhosted.org/packages/7f/2d/88f166bcaadc09d9fdbf1c336ad118e01b7fe1155e15675e125be2ff1899/importlib_resources-1.5.0-py2.py3-none-any.whl\n",
+            "Collecting flask-socketio~=4.2.1\n",
+            "  Downloading https://files.pythonhosted.org/packages/66/44/edc4715af85671b943c18ac8345d0207972284a0cd630126ff5251faa08b/Flask_SocketIO-4.2.1-py2.py3-none-any.whl\n",
+            "Collecting Pillow~=6.2.2\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/8a/fd/bbbc569f98f47813c50a116b539d97b3b17a86ac7a309f83b2022d26caf2/Pillow-6.2.2-cp36-cp36m-manylinux1_x86_64.whl (2.1MB)\n",
+            "\u001b[K     |████████████████████████████████| 2.1MB 34.7MB/s \n",
+            "\u001b[?25hCollecting requests~=2.22.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl (57kB)\n",
+            "\u001b[K     |████████████████████████████████| 61kB 6.6MB/s \n",
+            "\u001b[?25hCollecting aiortc==0.9.28\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/bf/54/beb8dcb9050aaf903c4426884970d0f18a76e49c69b5a06653812e404446/aiortc-0.9.28-cp36-cp36m-manylinux2010_x86_64.whl (2.0MB)\n",
+            "\u001b[K     |████████████████████████████████| 2.0MB 31.8MB/s \n",
+            "\u001b[?25hCollecting RestrictedPython~=5.0\n",
+            "  Downloading https://files.pythonhosted.org/packages/0b/8f/6a956c1c2eb58a9fd209c9f90124576d7ea830d7cc54c78e95cc967eb1d0/RestrictedPython-5.0-py2.py3-none-any.whl\n",
+            "Collecting tornado==4.5.3\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/e3/7b/e29ab3d51c8df66922fea216e2bddfcb6430fb29620e5165b16a216e0d3c/tornado-4.5.3.tar.gz (484kB)\n",
+            "\u001b[K     |████████████████████████████████| 491kB 37.0MB/s \n",
+            "\u001b[?25hCollecting notebook==5.7.8\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/f6/36/89ebfffc9dd8c8dbd81c1ffb53e3d4233ee666414c143959477cb07cc5f5/notebook-5.7.8-py2.py3-none-any.whl (9.0MB)\n",
+            "\u001b[K     |████████████████████████████████| 9.0MB 28.1MB/s \n",
+            "\u001b[?25hRequirement already satisfied: scipy~=1.4.1 in /usr/local/lib/python3.6/dist-packages (from syft[udacity]) (1.4.1)\n",
+            "Collecting tblib~=1.6.0\n",
+            "  Downloading https://files.pythonhosted.org/packages/0d/de/dca3e651ca62e59c08d324f4a51467fa4b8cbeaafb883b5e83720b4d4a47/tblib-1.6.0-py2.py3-none-any.whl\n",
+            "Requirement already satisfied: msgpack~=1.0.0 in /usr/local/lib/python3.6/dist-packages (from syft[udacity]) (1.0.0)\n",
+            "Requirement already satisfied: Flask~=1.1.1 in /usr/local/lib/python3.6/dist-packages (from syft[udacity]) (1.1.2)\n",
+            "Collecting websockets~=8.1.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/bb/d9/856af84843912e2853b1b6e898ac8b802989fcf9ecf8e8445a1da263bf3b/websockets-8.1-cp36-cp36m-manylinux2010_x86_64.whl (78kB)\n",
+            "\u001b[K     |████████████████████████████████| 81kB 9.0MB/s \n",
+            "\u001b[?25hCollecting tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/15/be/a4c0af9fdc5e5cee28495460538acf2766382bd572e01d4847abc7608dba/tf_encrypted-0.5.9-py3-none-manylinux1_x86_64.whl (2.7MB)\n",
+            "\u001b[K     |████████████████████████████████| 2.7MB 29.4MB/s \n",
+            "\u001b[?25hRequirement already satisfied: six in /usr/local/lib/python3.6/dist-packages (from websocket-client~=0.57.0->syft[udacity]) (1.15.0)\n",
+            "Requirement already satisfied: protobuf>=3.12.2 in /usr/local/lib/python3.6/dist-packages (from syft-proto~=0.5.0->syft[udacity]) (3.12.4)\n",
+            "Requirement already satisfied: importlib-metadata; python_version < \"3.8\" in /usr/local/lib/python3.6/dist-packages (from importlib-resources~=1.5.0->syft[udacity]) (1.7.0)\n",
+            "Requirement already satisfied: zipp>=0.4; python_version < \"3.8\" in /usr/local/lib/python3.6/dist-packages (from importlib-resources~=1.5.0->syft[udacity]) (3.1.0)\n",
+            "Collecting python-socketio>=4.3.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/3d/97/00741edd49788510b834b60a1a4d0afb2c4942770c11b8e0f6e914371718/python_socketio-4.6.0-py2.py3-none-any.whl (51kB)\n",
+            "\u001b[K     |████████████████████████████████| 61kB 7.0MB/s \n",
+            "\u001b[?25hRequirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests~=2.22.0->syft[udacity]) (1.24.3)\n",
+            "Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests~=2.22.0->syft[udacity]) (3.0.4)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests~=2.22.0->syft[udacity]) (2020.6.20)\n",
+            "Collecting idna<2.9,>=2.5\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl (58kB)\n",
+            "\u001b[K     |████████████████████████████████| 61kB 7.4MB/s \n",
+            "\u001b[?25hCollecting av<9.0.0,>=8.0.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/9e/62/9a992be76f8e13ce0e3a24a838191b546805545116f9fc869bd11bd21b5f/av-8.0.2-cp36-cp36m-manylinux2010_x86_64.whl (36.9MB)\n",
+            "\u001b[K     |████████████████████████████████| 36.9MB 145kB/s \n",
+            "\u001b[?25hCollecting pyee>=6.0.0\n",
+            "  Downloading https://files.pythonhosted.org/packages/f6/28/1cedd44c27907f1507a28ff2d36fc6cdb981c9deff2fa288bc48a700c7c9/pyee-7.0.2-py2.py3-none-any.whl\n",
+            "Collecting aioice<0.7.0,>=0.6.17\n",
+            "  Downloading https://files.pythonhosted.org/packages/8b/86/e3cdf660b67da7a9a7013253db5db7cf786a52296cb40078db1206177698/aioice-0.6.18-py3-none-any.whl\n",
+            "Collecting crc32c\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/33/ef/63dafd9e92fc6d03c7c5db893261d1304f8e67f187851eb486ede95bbec3/crc32c-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl (42kB)\n",
+            "\u001b[K     |████████████████████████████████| 51kB 5.4MB/s \n",
+            "\u001b[?25hCollecting pylibsrtp>=0.5.6\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/11/cc/89985f4c15320ed0d52b4074fd6f7baa6dd567d79414c10c9dbd9ade39b2/pylibsrtp-0.6.6-cp36-cp36m-manylinux2010_x86_64.whl (74kB)\n",
+            "\u001b[K     |████████████████████████████████| 81kB 8.8MB/s \n",
+            "\u001b[?25hCollecting cryptography>=2.2\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/ba/91/84a29d6a27fd6dfc21f475704c4d2053d58ed7a4033c2b0ce1b4ca4d03d9/cryptography-3.0-cp35-abi3-manylinux2010_x86_64.whl (2.7MB)\n",
+            "\u001b[K     |████████████████████████████████| 2.7MB 22.9MB/s \n",
+            "\u001b[?25hRequirement already satisfied: cffi>=1.0.0 in /usr/local/lib/python3.6/dist-packages (from aiortc==0.9.28->syft[udacity]) (1.14.1)\n",
+            "Requirement already satisfied: dataclasses; python_version < \"3.7\" in /usr/local/lib/python3.6/dist-packages (from aiortc==0.9.28->syft[udacity]) (0.7)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.6/dist-packages (from RestrictedPython~=5.0->syft[udacity]) (49.2.0)\n",
+            "Requirement already satisfied: pyzmq>=17 in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (19.0.2)\n",
+            "Requirement already satisfied: jupyter-client>=5.2.0 in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (5.3.5)\n",
+            "Requirement already satisfied: jupyter-core>=4.4.0 in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (4.6.3)\n",
+            "Requirement already satisfied: nbformat in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (5.0.7)\n",
+            "Requirement already satisfied: terminado>=0.8.1 in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (0.8.3)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (2.11.2)\n",
+            "Requirement already satisfied: nbconvert in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (5.6.1)\n",
+            "Requirement already satisfied: prometheus-client in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (0.8.0)\n",
+            "Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (0.2.0)\n",
+            "Requirement already satisfied: ipykernel in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (4.10.1)\n",
+            "Requirement already satisfied: Send2Trash in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (1.5.0)\n",
+            "Requirement already satisfied: traitlets>=4.2.1 in /usr/local/lib/python3.6/dist-packages (from notebook==5.7.8->syft[udacity]) (4.3.3)\n",
+            "Requirement already satisfied: click>=5.1 in /usr/local/lib/python3.6/dist-packages (from Flask~=1.1.1->syft[udacity]) (7.1.2)\n",
+            "Requirement already satisfied: itsdangerous>=0.24 in /usr/local/lib/python3.6/dist-packages (from Flask~=1.1.1->syft[udacity]) (1.1.0)\n",
+            "Requirement already satisfied: Werkzeug>=0.15 in /usr/local/lib/python3.6/dist-packages (from Flask~=1.1.1->syft[udacity]) (1.0.1)\n",
+            "Collecting pyyaml>=5.1\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz (269kB)\n",
+            "\u001b[K     |████████████████████████████████| 276kB 38.6MB/s \n",
+            "\u001b[?25hCollecting tensorflow<2,>=1.12.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/02/36/9a02e27f0ec248b676a380ffe910c1858e3af3027c0d4d513dd0b56a5613/tensorflow-1.15.3-cp36-cp36m-manylinux2010_x86_64.whl (110.5MB)\n",
+            "\u001b[K     |████████████████████████████████| 110.5MB 54kB/s \n",
+            "\u001b[?25hCollecting python-engineio>=3.13.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/4a/b0/602e549c6d735eb487f186b35e0b82e61c89459f57d1c24d5c7be6f56d05/python_engineio-3.13.2-py2.py3-none-any.whl (50kB)\n",
+            "\u001b[K     |████████████████████████████████| 51kB 5.9MB/s \n",
+            "\u001b[?25hCollecting netifaces\n",
+            "  Downloading https://files.pythonhosted.org/packages/0c/9b/c4c7eb09189548d45939a3d3a6b3d53979c67d124459b27a094c365c347f/netifaces-0.10.9-cp36-cp36m-manylinux1_x86_64.whl\n",
+            "Requirement already satisfied: pycparser in /usr/local/lib/python3.6/dist-packages (from cffi>=1.0.0->aiortc==0.9.28->syft[udacity]) (2.20)\n",
+            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.6/dist-packages (from jupyter-client>=5.2.0->notebook==5.7.8->syft[udacity]) (2.8.1)\n",
+            "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.6/dist-packages (from nbformat->notebook==5.7.8->syft[udacity]) (2.6.0)\n",
+            "Requirement already satisfied: ptyprocess; os_name != \"nt\" in /usr/local/lib/python3.6/dist-packages (from terminado>=0.8.1->notebook==5.7.8->syft[udacity]) (0.6.0)\n",
+            "Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.6/dist-packages (from jinja2->notebook==5.7.8->syft[udacity]) (1.1.1)\n",
+            "Requirement already satisfied: entrypoints>=0.2.2 in /usr/local/lib/python3.6/dist-packages (from nbconvert->notebook==5.7.8->syft[udacity]) (0.3)\n",
+            "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->notebook==5.7.8->syft[udacity]) (1.4.2)\n",
+            "Requirement already satisfied: testpath in /usr/local/lib/python3.6/dist-packages (from nbconvert->notebook==5.7.8->syft[udacity]) (0.4.4)\n",
+            "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.6/dist-packages (from nbconvert->notebook==5.7.8->syft[udacity]) (0.8.4)\n",
+            "Requirement already satisfied: bleach in /usr/local/lib/python3.6/dist-packages (from nbconvert->notebook==5.7.8->syft[udacity]) (3.1.5)\n",
+            "Requirement already satisfied: pygments in /usr/local/lib/python3.6/dist-packages (from nbconvert->notebook==5.7.8->syft[udacity]) (2.1.3)\n",
+            "Requirement already satisfied: defusedxml in /usr/local/lib/python3.6/dist-packages (from nbconvert->notebook==5.7.8->syft[udacity]) (0.6.0)\n",
+            "Requirement already satisfied: ipython>=4.0.0 in /usr/local/lib/python3.6/dist-packages (from ipykernel->notebook==5.7.8->syft[udacity]) (5.5.0)\n",
+            "Requirement already satisfied: decorator in /usr/local/lib/python3.6/dist-packages (from traitlets>=4.2.1->notebook==5.7.8->syft[udacity]) (4.4.2)\n",
+            "Requirement already satisfied: astor>=0.6.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (0.8.1)\n",
+            "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (3.3.0)\n",
+            "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (1.1.0)\n",
+            "Requirement already satisfied: wrapt>=1.11.1 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (1.12.1)\n",
+            "Collecting tensorflow-estimator==1.15.1\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/de/62/2ee9cd74c9fa2fa450877847ba560b260f5d0fb70ee0595203082dafcc9d/tensorflow_estimator-1.15.1-py2.py3-none-any.whl (503kB)\n",
+            "\u001b[K     |████████████████████████████████| 512kB 35.5MB/s \n",
+            "\u001b[?25hRequirement already satisfied: grpcio>=1.8.6 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (1.31.0)\n",
+            "Collecting tensorboard<1.16.0,>=1.15.0\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/1e/e9/d3d747a97f7188f48aa5eda486907f3b345cd409f0a0850468ba867db246/tensorboard-1.15.0-py3-none-any.whl (3.8MB)\n",
+            "\u001b[K     |████████████████████████████████| 3.8MB 33.4MB/s \n",
+            "\u001b[?25hCollecting keras-applications>=1.0.8\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/71/e3/19762fdfc62877ae9102edf6342d71b28fbfd9dea3d2f96a882ce099b03f/Keras_Applications-1.0.8-py3-none-any.whl (50kB)\n",
+            "\u001b[K     |████████████████████████████████| 51kB 6.3MB/s \n",
+            "\u001b[?25hRequirement already satisfied: absl-py>=0.7.0 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (0.9.0)\n",
+            "Collecting gast==0.2.2\n",
+            "  Downloading https://files.pythonhosted.org/packages/4e/35/11749bf99b2d4e3cceb4d55ca22590b0d7c2c62b9de38ac4a4a7f4687421/gast-0.2.2.tar.gz\n",
+            "Requirement already satisfied: keras-preprocessing>=1.0.5 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (1.1.2)\n",
+            "Requirement already satisfied: wheel>=0.26; python_version >= \"3\" in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (0.34.2)\n",
+            "Requirement already satisfied: google-pasta>=0.1.6 in /usr/local/lib/python3.6/dist-packages (from tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (0.2.0)\n",
+            "Requirement already satisfied: webencodings in /usr/local/lib/python3.6/dist-packages (from bleach->nbconvert->notebook==5.7.8->syft[udacity]) (0.5.1)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.6/dist-packages (from bleach->nbconvert->notebook==5.7.8->syft[udacity]) (20.4)\n",
+            "Requirement already satisfied: pickleshare in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0->ipykernel->notebook==5.7.8->syft[udacity]) (0.7.5)\n",
+            "Requirement already satisfied: simplegeneric>0.8 in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0->ipykernel->notebook==5.7.8->syft[udacity]) (0.8.1)\n",
+            "Requirement already satisfied: prompt-toolkit<2.0.0,>=1.0.4 in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0->ipykernel->notebook==5.7.8->syft[udacity]) (1.0.18)\n",
+            "Requirement already satisfied: pexpect; sys_platform != \"win32\" in /usr/local/lib/python3.6/dist-packages (from ipython>=4.0.0->ipykernel->notebook==5.7.8->syft[udacity]) (4.8.0)\n",
+            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.6/dist-packages (from tensorboard<1.16.0,>=1.15.0->tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (3.2.2)\n",
+            "Requirement already satisfied: h5py in /usr/local/lib/python3.6/dist-packages (from keras-applications>=1.0.8->tensorflow<2,>=1.12.0->tf-encrypted<0.6.0!=0.5.7,>=0.5.4; extra == \"udacity\"->syft[udacity]) (2.10.0)\n",
+            "Requirement already satisfied: pyparsing>=2.0.2 in /usr/local/lib/python3.6/dist-packages (from packaging->bleach->nbconvert->notebook==5.7.8->syft[udacity]) (2.4.7)\n",
+            "Requirement already satisfied: wcwidth in /usr/local/lib/python3.6/dist-packages (from prompt-toolkit<2.0.0,>=1.0.4->ipython>=4.0.0->ipykernel->notebook==5.7.8->syft[udacity]) (0.2.5)\n",
+            "Building wheels for collected packages: openmined.threepio, phe, psutil, tornado, pyyaml, gast\n",
+            "  Building wheel for openmined.threepio (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for openmined.threepio: filename=openmined.threepio-0.2.0-cp36-none-any.whl size=80096 sha256=04af90fcb3576f85c68e81c72487f3ae811b598faa2653dde00b84ce1229e0ee\n",
+            "  Stored in directory: /root/.cache/pip/wheels/1b/a5/c5/7e67449f5d4d487e1d3a583ba51d27403b315b18ef2e48a13c\n",
+            "  Building wheel for phe (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for phe: filename=phe-1.4.0-py2.py3-none-any.whl size=37362 sha256=388b84d6ed1aa1d532856b2f8c45c7637b770d57c6ba7e4686f3fad41bcd044e\n",
+            "  Stored in directory: /root/.cache/pip/wheels/f8/dc/36/dcb6bf0f1b9907e7b710ace63e64d08e7022340909315fdea4\n",
+            "  Building wheel for psutil (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for psutil: filename=psutil-5.7.0-cp36-cp36m-linux_x86_64.whl size=272676 sha256=a45cd7cdcd7410efc6527aeaaa6a677f662ef45edfb505d2e7712ea75884314e\n",
+            "  Stored in directory: /root/.cache/pip/wheels/d7/69/b4/3200b95828d1f0ddb3cb5699083717f4fdbd9b4223d0644c57\n",
+            "  Building wheel for tornado (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for tornado: filename=tornado-4.5.3-cp36-cp36m-linux_x86_64.whl size=433079 sha256=2061ded2005cf90a9cf746539bd561a7a5f46b49c68aa47f1cc09e61db236ebf\n",
+            "  Stored in directory: /root/.cache/pip/wheels/72/bf/f4/b68fa69596986881b397b18ff2b9af5f8181233aadcc9f76fd\n",
+            "  Building wheel for pyyaml (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for pyyaml: filename=PyYAML-5.3.1-cp36-cp36m-linux_x86_64.whl size=44621 sha256=d10275d9bd78a953a863e2bb333f74a302dc18234ea7cd261b5916c17af72cca\n",
+            "  Stored in directory: /root/.cache/pip/wheels/a7/c1/ea/cf5bd31012e735dc1dfea3131a2d5eae7978b251083d6247bd\n",
+            "  Building wheel for gast (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for gast: filename=gast-0.2.2-cp36-none-any.whl size=7540 sha256=a69d22848ba08b41f39fb72aacb413719d4695e456088e0901df77c425253ea7\n",
+            "  Stored in directory: /root/.cache/pip/wheels/5c/2e/7e/a1d4d4fcebe6c381f378ce7743a3ced3699feb89bcfbdadadd\n",
+            "Successfully built openmined.threepio phe psutil tornado pyyaml gast\n",
+            "\u001b[31mERROR: tensorflow-probability 0.11.0 has requirement gast>=0.3.2, but you'll have gast 0.2.2 which is incompatible.\u001b[0m\n",
+            "\u001b[31mERROR: google-colab 1.0.0 has requirement notebook~=5.3.0; python_version >= \"3.0\", but you'll have notebook 5.7.8 which is incompatible.\u001b[0m\n",
+            "\u001b[31mERROR: google-colab 1.0.0 has requirement requests~=2.23.0, but you'll have requests 2.22.0 which is incompatible.\u001b[0m\n",
+            "\u001b[31mERROR: google-colab 1.0.0 has requirement tornado~=5.1.0; python_version >= \"3.0\", but you'll have tornado 4.5.3 which is incompatible.\u001b[0m\n",
+            "\u001b[31mERROR: datascience 0.10.6 has requirement folium==0.2.1, but you'll have folium 0.8.3 which is incompatible.\u001b[0m\n",
+            "\u001b[31mERROR: bokeh 2.1.1 has requirement tornado>=5.1, but you'll have tornado 4.5.3 which is incompatible.\u001b[0m\n",
+            "\u001b[31mERROR: albumentations 0.1.12 has requirement imgaug<0.2.7,>=0.2.5, but you'll have imgaug 0.2.9 which is incompatible.\u001b[0m\n",
+            "Installing collected packages: idna, requests, requests-toolbelt, lz4, websocket-client, torch, Pillow, torchvision, openmined.threepio, syft-proto, phe, psutil, importlib-resources, python-engineio, python-socketio, flask-socketio, av, pyee, netifaces, aioice, crc32c, pylibsrtp, cryptography, aiortc, RestrictedPython, tornado, notebook, tblib, websockets, pyyaml, tensorflow-estimator, tensorboard, keras-applications, gast, tensorflow, tf-encrypted, syft\n",
+            "  Found existing installation: idna 2.10\n",
+            "    Uninstalling idna-2.10:\n",
+            "      Successfully uninstalled idna-2.10\n",
+            "  Found existing installation: requests 2.23.0\n",
+            "    Uninstalling requests-2.23.0:\n",
+            "      Successfully uninstalled requests-2.23.0\n",
+            "  Found existing installation: torch 1.6.0+cu101\n",
+            "    Uninstalling torch-1.6.0+cu101:\n",
+            "      Successfully uninstalled torch-1.6.0+cu101\n",
+            "  Found existing installation: Pillow 7.0.0\n",
+            "    Uninstalling Pillow-7.0.0:\n",
+            "      Successfully uninstalled Pillow-7.0.0\n",
+            "  Found existing installation: torchvision 0.7.0+cu101\n",
+            "    Uninstalling torchvision-0.7.0+cu101:\n",
+            "      Successfully uninstalled torchvision-0.7.0+cu101\n",
+            "  Found existing installation: psutil 5.4.8\n",
+            "    Uninstalling psutil-5.4.8:\n",
+            "      Successfully uninstalled psutil-5.4.8\n",
+            "  Found existing installation: tornado 5.1.1\n",
+            "    Uninstalling tornado-5.1.1:\n",
+            "      Successfully uninstalled tornado-5.1.1\n",
+            "  Found existing installation: notebook 5.3.1\n",
+            "    Uninstalling notebook-5.3.1:\n",
+            "      Successfully uninstalled notebook-5.3.1\n",
+            "  Found existing installation: tblib 1.7.0\n",
+            "    Uninstalling tblib-1.7.0:\n",
+            "      Successfully uninstalled tblib-1.7.0\n",
+            "  Found existing installation: PyYAML 3.13\n",
+            "    Uninstalling PyYAML-3.13:\n",
+            "      Successfully uninstalled PyYAML-3.13\n",
+            "  Found existing installation: tensorflow-estimator 2.3.0\n",
+            "    Uninstalling tensorflow-estimator-2.3.0:\n",
+            "      Successfully uninstalled tensorflow-estimator-2.3.0\n",
+            "  Found existing installation: tensorboard 2.3.0\n",
+            "    Uninstalling tensorboard-2.3.0:\n",
+            "      Successfully uninstalled tensorboard-2.3.0\n",
+            "  Found existing installation: gast 0.3.3\n",
+            "    Uninstalling gast-0.3.3:\n",
+            "      Successfully uninstalled gast-0.3.3\n",
+            "  Found existing installation: tensorflow 2.3.0\n",
+            "    Uninstalling tensorflow-2.3.0:\n",
+            "      Successfully uninstalled tensorflow-2.3.0\n",
+            "Successfully installed Pillow-6.2.2 RestrictedPython-5.0 aioice-0.6.18 aiortc-0.9.28 av-8.0.2 crc32c-2.0.1 cryptography-3.0 flask-socketio-4.2.1 gast-0.2.2 idna-2.8 importlib-resources-1.5.0 keras-applications-1.0.8 lz4-3.0.2 netifaces-0.10.9 notebook-5.7.8 openmined.threepio-0.2.0 phe-1.4.0 psutil-5.7.0 pyee-7.0.2 pylibsrtp-0.6.6 python-engineio-3.13.2 python-socketio-4.6.0 pyyaml-5.3.1 requests-2.22.0 requests-toolbelt-0.9.1 syft-0.2.8 syft-proto-0.5.2 tblib-1.6.0 tensorboard-1.15.0 tensorflow-1.15.3 tensorflow-estimator-1.15.1 tf-encrypted-0.5.9 torch-1.4.0 torchvision-0.5.0 tornado-4.5.3 websocket-client-0.57.0 websockets-8.1\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.colab-display-data+json": {
+              "pip_warning": {
+                "packages": [
+                  "PIL",
+                  "tornado"
+                ]
+              }
+            }
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PmPmXrzpoN8U",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Part 6 - Federated Learning on MNIST using a CNN\n",
+        "\n",
+        "## Upgrade to Federated Learning in 10 Lines of PyTorch + PySyft\n",
+        "\n",
+        "\n",
+        "### Context \n",
+        "\n",
+        "Federated Learning is a very exciting and upsurging Machine Learning technique that aims at building systems that learn on decentralized data. The idea is that the data remains in the hands of its producer (which is also known as the _worker_), which helps improving privacy and ownership, and the model is shared between workers. One immediate application is for example to predict the next word on your mobile phone when you write text: you don't want the data used for training — i.e. your text messages — to be sent to a central server.\n",
+        "\n",
+        "The rise of Federated Learning is therefore tightly connected to the spread of data privacy awareness, and the GDPR in EU which enforces data protection since May 2018 has acted as a catalyst. To anticipate on regulation, large actors like Apple or Google have started investing massively in this technology, especially to protect the mobile users' privacy, but they have not made their tools available. At OpenMined, we believe that anyone willing to conduct a Machine Learning project should be able to implement privacy preserving tools with very little effort. We have built tools for encrypting data in a single line [as mentioned in our blog post](https://blog.openmined.org/training-cnns-using-spdz/) and we now release our Federated Learning framework which leverage the new PyTorch 1.0 version to provide an intuitive interface to building secure and scalable models.\n",
+        "\n",
+        "In this tutorial, we'll use directly [the canonical example of training a CNN on MNIST using PyTorch](https://github.com/pytorch/examples/blob/master/mnist/main.py) and show how simple it is to implement Federated Learning with it using our [PySyft library](https://github.com/OpenMined/PySyft/). We will go through each part of the example and underline the code which is changed.\n",
+        "\n",
+        "You can also find this material in [our blogpost](https://blog.openmined.org/upgrade-to-federated-learning-in-10-lines).\n",
+        "\n",
+        "Authors:\n",
+        "- Théo Ryffel - GitHub: [@LaRiffle](https://github.com/LaRiffle)\n",
+        "\n",
+        "**Ok, let's get started!**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RL5JLpJEoN8U",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Imports and model specifications\n",
+        "\n",
+        "First we make the official imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "osdKt5AxoN8V",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "import torch.optim as optim\n",
+        "from torchvision import datasets, transforms"
+      ],
+      "execution_count": 17,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0LkTrpCtrxC6",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": 16,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "a9PyOuWWoN8Z",
+        "colab_type": "text"
+      },
+      "source": [
+        "And than those specific to PySyft. In particular we define remote workers `alice` and `bob`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "fkwlPFbioN8Z",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 88
+        },
+        "outputId": "75010c4f-4ad4-4c06-d4ef-609288f138a7"
+      },
+      "source": [
+        "import syft as sy  # <-- NEW: import the Pysyft library\n",
+        "hook = sy.TorchHook(torch)  # <-- NEW: hook PyTorch ie add extra functionalities to support Federated Learning\n",
+        "bob = sy.VirtualWorker(hook, id=\"bob\")  # <-- NEW: define remote worker bob\n",
+        "alice = sy.VirtualWorker(hook, id=\"alice\")  # <-- NEW: and alice"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow. Fix this by compiling custom ops. Missing file was '/usr/local/lib/python3.6/dist-packages/tf_encrypted/operations/secure_random/secure_random_module_tf_1.15.3.so'\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.6/dist-packages/tf_encrypted/session.py:24: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.\n",
+            "\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wlg5hSsZoN8c",
+        "colab_type": "text"
+      },
+      "source": [
+        "We define the setting of the learning task"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "msw_rvcpoN8d",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "class Arguments():\n",
+        "    def __init__(self):\n",
+        "        self.batch_size = 64\n",
+        "        self.test_batch_size = 1000\n",
+        "        self.epochs = epochs\n",
+        "        self.lr = 0.01\n",
+        "        self.momentum = 0.5\n",
+        "        self.no_cuda = False\n",
+        "        self.seed = 1\n",
+        "        self.log_interval = 30\n",
+        "        self.save_model = False\n",
+        "\n",
+        "args = Arguments()\n",
+        "\n",
+        "use_cuda = not args.no_cuda and torch.cuda.is_available()\n",
+        "\n",
+        "torch.manual_seed(args.seed)\n",
+        "\n",
+        "device = torch.device(\"cuda\" if use_cuda else \"cpu\")\n",
+        "\n",
+        "kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Cc4SQzwtoN8g",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Data loading and sending to workers\n",
+        "We first load the data and transform the training Dataset into a Federated Dataset split across the workers using the `.federate` method. This federated dataset is now given to a Federated DataLoader. The test dataset remains unchanged."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "QyuFSYMyoN8h",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "federated_train_loader = sy.FederatedDataLoader( # <-- this is now a FederatedDataLoader \n",
+        "    datasets.MNIST('../data', train=True, download=True,\n",
+        "                   transform=transforms.Compose([\n",
+        "                       transforms.ToTensor(),\n",
+        "                       transforms.Normalize((0.1307,), (0.3081,))\n",
+        "                   ]))\n",
+        "    .federate((bob, alice)), # <-- NEW: we distribute the dataset across all the workers, it's now a FederatedDataset\n",
+        "    batch_size=args.batch_size, shuffle=True, **kwargs)\n",
+        "\n",
+        "test_loader = torch.utils.data.DataLoader(\n",
+        "    datasets.MNIST('../data', train=False, transform=transforms.Compose([\n",
+        "                       transforms.ToTensor(),\n",
+        "                       transforms.Normalize((0.1307,), (0.3081,))\n",
+        "                   ])),\n",
+        "    batch_size=args.test_batch_size, shuffle=True, **kwargs)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8oUhOhWeoN8k",
+        "colab_type": "text"
+      },
+      "source": [
+        "### CNN specification\n",
+        "Here we use exactly the same CNN as in the official example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8927kOtioN8l",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "class Net(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super(Net, self).__init__()\n",
+        "        self.conv1 = nn.Conv2d(1, 20, 5, 1)\n",
+        "        self.conv2 = nn.Conv2d(20, 50, 5, 1)\n",
+        "        self.fc1 = nn.Linear(4*4*50, 500)\n",
+        "        self.fc2 = nn.Linear(500, 10)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        x = F.relu(self.conv1(x))\n",
+        "        x = F.max_pool2d(x, 2, 2)\n",
+        "        x = F.relu(self.conv2(x))\n",
+        "        x = F.max_pool2d(x, 2, 2)\n",
+        "        x = x.view(-1, 4*4*50)\n",
+        "        x = F.relu(self.fc1(x))\n",
+        "        x = self.fc2(x)\n",
+        "        return F.log_softmax(x, dim=1)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "q8ZIs6LooN8q",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Define the train and test functions\n",
+        "For the train function, because the data batches are distributed across `alice` and `bob`, you need to send the model to the right location for each batch. Then, you perform all the operations remotely with the same syntax like you're doing local PyTorch. When you're done, you get back the model updated and the loss to look for improvement."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6Xsnp5pPoN8q",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "def train(args, model, device, federated_train_loader, optimizer, epoch):\n",
+        "    model.train()\n",
+        "    for batch_idx, (data, target) in enumerate(federated_train_loader): # <-- now it is a distributed dataset\n",
+        "        model.send(data.location) # <-- NEW: send the model to the right location\n",
+        "        data, target = data.to(device), target.to(device)\n",
+        "        optimizer.zero_grad()\n",
+        "        output = model(data)\n",
+        "        loss = F.nll_loss(output, target)\n",
+        "        loss.backward()\n",
+        "        optimizer.step()\n",
+        "        model.get() # <-- NEW: get the model back\n",
+        "        if batch_idx % args.log_interval == 0:\n",
+        "            loss = loss.get() # <-- NEW: get the loss back\n",
+        "            print('Train Epoch: {} [{}/{} ({:.0f}%)]\\tLoss: {:.6f}'.format(\n",
+        "                epoch, batch_idx * args.batch_size, len(federated_train_loader) * args.batch_size,\n",
+        "                100. * batch_idx / len(federated_train_loader), loss.item()))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oI-vrtL_oN8t",
+        "colab_type": "text"
+      },
+      "source": [
+        "The test function does not change!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "n6J9SJkfoN8t",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "def test(args, model, device, test_loader):\n",
+        "    model.eval()\n",
+        "    test_loss = 0\n",
+        "    correct = 0\n",
+        "    with torch.no_grad():\n",
+        "        for data, target in test_loader:\n",
+        "            data, target = data.to(device), target.to(device)\n",
+        "            output = model(data)\n",
+        "            test_loss += F.nll_loss(output, target, reduction='sum').item() # sum up batch loss\n",
+        "            pred = output.argmax(1, keepdim=True) # get the index of the max log-probability \n",
+        "            correct += pred.eq(target.view_as(pred)).sum().item()\n",
+        "\n",
+        "    test_loss /= len(test_loader.dataset)\n",
+        "\n",
+        "    print('\\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\\n'.format(\n",
+        "        test_loss, correct, len(test_loader.dataset),\n",
+        "        100. * correct / len(test_loader.dataset)))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zsHN_EMSoN8v",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Launch the training !"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2b98kR2eoN8w",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "%%time\n",
+        "model = Net().to(device)\n",
+        "optimizer = optim.SGD(model.parameters(), lr=args.lr) # TODO momentum is not supported at the moment\n",
+        "\n",
+        "for epoch in range(1, args.epochs + 1):\n",
+        "    train(args, model, device, federated_train_loader, optimizer, epoch)\n",
+        "    test(args, model, device, test_loader)\n",
+        "\n",
+        "if (args.save_model):\n",
+        "    torch.save(model.state_dict(), \"mnist_cnn.pt\")\n",
+        "\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pSgQNppsoN8y",
+        "colab_type": "text"
+      },
+      "source": [
+        "Et voilà! Here you are, you have trained a model on remote data using Federated Learning!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "t1fFqQOHoN8z",
+        "colab_type": "text"
+      },
+      "source": [
+        "## One Last Thing\n",
+        "I know there's a question you're dying to ask: **how long does it takes to do Federated Learning compared to normal PyTorch?**\n",
+        "\n",
+        "The computation time is actually **less than twice the time** used for normal PyTorch execution! More precisely, it takes 1.9 times longer, which is very little compared to the features we were able to add."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SXFrMNdBoN8z",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Conclusion\n",
+        "\n",
+        "As you observe, we modified 10 lines of code to upgrade the official Pytorch example on MNIST to a real Federated Learning setting!\n",
+        "\n",
+        "Of course, there are dozen of improvements we could think of. We would like the computation to operate in parallel on the workers and to perform federated averaging, to update the central model every `n` batches only, to reduce the number of messages we use to communicate between workers, etc. These are features we're working on to make Federated Learning ready for a production environment and we'll write about them as soon as they are released!\n",
+        "\n",
+        "You should now be able to do Federated Learning by yourself! If you enjoyed this and would like to join the movement toward privacy preserving, decentralized ownership of AI and the AI supply chain (data), you can do so in the following ways! \n",
+        "\n",
+        "### Star PySyft on GitHub\n",
+        "\n",
+        "The easiest way to help our community is just by starring the repositories! This helps raise awareness of the cool tools we're building.\n",
+        "\n",
+        "- [Star PySyft](https://github.com/OpenMined/PySyft)\n",
+        "\n",
+        "### Pick our tutorials on GitHub!\n",
+        "\n",
+        "We made really nice tutorials to get a better understanding of what Federated and Privacy-Preserving Learning should look like and how we are building the bricks for this to happen.\n",
+        "\n",
+        "- [Checkout the PySyft tutorials](https://github.com/OpenMined/PySyft/tree/master/examples/tutorials)\n",
+        "\n",
+        "\n",
+        "### Join our Slack!\n",
+        "\n",
+        "The best way to keep up to date on the latest advancements is to join our community! \n",
+        "\n",
+        "- [Join slack.openmined.org](http://slack.openmined.org)\n",
+        "\n",
+        "### Join a Code Project!\n",
+        "\n",
+        "The best way to contribute to our community is to become a code contributor! If you want to start \"one off\" mini-projects, you can go to PySyft GitHub Issues page and search for issues marked `Good First Issue`.\n",
+        "\n",
+        "- [Good First Issue Tickets](https://github.com/OpenMined/PySyft/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)\n",
+        "\n",
+        "### Donate\n",
+        "\n",
+        "If you don't have time to contribute to our codebase, but would still like to lend support, you can also become a Backer on our Open Collective. All donations go toward our web hosting and other community expenses such as hackathons and meetups!\n",
+        "\n",
+        "- [Donate through OpenMined's Open Collective Page](https://opencollective.com/openmined)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TqHf8bu1oN80",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
 }

--- a/examples/tutorials/Part_06_Federated_Learning_on_MNIST_using_a_CNN.ipynb
+++ b/examples/tutorials/Part_06_Federated_Learning_on_MNIST_using_a_CNN.ipynb
@@ -41,7 +41,7 @@
       "source": [
         "epochs = 10"
       ],
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -56,10 +56,9 @@
         "outputId": "b54be575-d1d2-4443-9659-110ab2bd2f34"
       },
       "source": [
-        "pip install 'syft[udacity]'\n",
         "pip install \"pillow>7\""
       ],
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -375,7 +374,7 @@
         "import torch.optim as optim\n",
         "from torchvision import datasets, transforms"
       ],
-      "execution_count": 17,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -388,7 +387,7 @@
       "source": [
         ""
       ],
-      "execution_count": 16,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -418,7 +417,7 @@
         "bob = sy.VirtualWorker(hook, id=\"bob\")  # <-- NEW: define remote worker bob\n",
         "alice = sy.VirtualWorker(hook, id=\"alice\")  # <-- NEW: and alice"
       ],
-      "execution_count": 9,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",


### PR DESCRIPTION
## Description
I was getting the following error due to the version of Pillow in torchvision: 

> ImportError: cannot import name 'StringType'

from the following line
`from torchvision import datasets, transforms`

Adding the following cell at top of the notebook solved this issue:
`pip install 'syft[udacity]'
pip install "pillow>7"`

## How has this been tested?
Only small change is made,no test required.

