### PR TITLE
Remove duplicate method in base.py

### DIFF
--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -186,9 +186,6 @@ class BaseWorker(AbstractWorker):
         """
         return self.object_store.get_obj(obj_id)
 
-    def register_obj(self, obj):
-        self.object_store.register_obj(self, obj)
-
     def clear_objects(self, return_self: bool = True):
         """Removes all objects from the object storage.
 


### PR DESCRIPTION
Remove the duplicate `def register_obj(self, obj):` method

This resolves [#4477](https://github.com/OpenMined/PySyft/issues/4477)
There were two duplicate methods in `syft/workers/base.py` and this pull request fixes this by omitting one of the methods.
