### PR TITLE
Add bit injection

### DIFF
--- a/syft/frameworks/torch/mpc/aby3/aby3_helper.py
+++ b/syft/frameworks/torch/mpc/aby3/aby3_helper.py
@@ -1,0 +1,50 @@
+import torch
+
+from syft.frameworks.torch.tensors.interpreters.replicated_shared import ReplicatedSharingTensor
+from syft.frameworks.torch.mpc.falcon.falcon_helper import FalconHelper
+
+class ABY3Helper:
+    def bit_inject(rst_binary):
+        assert rst_binary.ring_size == 2
+
+        return_wrapper = rst_binary.is_wrapper
+        if return_wrapper:
+            rst_binary = rst_binary.child
+
+        players = rst_binary.players
+        shares_p0, shares_p1, shares_p2 = rst_binary.retrieve_pointers()
+
+        """
+            x shared in ring size 2
+            x_b = (x_b_0, x_b_1, x_b_2)
+
+            Share the shares in ring size L
+            Resharig the binary shares in arithmetic ones should have no communication cost
+            but because we use an orchestrator there is added the communication overhead
+
+            Step 1: x1_shares = ((x_b_0, 0), (0, 0), (0, x_b_0))
+            Step 2: x2_shares = ((0, x_b_1), (x_b_1, 0), (0, 0))
+            Step 3: x3_shares = ((0, 0), (0, x_b_2), (x_b_2, 0))
+
+            For emulating a xor on arithmetic shares:
+                * [[v1 xor v2]] = [[v1]] + [[v2]] - 2 * [[v1]] * [[v2]]
+
+            (x0_shares xor x1_shares xor x2_shares) == x_b (ring size L)
+        """
+
+        # Step 1
+        rst1 = FalconHelper.binary_to_arithmetic((shares_p0[0], shares_p2[1]), players)
+
+        # Step 2
+        rst2 = FalconHelper.binary_to_arithmetic((shares_p1[0], shares_p0[1]), players)
+
+        # Step 3
+        rst3 = FalconHelper.binary_to_arithmetic((shares_p2[0], shares_p1[1]), players)
+
+        tmp = FalconHelper.xor(rst1, rst2)
+        res = FalconHelper.xor(tmp, rst3)
+
+        if return_wrapper:
+            return res.wrap()
+
+        return res

--- a/syft/frameworks/torch/mpc/aby3/aby3_helper.py
+++ b/syft/frameworks/torch/mpc/aby3/aby3_helper.py
@@ -1,6 +1,3 @@
-import torch
-
-from syft.frameworks.torch.tensors.interpreters.replicated_shared import ReplicatedSharingTensor
 from syft.frameworks.torch.mpc.falcon.falcon_helper import FalconHelper
 
 

--- a/syft/frameworks/torch/mpc/aby3/aby3_helper.py
+++ b/syft/frameworks/torch/mpc/aby3/aby3_helper.py
@@ -3,6 +3,7 @@ import torch
 from syft.frameworks.torch.tensors.interpreters.replicated_shared import ReplicatedSharingTensor
 from syft.frameworks.torch.mpc.falcon.falcon_helper import FalconHelper
 
+
 class ABY3Helper:
     def bit_inject(rst_binary):
         assert rst_binary.ring_size == 2
@@ -19,7 +20,7 @@ class ABY3Helper:
             x_b = (x_b_0, x_b_1, x_b_2)
 
             Share the shares in ring size L
-            Resharig the binary shares in arithmetic ones should have no communication cost
+            Resharing the binary shares in arithmetic ones should have no communication cost
             but because we use an orchestrator there is added the communication overhead
 
             Step 1: x1_shares = ((x_b_0, 0), (0, 0), (0, x_b_0))

--- a/syft/frameworks/torch/mpc/aby3/aby3_helper.py
+++ b/syft/frameworks/torch/mpc/aby3/aby3_helper.py
@@ -34,13 +34,13 @@ class ABY3Helper:
         """
 
         # Step 1
-        rst1 = FalconHelper.binary_to_arithmetic((shares_p0[0], shares_p2[1]), players)
+        rst1 = FalconHelper.convert_b2a((shares_p0[0], shares_p2[1]), players)
 
         # Step 2
-        rst2 = FalconHelper.binary_to_arithmetic((shares_p1[0], shares_p0[1]), players)
+        rst2 = FalconHelper.convert_b2a((shares_p1[0], shares_p0[1]), players)
 
         # Step 3
-        rst3 = FalconHelper.binary_to_arithmetic((shares_p2[0], shares_p1[1]), players)
+        rst3 = FalconHelper.convert_b2a((shares_p2[0], shares_p1[1]), players)
 
         tmp = FalconHelper.xor(rst1, rst2)
         res = FalconHelper.xor(tmp, rst3)

--- a/syft/frameworks/torch/mpc/falcon/falcon_helper.py
+++ b/syft/frameworks/torch/mpc/falcon/falcon_helper.py
@@ -1,7 +1,6 @@
 import torch
 import syft
 
-from syft.generic.abstract.tensor import AbstractTensor
 from syft.workers.abstract import AbstractWorker
 from syft.generic.pointers.pointer_tensor import PointerTensor
 from syft.frameworks.torch.tensors.interpreters.replicated_shared import ReplicatedSharingTensor

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -84,13 +84,13 @@ def _get_random_tensor(name_generator, shape, worker_id, ring_size=RING_SIZE):
     return rand_elem
 
 
-def gen_alpha_3of3(worker, ring_size=RING_SIZE):
+def gen_alpha_3of3(worker, shape=(1,), ring_size=RING_SIZE):
     if worker == syft.local_worker:
         func = _generate_alpha_3of3
     else:
         func = remote(_generate_alpha_3of3, location=worker)
 
-    return func(worker.id, ring_size)
+    return func(worker.id, shape=shape, ring_size=ring_size)
 
 
 def gen_alpha_2of3(worker, ring_size=RING_SIZE):
@@ -103,7 +103,7 @@ def gen_alpha_2of3(worker, ring_size=RING_SIZE):
 
 
 @allow_command
-def _generate_alpha_3of3(worker_id, ring_size=RING_SIZE):
+def _generate_alpha_3of3(worker_id, shape=(1,), ring_size=RING_SIZE):
     """
     Generate a random number (alpha) using the two generators
     * generator cur - represents a generator initialized with this worker (i) seed
@@ -119,7 +119,7 @@ def _generate_alpha_3of3(worker_id, ring_size=RING_SIZE):
     cur_gen = generators["cur"]
     prev_gen = generators["prev"]
 
-    alpha = __get_next_elem(cur_gen, ring_size) - __get_next_elem(prev_gen, ring_size)
+    alpha = __get_next_elem(cur_gen, shape, ring_size) - __get_next_elem(prev_gen, shape, ring_size)
     return alpha
 
 
@@ -148,7 +148,7 @@ def _generate_alpha_2of3(worker_id, ring_size=RING_SIZE):
     return torch.tensor([alpha_cur.item(), alpha_prev.item()])
 
 
-def __get_next_elem(generator, ring_size=RING_SIZE, shape=(1,)):
+def __get_next_elem(generator, shape=(1,), ring_size=RING_SIZE):
     tensor = torch.empty(shape, dtype=torch.long)
     return tensor.random_(0, ring_size, generator=generator)
 

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -93,13 +93,13 @@ def gen_alpha_3of3(worker, shape=(1,), ring_size=RING_SIZE):
     return func(worker.id, shape=shape, ring_size=ring_size)
 
 
-def gen_alpha_2of3(worker, ring_size=RING_SIZE):
+def gen_alpha_2of3(worker, shape=(1,), ring_size=RING_SIZE):
     if worker == syft.local_worker:
         func = _generate_alpha_2of3
     else:
         func = remote(_generate_alpha_2of3, location=worker)
 
-    return func(worker.id, ring_size)
+    return func(worker.id, shape=shape, ring_size=ring_size)
 
 
 @allow_command
@@ -124,7 +124,7 @@ def _generate_alpha_3of3(worker_id, shape=(1,), ring_size=RING_SIZE):
 
 
 @allow_command
-def _generate_alpha_2of3(worker_id, ring_size=RING_SIZE):
+def _generate_alpha_2of3(worker_id, shape=(1,), ring_size=RING_SIZE):
     """
     Generate 2 random numbers (alpha_i, alpha_i-1) using the two generators
     * generator cur - represents a generator initialized with this worker (i) seed
@@ -142,8 +142,8 @@ def _generate_alpha_2of3(worker_id, ring_size=RING_SIZE):
     prev_gen = generators["prev"]
 
     alpha_cur, alpha_prev = (
-        __get_next_elem(cur_gen, ring_size),
-        __get_next_elem(prev_gen, ring_size),
+        __get_next_elem(cur_gen, shape=shape, ring_size=ring_size),
+        __get_next_elem(prev_gen, shape=shape, ring_size=ring_size),
     )
     return torch.tensor([alpha_cur.item(), alpha_prev.item()])
 

--- a/test/torch/mpc/aby3/test_aby3_helper.py
+++ b/test/torch/mpc/aby3/test_aby3_helper.py
@@ -5,7 +5,7 @@ from syft.frameworks.torch.mpc.aby3.aby3_helper import ABY3Helper
 
 def test_bit_inject(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
-    plain_text = torch.tensor([0, 1])
+    plain_text = torch.tensor([0, 1, 0, 1])
     secret = plain_text.share(bob, alice, james, protocol="falcon", field=2)
 
     new_secret = ABY3Helper.bit_inject(secret)

--- a/test/torch/mpc/aby3/test_aby3_helper.py
+++ b/test/torch/mpc/aby3/test_aby3_helper.py
@@ -1,0 +1,13 @@
+import torch
+
+from syft.frameworks.torch.mpc.aby3.aby3_helper import ABY3Helper
+
+
+def test_bit_inject(workers):
+    bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
+    plain_text = torch.tensor([0, 1])
+    secret = plain_text.share(bob, alice, james, protocol="falcon", field=2)
+
+    new_secret = ABY3Helper.bit_inject(secret)
+
+    assert (new_secret.reconstruct() == plain_text).all()

--- a/test/torch/mpc/falcon/test_falcon_helper.py
+++ b/test/torch/mpc/falcon/test_falcon_helper.py
@@ -97,7 +97,7 @@ def test_determine_sign(beta, workers):
     assert (expected_plaintext == plaintext).all()
 
 
-def test_rst_wrapper(workers):
+def test_xor_rst_wrapper(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     workers = [bob, alice, james]
     x = torch.tensor([0, 1, 2])
@@ -109,7 +109,7 @@ def test_rst_wrapper(workers):
     assert FalconHelper.xor(rst_wrapper, other_wrapper).is_wrapper
 
 
-def test_rst_no_wrap(workers):
+def test_xor_rst_no_wrap(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
     workers = [bob, alice, james]
     x = torch.tensor([0, 1, 2])


### PR DESCRIPTION
## Description
Added the bit injection for changing a share from ring_size 2 (binary) to an arithmetic share.
Followed the explanations from [here](https://eprint.iacr.org/2018/403.pdf).

Currently, we have a higher communication cost because we use another party that orchestrates all the communication between the parties.

Another idea (will be more readable, but in a real-life scenario will require more communication cost), is to make the remote workers reshare their binary shares and do the same computation -- this will also require adding serialization for the RST (a good next step might be this)

Fixes #4590 - this is for the **Malicious Setup**. Will start working on the Semi-Honest one - That one requires an **Oblivious Transfer Component** to it

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
