### PR TITLE
Fix get permissions

### DIFF
--- a/src/syft/ast/globals.py
+++ b/src/syft/ast/globals.py
@@ -18,13 +18,6 @@ class Globals(Module):
     def __init__(self) -> None:
         super().__init__("globals")
 
-    def add_framework(
-        self,
-        attr_name: str,
-        attr: Union[Callable, CallableT],
-    ) -> None:
-        self.attrs[attr_name] = attr
-
     def add_path(
         self,
         path: Union[str, List[str]],

--- a/src/syft/core/node/common/action/function_or_constructor_action.py
+++ b/src/syft/core/node/common/action/function_or_constructor_action.py
@@ -3,7 +3,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Set
 from typing import Tuple
 from typing import Union
 
@@ -24,8 +23,6 @@ from ....pointer.pointer import Pointer
 from ....store.storeable_object import StorableObject
 from ...abstract.node import AbstractNode
 from .common import ImmediateActionWithoutReply
-
-DEFAULT_AVAILABLE_READ_PERMISSIONS: Set[str] = {"torch.cuda.is_available"}
 
 
 class RunFunctionOrConstructorAction(ImmediateActionWithoutReply):
@@ -137,7 +134,7 @@ class RunFunctionOrConstructorAction(ImmediateActionWithoutReply):
 
         # If we have no permission (None or {}) we add some default permissions based on a permission list
         if result_read_permissions is None:
-            if self.path in DEFAULT_AVAILABLE_READ_PERMISSIONS:
+            if self.path in node.lib_ast.DRP:
                 result_read_permissions = {verify_key: result.id}
             else:
                 result_read_permissions = {}

--- a/src/syft/core/node/common/action/function_or_constructor_action.py
+++ b/src/syft/core/node/common/action/function_or_constructor_action.py
@@ -78,7 +78,7 @@ class RunFunctionOrConstructorAction(ImmediateActionWithoutReply):
     def execute_action(self, node: AbstractNode, verify_key: VerifyKey) -> None:
         method = node.lib_ast(self.path)
 
-        result_read_permissions: Dict[VerifyKey, UID] = {}
+        result_read_permissions: Union[None, Dict[VerifyKey, UID]] = None
 
         resolved_args = list()
         for arg in self.args:
@@ -135,12 +135,12 @@ class RunFunctionOrConstructorAction(ImmediateActionWithoutReply):
             # else:
             # TODO: Solve this problem where its an issue
 
-        # If we do not get args/kwargs, we add some default permissions based on a permission list
-        if (
-            not result_read_permissions
-            and self.path in DEFAULT_AVAILABLE_READ_PERMISSIONS
-        ):
-            result_read_permissions = {verify_key: result.id}
+        # If we have no permission (None or {}) we add some default permissions based on a permission list
+        if result_read_permissions is None:
+            if self.path in DEFAULT_AVAILABLE_READ_PERMISSIONS:
+                result_read_permissions = {verify_key: result.id}
+            else:
+                result_read_permissions = {}
 
         if not isinstance(result, StorableObject):
             result = StorableObject(

--- a/src/syft/lib/__init__.py
+++ b/src/syft/lib/__init__.py
@@ -1,6 +1,8 @@
 # syft relative
 from ..ast.globals import Globals
+from ..lib.python import DEFAULT_READ_PERMISSION as PYTHON_DRP
 from ..lib.python import create_python_ast
+from ..lib.torch import DEFAULT_READ_PERMISSION as TORCH_DRP
 from ..lib.torch import create_torch_ast
 from ..lib.torchvision import create_torchvision_ast
 
@@ -17,6 +19,7 @@ def create_lib_ast() -> Globals:
     lib_ast.add_attr(attr_name="syft", attr=python_ast.attrs["syft"])
     lib_ast.add_attr(attr_name="torch", attr=torch_ast.attrs["torch"])
     lib_ast.add_attr(attr_name="torchvision", attr=torchvision_ast.attrs["torchvision"])
+
     # lib_ast.add_attr(attr_name="numpy", attr=numpy_ast.attrs["numpy"])
 
     return lib_ast
@@ -25,3 +28,7 @@ def create_lib_ast() -> Globals:
 # constructor: copyType = create_lib_ast
 lib_ast = create_lib_ast()
 lib_ast._copy = create_lib_ast
+
+
+DRP = frozenset(PYTHON_DRP + TORCH_DRP)
+setattr(lib_ast, "DRP", DRP)

--- a/src/syft/lib/python/__init__.py
+++ b/src/syft/lib/python/__init__.py
@@ -103,3 +103,15 @@ def create_python_ast() -> Globals:
         klass.create_storable_object_attr_convenience_methods()
 
     return ast
+
+
+DEFAULT_READ_PERMISSION: TypeList[str] = [
+    "syft.lib.python.Bool",
+    "syft.lib.python.Complex",
+    "syft.lib.python.Dict",
+    "syft.lib.python.Float",
+    "syft.lib.python.Int",
+    "syft.lib.python.List",
+    "syft.lib.python.String",
+    "syft.lib.python.SyNone",
+]

--- a/src/syft/lib/torch/__init__.py
+++ b/src/syft/lib/torch/__init__.py
@@ -1,5 +1,6 @@
 # stdlib
 from typing import Dict
+from typing import List as TypeList
 from typing import Union
 
 # third party
@@ -57,3 +58,6 @@ def create_torch_ast() -> Globals:
         klass.create_serialization_methods()
         klass.create_storable_object_attr_convenience_methods()
     return ast
+
+
+DEFAULT_READ_PERMISSION: TypeList[str] = ["torch.cuda.is_available"]

--- a/src/syft/lib/torch/allowlist.py
+++ b/src/syft/lib/torch/allowlist.py
@@ -639,6 +639,7 @@ allowlist["torch.device"] = "torch.device"
 allowlist["torch.device.index"] = "syft.lib.python.Int"
 allowlist["torch.device.type"] = "syft.lib.python.String"
 allowlist["torch.cuda.is_available"] = "syft.lib.python.Bool"
+allowlist["torch.random.initial_seed"] = "syft.lib.python.Int"
 
 # Modules
 allowlist["torch.nn.Module"] = "torch.nn.Module"

--- a/tests/syft/core/node/common/action/function_or_constructor_action_test.py
+++ b/tests/syft/core/node/common/action/function_or_constructor_action_test.py
@@ -28,7 +28,7 @@ def test_constructor_not_in_default_permissions() -> None:
     alice_client = alice.get_client()
 
     torch = alice_client.torch
-    ptr = torch.Tensor([1, 2, 3])
+    ptr = torch.random.initial_seed()
 
     with pytest.raises(Exception) as e:
         ptr.get()

--- a/tests/syft/core/node/common/action/function_or_constructor_action_test.py
+++ b/tests/syft/core/node/common/action/function_or_constructor_action_test.py
@@ -1,4 +1,5 @@
 # third party
+import pytest
 import torch as th
 
 # syft absolute
@@ -10,6 +11,32 @@ from syft.core.node.common.action.function_or_constructor_action import (
 
 # TODO test execution
 # TODO test permissions
+
+
+def test_constructor_in_default_permissions() -> None:
+    alice = sy.VirtualMachine(name="alice")
+    alice_client = alice.get_client()
+
+    torch = alice_client.torch
+    ptr = torch.cuda.is_available()
+
+    assert ptr.get() == th.cuda.is_available()
+
+
+def test_constructor_not_in_default_permissions() -> None:
+    alice = sy.VirtualMachine(name="alice")
+    alice_client = alice.get_client()
+
+    torch = alice_client.torch
+    ptr = torch.Tensor([1, 2, 3])
+
+    with pytest.raises(Exception) as e:
+        ptr.get()
+
+    assert (
+        str(e.value)
+        == "You do not have permission to .get() this tensor. Please submit a request."
+    )
 
 
 def test_run_function_or_constructor_action_serde() -> None:


### PR DESCRIPTION
## Description
In case we create a new object remotely, we set no permission for it.
This PR adds a list of default read permissions in case there is no permissions added (there is not args/kwargs).

The list might be extended.

## Affected Dependencies
Currently, we use only ```torch.cuda.is_available``` (for showcase).
It might impose a **security risk**. Cuda machine vs non-cuda machine, it might mean that a machine has more data?

## How has this been tested?
* Added tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests