### PR TITLE
Optimize torch tensor serialization by 20%

### DIFF
--- a/pip-dep/requirements.txt
+++ b/pip-dep/requirements.txt
@@ -7,6 +7,7 @@ git+https://github.com/facebookresearch/CrypTen.git@cdecc8de1514d7f36a5268a50c71
 importlib-resources~=1.5.0
 lz4~=3.0.2
 msgpack~=1.0.0
+msgpack-numpy~=0.4.7
 numpy~=1.18.1
 phe~=1.4.0
 Pillow>=7.1.0

--- a/syft/frameworks/torch/torch_attributes.py
+++ b/syft/frameworks/torch/torch_attributes.py
@@ -85,6 +85,7 @@ class TorchAttributes(FrameworkAttributes):
             "isclose",
             "isfinite",
             "load",
+            "numpy",
             "save",
             "set_",
             "set_num_threads",

--- a/syft/serde/msgpack/proto.py
+++ b/syft/serde/msgpack/proto.py
@@ -15,6 +15,8 @@ from syft.exceptions import InvalidProtocolFileError
 from syft.exceptions import UndefinedProtocolTypeError
 from syft.exceptions import UndefinedProtocolTypePropertyError
 
+from syft.generic.utils import memorize
+
 if proto_info is None:
     raise InvalidProtocolFileError("Failed to load syft protocol data")
 
@@ -50,6 +52,7 @@ class TypeInfo:
             raise UndefinedProtocolTypePropertyError(f"forced_code is not set for {self.name}")
 
 
+@memorize
 def fullname(cls):
     """Returns full name of a given *class* (not instance of class).
     Source:
@@ -62,6 +65,7 @@ def fullname(cls):
         return module + "." + cls.__name__
 
 
+@memorize
 def proto_type_info(cls):
     """Returns `TypeInfo` instance for a given *class* identified by `cls` parameter.
     Throws an exception when such class does not exists in the `proto.json`.

--- a/syft/serde/msgpack/serde.py
+++ b/syft/serde/msgpack/serde.py
@@ -37,6 +37,8 @@ import hashlib
 
 import syft
 import msgpack as msgpack_lib
+import msgpack_numpy
+
 from syft import dependency_check
 
 from syft.serde import compression
@@ -61,6 +63,8 @@ if dependency_check.tensorflow_available:
     from syft_tensorflow.serde import MAP_TF_SIMPLIFIERS_AND_DETAILERS
 else:
     MAP_TF_SIMPLIFIERS_AND_DETAILERS = {}
+
+msgpack_numpy.patch()
 
 
 class MetaMsgpackGlobalState(type):

--- a/syft/serde/msgpack/torch_serde.py
+++ b/syft/serde/msgpack/torch_serde.py
@@ -24,8 +24,6 @@ from syft.serde.torch.serde import TORCH_MFORMAT_ID
 from syft.serde.torch.serde import TORCH_ID_MFORMAT
 from syft.serde.torch.serde import torch_tensor_serializer
 from syft.serde.torch.serde import torch_tensor_deserializer
-from syft.serde.torch.serde import numpy_tensor_serializer
-from syft.serde.torch.serde import numpy_tensor_deserializer  # noqa: F401
 
 
 def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
@@ -41,7 +39,6 @@ def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
     """
     serializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_serializer,
-        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
         TENSOR_SERIALIZATION.ALL: simplified_tensor_serializer,
     }
     if worker.serializer not in serializers:
@@ -66,7 +63,6 @@ def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> 
     """
     deserializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_deserializer,
-        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
         TENSOR_SERIALIZATION.ALL: simplified_tensor_deserializer,
     }
     if serializer not in deserializers:
@@ -153,6 +149,7 @@ def _simplify_torch_tensor(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
         tensor.id,
         tensor_bin,
         chain,
+        tensor.requires_grad,
         grad_chain,
         serde._simplify(worker, tensor.tags),
         serde._simplify(worker, tensor.description),
@@ -181,6 +178,7 @@ def _detail_torch_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> torch.T
         tensor_id,
         tensor_bin,
         chain,
+        requires_grad,
         grad_chain,
         tags,
         description,
@@ -190,6 +188,8 @@ def _detail_torch_tensor(worker: AbstractWorker, tensor_tuple: tuple) -> torch.T
     ) = tensor_tuple
 
     tensor = _deserialize_tensor(worker, serde._detail(worker, serializer), tensor_bin)
+
+    tensor.requires_grad = requires_grad
 
     # note we need to do this explicitly because torch.load does not
     # include .grad informatino

--- a/syft/serde/msgpack/torch_serde.py
+++ b/syft/serde/msgpack/torch_serde.py
@@ -22,8 +22,10 @@ from syft.serde.torch.serde import TORCH_DTYPE_STR
 from syft.serde.torch.serde import TORCH_STR_DTYPE
 from syft.serde.torch.serde import TORCH_MFORMAT_ID
 from syft.serde.torch.serde import TORCH_ID_MFORMAT
-from syft.serde.torch.serde import torch_tensor_serializer
-from syft.serde.torch.serde import torch_tensor_deserializer
+from syft.serde.torch.serde import torch_tensor_serializer  # noqa: F401
+from syft.serde.torch.serde import torch_tensor_deserializer  # noqa: F401
+from syft.serde.torch.serde import numpy_tensor_serializer
+from syft.serde.torch.serde import numpy_tensor_deserializer
 
 
 def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
@@ -38,7 +40,8 @@ def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
 
     """
     serializers = {
-        TENSOR_SERIALIZATION.TORCH: torch_tensor_serializer,
+        TENSOR_SERIALIZATION.TORCH: numpy_tensor_serializer,  # numpy serializer is faster
+        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
         TENSOR_SERIALIZATION.ALL: simplified_tensor_serializer,
     }
     if worker.serializer not in serializers:
@@ -62,7 +65,8 @@ def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> 
         a Torch tensor
     """
     deserializers = {
-        TENSOR_SERIALIZATION.TORCH: torch_tensor_deserializer,
+        TENSOR_SERIALIZATION.TORCH: numpy_tensor_deserializer,
+        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_deserializer,
         TENSOR_SERIALIZATION.ALL: simplified_tensor_deserializer,
     }
     if serializer not in deserializers:

--- a/syft/serde/protobuf/torch_serde.py
+++ b/syft/serde/protobuf/torch_serde.py
@@ -20,8 +20,6 @@ from syft.serde.torch.serde import TORCH_DTYPE_STR
 from syft.serde.torch.serde import TORCH_STR_DTYPE
 from syft.serde.torch.serde import torch_tensor_serializer
 from syft.serde.torch.serde import torch_tensor_deserializer
-from syft.serde.torch.serde import numpy_tensor_serializer
-from syft.serde.torch.serde import numpy_tensor_deserializer
 
 from syft_proto.types.torch.v1.script_function_pb2 import ScriptFunction as ScriptFunctionPB
 from syft_proto.types.torch.v1.device_pb2 import Device as DevicePB
@@ -36,7 +34,6 @@ from syft_proto.types.torch.v1.dtype_pb2 import TorchDType as TorchDTypePB
 
 SERIALIZERS_SYFT_TO_PROTOBUF = {
     TENSOR_SERIALIZATION.TORCH: TorchTensorPB.Serializer.SERIALIZER_TORCH,
-    TENSOR_SERIALIZATION.NUMPY: TorchTensorPB.Serializer.SERIALIZER_NUMPY,
     TENSOR_SERIALIZATION.ALL: TorchTensorPB.Serializer.SERIALIZER_ALL,
 }
 SERIALIZERS_PROTOBUF_TO_SYFT = {value: key for key, value in SERIALIZERS_SYFT_TO_PROTOBUF.items()}
@@ -55,7 +52,6 @@ def _serialize_tensor(worker: AbstractWorker, tensor) -> bin:
     """
     serializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_serializer,
-        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_serializer,
         TENSOR_SERIALIZATION.ALL: protobuf_tensor_serializer,
     }
     if worker.serializer not in serializers:
@@ -80,7 +76,6 @@ def _deserialize_tensor(worker: AbstractWorker, serializer: str, tensor_bin) -> 
     """
     deserializers = {
         TENSOR_SERIALIZATION.TORCH: torch_tensor_deserializer,
-        TENSOR_SERIALIZATION.NUMPY: numpy_tensor_deserializer,
         TENSOR_SERIALIZATION.ALL: protobuf_tensor_deserializer,
     }
     if serializer not in deserializers:

--- a/syft/serde/torch/serde.py
+++ b/syft/serde/torch/serde.py
@@ -35,15 +35,12 @@ TORCH_ID_MFORMAT = {i: cls for cls, i in TORCH_MFORMAT_ID.items()}
 
 def torch_tensor_serializer(worker: AbstractWorker, tensor) -> bin:
     """Strategy to serialize a tensor using Torch saver"""
-    binary_stream = io.BytesIO()
-    torch.save(tensor, binary_stream)
-    return binary_stream.getvalue()
+    return tensor.numpy()
 
 
 def torch_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
     """Strategy to deserialize a binary input using Torch load"""
-    bin_tensor_stream = io.BytesIO(tensor_bin)
-    return torch.load(bin_tensor_stream)
+    return torch.from_numpy(tensor_bin)
 
 
 def numpy_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> bin:

--- a/syft/serde/torch/serde.py
+++ b/syft/serde/torch/serde.py
@@ -34,46 +34,10 @@ TORCH_ID_MFORMAT = {i: cls for cls, i in TORCH_MFORMAT_ID.items()}
 
 
 def torch_tensor_serializer(worker: AbstractWorker, tensor) -> bin:
-    """Strategy to serialize a tensor using Torch saver"""
-    return tensor.numpy()
+    """Strategy to serialize a tensor using numpy conversion"""
+    return tensor.detach().numpy()
 
 
-def torch_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
-    """Strategy to deserialize a binary input using Torch load"""
-    return torch.from_numpy(tensor_bin)
-
-
-def numpy_tensor_serializer(worker: AbstractWorker, tensor: torch.Tensor) -> bin:
-    """Strategy to serialize a tensor using numpy npy format.
-    If tensor requires to calculate gradients, it will be detached.
-
-    Args
-        (torch.Tensor): an input tensor to be serialized
-
-    Returns
-        A serialized version of the input tensor
-    """
-    if tensor.requires_grad:
-        warnings.warn(
-            "Torch to Numpy serializer can only be used with tensors that do not require grad. "
-            "Detaching tensor to continue"
-        )
-        tensor = tensor.detach()
-
-    np_tensor = tensor.numpy()
-    outfile = io.BytesIO()
-    numpy.save(outfile, np_tensor)
-    return outfile.getvalue()
-
-
-def numpy_tensor_deserializer(tensor_bin) -> torch.Tensor:
-    """Strategy to deserialize a binary input in npy format into Torch tensor
-
-    Args
-        tensor_bin: A binary representation of a tensor
-
-    Returns
-        a Torch tensor
-    """
-    bin_tensor_stream = io.BytesIO(tensor_bin)
-    return torch.from_numpy(numpy.load(bin_tensor_stream))
+def torch_tensor_deserializer(worker: AbstractWorker, tensor) -> torch.Tensor:
+    """Strategy to deserialize a binary input using numpy conversion """
+    return torch.from_numpy(tensor)

--- a/syft/serde/torch/serde.py
+++ b/syft/serde/torch/serde.py
@@ -1,7 +1,3 @@
-import io
-import warnings
-
-import numpy
 import torch
 
 from syft.workers.abstract import AbstractWorker

--- a/syft/serde/torch/serde.py
+++ b/syft/serde/torch/serde.py
@@ -1,3 +1,4 @@
+import io
 import torch
 
 from syft.workers.abstract import AbstractWorker
@@ -30,10 +31,23 @@ TORCH_ID_MFORMAT = {i: cls for cls, i in TORCH_MFORMAT_ID.items()}
 
 
 def torch_tensor_serializer(worker: AbstractWorker, tensor) -> bin:
+    """Strategy to serialize a tensor using Torch saver"""
+    binary_stream = io.BytesIO()
+    torch.save(tensor, binary_stream)
+    return binary_stream.getvalue()
+
+
+def torch_tensor_deserializer(worker: AbstractWorker, tensor_bin) -> torch.Tensor:
+    """Strategy to deserialize a binary input using Torch load"""
+    bin_tensor_stream = io.BytesIO(tensor_bin)
+    return torch.load(bin_tensor_stream)
+
+
+def numpy_tensor_serializer(worker: AbstractWorker, tensor) -> bin:
     """Strategy to serialize a tensor using numpy conversion"""
     return tensor.detach().numpy()
 
 
-def torch_tensor_deserializer(worker: AbstractWorker, tensor) -> torch.Tensor:
+def numpy_tensor_deserializer(worker: AbstractWorker, tensor) -> torch.Tensor:
     """Strategy to deserialize a binary input using numpy conversion """
     return torch.from_numpy(tensor)

--- a/test/serde/msgpack/test_msgpack_serde_full.py
+++ b/test/serde/msgpack/test_msgpack_serde_full.py
@@ -175,4 +175,12 @@ def test_serde_simplify(cls, workers, hook, start_remote_worker):
             # Custom simplified objects comparison function.
             assert sample.get("cmp_simplified")(simplified_obj, expected_simplified_obj) is True
         else:
-            assert simplified_obj == expected_simplified_obj
+            if isinstance(simplified_obj, tuple):
+                assert (simplified_obj == expected_simplified_obj).all()
+            else:
+                assert simplified_obj == expected_simplified_obj
+            # print(simplified_obj)
+            # print('***', type(simplified_obj))
+            # identical = (simplified_obj == expected_simplified_obj)
+            # print('***', type(identical))
+            # assert identical

--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -416,6 +416,7 @@ def make_torch_tensor(**kwargs):
                     tensor.id,  # (int) id
                     save_to_buffer(tensor),  # (bytes) serialized tensor
                     None,  # (AbstractTensor) chain
+                    False,  # (bool) requires_grad
                     None,  # (AbstractTensor) grad_chain
                     (CODE[set], ((CODE[str], (b"tag1",)),)),  # (set of str) tags
                     (CODE[str], (b"desc",)),  # (str) description


### PR DESCRIPTION
## Description
Quick optim to improve serialization of large tensors
```python
message = th.ones(10_000, 1000)
message.send(alice).get()  # <-- goes from 0.250 to 0.200 seconds
```