### PR TITLE
Corrected good first issue link in tutorial part 1.

### DIFF
--- a/examples/tutorials/Part 01 - The Basic Tools of Private Deep Learning.ipynb
+++ b/examples/tutorials/Part 01 - The Basic Tools of Private Deep Learning.ipynb
@@ -593,7 +593,7 @@
     "The best way to contribute to our community is to become a code contributor! At any time you can go to PySyft GitHub Issues page and filter for \"Projects\". This will show you all the top level Tickets giving an overview of what projects you can join! If you don't want to join a project, but you would like to do a bit of coding, you can also look for more \"one off\" mini-projects by searching for GitHub issues marked \"good first issue\".\n",
     "\n",
     "- [PySyft Projects](https://github.com/OpenMined/PySyft/issues?q=is%3Aopen+is%3Aissue+label%3AProject)\n",
-    "- [Good First Issue Tickets](https://github.com/OpenMined/PySyft/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)\n",
+    "- [Good First Issue Tickets](https://github.com/OpenMined/PySyft/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+issue+%3Amortar_board%3A%22)\n",
     "\n",
     "### Donate\n",
     "\n",


### PR DESCRIPTION
## Description
At the end of the notebook for part 1 of the tutorial, there is a link which reads "Good first issues". This link doesn't work as it assumes that the label for a good first issue doesn't have a mortar board at the end. I have changed the URL to include the mortar board so that the link now works.

## Affected Dependencies
None

## How has this been tested?
That the current link doesn't work can be tested by clicking it, you will find no issues with that search.
I have tested the link from inside a running notebook and it correctly showed the current good first issues.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
