### PR TITLE
Fixing several issues in federated_avg()

### DIFF
--- a/syft/frameworks/torch/fl/utils.py
+++ b/syft/frameworks/torch/fl/utils.py
@@ -1,8 +1,10 @@
-import syft as sy
 import torch
+import copy
+import logging
+import syft as sy
 from typing import Dict
 from typing import Any
-import logging
+from functools import reduce
 
 logger = logging.getLogger(__name__)
 
@@ -39,15 +41,15 @@ def add_model(dst_model, src_model):
         torch.nn.Module: the resulting model of the addition.
 
     """
-
-    params1 = src_model.named_parameters()
-    params2 = dst_model.named_parameters()
-    dict_params2 = dict(params2)
+    params1 = dst_model.state_dict().copy()
+    params2 = src_model.state_dict().copy()
     with torch.no_grad():
-        for name1, param1 in params1:
-            if name1 in dict_params2:
-                dict_params2[name1].set_(param1.data + dict_params2[name1].data)
-    return dst_model
+        for name1 in params1:
+            if name1 in params2:
+                params1[name1] = params1[name1] + params2[name1]
+    model = copy.deepcopy(dst_model)
+    model.load_state_dict(params1, strict=False)
+    return model
 
 
 def scale_model(model, scale):
@@ -60,12 +62,14 @@ def scale_model(model, scale):
         torch.nn.Module: the module with scaled parameters.
 
     """
-    params = model.named_parameters()
-    dict_params = dict(params)
+    params = model.state_dict().copy()
+    scale = torch.tensor(scale)
     with torch.no_grad():
-        for name, param in dict_params.items():
-            dict_params[name].set_(dict_params[name].data * scale)
-    return model
+        for name in params:
+            params[name] = params[name].type_as(scale) * scale
+    scaled_model = copy.deepcopy(model)
+    scaled_model.load_state_dict(params, strict=False)
+    return scaled_model
 
 
 def federated_avg(models: Dict[Any, torch.nn.Module]) -> torch.nn.Module:
@@ -82,11 +86,11 @@ def federated_avg(models: Dict[Any, torch.nn.Module]) -> torch.nn.Module:
     """
     nr_models = len(models)
     model_list = list(models.values())
-    model = type(model_list[0])()
-
-    for i in range(nr_models):
-        model = add_model(model, model_list[i])
-    model = scale_model(model, 1.0 / nr_models)
+    if nr_models > 1:
+        model = reduce(add_model, model_list)
+        model = scale_model(model, 1.0 / nr_models)
+    else:
+        model = model_list[0].copy()
     return model
 
 

--- a/syft/frameworks/torch/fl/utils.py
+++ b/syft/frameworks/torch/fl/utils.py
@@ -90,7 +90,7 @@ def federated_avg(models: Dict[Any, torch.nn.Module]) -> torch.nn.Module:
         model = reduce(add_model, model_list)
         model = scale_model(model, 1.0 / nr_models)
     else:
-        model = model_list[0].copy()
+        model = copy.deepcopy(model_list[0])
     return model
 
 


### PR DESCRIPTION
## Description
The current version of `federated_avg()` has following issues:
- The sum of model parameters would be affected by the non zero initial model (#3863)
- Fails when aggregated models are located on GPU (#3863)
- Only includes the parameters in `named_parameters()`, whereas those of in `_buffers` and `_modules` are left.

## Affected Dependencies
I imported two new packages in my editing:
- copy
- functors

However, they are both native python packages.

## How has this been tested?
- I passed the test cases in `test/torch/federated/test_utils.py`
- I passed the test case modified from #3863
![tc02](https://user-images.githubusercontent.com/8715395/94199535-8c218c80-feeb-11ea-9af9-959741ead0a0.png)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
