### PR TITLE
Remote execution of torch hooks

### DIFF
--- a/syft/frameworks/torch/fl/dataset.py
+++ b/syft/frameworks/torch/fl/dataset.py
@@ -270,7 +270,7 @@ def dataset_federate(dataset, *workers, **kwargs) -> "FederatedDataset":
             to the workers
     """
     # Compat with the old signature without the (*)workers
-    if isinstance(workers[0], tuple):
+    if isinstance(workers[0], (list, tuple)):
         workers = workers[0]
 
     logger.info(f"Scanning and sending data to {', '.join([w.id for w in workers])}...")

--- a/syft/frameworks/torch/fl/dataset.py
+++ b/syft/frameworks/torch/fl/dataset.py
@@ -257,7 +257,7 @@ class BaseDataset(AbstractSendable):
         return BaseDatasetPB
 
 
-def dataset_federate(dataset, workers):
+def dataset_federate(dataset, *workers, **kwargs):
     """
     Add a method to easily transform a torch.Dataset or a sy.BaseDataset
     into a sy.FederatedDataset. The dataset given is split in len(workers)
@@ -273,8 +273,8 @@ def dataset_federate(dataset, workers):
     for dataset_idx, (data, targets) in enumerate(data_loader):
         worker = workers[dataset_idx % len(workers)]
         logger.debug("Sending data to worker %s", worker.id)
-        data = data.send(worker)
-        targets = targets.send(worker)
+        data = data.send(worker, **kwargs)
+        targets = targets.send(worker, **kwargs)
         datasets.append(BaseDataset(data, targets))  # .send(worker)
 
     logger.debug("Done!")
@@ -314,6 +314,8 @@ class FederatedDataset:
         """
 
         return list(self.datasets.keys())
+
+    locations = workers
 
     def get_dataset(self, worker):
         self[worker].federated = False

--- a/syft/frameworks/torch/fl/dataset.py
+++ b/syft/frameworks/torch/fl/dataset.py
@@ -257,11 +257,17 @@ class BaseDataset(AbstractSendable):
         return BaseDatasetPB
 
 
-def dataset_federate(dataset, *workers, **kwargs):
+def dataset_federate(dataset, *workers, **kwargs) -> "FederatedDataset":
     """
     Add a method to easily transform a torch.Dataset or a sy.BaseDataset
     into a sy.FederatedDataset. The dataset given is split in len(workers)
     part and sent to each workers
+
+    Args:
+        dataset (Dataset): the dataset to federate across workers
+        *workers (BaseWorker): the workers receiving parts of the dataset
+        **kwargs (dict): any kwargs to use when sending parts of the dataset
+            to the workers
     """
     logger.info(f"Scanning and sending data to {', '.join([w.id for w in workers])}...")
 

--- a/syft/frameworks/torch/fl/dataset.py
+++ b/syft/frameworks/torch/fl/dataset.py
@@ -269,6 +269,10 @@ def dataset_federate(dataset, *workers, **kwargs) -> "FederatedDataset":
         **kwargs (dict): any kwargs to use when sending parts of the dataset
             to the workers
     """
+    # Compat with the old signature without the (*)workers
+    if isinstance(workers[0], tuple):
+        workers = workers[0]
+
     logger.info(f"Scanning and sending data to {', '.join([w.id for w in workers])}...")
 
     # take ceil to have exactly len(workers) sets after splitting

--- a/syft/frameworks/torch/hook/hook_args.py
+++ b/syft/frameworks/torch/hook/hook_args.py
@@ -77,6 +77,7 @@ ambiguous_functions = {
     "cat",
     "torch.mean",
     "torch.sum",
+    "torch.einsum",
     "torch.chunk",
     "chunk",
     "torch.functional.split",

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -124,14 +124,18 @@ class TorchTensor(AbstractTensor):
         Run the hook function stored in the _hook_function attribute using the
         pointer to the gradient received.
 
-        trigger_hook_function is called on the tensor while it should run on the
+        trigger_hook_function is called on the tensor while it can be run on the
         tensor.grad_fn (confusion is due to both sharing the same id), that's why
-        we get the grad_fn attribute.
+        we check the grad_fn attribute also. For module hooks, grad_fn will be
+        used, for simple tensor hooks, it won't by default.
 
         Args:
             outputs (PointerTensor): a pointer to a remote gradient
         """
-        self.child.grad_fn.child._hook_function(inputs=None, outputs=(outputs.wrap(),))
+        if hasattr(self.child.grad_fn.child, "_hook_function"):
+            self.child.grad_fn.child._hook_function(inputs=None, outputs=(outputs.wrap(),))
+        else:
+            self.child._hook_function(inputs=None, outputs=(outputs.wrap(),))
 
     def set_grad(self, grad):
         self.grad = grad

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -89,11 +89,21 @@ class TorchTensor(AbstractTensor):
 
         return trigger_origin_backward
 
-    def register_hook_to_callback(self, message, location):
+    def register_callback_hook(self, message, location):
+        """
+        Register a Torch hook (that is triggered when the `self` tensor has a gradient
+        update) which will send back to a location a specific message whose arguments
+        are updated with a reference to `self`.
+
+        Args:
+            message: the message to send back
+            location: the worker to which the message should be sent
+        """
         location = self.owner.get_worker(location)
 
         def callback(grad):
-            assert isinstance(grad, torch.Tensor), "Grad in callback should be Tensor"
+            assert isinstance(grad, torch.Tensor), "Grad in callback should be a Tensor"
+            # the grad tensor is created by the torch backprop and might not be registered properly
             self.owner.register_obj(grad)
             pointer = PointerTensor(
                 location=self.owner,
@@ -101,13 +111,26 @@ class TorchTensor(AbstractTensor):
                 owner=location,
                 id=syft.ID_PROVIDER.pop(),
             )
+            # update the message arguments
             message.action.args = (pointer,)
             self.owner.send_msg(message=message, location=location)
+            # De-register the grad after the callback has been handled
             self.owner.de_register_obj(grad)
 
         self.register_hook(callback)
 
     def trigger_hook_function(self, outputs):
+        """
+        Run the hook function stored in the _hook_function attribute using the
+        pointer to the gradient received.
+
+        trigger_hook_function is called on the tensor while it should run on the
+        tensor.grad_fn (confusion is due to both sharing the same id), that's why
+        we get the grad_fn attribute.
+
+        Args:
+            outputs (PointerTensor): a pointer to a remote gradient
+        """
         self.child.grad_fn.child._hook_function(inputs=None, outputs=(outputs.wrap(),))
 
     def set_grad(self, grad):

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -96,8 +96,8 @@ class TorchTensor(AbstractTensor):
         are updated with a reference to `self`.
 
         Args:
-            message: the message to send back
-            location: the worker to which the message should be sent
+            message (Message): the message to send back
+            location (BaseWorker): the worker to which the message should be sent
         """
         location = self.owner.get_worker(location)
 

--- a/syft/generic/object_storage.py
+++ b/syft/generic/object_storage.py
@@ -175,3 +175,6 @@ class ObjectStore:
         Return the number of objects in the store
         """
         return len(self._objects)
+
+    def __str__(self):
+        return f"<ObjectStorage of {self.owner.id}>"

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -136,6 +136,20 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         self._grad = new_grad
 
     @property
+    def grad_fn(self):
+        if not hasattr(self, "_grad_fn"):
+            self._grad_fn = self.attr("grad_fn")
+
+        if self._grad_fn.child.is_none():
+            return None
+
+        return self._grad_fn
+
+    @grad_fn.setter
+    def grad_fn(self, new_grad_fn):
+        self._grad_fn = new_grad_fn
+
+    @property
     def data(self):
         if not hasattr(self, "_data"):
             self._data = self.attr("data")

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -200,12 +200,12 @@ class PointerTensor(ObjectPointer, AbstractTensor):
             recipient=self.location,
             cmd_name="register_callback_hook",
             target=self,
-            args_=tuple(),
+            args_=(),
             kwargs_=dict(
                 # args & kwargs are not provided, they will be filled by
                 # the remote party
                 message=TensorCommandMessage.computation(
-                    "trigger_hook_function", self.id, tuple(), {}, None
+                    "trigger_hook_function", self.id, (), {}, None
                 ),
                 location=self.owner.id,
             ),

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -160,18 +160,50 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         self._data = new_data
 
     def register_hook(self, hook_function):
+        """
+        This allows to register torch hooks on remote tensors. Such operation
+        is tricky because you can't really send the hook function to a remote
+        party, as python functions are not serializable within PySyft. So you
+        need to keep it attached to the PointerTensor.
+        On the other hand, the PointerTensor cannot watch for gradient update
+        or be triggered natively by torch when backpropagation happens. That's
+        why we actually remotely set a hook that we call a callback hook whose
+        function is only to call back the pointer during the backpropagation
+        to effectively run the hook function.
+        So the workflow is: the remote hook is triggered by pytorch, a message
+        is sent back to the pointer owner which has the hook function, then
+        the hook function is run remotely on the remote gradient, and a termi-
+        nation message is returned to the gradient owner.
+
+        Args:
+            hook_function (Callable): the function to run when the hook is
+                triggered. It should be able to run on PointerTensor, other-
+                wise you will get an error, which will by hard to understand
+                as only the backward engine of torch will return a generic
+                error.
+        """
         # store the hook_function
         self._hook_function = hook_function
-        # send a request to set a hook to trigger back the hook
+        # The hook function is run on tensor.grad_fn, but we register it
+        # on the tensor because we only interact remotely with tensors.
+        # `self` is a pointer to tensor.grad_fn, but we can easily retrieve
+        # the pointer to the tensor by temporarily setting self.point_to_attr
+        # to None. Note that the id & id_at_location are the same, so now
+        # self is (temporarily) a direct reference to tensor, but self.id in
+        # the message also refers to the tensor while we would need to refer
+        # to the tensor.grad_fn, that's why trigger_hook_function actually
+        # takes the .grad_fn attribute
         point_to_attr = self.point_to_attr
         self.point_to_attr = None
+        # send a request to set a hook to trigger back the real hook
         self.owner.send_command(
             recipient=self.location,
-            cmd_name="register_hook_to_callback",
+            cmd_name="register_callback_hook",
             target=self,
             args_=tuple(),
             kwargs_=dict(
-                # args & kwargs are not provided, they will be filled later
+                # args & kwargs are not provided, they will be filled by
+                # the remote party
                 message=TensorCommandMessage.computation(
                     "trigger_hook_function", self.id, tuple(), {}, None
                 ),

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -184,15 +184,15 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         """
         # store the hook_function
         self._hook_function = hook_function
-        # The hook function is run on tensor.grad_fn, but we register it
+        # The hook function can run on tensor.grad_fn, but we always register it
         # on the tensor because we only interact remotely with tensors.
-        # `self` is a pointer to tensor.grad_fn, but we can easily retrieve
+        # `self` can be a pointer to tensor.grad_fn, but we can easily retrieve
         # the pointer to the tensor by temporarily setting self.point_to_attr
         # to None. Note that the id & id_at_location are the same, so now
         # self is (temporarily) a direct reference to tensor, but self.id in
-        # the message also refers to the tensor while we would need to refer
+        # the message also refers to the tensor while we might need to refer
         # to the tensor.grad_fn, that's why trigger_hook_function actually
-        # takes the .grad_fn attribute
+        # checks the .grad_fn attribute
         point_to_attr = self.point_to_attr
         self.point_to_attr = None
         # send a request to set a hook to trigger back the real hook

--- a/test/generic/pointers/test_pointer_tensor.py
+++ b/test/generic/pointers/test_pointer_tensor.py
@@ -399,6 +399,18 @@ def test_remote_function_with_multi_ouput(workers):
     assert argmax_idx.get().item() == 3
 
 
+def test_inplace_binary_method_with_non_pointers(workers):
+    """Under very specific conditions, ie inplace methods containing a
+    single argument which is a Tensor, we allow automatic sending of
+    this tensor. This is helpful to facilitate utilizing python code
+    of other library for remote execution"""
+    alice = workers["alice"]
+    p = th.tensor([1.0, 2]).send(alice)
+    x = th.tensor([1.0, 1])
+    p += x
+    assert (p.get() == th.tensor([2.0, 3])).all()
+
+
 def test_raising_error_when_item_func_called(workers):
     pointer = PointerTensor(id=1000, location=workers["alice"], owner=workers["me"])
     with pytest.raises(RuntimeError):

--- a/test/generic/pointers/test_pointer_tensor.py
+++ b/test/generic/pointers/test_pointer_tensor.py
@@ -630,7 +630,7 @@ def test_register_hook_on_remote_tensor_or_modules(workers):
     flag = []
 
     def hook_function(inputs, outputs):
-        flag.append(True)
+        flag.append(True)  # pragma: no cover
 
     p = th.tensor([1.0, 2], requires_grad=True).send(alice)
     p.register_hook(hook_function)
@@ -644,7 +644,7 @@ def test_register_hook_on_remote_tensor_or_modules(workers):
     flag = []
 
     def hook_function(model, inputs, outputs):
-        flag.append(True)
+        flag.append(True)  # pragma: no cover
 
     x = th.tensor([1.0, 2])
     model = torch.nn.Linear(2, 1)
@@ -654,3 +654,5 @@ def test_register_hook_on_remote_tensor_or_modules(workers):
     assert len(flag) == 0
     loss.backward()
     assert len(flag) == 1
+
+    syft.local_worker.is_client_worker = True

--- a/test/torch/federated/test_dataset.py
+++ b/test/torch/federated/test_dataset.py
@@ -78,6 +78,14 @@ def test_dataset_to_federate(workers):
     assert fed_dataset["bob"].location.id == "bob"
     assert len(fed_dataset) == 6
 
+    fed_dataset = dataset.federate((bob, alice))
+
+    assert isinstance(fed_dataset, sy.FederatedDataset)
+
+    assert fed_dataset.workers == ["bob", "alice"]
+    assert fed_dataset["bob"].location.id == "bob"
+    assert len(fed_dataset) == 6
+
 
 def test_federated_dataset_search(workers):
 

--- a/test/torch/federated/test_dataset.py
+++ b/test/torch/federated/test_dataset.py
@@ -70,7 +70,7 @@ def test_dataset_to_federate(workers):
 
     dataset = BaseDataset(th.tensor([1.0, 2, 3, 4, 5, 6]), th.tensor([1.0, 2, 3, 4, 5, 6]))
 
-    fed_dataset = dataset.federate((bob, alice))
+    fed_dataset = dataset.federate(bob, alice)
 
     assert isinstance(fed_dataset, sy.FederatedDataset)
 


### PR DESCRIPTION
## Description
This provides a mechanism to set hook functions (during pytorch backprop) on remote tensors and models.

This allows to register torch hooks on remote tensors. Such operation
        is tricky because you can't really send the hook function to a remote
        party, as python functions are not serializable within PySyft. So you
        need to keep it attached to the PointerTensor.
        On the other hand, the PointerTensor cannot watch for gradient update
        or be triggered natively by torch when backpropagation happens. That's
        why we actually remotely set a hook that we call a callback hook whose
        function is only to call back the pointer during the backpropagation
        to effectively run the hook function.
        So the workflow is: the remote hook is triggered by pytorch, a message
        is sent back to the pointer owner which has the hook function, then
        the hook function is run remotely on the remote gradient, and a termi-
        nation message is returned to the gradient owner.



## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
