### PR TITLE
Reference count on the store that keeps the obj

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -407,7 +407,7 @@ or in case you are lazy! you can use  `Github for Desktop. <https://desktop.gith
 Step 2 - Install Microsoft Build tools
 --------------------------------------
 
-Go to the `Download page <https://visualstudio.microsoft.com/downloads/>`_ and click on `Free download` under **Community** in the Visual Studio download section. 
+Go to the `Download page <https://visualstudio.microsoft.com/downloads/>`_ and click on `Free download` under **Community** in the Visual Studio download section.
 
 After the download is finished, run the downloaded package. In the installation window select `Desktop development with C++` and click on `Install` at the bottom-right corner of the page. (In the above screenshot you see a `Close` button instead since I have already installed it.)
 
@@ -547,7 +547,7 @@ it by installing the latest version.
 .. code:: console
 
     pip install torch -U
-    
+
 or else you can get the installation command from `here. <https://pytorch.org/get-started/locally/>`_ (use the pip option)
 
 Step 7 - Install PySyft
@@ -567,7 +567,7 @@ If you don't want this fanciness you can also run the good ole fashioned setup.p
 .. code:: python
 
     python setup.py install
-    
+
 Step 6 - Run Light Tests
 ------------------------
 

--- a/src/syft/core/node/common/action/save_object_action.py
+++ b/src/syft/core/node/common/action/save_object_action.py
@@ -37,7 +37,7 @@ class SaveObjectAction(ImmediateActionWithoutReply, Serializable):
 
     def execute_action(self, node: AbstractNode, verify_key: VerifyKey) -> None:
         # save the object to the store
-        obj=StorableObject(
+        obj = StorableObject(
             # ignoring this - the fundamental problem is that we can't force the classes
             # we want to use to subclass from something without creating wrappers for
             # everything which are mandatory for all operations. It's plausible that we
@@ -57,9 +57,7 @@ class SaveObjectAction(ImmediateActionWithoutReply, Serializable):
                 if hasattr(self.obj, "description")
                 else ""
             ),
-            search_permissions={All(): None}
-            if self.anyone_can_search_for_this
-            else {},
+            search_permissions={All(): None} if self.anyone_can_search_for_this else {},
             read_permissions={
                 node.verify_key: node.id,
                 verify_key: None,  # we dont have the passed in sender's UID

--- a/src/syft/core/node/common/action/save_object_action.py
+++ b/src/syft/core/node/common/action/save_object_action.py
@@ -37,36 +37,36 @@ class SaveObjectAction(ImmediateActionWithoutReply, Serializable):
 
     def execute_action(self, node: AbstractNode, verify_key: VerifyKey) -> None:
         # save the object to the store
-        node.store.store(
-            obj=StorableObject(
-                # ignoring this - the fundamental problem is that we can't force the classes
-                # we want to use to subclass from something without creating wrappers for
-                # everything which are mandatory for all operations. It's plausible that we
-                # will have to do this - but for now we aren't so we need to simply assume
-                # that we're adding ids to things. I don't like it though - wish there was a
-                # better way. But we want to support other frameworks so - gotta do it.
-                id=self.obj.id,  # type: ignore
-                data=self.obj,
-                tags=(
-                    # QUESTION: do we want None or an empty []
-                    self.obj.tags  # type: ignore
-                    if hasattr(self.obj, "tags")
-                    else None
-                ),
-                description=(
-                    self.obj.description  # type: ignore
-                    if hasattr(self.obj, "description")
-                    else ""
-                ),
-                search_permissions={All(): None}
-                if self.anyone_can_search_for_this
-                else {},
-                read_permissions={
-                    node.verify_key: node.id,
-                    verify_key: None,  # we dont have the passed in sender's UID
-                },
-            )
+        obj=StorableObject(
+            # ignoring this - the fundamental problem is that we can't force the classes
+            # we want to use to subclass from something without creating wrappers for
+            # everything which are mandatory for all operations. It's plausible that we
+            # will have to do this - but for now we aren't so we need to simply assume
+            # that we're adding ids to things. I don't like it though - wish there was a
+            # better way. But we want to support other frameworks so - gotta do it.
+            id=self.obj.id,  # type: ignore
+            data=self.obj,
+            tags=(
+                # QUESTION: do we want None or an empty []
+                self.obj.tags  # type: ignore
+                if hasattr(self.obj, "tags")
+                else None
+            ),
+            description=(
+                self.obj.description  # type: ignore
+                if hasattr(self.obj, "description")
+                else ""
+            ),
+            search_permissions={All(): None}
+            if self.anyone_can_search_for_this
+            else {},
+            read_permissions={
+                node.verify_key: node.id,
+                verify_key: None,  # we dont have the passed in sender's UID
+            },
         )
+
+        node.store.store(obj=obj)
 
     @syft_decorator(typechecking=True)
     def _object2proto(self) -> SaveObjectAction_PB:

--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -321,7 +321,7 @@ class Pointer(AbstractPointer):
 
     def __del__(self) -> None:
         _client_type = type(self.client)
-        if (_client_type == Address) or issubclass(_client_type, AbstractNode):
+        if _client_type == Address or issubclass(_client_type, AbstractNode):
             # it is a serialized pointer that we receive from another client do nothing
             return
 

--- a/src/syft/core/store/store_memory.py
+++ b/src/syft/core/store/store_memory.py
@@ -1,12 +1,14 @@
 # stdlib
+from collections import defaultdict
+import threading
+from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import KeysView
 from typing import Set
+from typing import Tuple
 from typing import Union
 from typing import ValuesView
-
-import threading
-from collections import defaultdict
 
 # third party
 from google.protobuf.reflection import GeneratedProtocolMessageType
@@ -16,6 +18,14 @@ from . import ObjectStore
 from ...decorators import syft_decorator
 from ..common.storeable_object import AbstractStorableObject
 from ..common.uid import UID
+
+
+def atomic_op(func: Callable) -> Callable:
+    def wrapper(mem_store: Any, *args: Tuple[Any], **kwargs: Dict[Any, Any]) -> Any:
+        with mem_store._lock:
+            return func(*args, **kwargs)
+
+    return wrapper
 
 
 class MemoryStore(ObjectStore):
@@ -35,36 +45,40 @@ class MemoryStore(ObjectStore):
         self._objects: Dict[UID, AbstractStorableObject] = {}
         self._reference_count: Dict[UID, int] = defaultdict(lambda: 0)
         self._search_engine = None
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self.post_init()
 
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def get_object(self, id: UID) -> Union[AbstractStorableObject, None]:
         return self._objects.get(id, None)
 
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def get_objects_of_type(self, obj_type: type) -> Set[AbstractStorableObject]:
         return {obj for obj in self.values() if isinstance(obj.data, obj_type)}
 
-    @syft_decorator(typechecking=True)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def __sizeof__(self) -> int:
         return self._objects.__sizeof__()
 
-    @syft_decorator(typechecking=True)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def __str__(self) -> str:
-        return str(self._objects)
+        with self._lock:
+            return str(self._objects)
 
-    @syft_decorator(typechecking=True)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def __len__(self) -> int:
-        return len(self._objects)
+        with self._lock:
+            return len(self._objects)
 
-    @syft_decorator(typechecking=True)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def keys(self) -> KeysView[UID]:
         return self._objects.keys()
 
-    @syft_decorator(typechecking=True)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def values(self) -> ValuesView[AbstractStorableObject]:
         return self._objects.values()
 
-    @syft_decorator(typechecking=True)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def store(self, obj: AbstractStorableObject) -> None:
         # TODO: obj should be just "object" and the attributes
         #  of StoreableObject should be put in the metadatastore
@@ -72,31 +86,39 @@ class MemoryStore(ObjectStore):
             self._reference_count[obj.id] += 1
             self._objects[obj.id] = obj
 
-    @syft_decorator(typechecking=True, prohibit_args=False)
+    @syft_decorator(
+        typechecking=True, prohibit_args=False, other_decorators=[atomic_op]
+    )
     def __contains__(self, key: UID) -> bool:
         return key in self._objects.keys()
 
-    @syft_decorator(typechecking=True, prohibit_args=False)
+    @syft_decorator(
+        typechecking=True, prohibit_args=False, other_decorators=[atomic_op]
+    )
     def __getitem__(self, key: UID) -> AbstractStorableObject:
         return self._objects[key]
 
-    @syft_decorator(typechecking=True, prohibit_args=False)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def __setitem__(self, key: UID, value: AbstractStorableObject) -> None:
         self._objects[key] = value
 
-    @syft_decorator(typechecking=True, prohibit_args=False)
+    @syft_decorator(
+        typechecking=True, prohibit_args=False, other_decorators=[atomic_op]
+    )
     def __delitem__(self, key: UID) -> None:
-        with self._lock:
-            self._reference_count[key] -= 1
-            assert self._reference_count[key] >= 0, f"Reference count reached a negative value for {key}"
+        self._reference_count[key] -= 1
+        assert (
+            self._reference_count[key] >= 0
+        ), f"Reference count reached a negative value for {key}"
 
-            if self._reference_count[key] == 0:
-                del self._objects[key]
-                del self._reference_count[key]
+        if self._reference_count[key] == 0:
+            del self._objects[key]
+            del self._reference_count[key]
 
-    @syft_decorator(typechecking=True)
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def clear(self) -> None:
         self._objects.clear()
+        self._reference_count.clear()
 
     def _object2proto(self) -> GeneratedProtocolMessageType:
         pass
@@ -105,5 +127,6 @@ class MemoryStore(ObjectStore):
     def _proto2object(proto: GeneratedProtocolMessageType) -> "MemoryStore":
         pass
 
+    @syft_decorator(typechecking=True, other_decorators=[atomic_op])
     def __repr__(self) -> str:
         return self._objects.__repr__()

--- a/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
+++ b/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
@@ -20,11 +20,8 @@ def test_torch_remote_tensor_register() -> None:
 
     assert len(alice.store) == 1
 
-    # TODO: Fix this from deleting the object in the store due to the variable
-    # ptr being assigned a second time and triggering __del__ on the old variable
-    # ptr used to be assigned to (Even though its new assignment is the same object)
-    # ptr = x.send(alice_client)
-    # assert len(alice.store) == 1  # Same id
+    ptr = x.send(alice_client)
+    assert len(alice.store) == 1  # Same id
 
     ptr.get()
     assert len(alice.store) == 0  # Get removes the object


### PR DESCRIPTION
## Description
Add a reference count on the store side where we are keeping the objects.
In case 2 have 2 clients and they both refer to the same object, deleting a pointer should not delete the object on the server.

## How has this been tested?
- Re-enabled a test where the ```GarbageCollectObjectAction``` arrived after creating a new object (with the same object).
  - if the GarbageCollectObjectAction arrives before doing ```ptr = x.send(alice)``` then we delete the object from the server and we recreate it when we send it
  - if the GarbageCollectObjectAction arrives after doing ```ptr=x.send(alice0``` then we have 2 reference counts on the same object (even if they are held by the same client) then comes the message and only decrements the reference count.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
