### PR TITLE
fix: Corrects folder name pip-deps to pip-dep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,13 +116,13 @@ or renaming/moving related classes can make unit tests fail because `proto.json`
 Use following process:
 
  1. Fork [OpenMined/syft-proto](https://github.com/OpenMined/syft-proto) and create new branch.
- 2. In your PySyft branch, update `pip-deps/requirements.txt` file to have `git+git://github.com/<your_account>/syft-proto@<branch>#egg=syft-proto` instead of `syft-proto>=*`.
+ 2. In your PySyft branch, update `pip-dep/requirements.txt` file to have `git+git://github.com/<your_account>/syft-proto@<branch>#egg=syft-proto` instead of `syft-proto>=*`.
  3. Make required changes in your PySyft and syft-proto branches. [`helpers/update_types.py`](https://github.com/OpenMined/syft-proto/blob/master/helpers/update_types.py) can help update `proto.json` automatically.
  4. Create PRs in PySyft and syft-proto repos.
  5. PRs should pass CI checks.
  6. After syft-proto PR is merged, new version of syft-proto will be published automatically. You can look up new version [in PyPI
 ](https://pypi.org/project/syft-proto/#history).
- 7. Before merging PySyft PR, update `pip-deps/requirements.txt` to revert from `git+git://github.com/<your_account>/syft-proto@<branch>#egg=syft-proto` to `syft-proto>=<new version>`.
+ 7. Before merging PySyft PR, update `pip-dep/requirements.txt` to revert from `git+git://github.com/<your_account>/syft-proto@<branch>#egg=syft-proto` to `syft-proto>=<new version>`.
 
 ### Documentation and Codestyle
 


### PR DESCRIPTION
## Description
Corrects typo in section that mentions folder `pip-deps` to `pip-dep`. Would resolve Issue #4575 

## Affected Dependencies
None

## How has this been tested?
Tested via GitHub in the browser

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
