### PR TITLE
Added value of epochs in the tutorial

### DIFF
--- a/examples/tutorials/advanced/split_neural_network/Tutorial 1 - SplitNN Introduction.ipynb
+++ b/examples/tutorials/advanced/split_neural_network/Tutorial 1 - SplitNN Introduction.ipynb
@@ -222,6 +222,7 @@
     }
    ],
    "source": [
+    "epochs = 14\n",
     "for i in range(epochs):\n",
     "    running_loss = 0\n",
     "    for images, labels in trainloader:\n",


### PR DESCRIPTION
## Description
While running the tutorial, an error I received was that the value of epochs was missing. Hence I added the value of epochs based on the sample output.

## Affected Dependencies
None

## How has this been tested?
- The final output of the code is as given in the earlier sample output.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- x ] My changes are covered by tests
