### PR TITLE
Add docstring to `SyftMessage` and `SignedMessage`

### DIFF
--- a/src/syft/core/common/message.py
+++ b/src/syft/core/common/message.py
@@ -57,12 +57,33 @@ class AbstractMessage(ObjectWithID, Generic[SignedMessageT]):
 
 
 class SyftMessage(AbstractMessage):
+    """
+    SyftMessages are an abstraction that represent information that is sent between 2 actors.
+    In Syft, a lot of things are done by sending a message from a :class:`Client` to a :class:`Node`.
+    This class cannot be used as is: to get some useful objects, we need to derive from it. For instance,
+    :class:`Action`s inherit from :class:`SyftMessage`.
+    There are many types of SyftMessage which boil down to whether or not they are Sync or Async,
+    and whether or not they expect a response.
+
+    Attributes:
+        address: the :class:`Address` to which the message needs to be delivered.
+    """
+
     def __init__(self, address: Address, msg_id: Optional[UID] = None) -> None:
         self.address = address
         super().__init__(id=msg_id)
         self.post_init()
 
     def sign(self, signing_key: SigningKey) -> SignedMessageT:
+        """Method used to sign a SyftMessage and get a :class:`SignedMessage`.
+
+        Args:
+            signing_key: The key to use to sign the SyftMessage.
+
+        Returns:
+            A :class:`SignedMessage`
+
+        """
         if sy.VERBOSE:
             print(
                 f"> Signing with {self.address.key_emoji(key=signing_key.verify_key)}"
@@ -83,6 +104,18 @@ class SyftMessage(AbstractMessage):
 
 
 class SignedMessage(SyftMessage):
+    """
+    SignedMessages are :class:`SyftMessage`s that have been signed by someone.
+    In addition to what has a :class:`SyftMessage`, they have a signature, a verify key
+    and a :meth:`is_valid` property that are here to check that the message was really
+    signed and sent by the verify key owner.
+
+    Attributes:
+        obj_type (string): the string representation of the type of the original message.
+        signature (bytes): the signature of the message.
+        verify_key (VerifyKey): the signer's public key with which the signature can be verified.
+        serialized_message: the serialized original message.
+    """
 
     obj_type: str
     signature: bytes

--- a/src/syft/core/common/message.py
+++ b/src/syft/core/common/message.py
@@ -88,7 +88,9 @@ class SyftMessage(AbstractMessage):
 
         """
         if sy.VERBOSE:
-            print(f"> Signing with {self.address.key_emoji(key=signing_key.verify_key)}")
+            print(
+                f"> Signing with {self.address.key_emoji(key=signing_key.verify_key)}"
+            )
         signed_message = signing_key.sign(self.serialize(to_binary=True))
 
         # signed_type will be the final subclass callee's closest parent signed_type
@@ -261,6 +263,8 @@ class ImmediateSyftMessageWithReply(ImmediateSyftMessage, SyftMessageWithReply):
 
     signed_type = SignedImmediateSyftMessageWithReply
 
-    def __init__(self, reply_to: Address, address: Address, msg_id: Optional[UID] = None) -> None:
+    def __init__(
+        self, reply_to: Address, address: Address, msg_id: Optional[UID] = None
+    ) -> None:
         super().__init__(address=address, msg_id=msg_id)
         self.reply_to = reply_to

--- a/src/syft/core/common/message.py
+++ b/src/syft/core/common/message.py
@@ -58,8 +58,8 @@ class AbstractMessage(ObjectWithID, Generic[SignedMessageT]):
 
 class SyftMessage(AbstractMessage):
     """
-    SyftMessages are an abstraction that represent information that is sent between 2 actors.
-    In Syft, a lot of things are done by sending a message from a :class:`Client` to a :class:`Node`.
+    SyftMessages are an abstraction that represent information that is sent between a :class:`Client`
+    and a :class:`Node`. In Syft's decentralized setup, we can easily see why SyftMessages are so important.
     This class cannot be used as is: to get some useful objects, we need to derive from it. For instance,
     :class:`Action`s inherit from :class:`SyftMessage`.
     There are many types of SyftMessage which boil down to whether or not they are Sync or Async,
@@ -75,7 +75,10 @@ class SyftMessage(AbstractMessage):
         self.post_init()
 
     def sign(self, signing_key: SigningKey) -> SignedMessageT:
-        """Method used to sign a SyftMessage and get a :class:`SignedMessage`.
+        """
+        It's important for all messages to be able to prove who they were sent from.
+        This method endows every message with the ability for someone to "sign" (with a hash of the message)
+        as the sender of the message so that someone else, at a later date, can verify the sender.
 
         Args:
             signing_key: The key to use to sign the SyftMessage.
@@ -85,9 +88,7 @@ class SyftMessage(AbstractMessage):
 
         """
         if sy.VERBOSE:
-            print(
-                f"> Signing with {self.address.key_emoji(key=signing_key.verify_key)}"
-            )
+            print(f"> Signing with {self.address.key_emoji(key=signing_key.verify_key)}")
         signed_message = signing_key.sign(self.serialize(to_binary=True))
 
         # signed_type will be the final subclass callee's closest parent signed_type
@@ -260,8 +261,6 @@ class ImmediateSyftMessageWithReply(ImmediateSyftMessage, SyftMessageWithReply):
 
     signed_type = SignedImmediateSyftMessageWithReply
 
-    def __init__(
-        self, reply_to: Address, address: Address, msg_id: Optional[UID] = None
-    ) -> None:
+    def __init__(self, reply_to: Address, address: Address, msg_id: Optional[UID] = None) -> None:
         super().__init__(address=address, msg_id=msg_id)
         self.reply_to = reply_to

--- a/src/syft/lib/python/bool.py
+++ b/src/syft/lib/python/bool.py
@@ -279,17 +279,6 @@ class Bool(PyPrimitive):
         other = dispatch_other(other)
         return PrimitiveFactory.generate_primitive(value=self.value.__xor__(other))
 
-    @property
-    def id(self) -> UID:
-        """We reveal PyPrimitive.id as a property to discourage users and
-        developers of Syft from modifying .id attributes after an object
-        has been initialized.
-
-        :return: returns the unique id of the object
-        :rtype: UID
-        """
-        return self._id
-
     # @syft_decorator(typechecking=True, prohibit_args=False)
     # def as_integer_ratio():
     #     return PrimitiveFactory.generate_primitive(value=self.value.as_integer_ratio())


### PR DESCRIPTION
## Description
Add docstring to `SyftMessage` and `SignedMessage`.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)