### PR TITLE
Add get_copy argument in  get()  and related methods.

### DIFF
--- a/syft/generic/pointers/object_pointer.py
+++ b/syft/generic/pointers/object_pointer.py
@@ -225,14 +225,14 @@ class ObjectPointer(AbstractSendable):
             pointer = err.pointer
             return pointer
 
-    def get(self, user=None, reason: str = "", deregister_ptr: bool = True):
+    def get(self, user=None, reason: str = "", deregister_ptr: bool = True, get_copy: bool = False):
         """Requests the object being pointed to.
 
         The object to which the pointer points will be requested, serialized and returned.
 
         Note:
             This will typically mean that the remote object will be
-            removed/destroyed.
+            removed/destroyed. Setting get_copy True doesn't destroy remote.
 
         Args:
             user (obj, optional) : authenticate/allow user to perform get on remote private objects.
@@ -242,12 +242,11 @@ class ObjectPointer(AbstractSendable):
                 method. This defaults to True because the main reason people use
                 this method is to move the tensor from the location to the
                 local one, at which time the pointer has no use.
+            get_copy (bool): Setting get_copy True doesn't destroy remote.
 
         Returns:
             An AbstractObject object which is the tensor (or chain) that this
             object used to point to on a location.
-
-        TODO: add param get_copy which doesn't destroy remote if true.
         """
 
         if self.point_to_attr is not None:
@@ -266,7 +265,7 @@ class ObjectPointer(AbstractSendable):
                 obj = obj.child
         else:
             # get tensor from location
-            obj = self.owner.request_obj(self.id_at_location, self.location, user, reason)
+            obj = self.owner.request_obj(self.id_at_location, self.location, user, reason, get_copy)
 
         # Remove this pointer by default
         if deregister_ptr:

--- a/syft/generic/pointers/pointer_tensor.py
+++ b/syft/generic/pointers/pointer_tensor.py
@@ -363,7 +363,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
         self.owner.send_command(cmd_name="mid_get", target=self, recipient=self.location)
         return self
 
-    def get(self, user=None, reason: str = "", deregister_ptr: bool = True):
+    def get(self, user=None, reason: str = "", deregister_ptr: bool = True, get_copy: bool = False):
         """Requests the tensor/chain being pointed to, be serialized and return
 
         Since PointerTensor objects always point to a remote tensor (or chain
@@ -373,8 +373,7 @@ class PointerTensor(ObjectPointer, AbstractTensor):
 
         Note:
             This will typically mean that the remote object will be
-            removed/destroyed. To just bring a copy back to the local worker,
-            call .copy() before calling .get().
+            removed/destroyed. Setting get_copy True doesn't destroy remote object.
 
 
         Args:
@@ -385,12 +384,15 @@ class PointerTensor(ObjectPointer, AbstractTensor):
                 method. This defaults to True because the main reason people use
                 this method is to move the tensor from the remote machine to the
                 local one, at which time the pointer has no use.
+            get_copy (bool): Setting get_copy True doesn't destroy remote.
 
         Returns:
             An AbstractTensor object which is the tensor (or chain) that this
             object used to point to #on a remote machine.
         """
-        tensor = ObjectPointer.get(self, user=user, reason=reason, deregister_ptr=deregister_ptr)
+        tensor = ObjectPointer.get(
+            self, user=user, reason=reason, deregister_ptr=deregister_ptr, get_copy=get_copy
+        )
 
         # TODO: remove these 3 lines
         # The fact we have to check this means

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -414,7 +414,9 @@ class ObjectRequestMessage(Message):
         """
         obj_id = sy.serde.protobuf.proto.get_protobuf_id(proto_msg.object_id)
         # add worker support when it will be available
-        return ObjectRequestMessage(obj_id=obj_id, user=None, reason=proto_msg.reason)
+        return ObjectRequestMessage(
+            obj_id=obj_id, user=None, reason=proto_msg.reason, get_copy=False
+        )
 
     @staticmethod
     def get_protobuf_schema():

--- a/syft/messaging/message.py
+++ b/syft/messaging/message.py
@@ -331,12 +331,13 @@ class ObjectRequestMessage(Message):
     # TODO: add more efficient detailer and simplifier custom for this type
     # https://github.com/OpenMined/PySyft/issues/2512
 
-    def __init__(self, obj_id, user, reason):
+    def __init__(self, obj_id, user, reason, get_copy):
         """Initialize the message."""
 
         self.object_id = obj_id
         self.user = user
         self.reason = reason
+        self.get_copy = get_copy
 
     def __str__(self):
         """Return a human readable version of this message"""
@@ -359,6 +360,7 @@ class ObjectRequestMessage(Message):
             sy.serde.msgpack.serde._simplify(worker, msg.object_id),
             sy.serde.msgpack.serde._simplify(worker, msg.user),
             sy.serde.msgpack.serde._simplify(worker, msg.reason),
+            sy.serde.msgpack.serde._simplify(worker, msg.get_copy),
         )
 
     @staticmethod
@@ -380,6 +382,7 @@ class ObjectRequestMessage(Message):
             sy.serde.msgpack.serde._detail(worker, msg_tuple[0]),
             sy.serde.msgpack.serde._detail(worker, msg_tuple[1]),
             sy.serde.msgpack.serde._detail(worker, msg_tuple[2]),
+            sy.serde.msgpack.serde._detail(worker, msg_tuple[3]),
         )
 
     @staticmethod

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -589,7 +589,12 @@ class BaseWorker(AbstractWorker):
         return self.send_msg(ObjectMessage(obj), location)
 
     def request_obj(
-        self, obj_id: Union[str, int], location: "BaseWorker", user=None, reason: str = ""
+        self,
+        obj_id: Union[str, int],
+        location: "BaseWorker",
+        user=None,
+        reason: str = "",
+        get_copy: bool = False,
     ) -> object:
         """Returns the requested object from specified location.
 
@@ -599,10 +604,11 @@ class BaseWorker(AbstractWorker):
                 location.
             user (object, optional): user credentials to perform user authentication.
             reason (string, optional): a description of why the data scientist wants to see it.
+            get_copy (bool): Setting get_copy True doesn't destroy remote.
         Returns:
             A torch Tensor or Variable object.
         """
-        obj = self.send_msg(ObjectRequestMessage(obj_id, user, reason), location)
+        obj = self.send_msg(ObjectRequestMessage(obj_id, user, reason, get_copy), location)
         return obj
 
     # SECTION: Manage the workers network

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -206,8 +206,8 @@ class BaseMessageHandler(AbstractMessageHandler):
         elif not get_copy:
             self.object_store.de_register_obj(obj)
             return obj
-        else:
-            return obj
+
+        return obj
 
     def handle_force_delete_object_msg(self, msg: ForceObjectDeleteMessage):
         for object_id in msg.object_ids:

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -196,14 +196,17 @@ class BaseMessageHandler(AbstractMessageHandler):
         obj_id = msg.object_id
         user = msg.user
         reason = msg.reason
+        get_copy = msg.get_copy
 
         obj = self.get_obj(obj_id)
 
         permitted = all(map_chain_call(obj, "allow", user=user))
         if not permitted:
             raise GetNotPermittedError()
-        else:
+        elif not get_copy:
             self.object_store.de_register_obj(obj)
+            return obj
+        else:
             return obj
 
     def handle_force_delete_object_msg(self, msg: ForceObjectDeleteMessage):

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -205,7 +205,6 @@ class BaseMessageHandler(AbstractMessageHandler):
             raise GetNotPermittedError()
         elif not get_copy:
             self.object_store.de_register_obj(obj)
-            return obj
 
         return obj
 

--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -1823,6 +1823,7 @@ def make_objectrequestmessage(**kwargs):
         assert detailed.object_id == original.object_id
         assert detailed.user == original.user
         assert detailed.reason == original.reason
+        assert detailed.get_copy == original.get_copy
         return True
 
     return [
@@ -1834,6 +1835,7 @@ def make_objectrequestmessage(**kwargs):
                     msgpack.serde._simplify(kwargs["workers"]["serde_worker"], obj_req.object_id),
                     msgpack.serde._simplify(kwargs["workers"]["serde_worker"], obj_req.user),
                     msgpack.serde._simplify(kwargs["workers"]["serde_worker"], obj_req.reason),
+                    msgpack.serde._simplify(kwargs["workers"]["serde_worker"], obj_req.get_copy),
                 ),
             ),
             "cmp_detailed": compare,

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -103,7 +103,7 @@ def test_recv_msg():
     # Test 2: get tensor back from alice
 
     # Create message: Get tensor from alice
-    message = ObjectRequestMessage(obj.id, None, "")
+    message = ObjectRequestMessage(obj.id, None, "", False)
 
     # serialize message
     bin_msg = serde.serialize(message)


### PR DESCRIPTION
## Description
Add get_copy argument in ` get ` and related methods for getting objects without removing the remote object.
This was a todo listed in get() method (https://github.com/OpenMined/PySyft/blob/1ead29ce04d6ced3e08c3bd2c48c66851ffa50cf/syft/generic/pointers/object_pointer.py#L249)

This will enable persisting remote tensors and PySyft objects.

This is required in SyferText to host permanent Pipelines and SyferText objects on Pygrid Nodes



## Affected Dependencies
None

## How has this been tested?
No tests added

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
