### PR TITLE
 prevent federated_avg() from adding noise to model

### DIFF
--- a/syft/frameworks/torch/fl/utils.py
+++ b/syft/frameworks/torch/fl/utils.py
@@ -86,8 +86,8 @@ def federated_avg(models: Dict[Any, torch.nn.Module]) -> torch.nn.Module:
     
     # setting all model parameters to zero
     for p in model.parameters():
-        nn.init.zeros_(p)
-
+        torch.nn.init.zeros_(p)
+    
     for i in range(nr_models):
         model = add_model(model, model_list[i])
     model = scale_model(model, 1.0 / nr_models)

--- a/syft/frameworks/torch/fl/utils.py
+++ b/syft/frameworks/torch/fl/utils.py
@@ -83,11 +83,11 @@ def federated_avg(models: Dict[Any, torch.nn.Module]) -> torch.nn.Module:
     nr_models = len(models)
     model_list = list(models.values())
     model = type(model_list[0])()
-    
+
     # setting all model parameters to zero
     for p in model.parameters():
         torch.nn.init.zeros_(p)
-    
+
     for i in range(nr_models):
         model = add_model(model, model_list[i])
     model = scale_model(model, 1.0 / nr_models)

--- a/syft/frameworks/torch/fl/utils.py
+++ b/syft/frameworks/torch/fl/utils.py
@@ -83,6 +83,10 @@ def federated_avg(models: Dict[Any, torch.nn.Module]) -> torch.nn.Module:
     nr_models = len(models)
     model_list = list(models.values())
     model = type(model_list[0])()
+    
+    # setting all model parameters to zero
+    for p in model.parameters():
+        nn.init.zeros_(p)
 
     for i in range(nr_models):
         model = add_model(model, model_list[i])


### PR DESCRIPTION

## Description
`model = type(model_list[0])()` instantiates a new model in most cases with random weights, which then will be added to the merged model. This is probably an unwanted behavior. Hence, we should overwrite all weights with zeros: 
```
for p in model.parameters():
        nn.init.zeros_(p)
```

## Affected Dependencies
none

## How has this been tested?
standard github ci test

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
