### PR TITLE
changed all asset to if/raise to prevent disable of assert during PYTHONOPTIMISE env

### DIFF
--- a/syft/execution/action.py
+++ b/syft/execution/action.py
@@ -110,11 +110,7 @@ class Action(ABC, SyftSerializable):
 
     def _type_check(self, field_name, expected_type):
         actual_value = getattr(self, field_name)
-        # assert actual_value is None or isinstance(actual_value, expected_type), (
-        #     f"{field_name} must be {expected_type.__name__}, but was "
-        #     f"{type(actual_value).__name__}: {actual_value}."
-        # )
-        if actual_value is not None and not isinstance(actual_value, expected_type):
+        if not (actual_value is None or isinstance(actual_value, expected_type)):
             raise ValueError(
                 f"{field_name} must be {expected_type.__name__}, but was "
                 f"{type(actual_value).__name__}: {actual_value}."

--- a/syft/execution/action.py
+++ b/syft/execution/action.py
@@ -110,10 +110,15 @@ class Action(ABC, SyftSerializable):
 
     def _type_check(self, field_name, expected_type):
         actual_value = getattr(self, field_name)
-        assert actual_value is None or isinstance(actual_value, expected_type), (
-            f"{field_name} must be {expected_type.__name__}, but was "
-            f"{type(actual_value).__name__}: {actual_value}."
-        )
+        # assert actual_value is None or isinstance(actual_value, expected_type), (
+        #     f"{field_name} must be {expected_type.__name__}, but was "
+        #     f"{type(actual_value).__name__}: {actual_value}."
+        # )
+        if actual_value is not None or not isinstance(actual_value, expected_type):
+            raise ValueError(
+                f"{field_name} must be {expected_type.__name__}, but was "
+                f"{type(actual_value).__name__}: {actual_value}."
+            )
 
     # These methods must be implemented by child classes in order to return the correct type
     # and to be detected by the serdes as serializable. They are therefore marked as abstract

--- a/syft/execution/action.py
+++ b/syft/execution/action.py
@@ -114,7 +114,7 @@ class Action(ABC, SyftSerializable):
         #     f"{field_name} must be {expected_type.__name__}, but was "
         #     f"{type(actual_value).__name__}: {actual_value}."
         # )
-        if actual_value is not None or not isinstance(actual_value, expected_type):
+        if actual_value is not None and not isinstance(actual_value, expected_type):
             raise ValueError(
                 f"{field_name} must be {expected_type.__name__}, but was "
                 f"{type(actual_value).__name__}: {actual_value}."

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -64,7 +64,11 @@ def load(tag: str, src: int, **kwargs):
         results = worker.search(tag)
 
         # Make sure there is only one result
-        assert len(results) == 1
+        if len(results) != 1:
+            if len(results) == 0:
+                raise RuntimeError("No worker result found.")
+            else:
+                raise RuntimeError("More than one worker result found.")
 
         result = crypten.load_from_party(preloaded=results[0], src=src, **kwargs)
 
@@ -86,7 +90,12 @@ def load_model(tag: str):
     results = worker.search(tag)
 
     # Make sure there is only one result
-    assert len(results) == 1
+    # assert len(results) == 1
+    if len(results) != 1:
+        if len(results) == 0:
+            raise RuntimeError("No worker result found.")
+        else:
+            raise RuntimeError("More than one worker result found.")
 
     result = results[0].to_crypten()
     return result

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -64,7 +64,6 @@ def load(tag: str, src: int, **kwargs):
         results = worker.search(tag)
 
         # Make sure there is only one result
-        # assert len(results) == 1
         if len(results) != 1:
             raise RuntimeError(
                 f"Error: {len(results)} worker result found. There should be only 1."
@@ -90,7 +89,6 @@ def load_model(tag: str):
     results = worker.search(tag)
 
     # Make sure there is only one result
-    # assert len(results) == 1
     if len(results) != 1:
         raise RuntimeError(f"Error: {len(results)} worker result found. There should be only 1.")
 

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -64,11 +64,9 @@ def load(tag: str, src: int, **kwargs):
         results = worker.search(tag)
 
         # Make sure there is only one result
+        # assert len(results) == 1
         if len(results) != 1:
-            if len(results) == 0:
-                raise RuntimeError("No worker result found.")
-            else:
-                raise RuntimeError("More than one worker result found.")
+            raise RuntimeError("Either None OR More than One worker result found.")
 
         result = crypten.load_from_party(preloaded=results[0], src=src, **kwargs)
 
@@ -92,10 +90,7 @@ def load_model(tag: str):
     # Make sure there is only one result
     # assert len(results) == 1
     if len(results) != 1:
-        if len(results) == 0:
-            raise RuntimeError("No worker result found.")
-        else:
-            raise RuntimeError("More than one worker result found.")
+        raise RuntimeError("Either None OR More than One worker result found.")
 
     result = results[0].to_crypten()
     return result

--- a/syft/frameworks/crypten/__init__.py
+++ b/syft/frameworks/crypten/__init__.py
@@ -66,7 +66,9 @@ def load(tag: str, src: int, **kwargs):
         # Make sure there is only one result
         # assert len(results) == 1
         if len(results) != 1:
-            raise RuntimeError("Either None OR More than One worker result found.")
+            raise RuntimeError(
+                f"Error: {len(results)} worker result found. There should be only 1."
+            )
 
         result = crypten.load_from_party(preloaded=results[0], src=src, **kwargs)
 
@@ -90,7 +92,7 @@ def load_model(tag: str):
     # Make sure there is only one result
     # assert len(results) == 1
     if len(results) != 1:
-        raise RuntimeError("Either None OR More than One worker result found.")
+        raise RuntimeError(f"Error: {len(results)} worker result found. There should be only 1.")
 
     result = results[0].to_crypten()
     return result

--- a/syft/frameworks/crypten/message_handler.py
+++ b/syft/frameworks/crypten/message_handler.py
@@ -44,14 +44,12 @@ class CryptenMessageHandler(AbstractMessageHandler):
 
         # TODO Change this, we need a way to handle multiple plan definitions
         plans = self.worker.search("crypten_plan")
-        # assert len(plans) == 1
         if len(plans) != 1:
             raise ValueError(f"Error: {len(plans)} plans found. There should be only 1.")
 
         plan = plans[0].get()
 
         rank = self._current_rank(rank_to_worker_id)
-        # assert rank is not None
         if rank is None:
             raise ValueError("Current rank can't be None")
 
@@ -91,7 +89,6 @@ class CryptenMessageHandler(AbstractMessageHandler):
         jail_runner = JailRunner.detail(ser_func, model=crypten_model)
 
         rank = self._current_rank(rank_to_worker_id)
-        # assert rank is not None
         if rank is None:
             raise ValueError("Current rank can't be None")
 

--- a/syft/frameworks/crypten/message_handler.py
+++ b/syft/frameworks/crypten/message_handler.py
@@ -44,12 +44,16 @@ class CryptenMessageHandler(AbstractMessageHandler):
 
         # TODO Change this, we need a way to handle multiple plan definitions
         plans = self.worker.search("crypten_plan")
-        assert len(plans) == 1
+        # assert len(plans) == 1
+        if len(plans) != 1:
+            raise ValueError("More than one plans found. Currently not supported.")
 
         plan = plans[0].get()
 
         rank = self._current_rank(rank_to_worker_id)
-        assert rank is not None
+        # assert rank is not None
+        if rank is None:
+            raise ValueError("Current rank can't be None")
 
         if crypten_model:
             args = (crypten_model,)
@@ -87,7 +91,9 @@ class CryptenMessageHandler(AbstractMessageHandler):
         jail_runner = JailRunner.detail(ser_func, model=crypten_model)
 
         rank = self._current_rank(rank_to_worker_id)
-        assert rank is not None
+        # assert rank is not None
+        if rank is None:
+            raise ValueError("Current rank can't be None")
 
         return_value = run_party(
             cid, jail_runner, rank, world_size, master_addr, master_port, (), {}

--- a/syft/frameworks/crypten/message_handler.py
+++ b/syft/frameworks/crypten/message_handler.py
@@ -46,7 +46,7 @@ class CryptenMessageHandler(AbstractMessageHandler):
         plans = self.worker.search("crypten_plan")
         # assert len(plans) == 1
         if len(plans) != 1:
-            raise ValueError("More than one plans found. Currently not supported.")
+            raise ValueError(f"Error: {len(plans)} plans found. There should be only 1.")
 
         plan = plans[0].get()
 

--- a/syft/frameworks/torch/dp/pate.py
+++ b/syft/frameworks/torch/dp/pate.py
@@ -228,7 +228,6 @@ def perform_analysis(
     labels = set(teacher_preds.flatten())
     num_labels = len(labels)
 
-    # assert num_examples == _num_examples
     if num_examples != _num_examples:
         raise ValueError("Check the shape of teacher_preds & indices.")
 
@@ -474,7 +473,6 @@ def perform_analysis_torch(
     _num_examples = indices.shape[0]
 
     # Check that preds is shape (teachers x examples)
-    # assert num_examples == _num_examples
     if num_examples != _num_examples:
         raise ValueError("Check the shape of preds & indices.")
 

--- a/syft/frameworks/torch/dp/pate.py
+++ b/syft/frameworks/torch/dp/pate.py
@@ -228,7 +228,9 @@ def perform_analysis(
     labels = set(teacher_preds.flatten())
     num_labels = len(labels)
 
-    assert num_examples == _num_examples
+    # assert num_examples == _num_examples
+    if num_examples != _num_examples:
+        raise ValueError("Check the shape of teacher_preds & indices.")
 
     counts_mat = np.zeros((num_examples, num_labels))
 
@@ -472,7 +474,9 @@ def perform_analysis_torch(
     _num_examples = indices.shape[0]
 
     # Check that preds is shape (teachers x examples)
-    assert num_examples == _num_examples
+    # assert num_examples == _num_examples
+    if num_examples != _num_examples:
+        raise ValueError("Check the shape of preds & indices.")
 
     labels = list(preds.flatten())
     labels = {tensor.item() for tensor in labels}

--- a/syft/frameworks/torch/he/fv/context.py
+++ b/syft/frameworks/torch/he/fv/context.py
@@ -51,7 +51,9 @@ class Context:
         next_parms.set_coeff_modulus(next_coeff_modulus)
         next_param_id = next_parms.param_id
 
-        assert next_param_id != prev_parms_id
+        # assert next_param_id != prev_parms_id
+        if next_param_id == prev_parms_id:
+            raise ValueError("next param can't be same as prev param")
 
         next_context_data = ContextData(next_parms)
         self.context_data_map[next_param_id] = next_context_data

--- a/syft/frameworks/torch/he/fv/context.py
+++ b/syft/frameworks/torch/he/fv/context.py
@@ -51,7 +51,6 @@ class Context:
         next_parms.set_coeff_modulus(next_coeff_modulus)
         next_param_id = next_parms.param_id
 
-        # assert next_param_id != prev_parms_id
         if next_param_id == prev_parms_id:
             raise ValueError("next param can't be same as prev param")
 

--- a/syft/frameworks/torch/linalg/operations.py
+++ b/syft/frameworks/torch/linalg/operations.py
@@ -115,7 +115,9 @@ def qr(t, mode="reduced", norm_factor=None):  # noqa: C901
         )
 
     # Check if t is 2-dim
-    assert len(t.shape) == 2
+    # assert len(t.shape) == 2
+    if len(t.shape) != 2:
+        raise ValueError("t isn't 2-dimensional")
 
     if mode not in ["reduced", "complete", "r"]:
         raise ValueError(

--- a/syft/frameworks/torch/linalg/operations.py
+++ b/syft/frameworks/torch/linalg/operations.py
@@ -115,7 +115,6 @@ def qr(t, mode="reduced", norm_factor=None):  # noqa: C901
         )
 
     # Check if t is 2-dim
-    # assert len(t.shape) == 2
     if len(t.shape) != 2:
         raise ValueError("t isn't 2-dimensional")
 

--- a/syft/frameworks/torch/mpc/falcon/falcon_helper.py
+++ b/syft/frameworks/torch/mpc/falcon/falcon_helper.py
@@ -46,17 +46,6 @@ class FalconHelper:
         if torch.is_tensor(other) and other.is_wrapper:
             other = other.child
 
-        # assert (
-        #     isinstance(value, ReplicatedSharingTensor) and value.ring_size == 2
-        # ), "First argument should be a RST with ring size 2"
-        # assert any(
-        #     [
-        #         isinstance(other, ReplicatedSharingTensor) and other.ring_size == 2,
-        #         isinstance(other, int) and other in {0, 1},
-        #         isinstance(other, torch.LongTensor) and ((other == 0) + (other == 1)).all(),
-        #     ]
-        # ), "Second argument should be RST
-        # (with ring size of 2)/Integer/LongTensor values in {0, 1}"
         if (not isinstance(value, ReplicatedSharingTensor)) or (value.ring_size != 2):
             raise TypeError("First argument should be a RST with ring size 2")
 

--- a/syft/frameworks/torch/mpc/falcon/falcon_helper.py
+++ b/syft/frameworks/torch/mpc/falcon/falcon_helper.py
@@ -46,16 +46,31 @@ class FalconHelper:
         if torch.is_tensor(other) and other.is_wrapper:
             other = other.child
 
-        assert (
-            isinstance(value, ReplicatedSharingTensor) and value.ring_size == 2
-        ), "First argument should be a RST with ring size 2"
-        assert any(
+        # assert (
+        #     isinstance(value, ReplicatedSharingTensor) and value.ring_size == 2
+        # ), "First argument should be a RST with ring size 2"
+        # assert any(
+        #     [
+        #         isinstance(other, ReplicatedSharingTensor) and other.ring_size == 2,
+        #         isinstance(other, int) and other in {0, 1},
+        #         isinstance(other, torch.LongTensor) and ((other == 0) + (other == 1)).all(),
+        #     ]
+        # ), "Second argument should be RST
+        # (with ring size of 2)/Integer/LongTensor values in {0, 1}"
+        if (not isinstance(value, ReplicatedSharingTensor)) or (value.ring_size != 2):
+            raise TypeError("First argument should be a RST with ring size 2")
+
+        if not any(
             [
                 isinstance(other, ReplicatedSharingTensor) and other.ring_size == 2,
                 isinstance(other, int) and other in {0, 1},
                 isinstance(other, torch.LongTensor) and ((other == 0) + (other == 1)).all(),
             ]
-        ), "Second argument should be RST (with ring size of 2)/Integer/LongTensor values in {0, 1}"
+        ):
+            raise TypeError(
+                "Second argument should be RST "
+                "(with ring size of 2)/Integer/LongTensor values in {0, 1}"
+            )
 
         result = value + other - 2 * value * other
 

--- a/syft/frameworks/torch/mpc/fss.py
+++ b/syft/frameworks/torch/mpc/fss.py
@@ -26,7 +26,6 @@ from syft.generic.utils import remote
 λ = 127  # security parameter
 n = 32  # bit precision
 λs = math.ceil(λ / 64)  # how many int64 are needed to store λ, here 2
-# assert λs == 2
 if λs != 2:
     raise ValueError("Check the value of security parameter")
 
@@ -483,7 +482,6 @@ def bit_decomposition(x):
 
 
 def randbit(shape):
-    # assert len(shape) == 3
     if len(shape) != 3:
         raise ValueError("size of shape is not 3")
     byte_dim = shape[-2]
@@ -505,13 +503,11 @@ def split_last_bit(buffer):
 def G(seed):
     """Pseudo Random Generator λ -> 2(λ + 1)"""
 
-    # assert len(seed.shape) == 2
     if len(seed.shape) != 2:
         raise ValueError("size of seed shape needs to be 2")
 
     n_values = seed.shape[1]
 
-    # assert seed.shape[0] == λs
     if seed.shape[0] != λs:
         raise ValueError("check the security parameter and seed shape")
 
@@ -521,7 +517,6 @@ def G(seed):
     x2 = x.view(dtype=dt1)
     x = x2["uint8"].reshape(*x.shape[:-1], -1)
 
-    # assert x.shape == (n_values, 2 * 8)
     if x.shape != (n_values, 2 * 8):
         raise ValueError(f"shape of x needs to be ({n_values}, 16)")
 
@@ -556,12 +551,10 @@ def H(seed, idx=0):
     h0 is erased by h1
     """
 
-    # assert len(seed.shape) == 2
     if len(seed.shape) != 2:
         raise ValueError("size of seed shape needs to be 2")
     n_values = seed.shape[1]
 
-    # assert seed.shape[0] == λs
     if seed.shape[0] != λs:
         raise ValueError("check the security parameter and seed shape")
 
@@ -571,7 +564,6 @@ def H(seed, idx=0):
     x2 = x.view(dtype=dt1)
     x = x2["uint8"].reshape(*x.shape[:-1], -1)
 
-    # assert x.shape == (n_values, 2 * 8)
     if x.shape != (n_values, 2 * 8):
         raise ValueError(f"shape of x needs to be ({n_values}, 16)")
 

--- a/syft/frameworks/torch/mpc/fss.py
+++ b/syft/frameworks/torch/mpc/fss.py
@@ -26,7 +26,9 @@ from syft.generic.utils import remote
 λ = 127  # security parameter
 n = 32  # bit precision
 λs = math.ceil(λ / 64)  # how many int64 are needed to store λ, here 2
-assert λs == 2
+# assert λs == 2
+if λs != 2:
+    raise ValueError("Check the value of security parameter")
 
 no_wrap = {"no_wrap": True}
 
@@ -481,7 +483,9 @@ def bit_decomposition(x):
 
 
 def randbit(shape):
-    assert len(shape) == 3
+    # assert len(shape) == 3
+    if len(shape) != 3:
+        raise ValueError("size of shape is not 3")
     byte_dim = shape[-2]
     shape_with_bytes = shape[:-2] + (math.ceil(byte_dim / 64), shape[-1])
     randvalues = np.random.randint(0, 2 ** 64, size=shape_with_bytes, dtype=np.uint64)
@@ -501,16 +505,25 @@ def split_last_bit(buffer):
 def G(seed):
     """Pseudo Random Generator λ -> 2(λ + 1)"""
 
-    assert len(seed.shape) == 2
+    # assert len(seed.shape) == 2
+    if len(seed.shape) != 2:
+        raise ValueError("size of seed shape needs to be 2")
+
     n_values = seed.shape[1]
-    assert seed.shape[0] == λs
+
+    # assert seed.shape[0] == λs
+    if seed.shape[0] != λs:
+        raise ValueError("check the security parameter and seed shape")
+
     x = seed
     x = x.T
     dt1 = np.dtype((np.uint64, [("uint8", np.uint8, 8)]))
     x2 = x.view(dtype=dt1)
     x = x2["uint8"].reshape(*x.shape[:-1], -1)
 
-    assert x.shape == (n_values, 2 * 8)
+    # assert x.shape == (n_values, 2 * 8)
+    if x.shape != (n_values, 2 * 8):
+        raise ValueError(f"shape of x needs to be ({n_values}, 16)")
 
     out = np.empty((n_values, 4 * 8), dtype=np.uint8)
 
@@ -543,16 +556,24 @@ def H(seed, idx=0):
     h0 is erased by h1
     """
 
-    assert len(seed.shape) == 2
+    # assert len(seed.shape) == 2
+    if len(seed.shape) != 2:
+        raise ValueError("size of seed shape needs to be 2")
     n_values = seed.shape[1]
-    assert seed.shape[0] == λs
+
+    # assert seed.shape[0] == λs
+    if seed.shape[0] != λs:
+        raise ValueError("check the security parameter and seed shape")
+
     x = seed
     x = x.T
     dt1 = np.dtype((np.uint64, [("uint8", np.uint8, 8)]))
     x2 = x.view(dtype=dt1)
     x = x2["uint8"].reshape(*x.shape[:-1], -1)
 
-    assert x.shape == (n_values, 2 * 8)
+    # assert x.shape == (n_values, 2 * 8)
+    if x.shape != (n_values, 2 * 8):
+        raise ValueError(f"shape of x needs to be ({n_values}, 16)")
 
     if (n_values, idx) not in empty_dict:
         # 64 bytes are needed to store a sha512

--- a/syft/frameworks/torch/mpc/primitives.py
+++ b/syft/frameworks/torch/mpc/primitives.py
@@ -174,7 +174,9 @@ class PrimitiveStorage:
             n_instances (int): how many of them are needed
             **kwargs: any parameters needed for the primitive builder
         """
-        assert isinstance(op, str)
+        # assert isinstance(op, str)
+        if not isinstance(op, str):
+            raise TypeError("op should be a string")
 
         worker_types_primitives = defaultdict(dict)
 
@@ -199,7 +201,9 @@ class PrimitiveStorage:
             types_primitives: dict {op: str: primitives: list}
         """
         for op, primitives in types_primitives.items():
-            assert hasattr(self, op), f"Unknown crypto primitives {op}"
+            # assert hasattr(self, op), f"Unknown crypto primitives {op}"
+            if not hasattr(self, op):
+                raise ValueError(f"Unknown crypto primitives {op}")
 
             current_primitives = getattr(self, op)
             if op in {"mul", "matmul"}:
@@ -242,9 +246,13 @@ class PrimitiveStorage:
         n = sy.frameworks.torch.mpc.fss.n
 
         def build_separate_fss_keys(n_party: int, n_instances: int = 100):
-            assert (
-                n_party == 2
-            ), f"The FSS protocol only works for 2 workers, {n_party} were provided."
+            # assert (
+            #     n_party == 2
+            # ), f"The FSS protocol only works for 2 workers, {n_party} were provided."
+            if n_party != 2:
+                raise AttributeError(
+                    f"The FSS protocol only works for 2 workers, " f"{n_party} were provided."
+                )
             alpha, s_00, s_01, *CW = sy.frameworks.torch.mpc.fss.keygen(n_values=n_instances, op=op)
             # simulate sharing TODO clean this
             mask = np.random.randint(0, 2 ** n, alpha.shape, dtype=alpha.dtype)
@@ -258,15 +266,25 @@ class PrimitiveStorage:
         """
 
         def build_separate_triples(n_party: int, n_instances: int, **kwargs) -> list:
-            assert n_party == 2, (
-                "Only 2 workers supported for the moment. "
-                "Please fill an issue if you have an urgent need."
-            )
+            # assert n_party == 2, (
+            #     "Only 2 workers supported for the moment. "
+            #     "Please fill an issue if you have an urgent need."
+            # )
+            if n_party != 2:
+                raise NotImplementedError(
+                    "Only 2 workers supported for the moment. "
+                    "Please fill an issue if you have an urgent need."
+                )
             shapes = kwargs["shapes"]  # should be a list of pairs of shapes
             if not isinstance(shapes, list):
                 # if shapes was not given a list, we check that it is a pair of two shapes,
                 # the one of x and y
-                assert len(shapes) == 2
+                # assert len(shapes) == 2
+                if len(shapes) != 2:
+                    raise ValueError(
+                        "if shapes was not given a list, we check that it is a pair of two shapes, "
+                        "the one of x and y"
+                    )
                 shapes = [shapes]
 
             # get params and set default values

--- a/syft/frameworks/torch/mpc/primitives.py
+++ b/syft/frameworks/torch/mpc/primitives.py
@@ -174,7 +174,6 @@ class PrimitiveStorage:
             n_instances (int): how many of them are needed
             **kwargs: any parameters needed for the primitive builder
         """
-        # assert isinstance(op, str)
         if not isinstance(op, str):
             raise TypeError("op should be a string")
 
@@ -201,7 +200,6 @@ class PrimitiveStorage:
             types_primitives: dict {op: str: primitives: list}
         """
         for op, primitives in types_primitives.items():
-            # assert hasattr(self, op), f"Unknown crypto primitives {op}"
             if not hasattr(self, op):
                 raise ValueError(f"Unknown crypto primitives {op}")
 
@@ -246,9 +244,6 @@ class PrimitiveStorage:
         n = sy.frameworks.torch.mpc.fss.n
 
         def build_separate_fss_keys(n_party: int, n_instances: int = 100):
-            # assert (
-            #     n_party == 2
-            # ), f"The FSS protocol only works for 2 workers, {n_party} were provided."
             if n_party != 2:
                 raise AttributeError(
                     f"The FSS protocol only works for 2 workers, " f"{n_party} were provided."
@@ -266,10 +261,6 @@ class PrimitiveStorage:
         """
 
         def build_separate_triples(n_party: int, n_instances: int, **kwargs) -> list:
-            # assert n_party == 2, (
-            #     "Only 2 workers supported for the moment. "
-            #     "Please fill an issue if you have an urgent need."
-            # )
             if n_party != 2:
                 raise NotImplementedError(
                     "Only 2 workers supported for the moment. "
@@ -279,7 +270,6 @@ class PrimitiveStorage:
             if not isinstance(shapes, list):
                 # if shapes was not given a list, we check that it is a pair of two shapes,
                 # the one of x and y
-                # assert len(shapes) == 2
                 if len(shapes) != 2:
                     raise ValueError(
                         "if shapes was not given a list, we check that it is a pair of two shapes, "

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -74,7 +74,9 @@ def _initialize_generators(cur_seed, prev_seed):
 @allow_command
 def _get_random_tensor(name_generator, shape, worker_id, ring_size=RING_SIZE):
     worker = syft.local_worker.get_worker(worker_id)
-    assert worker.crypto_store.przs.generators, ERR_MSG
+    # assert worker.crypto_store.przs.generators, ERR_MSG
+    if not worker.crypto_store.przs.generators:
+        raise ValueError(ERR_MSG)
 
     generators = worker.crypto_store.przs.generators
 
@@ -110,7 +112,9 @@ def _generate_alpha_3of3(worker_id, ring_size=RING_SIZE):
                 the previous worker (i-1) seed
     """
     worker = syft.local_worker.get_worker(worker_id)
-    assert worker.crypto_store.przs.generators, ERR_MSG
+    # assert worker.crypto_store.przs.generators, ERR_MSG
+    if not worker.crypto_store.przs.generators:
+        raise ValueError(ERR_MSG)
 
     generators = worker.crypto_store.przs.generators
 
@@ -131,7 +135,9 @@ def _generate_alpha_2of3(worker_id, ring_size=RING_SIZE):
                 the previous worker (i-1) seed and it generates alpha_i-1
     """
     worker = syft.local_worker.get_worker(worker_id)
-    assert worker.crypto_store.przs.generators, ERR_MSG
+    # assert worker.crypto_store.przs.generators, ERR_MSG
+    if not worker.crypto_store.przs.generators:
+        raise ValueError(ERR_MSG)
 
     generators = worker.crypto_store.przs.generators
 

--- a/syft/frameworks/torch/mpc/przs.py
+++ b/syft/frameworks/torch/mpc/przs.py
@@ -74,7 +74,6 @@ def _initialize_generators(cur_seed, prev_seed):
 @allow_command
 def _get_random_tensor(name_generator, shape, worker_id, ring_size=RING_SIZE):
     worker = syft.local_worker.get_worker(worker_id)
-    # assert worker.crypto_store.przs.generators, ERR_MSG
     if not worker.crypto_store.przs.generators:
         raise ValueError(ERR_MSG)
 
@@ -112,7 +111,6 @@ def _generate_alpha_3of3(worker_id, ring_size=RING_SIZE):
                 the previous worker (i-1) seed
     """
     worker = syft.local_worker.get_worker(worker_id)
-    # assert worker.crypto_store.przs.generators, ERR_MSG
     if not worker.crypto_store.przs.generators:
         raise ValueError(ERR_MSG)
 
@@ -135,7 +133,6 @@ def _generate_alpha_2of3(worker_id, ring_size=RING_SIZE):
                 the previous worker (i-1) seed and it generates alpha_i-1
     """
     worker = syft.local_worker.get_worker(worker_id)
-    # assert worker.crypto_store.przs.generators, ERR_MSG
     if not worker.crypto_store.przs.generators:
         raise ValueError(ERR_MSG)
 

--- a/syft/frameworks/torch/mpc/securenn.py
+++ b/syft/frameworks/torch/mpc/securenn.py
@@ -73,9 +73,6 @@ def flip(x, dim, dtype):
     """
     Reverse the order of the elements in a tensor
     """
-    # assert (
-    #     x.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if x.dtype == "custom":
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -151,9 +148,6 @@ def select_share(alpha_sh, x_sh, y_sh):
     Return:
         z_sh = (1 - alpha_sh) * x_sh + alpha_sh * y_sh
     """
-    # assert (
-    #     alpha_sh.dtype == x_sh.dtype == y_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if not (alpha_sh.dtype == x_sh.dtype == y_sh.dtype != "custom"):
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -191,9 +185,6 @@ def private_compare(x_bit_sh, r, beta, L):
     return:
         β′ = β ⊕ (x > r).
     """
-    # assert isinstance(x_bit_sh, sy.AdditiveSharingTensor)
-    # assert isinstance(r, sy.MultiPointerTensor)
-    # assert isinstance(beta, sy.MultiPointerTensor)
     if not isinstance(x_bit_sh, sy.AdditiveSharingTensor):
         raise TypeError("x_bit_sh should be AdditiveSharingTensor.")
     if not isinstance(r, sy.MultiPointerTensor):
@@ -397,12 +388,8 @@ def share_convert(a_sh):
     Return:
         An additive sharing tensor with shares in field L-1
     """
-    # assert isinstance(a_sh, sy.AdditiveSharingTensor)
     if not isinstance(a_sh, sy.AdditiveSharingTensor):
         raise TypeError("a_sh should be AdditiveSharingTensor")
-    # assert (
-    #     a_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if a_sh.dtype == "custom":
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -512,9 +499,6 @@ def relu_deriv(a_sh):
         1 if Dec(a_sh) > 0
         encrypted in an AdditiveSharingTensor
     """
-    # assert (
-    #     a_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if a_sh.dtype == "custom":
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -559,9 +543,6 @@ def relu(a_sh):
         Dec(a_sh) > 0
         encrypted in an AdditiveSharingTensor
     """
-    # assert (
-    #     a_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if a_sh.dtype == "custom":
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -588,9 +569,6 @@ def division(x_sh, y_sh, bit_len_max=None):
     Returns:
         element-wise integer division of x_sh by y_sh
     """
-    # assert (
-    #     x_sh.dtype == y_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if not (x_sh.dtype == y_sh.dtype != "custom"):
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -604,7 +582,6 @@ def division(x_sh, y_sh, bit_len_max=None):
 
     x_shape = x_sh.shape
     y_shape = y_sh.shape
-    # assert x_shape == y_shape or list(y_shape) == [1]
     if not (x_shape == y_shape or list(y_shape) == [1]):
         raise ValueError("Check shape of x_sh and y_sh")
 
@@ -654,9 +631,6 @@ def maxpool(x_sh):
         maximum value as an AdditiveSharingTensor
         index of this value in the flattened tensor as an AdditiveSharingTensor
     """
-    # assert (
-    #     x_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if x_sh.dtype == "custom":
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -712,9 +686,6 @@ def maxpool_deriv(x_sh):
         an AdditiveSharingTensor of the same shape as x_sh full of zeros except for
         a 1 at the position of the max value
     """
-    # assert (
-    #     x_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if x_sh.dtype == "custom":
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
@@ -728,7 +699,6 @@ def maxpool_deriv(x_sh):
 
     n1, n2 = x_sh.shape
     n = n1 * n2
-    # assert L % n == 0
     if L % n != 0:
         raise ValueError("Check x_sh.field and x_sh.shape ")
     x_sh = x_sh.view(-1)
@@ -770,14 +740,10 @@ def maxpool2d(a_sh, kernel_size: int = 1, stride: int = 1, padding: int = 0):
         stride: the stride of the window
         padding: implicit zero padding to be added on both sides
     """
-    # assert (
-    #     a_sh.dtype != "custom"
-    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
     if a_sh.dtype == "custom":
         raise TypeError(
             "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
         )
-    # assert len(a_sh.shape) == 4
     if len(a_sh.shape) != 4:
         raise ValueError("Size of a_sh.shape should be 4")
 

--- a/syft/frameworks/torch/mpc/securenn.py
+++ b/syft/frameworks/torch/mpc/securenn.py
@@ -73,9 +73,13 @@ def flip(x, dim, dtype):
     """
     Reverse the order of the elements in a tensor
     """
-    assert (
-        x.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert (
+    #     x.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if x.dtype == "custom":
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
     indices = torch.arange(x.shape[dim] - 1, -1, -1).type(dtype)
 
     if hasattr(x, "child") and isinstance(x.child, dict):
@@ -147,9 +151,13 @@ def select_share(alpha_sh, x_sh, y_sh):
     Return:
         z_sh = (1 - alpha_sh) * x_sh + alpha_sh * y_sh
     """
-    assert (
-        alpha_sh.dtype == x_sh.dtype == y_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert (
+    #     alpha_sh.dtype == x_sh.dtype == y_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if not (alpha_sh.dtype == x_sh.dtype == y_sh.dtype != "custom"):
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
 
     workers = alpha_sh.locations
     crypto_provider = alpha_sh.crypto_provider
@@ -183,9 +191,16 @@ def private_compare(x_bit_sh, r, beta, L):
     return:
         β′ = β ⊕ (x > r).
     """
-    assert isinstance(x_bit_sh, sy.AdditiveSharingTensor)
-    assert isinstance(r, sy.MultiPointerTensor)
-    assert isinstance(beta, sy.MultiPointerTensor)
+    # assert isinstance(x_bit_sh, sy.AdditiveSharingTensor)
+    # assert isinstance(r, sy.MultiPointerTensor)
+    # assert isinstance(beta, sy.MultiPointerTensor)
+    if not isinstance(x_bit_sh, sy.AdditiveSharingTensor):
+        raise TypeError("x_bit_sh should be AdditiveSharingTensor.")
+    if not isinstance(r, sy.MultiPointerTensor):
+        raise TypeError("r should be MultiPointerTensor.")
+    if not isinstance(beta, sy.MultiPointerTensor):
+        raise TypeError("beta should be MultiPointerTensor.")
+
     # Would it be safer to have a different r/beta for each value in the tensor?
 
     workers = x_bit_sh.locations
@@ -382,10 +397,16 @@ def share_convert(a_sh):
     Return:
         An additive sharing tensor with shares in field L-1
     """
-    assert isinstance(a_sh, sy.AdditiveSharingTensor)
-    assert (
-        a_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert isinstance(a_sh, sy.AdditiveSharingTensor)
+    if not isinstance(a_sh, sy.AdditiveSharingTensor):
+        raise TypeError("a_sh should be AdditiveSharingTensor")
+    # assert (
+    #     a_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if a_sh.dtype == "custom":
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
 
     workers = a_sh.locations
     crypto_provider = a_sh.crypto_provider
@@ -491,9 +512,13 @@ def relu_deriv(a_sh):
         1 if Dec(a_sh) > 0
         encrypted in an AdditiveSharingTensor
     """
-    assert (
-        a_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert (
+    #     a_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if a_sh.dtype == "custom":
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
 
     workers = a_sh.locations
     crypto_provider = a_sh.crypto_provider
@@ -534,9 +559,13 @@ def relu(a_sh):
         Dec(a_sh) > 0
         encrypted in an AdditiveSharingTensor
     """
-    assert (
-        a_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert (
+    #     a_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if a_sh.dtype == "custom":
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
 
     workers = a_sh.locations
     crypto_provider = a_sh.crypto_provider
@@ -559,9 +588,13 @@ def division(x_sh, y_sh, bit_len_max=None):
     Returns:
         element-wise integer division of x_sh by y_sh
     """
-    assert (
-        x_sh.dtype == y_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert (
+    #     x_sh.dtype == y_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if not (x_sh.dtype == y_sh.dtype != "custom"):
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
     workers = x_sh.locations
     crypto_provider = x_sh.crypto_provider
     L = x_sh.field
@@ -571,7 +604,9 @@ def division(x_sh, y_sh, bit_len_max=None):
 
     x_shape = x_sh.shape
     y_shape = y_sh.shape
-    assert x_shape == y_shape or list(y_shape) == [1]
+    # assert x_shape == y_shape or list(y_shape) == [1]
+    if not (x_shape == y_shape or list(y_shape) == [1]):
+        raise ValueError("Check shape of x_sh and y_sh")
 
     x_sh = x_sh.view(-1)
     y_sh = y_sh.view(-1)
@@ -619,9 +654,13 @@ def maxpool(x_sh):
         maximum value as an AdditiveSharingTensor
         index of this value in the flattened tensor as an AdditiveSharingTensor
     """
-    assert (
-        x_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert (
+    #     x_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if x_sh.dtype == "custom":
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
 
     if x_sh.is_wrapper:
         x_sh = x_sh.child
@@ -673,9 +712,13 @@ def maxpool_deriv(x_sh):
         an AdditiveSharingTensor of the same shape as x_sh full of zeros except for
         a 1 at the position of the max value
     """
-    assert (
-        x_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    # assert (
+    #     x_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if x_sh.dtype == "custom":
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
 
     workers = x_sh.locations
     crypto_provider = x_sh.crypto_provider
@@ -685,7 +728,9 @@ def maxpool_deriv(x_sh):
 
     n1, n2 = x_sh.shape
     n = n1 * n2
-    assert L % n == 0
+    # assert L % n == 0
+    if L % n != 0:
+        raise ValueError("Check x_sh.field and x_sh.shape ")
     x_sh = x_sh.view(-1)
 
     # Common Randomness
@@ -725,10 +770,16 @@ def maxpool2d(a_sh, kernel_size: int = 1, stride: int = 1, padding: int = 0):
         stride: the stride of the window
         padding: implicit zero padding to be added on both sides
     """
-    assert (
-        a_sh.dtype != "custom"
-    ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
-    assert len(a_sh.shape) == 4
+    # assert (
+    #     a_sh.dtype != "custom"
+    # ), "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+    if a_sh.dtype == "custom":
+        raise TypeError(
+            "`custom` dtype shares are unsupported in SecureNN, use dtype = `long` or `int` instead"
+        )
+    # assert len(a_sh.shape) == 4
+    if len(a_sh.shape) != 4:
+        raise ValueError("Size of a_sh.shape should be 4")
 
     # Change to tuple if not one
     kernel = torch.nn.modules.utils._pair(kernel_size)

--- a/syft/frameworks/torch/nn/conv.py
+++ b/syft/frameworks/torch/nn/conv.py
@@ -66,7 +66,6 @@ class Conv2d(nn.Module):
 
     def forward(self, input):
 
-        # assert input.shape[1] == self.in_channels
         if input.shape[1] != self.in_channels:
             raise ValueError("Please check the input shape and in channels")
 

--- a/syft/frameworks/torch/nn/conv.py
+++ b/syft/frameworks/torch/nn/conv.py
@@ -66,7 +66,9 @@ class Conv2d(nn.Module):
 
     def forward(self, input):
 
-        assert input.shape[1] == self.in_channels
+        # assert input.shape[1] == self.in_channels
+        if input.shape[1] != self.in_channels:
+            raise ValueError("Please check the input shape and in channels")
 
         return conv2d(
             input, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -56,7 +56,6 @@ def batch_norm(
     input = input.t()
 
     if training:
-        # assert exponential_average_factor == 0  # == momentum
         if exponential_average_factor != 0:
             raise NotImplementedError(
                 "exponential_average_factor is not supported for the moment and should be set to 0"
@@ -89,9 +88,6 @@ def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=
     Because all the computation are local, we add the @allow_command and run it directly
     on each share of the additive sharing tensor, when running mpc computations
     """
-
-    # assert len(input.shape) == 4
-    # assert len(weight.shape) == 4
     if len(input.shape) != 4:
         raise ValueError(f"Size of input.shape is {len(input.shape)}, it should be 4")
     if len(weight.shape) != 4:
@@ -107,7 +103,6 @@ def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=
     nb_channels_out, nb_channels_kernel, nb_rows_kernel, nb_cols_kernel = weight.shape
 
     if bias is not None:
-        # assert len(bias) == nb_channels_out
         if len(bias) != nb_channels_out:
             raise ValueError(
                 f"Size of bias should be same as nb_channels_out. Size "
@@ -115,9 +110,6 @@ def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=
             )
 
     # Check if inputs are coherent
-    # assert nb_channels_in == nb_channels_kernel * groups
-    # assert nb_channels_in % groups == 0
-    # assert nb_channels_out % groups == 0
     if nb_channels_in != nb_channels_kernel * groups:
         raise ValueError(
             f"Given inputs are not supported. Given inputs: "
@@ -252,8 +244,6 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     input_fp, weight_fp = input, weight
 
     if isinstance(input.child, FrameworkTensor) or isinstance(weight.child, FrameworkTensor):
-        # assert isinstance(input.child, FrameworkTensor)
-        # assert isinstance(weight.child, FrameworkTensor)
         if not isinstance(input.child, FrameworkTensor):
             raise TypeError("input.child needs to be FrameworkTensor")
         if not isinstance(weight.child, FrameworkTensor):
@@ -278,9 +268,6 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
 
     if bias is not None:
         bias = bias.child
-        # assert isinstance(
-        #     bias, sy.AdditiveSharingTensor
-        # ), "Have you provided bias as a kwarg? If so, please remove `bias=`."
         if not isinstance(bias, sy.AdditiveSharingTensor):
             raise TypeError("Have you provided bias as a kwarg? If so, please remove `bias=`.")
 
@@ -375,8 +362,6 @@ def _pre_pool(input, kernel_size, stride=1, padding=0, dilation=1, groups=1):
 
     # Check if inputs are coherent
     # assert nb_channels_in == nb_channels_kernel * groups
-    # assert nb_channels_in % groups == 0
-    # assert nb_channels_out % groups == 0
     if nb_channels_in % groups != 0:
         raise ValueError(
             f"Given inputs are not supported. Given inputs: "
@@ -509,7 +494,6 @@ def _pool2d(
     input, kernel_size: int = 2, stride: int = 2, padding=0, dilation=1, ceil_mode=None, mode="avg"
 ):
     if isinstance(kernel_size, tuple):
-        # assert kernel_size[0] == kernel_size[1]
         if kernel_size[0] != kernel_size[1]:
             raise ValueError(
                 f"kernel_size[0] should be equal to kernel_size[1], "
@@ -517,7 +501,6 @@ def _pool2d(
             )
         kernel_size = kernel_size[0]
     if isinstance(stride, tuple):
-        # assert stride[0] == stride[1]
         if stride[0] != stride[1]:
             raise ValueError(
                 f"stride[0] should be equal to stride[1], " f"Check the given stride {stride}"
@@ -584,12 +567,10 @@ def _pool2d(
 
 def adaptive_avg_pool2d(tensor, output_size):
     if isinstance(output_size, tuple):
-        # assert output_size[0] == output_size[1]
         if output_size[0] != output_size[1]:
             raise ValueError("Check given output_size")
         output_size = output_size[0]
 
-    # assert tensor.shape[2] == tensor.shape[3]
     if tensor.shape[2] != tensor.shape[3]:
         raise ValueError(
             f"Shape of given tensor is invalid, "
@@ -599,7 +580,6 @@ def adaptive_avg_pool2d(tensor, output_size):
 
     input_size = tensor.shape[2]
 
-    # assert input_size >= output_size
     if input_size < output_size:
         raise ValueError("tensor.shape[2] should be greater or equal to output_size")
 

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -92,8 +92,10 @@ def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=
 
     # assert len(input.shape) == 4
     # assert len(weight.shape) == 4
-    if len(input.shape) != 4 or len(weight.shape) != 4:
-        raise ValueError("Check size of input and weight, it should be 4")
+    if len(input.shape) != 4:
+        raise ValueError(f"Size of input.shape is {len(input.shape)}, it should be 4")
+    if len(weight.shape) != 4:
+        raise ValueError(f"Size of weight.shape is {len(weight.shape)}, it should be 4")
 
     # Change to tuple if not one
     stride = torch.nn.modules.utils._pair(stride)
@@ -107,20 +109,33 @@ def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=
     if bias is not None:
         # assert len(bias) == nb_channels_out
         if len(bias) != nb_channels_out:
-            raise ValueError("Check size of bias")
+            raise ValueError(
+                f"Size of bias should be same as nb_channels_out. Size "
+                f"of bias: {len(bias)}, nb_channels_out: {nb_channels_out}"
+            )
 
     # Check if inputs are coherent
     # assert nb_channels_in == nb_channels_kernel * groups
     # assert nb_channels_in % groups == 0
     # assert nb_channels_out % groups == 0
     if nb_channels_in != nb_channels_kernel * groups:
-        raise ValueError("Given inputs are not supported")
+        raise ValueError(
+            f"Given inputs are not supported. Given inputs: "
+            f"nb_channels_in: {nb_channels_in}, "
+            f"nb_channels_kernel: {nb_channels_kernel}, groups: {groups}"
+        )
 
     if nb_channels_in % groups != 0:
-        raise ValueError("Given inputs are not supported")
+        raise ValueError(
+            f"Given inputs are not supported. Given inputs: "
+            f"nb_channels_in: {nb_channels_in}, groups: {groups}"
+        )
 
     if nb_channels_out % groups != 0:
-        raise ValueError("Given inputs are not supported")
+        raise ValueError(
+            f"Given inputs are not supported. Given inputs: "
+            f"nb_channels_out: {nb_channels_out}, groups: {groups}"
+        )
 
     # Compute output shape
     nb_rows_out = int(
@@ -240,9 +255,9 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
         # assert isinstance(input.child, FrameworkTensor)
         # assert isinstance(weight.child, FrameworkTensor)
         if not isinstance(input.child, FrameworkTensor):
-            raise TypeError("input needs to be FrameworkTensor")
+            raise TypeError("input.child needs to be FrameworkTensor")
         if not isinstance(weight.child, FrameworkTensor):
-            raise TypeError("input needs to be FrameworkTensor")
+            raise TypeError("weight.child needs to be FrameworkTensor")
         im_reshaped, weight_reshaped, *params = _pre_conv(
             input, weight, bias, stride, padding, dilation, groups
         )
@@ -363,9 +378,15 @@ def _pre_pool(input, kernel_size, stride=1, padding=0, dilation=1, groups=1):
     # assert nb_channels_in % groups == 0
     # assert nb_channels_out % groups == 0
     if nb_channels_in % groups != 0:
-        raise ValueError("Given inputs are not supported")
+        raise ValueError(
+            f"Given inputs are not supported. Given inputs: "
+            f"nb_channels_in: {nb_channels_in}, groups: {groups}"
+        )
     if nb_channels_out % groups != 0:
-        raise ValueError("Given inputs are not supported")
+        raise ValueError(
+            f"Given inputs are not supported. Given inputs: "
+            f"nb_channels_out: {nb_channels_out}, groups: {groups}"
+        )
 
     # Compute output shape
     nb_rows_out = int(
@@ -490,12 +511,17 @@ def _pool2d(
     if isinstance(kernel_size, tuple):
         # assert kernel_size[0] == kernel_size[1]
         if kernel_size[0] != kernel_size[1]:
-            raise ValueError("Check the given kernel_size")
+            raise ValueError(
+                f"kernel_size[0] should be equal to kernel_size[1], "
+                f"Check the given kernel_size {kernel_size}"
+            )
         kernel_size = kernel_size[0]
     if isinstance(stride, tuple):
         # assert stride[0] == stride[1]
         if stride[0] != stride[1]:
-            raise ValueError("Check the given stride")
+            raise ValueError(
+                f"stride[0] should be equal to stride[1], " f"Check the given stride {stride}"
+            )
         stride = stride[0]
 
     input_fp = input
@@ -565,7 +591,11 @@ def adaptive_avg_pool2d(tensor, output_size):
 
     # assert tensor.shape[2] == tensor.shape[3]
     if tensor.shape[2] != tensor.shape[3]:
-        raise ValueError("Check given tensor")
+        raise ValueError(
+            f"Shape of given tensor is invalid, "
+            f"tensor.shape[2] should be equal to tensor.shape[3], "
+            f"Given tensor.shape: {tensor.shape}"
+        )
 
     input_size = tensor.shape[2]
 

--- a/syft/frameworks/torch/nn/functional.py
+++ b/syft/frameworks/torch/nn/functional.py
@@ -56,7 +56,11 @@ def batch_norm(
     input = input.t()
 
     if training:
-        assert exponential_average_factor == 0  # == momentum
+        # assert exponential_average_factor == 0  # == momentum
+        if exponential_average_factor != 0:
+            raise NotImplementedError(
+                "exponential_average_factor is not supported for the moment and should be set to 0"
+            )
         mean = input.mean(dim=0)
         var = input.var(dim=0) + eps
     else:
@@ -85,8 +89,11 @@ def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=
     Because all the computation are local, we add the @allow_command and run it directly
     on each share of the additive sharing tensor, when running mpc computations
     """
-    assert len(input.shape) == 4
-    assert len(weight.shape) == 4
+
+    # assert len(input.shape) == 4
+    # assert len(weight.shape) == 4
+    if len(input.shape) != 4 or len(weight.shape) != 4:
+        raise ValueError("Check size of input and weight, it should be 4")
 
     # Change to tuple if not one
     stride = torch.nn.modules.utils._pair(stride)
@@ -98,12 +105,22 @@ def _pre_conv(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=
     nb_channels_out, nb_channels_kernel, nb_rows_kernel, nb_cols_kernel = weight.shape
 
     if bias is not None:
-        assert len(bias) == nb_channels_out
+        # assert len(bias) == nb_channels_out
+        if len(bias) != nb_channels_out:
+            raise ValueError("Check size of bias")
 
     # Check if inputs are coherent
-    assert nb_channels_in == nb_channels_kernel * groups
-    assert nb_channels_in % groups == 0
-    assert nb_channels_out % groups == 0
+    # assert nb_channels_in == nb_channels_kernel * groups
+    # assert nb_channels_in % groups == 0
+    # assert nb_channels_out % groups == 0
+    if nb_channels_in != nb_channels_kernel * groups:
+        raise ValueError("Given inputs are not supported")
+
+    if nb_channels_in % groups != 0:
+        raise ValueError("Given inputs are not supported")
+
+    if nb_channels_out % groups != 0:
+        raise ValueError("Given inputs are not supported")
 
     # Compute output shape
     nb_rows_out = int(
@@ -220,8 +237,12 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     input_fp, weight_fp = input, weight
 
     if isinstance(input.child, FrameworkTensor) or isinstance(weight.child, FrameworkTensor):
-        assert isinstance(input.child, FrameworkTensor)
-        assert isinstance(weight.child, FrameworkTensor)
+        # assert isinstance(input.child, FrameworkTensor)
+        # assert isinstance(weight.child, FrameworkTensor)
+        if not isinstance(input.child, FrameworkTensor):
+            raise TypeError("input needs to be FrameworkTensor")
+        if not isinstance(weight.child, FrameworkTensor):
+            raise TypeError("input needs to be FrameworkTensor")
         im_reshaped, weight_reshaped, *params = _pre_conv(
             input, weight, bias, stride, padding, dilation, groups
         )
@@ -242,9 +263,11 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
 
     if bias is not None:
         bias = bias.child
-        assert isinstance(
-            bias, sy.AdditiveSharingTensor
-        ), "Have you provided bias as a kwarg? If so, please remove `bias=`."
+        # assert isinstance(
+        #     bias, sy.AdditiveSharingTensor
+        # ), "Have you provided bias as a kwarg? If so, please remove `bias=`."
+        if not isinstance(bias, sy.AdditiveSharingTensor):
+            raise TypeError("Have you provided bias as a kwarg? If so, please remove `bias=`.")
 
     locations = input.locations
 
@@ -337,8 +360,12 @@ def _pre_pool(input, kernel_size, stride=1, padding=0, dilation=1, groups=1):
 
     # Check if inputs are coherent
     # assert nb_channels_in == nb_channels_kernel * groups
-    assert nb_channels_in % groups == 0
-    assert nb_channels_out % groups == 0
+    # assert nb_channels_in % groups == 0
+    # assert nb_channels_out % groups == 0
+    if nb_channels_in % groups != 0:
+        raise ValueError("Given inputs are not supported")
+    if nb_channels_out % groups != 0:
+        raise ValueError("Given inputs are not supported")
 
     # Compute output shape
     nb_rows_out = int(
@@ -461,10 +488,14 @@ def _pool2d(
     input, kernel_size: int = 2, stride: int = 2, padding=0, dilation=1, ceil_mode=None, mode="avg"
 ):
     if isinstance(kernel_size, tuple):
-        assert kernel_size[0] == kernel_size[1]
+        # assert kernel_size[0] == kernel_size[1]
+        if kernel_size[0] != kernel_size[1]:
+            raise ValueError("Check the given kernel_size")
         kernel_size = kernel_size[0]
     if isinstance(stride, tuple):
-        assert stride[0] == stride[1]
+        # assert stride[0] == stride[1]
+        if stride[0] != stride[1]:
+            raise ValueError("Check the given stride")
         stride = stride[0]
 
     input_fp = input
@@ -527,11 +558,21 @@ def _pool2d(
 
 def adaptive_avg_pool2d(tensor, output_size):
     if isinstance(output_size, tuple):
-        assert output_size[0] == output_size[1]
+        # assert output_size[0] == output_size[1]
+        if output_size[0] != output_size[1]:
+            raise ValueError("Check given output_size")
         output_size = output_size[0]
-    assert tensor.shape[2] == tensor.shape[3]
+
+    # assert tensor.shape[2] == tensor.shape[3]
+    if tensor.shape[2] != tensor.shape[3]:
+        raise ValueError("Check given tensor")
+
     input_size = tensor.shape[2]
-    assert input_size >= output_size
+
+    # assert input_size >= output_size
+    if input_size < output_size:
+        raise ValueError("tensor.shape[2] should be greater or equal to output_size")
+
     stride = input_size // output_size
     kernel_size = input_size - (output_size - 1) * stride
     padding = 0

--- a/syft/frameworks/torch/nn/pool.py
+++ b/syft/frameworks/torch/nn/pool.py
@@ -40,11 +40,11 @@ class AvgPool2d(Module):
         # assert ceil_mode is False
         # assert count_include_pad is True
         # assert divisor_override is None
-        if (
-            (padding != 0)
-            or (ceil_mode is True)
-            or (count_include_pad is False)
-            or (divisor_override is not None)
+        if not (
+            (padding == 0)
+            and (ceil_mode is False)
+            and (count_include_pad is True)
+            and (divisor_override is None)
         ):
             raise NotImplementedError("Not supported settings")
 

--- a/syft/frameworks/torch/nn/pool.py
+++ b/syft/frameworks/torch/nn/pool.py
@@ -36,10 +36,17 @@ class AvgPool2d(Module):
         # I have not implemented all functionality from torch.nn.AvgPool2d
         # These assertions are the required settings.
 
-        assert padding == 0
-        assert ceil_mode is False
-        assert count_include_pad is True
-        assert divisor_override is None
+        # assert padding == 0
+        # assert ceil_mode is False
+        # assert count_include_pad is True
+        # assert divisor_override is None
+        if (
+            (padding != 0)
+            or (ceil_mode is True)
+            or (count_include_pad is False)
+            or (divisor_override is not None)
+        ):
+            raise NotImplementedError("Not supported settings")
 
         if stride is None:
             stride = kernel_size

--- a/syft/frameworks/torch/nn/pool.py
+++ b/syft/frameworks/torch/nn/pool.py
@@ -36,10 +36,6 @@ class AvgPool2d(Module):
         # I have not implemented all functionality from torch.nn.AvgPool2d
         # These assertions are the required settings.
 
-        # assert padding == 0
-        # assert ceil_mode is False
-        # assert count_include_pad is True
-        # assert divisor_override is None
         if not (
             (padding == 0)
             and (ceil_mode is False)

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -477,7 +477,11 @@ class AdditiveSharingTensor(AbstractTensor):
                 *self.child.keys(), **self.get_class_attributes(), **no_wrap
             ).child
 
-        assert len(shares) == len(operand)
+        if len(shares) != len(operand):
+            raise ValueError(
+                "Size of shares(%d) is not equal to that of operand(%d)."
+                % (len(shares), len(operand))
+            )
         return {worker: op(share, operand[worker]) for worker, share in shares.items()}
 
     @overloaded.method
@@ -530,10 +534,16 @@ class AdditiveSharingTensor(AbstractTensor):
                 summation form
         """
         # check to see that operation is either mul or matmul
-        assert equation == "mul" or equation == "matmul"
+        # assert equation == "mul" or equation == "matmul"
+        if equation != "mul" and equation != "matmul":
+            raise NotImplementedError(
+                f"Operation({equation}) is not possible, only mul or matmul are allowed"
+            )
         cmd = getattr(torch, equation)
 
-        assert isinstance(other, AdditiveSharingTensor)
+        # assert isinstance(other, AdditiveSharingTensor)
+        if not isinstance(other, AdditiveSharingTensor):
+            raise TypeError("other is not an AdditiveSharingTensor")
 
         if self.crypto_provider is None:
             raise AttributeError("For multiplication a crypto_provider must be passed.")
@@ -563,7 +573,11 @@ class AdditiveSharingTensor(AbstractTensor):
             equation: a string representation of the equation to be computed in einstein
                 summation form
         """
-        assert equation == "mul" or equation == "matmul"
+        # assert equation == "mul" or equation == "matmul"
+        if equation != "mul" and equation != "matmul":
+            raise NotImplementedError(
+                f"Operation({equation}) is not possible, only mul or matmul are allowed"
+            )
         cmd = getattr(torch, equation)
         if isinstance(other, dict):
             return {
@@ -671,7 +685,9 @@ class AdditiveSharingTensor(AbstractTensor):
 
     @overloaded.method
     def mod(self, shares: dict, modulus: int):
-        assert isinstance(modulus, int)
+        # assert isinstance(modulus, int)
+        if not isinstance(modulus, int):
+            raise TypeError("modulus param should be an int instance.")
 
         return {worker: share % modulus for worker, share in shares.items()}
 
@@ -1042,7 +1058,11 @@ class AdditiveSharingTensor(AbstractTensor):
         Returns:
             the max of the tensor self
         """
-        assert algorithm == "pairwise", "Other methods not supported for the moment"
+        # assert algorithm == "pairwise", "Other methods not supported for the moment"
+        if algorithm != "pairwise":
+            raise NotImplementedError(
+                "Other methods not supported for the moment, only pairwise supported for now"
+            )
 
         argmax_result = self.argmax(dim=dim, keepdim=keepdim, one_hot=True)
         if dim is not None:

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -477,10 +477,10 @@ class AdditiveSharingTensor(AbstractTensor):
                 *self.child.keys(), **self.get_class_attributes(), **no_wrap
             ).child
 
+        # assert len(shares) == len(operand)
         if len(shares) != len(operand):
             raise ValueError(
-                "Size of shares(%d) is not equal to that of operand(%d)."
-                % (len(shares), len(operand))
+                f"Size of shares({len(shares)}) is not equal to that of operand({len(operand)})"
             )
         return {worker: op(share, operand[worker]) for worker, share in shares.items()}
 

--- a/syft/frameworks/torch/tensors/interpreters/additive_shared.py
+++ b/syft/frameworks/torch/tensors/interpreters/additive_shared.py
@@ -477,7 +477,6 @@ class AdditiveSharingTensor(AbstractTensor):
                 *self.child.keys(), **self.get_class_attributes(), **no_wrap
             ).child
 
-        # assert len(shares) == len(operand)
         if len(shares) != len(operand):
             raise ValueError(
                 f"Size of shares({len(shares)}) is not equal to that of operand({len(operand)})"
@@ -534,14 +533,12 @@ class AdditiveSharingTensor(AbstractTensor):
                 summation form
         """
         # check to see that operation is either mul or matmul
-        # assert equation == "mul" or equation == "matmul"
         if equation != "mul" and equation != "matmul":
             raise NotImplementedError(
                 f"Operation({equation}) is not possible, only mul or matmul are allowed"
             )
         cmd = getattr(torch, equation)
 
-        # assert isinstance(other, AdditiveSharingTensor)
         if not isinstance(other, AdditiveSharingTensor):
             raise TypeError("other is not an AdditiveSharingTensor")
 
@@ -573,7 +570,6 @@ class AdditiveSharingTensor(AbstractTensor):
             equation: a string representation of the equation to be computed in einstein
                 summation form
         """
-        # assert equation == "mul" or equation == "matmul"
         if equation != "mul" and equation != "matmul":
             raise NotImplementedError(
                 f"Operation({equation}) is not possible, only mul or matmul are allowed"
@@ -685,7 +681,6 @@ class AdditiveSharingTensor(AbstractTensor):
 
     @overloaded.method
     def mod(self, shares: dict, modulus: int):
-        # assert isinstance(modulus, int)
         if not isinstance(modulus, int):
             raise TypeError("modulus param should be an int instance.")
 
@@ -1058,7 +1053,6 @@ class AdditiveSharingTensor(AbstractTensor):
         Returns:
             the max of the tensor self
         """
-        # assert algorithm == "pairwise", "Other methods not supported for the moment"
         if algorithm != "pairwise":
             raise NotImplementedError(
                 "Other methods not supported for the moment, only pairwise supported for now"

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -104,7 +104,9 @@ class TorchTensor(AbstractTensor):
         location = self.owner.get_worker(location)
 
         def callback(grad):
-            assert isinstance(grad, torch.Tensor), "Grad in callback should be a Tensor"
+            # assert isinstance(grad, torch.Tensor), "Grad in callback should be a Tensor"
+            if not isinstance(grad, torch.Tensor):
+                raise TypeError("Grad in callback should be a Tensor")
             # the grad tensor is created by the torch backprop and might not be registered properly
             self.owner.register_obj(grad)
             pointer = PointerTensor(
@@ -1060,7 +1062,9 @@ class TorchTensor(AbstractTensor):
 
         """
 
-        assert isinstance(self.child, PointerTensor)
+        # assert isinstance(self.child, PointerTensor)
+        if not isinstance(self.child, PointerTensor):
+            raise TypeError("child should be a PointerTensor")
 
         ps = list(pointers)
         ps.append(self)

--- a/syft/frameworks/torch/tensors/interpreters/native.py
+++ b/syft/frameworks/torch/tensors/interpreters/native.py
@@ -104,7 +104,6 @@ class TorchTensor(AbstractTensor):
         location = self.owner.get_worker(location)
 
         def callback(grad):
-            # assert isinstance(grad, torch.Tensor), "Grad in callback should be a Tensor"
             if not isinstance(grad, torch.Tensor):
                 raise TypeError("Grad in callback should be a Tensor")
             # the grad tensor is created by the torch backprop and might not be registered properly
@@ -1062,7 +1061,6 @@ class TorchTensor(AbstractTensor):
 
         """
 
-        # assert isinstance(self.child, PointerTensor)
         if not isinstance(self.child, PointerTensor):
             raise TypeError("child should be a PointerTensor")
 

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -121,11 +121,17 @@ class FixedPrecisionTensor(AbstractTensor):
         rational = self.child
         upscaled = (rational * self.base ** self.precision_fractional).long()
         if check_range:
-            assert (
-                upscaled.abs() < (self.field / 2)
-            ).all(), (
-                f"{rational} cannot be correctly embedded: choose bigger field or a lower precision"
-            )
+            # assert (
+            #     upscaled.abs() < (self.field / 2)
+            # ).all(), (
+            #     f"{rational} cannot be correctly embedded: "
+            #     f"choose bigger field or a lower precision"
+            # )
+            if not ((upscaled.abs() < (self.field / 2)).all()):
+                raise ValueError(
+                    f"{rational} cannot be correctly embedded: "
+                    f"choose bigger field or a lower precision"
+                )
         field_element = upscaled
         field_element.owner = rational.owner
         self.child = field_element.type(self.torch_dtype)
@@ -282,10 +288,16 @@ class FixedPrecisionTensor(AbstractTensor):
         """
         changed_sign = False
         if isinstance(other, FixedPrecisionTensor):
-            assert (
-                self.precision_fractional == other.precision_fractional
-            ), "In mul and div, all args should have the same precision_fractional"
-            assert self.base == other.base, "In mul and div, all args should have the same base"
+            # assert (
+            #     self.precision_fractional == other.precision_fractional
+            # ), "In mul and div, all args should have the same precision_fractional"
+            if self.precision_fractional != other.precision_fractional:
+                raise ValueError(
+                    "In mul and div, all args should have the same precision_fractional"
+                )
+            # assert self.base == other.base, "In mul and div, all args should have the same base"
+            if self.base != other.base:
+                raise ValueError("In mul and div, all args should have the same base")
 
         if isinstance(other, (int, torch.Tensor, AdditiveSharingTensor)):
             new_self = self.child
@@ -439,9 +451,11 @@ class FixedPrecisionTensor(AbstractTensor):
         other = args[0]
 
         if isinstance(other, FixedPrecisionTensor):
-            assert (
-                self.precision_fractional == other.precision_fractional
-            ), "In matmul, all args should have the same precision_fractional"
+            # assert (
+            #     self.precision_fractional == other.precision_fractional
+            # ), "In matmul, all args should have the same precision_fractional"
+            if self.precision_fractional != other.precision_fractional:
+                raise ValueError("In matmul, all args should have the same precision_fractional")
 
         if isinstance(self.child, AdditiveSharingTensor) and isinstance(other.child, torch.Tensor):
             # If we try to matmul a FPT>AST with a FPT>torch.tensor,
@@ -553,8 +567,12 @@ class FixedPrecisionTensor(AbstractTensor):
         """
         # TODO: should we add non-approximate version if self.child is a pure tensor?
 
-        assert len(self.shape) >= 2, "Can't compute inverse on non-matrix"
-        assert self.shape[-1] == self.shape[-2], "Must be batches of square matrices"
+        # assert len(self.shape) >= 2, "Can't compute inverse on non-matrix"
+        if len(self.shape) < 2:
+            raise ValueError("Can't compute inverse on non-matrix")
+        # assert self.shape[-1] == self.shape[-2], "Must be batches of square matrices"
+        if self.shape[-1] != self.shape[-2]:
+            raise ValueError("Must be batches of square matrices")
 
         inverse = (0.1 * torch.eye(self.shape[-1])).fix_prec(**self.get_class_attributes()).child
 
@@ -947,10 +965,17 @@ class FixedPrecisionTensor(AbstractTensor):
         if dtype is None:
             dtype = self.dtype
         else:
-            assert (
-                dtype == self.dtype
-            ), "When sharing a FixedPrecisionTensor, the dtype of the resulting AdditiveSharingTensor \
-                must be the same as the one of the original tensor"
+            # assert (
+            #     dtype == self.dtype
+            # ), "When sharing a FixedPrecisionTensor, the dtype of "
+            #    "the resulting AdditiveSharingTensor "
+            #     "must be the same as the one of the original tensor"
+            if dtype != self.dtype:
+                raise TypeError(
+                    "When sharing a FixedPrecisionTensor, "
+                    "the dtype of the resulting AdditiveSharingTensor"
+                    "must be the same as the one of the original tensor"
+                )
 
         tensor = FixedPrecisionTensor(owner=self.owner, **self.get_class_attributes())
 
@@ -973,10 +998,16 @@ class FixedPrecisionTensor(AbstractTensor):
         if dtype is None:
             kwargs["dtype"] = self.dtype
         else:
-            assert (
-                dtype == self.dtype
-            ), "When sharing a FixedPrecisionTensor, the dtype of the resulting AdditiveSharingTensor \
-                must be the same as the one of the original tensor"
+            # assert (
+            #     dtype == self.dtype
+            # ), "When sharing a FixedPrecisionTensor,
+            # the dtype of the resulting AdditiveSharingTensor \
+            #     must be the same as the one of the original tensor"
+            if dtype != self.dtype:
+                raise TypeError(
+                    "When sharing a FixedPrecisionTensor, the dtype of the resulting "
+                    "AdditiveSharingTensor must be the same as the one of the original tensor"
+                )
         kwargs.pop("no_wrap", None)
         self.child = self.child.share_(*args, no_wrap=True, **kwargs)
         return self

--- a/syft/frameworks/torch/tensors/interpreters/precision.py
+++ b/syft/frameworks/torch/tensors/interpreters/precision.py
@@ -121,12 +121,6 @@ class FixedPrecisionTensor(AbstractTensor):
         rational = self.child
         upscaled = (rational * self.base ** self.precision_fractional).long()
         if check_range:
-            # assert (
-            #     upscaled.abs() < (self.field / 2)
-            # ).all(), (
-            #     f"{rational} cannot be correctly embedded: "
-            #     f"choose bigger field or a lower precision"
-            # )
             if not ((upscaled.abs() < (self.field / 2)).all()):
                 raise ValueError(
                     f"{rational} cannot be correctly embedded: "
@@ -288,14 +282,10 @@ class FixedPrecisionTensor(AbstractTensor):
         """
         changed_sign = False
         if isinstance(other, FixedPrecisionTensor):
-            # assert (
-            #     self.precision_fractional == other.precision_fractional
-            # ), "In mul and div, all args should have the same precision_fractional"
             if self.precision_fractional != other.precision_fractional:
                 raise ValueError(
                     "In mul and div, all args should have the same precision_fractional"
                 )
-            # assert self.base == other.base, "In mul and div, all args should have the same base"
             if self.base != other.base:
                 raise ValueError("In mul and div, all args should have the same base")
 
@@ -451,9 +441,6 @@ class FixedPrecisionTensor(AbstractTensor):
         other = args[0]
 
         if isinstance(other, FixedPrecisionTensor):
-            # assert (
-            #     self.precision_fractional == other.precision_fractional
-            # ), "In matmul, all args should have the same precision_fractional"
             if self.precision_fractional != other.precision_fractional:
                 raise ValueError("In matmul, all args should have the same precision_fractional")
 
@@ -567,10 +554,8 @@ class FixedPrecisionTensor(AbstractTensor):
         """
         # TODO: should we add non-approximate version if self.child is a pure tensor?
 
-        # assert len(self.shape) >= 2, "Can't compute inverse on non-matrix"
         if len(self.shape) < 2:
             raise ValueError("Can't compute inverse on non-matrix")
-        # assert self.shape[-1] == self.shape[-2], "Must be batches of square matrices"
         if self.shape[-1] != self.shape[-2]:
             raise ValueError("Must be batches of square matrices")
 
@@ -965,11 +950,6 @@ class FixedPrecisionTensor(AbstractTensor):
         if dtype is None:
             dtype = self.dtype
         else:
-            # assert (
-            #     dtype == self.dtype
-            # ), "When sharing a FixedPrecisionTensor, the dtype of "
-            #    "the resulting AdditiveSharingTensor "
-            #     "must be the same as the one of the original tensor"
             if dtype != self.dtype:
                 raise TypeError(
                     "When sharing a FixedPrecisionTensor, "
@@ -998,11 +978,6 @@ class FixedPrecisionTensor(AbstractTensor):
         if dtype is None:
             kwargs["dtype"] = self.dtype
         else:
-            # assert (
-            #     dtype == self.dtype
-            # ), "When sharing a FixedPrecisionTensor,
-            # the dtype of the resulting AdditiveSharingTensor \
-            #     must be the same as the one of the original tensor"
             if dtype != self.dtype:
                 raise TypeError(
                     "When sharing a FixedPrecisionTensor, the dtype of the resulting "

--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -113,7 +113,6 @@ def unwrap_args_from_method(attr, method_self, args_, kwargs_):
     # As they won't be used with the same arg types
     attr_id = type(method_self).__name__ + "." + attr
     try:
-        # assert attr not in ambiguous_methods
         if attr in ambiguous_methods:
             raise AssertionError(f"{attr} is part of ambiguous_methods")
 
@@ -149,7 +148,6 @@ def unwrap_args_from_function(attr, args_, kwargs_, return_args_type=False):
         (- the type of the tensors in the arguments)
     """
     try:
-        # assert attr not in ambiguous_functions
         if attr in ambiguous_functions:
             raise AssertionError(f"{attr} is part of ambiguous_functions")
 
@@ -235,7 +233,6 @@ def hook_response(attr, response, wrap_type, wrap_args={}, new_self=None):
     attr_id = f"{attr}@{wrap_type.__name__}.{response_is_tuple}.{hash_wrap_args}"
 
     try:
-        # assert attr not in ambiguous_functions
         if attr in ambiguous_functions:
             raise AssertionError(f"{attr} is part of ambiguous_functions")
 
@@ -618,7 +615,6 @@ def typed_identity(a):
     if a is None:
 
         def none_identity(i):
-            # assert i is None
             if i is not None:
                 raise AssertionError("Supposed to be None")
             return i
@@ -628,7 +624,6 @@ def typed_identity(a):
     elif type(a) in (int, float, bool):
 
         def number_identity(i):
-            # assert isinstance(i, type(a))
             if not isinstance(i, type(a)):
                 raise AssertionError(f"Check type: {type(a)}")
             return i
@@ -675,8 +670,6 @@ def register_response(
     attr_id = f"{attr}"
 
     try:
-        # assert attr not in ambiguous_functions
-        # assert attr not in ambiguous_methods
         if attr in ambiguous_functions:
             raise AssertionError(f"{attr} is part of ambiguous_functions")
         if attr in ambiguous_methods:

--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -620,7 +620,7 @@ def typed_identity(a):
         def none_identity(i):
             # assert i is None
             if i is not None:
-                raise ValueError("Supposed to be None")
+                raise AssertionError("Supposed to be None")
             return i
 
         return none_identity

--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -113,7 +113,9 @@ def unwrap_args_from_method(attr, method_self, args_, kwargs_):
     # As they won't be used with the same arg types
     attr_id = type(method_self).__name__ + "." + attr
     try:
-        assert attr not in ambiguous_methods
+        # assert attr not in ambiguous_methods
+        if attr in ambiguous_methods:
+            raise AttributeError("attr is part of ambiguous_methods")
 
         # Load the utility function to transform the args
         hook_args = hook_method_args_functions[attr_id]
@@ -147,7 +149,10 @@ def unwrap_args_from_function(attr, args_, kwargs_, return_args_type=False):
         (- the type of the tensors in the arguments)
     """
     try:
-        assert attr not in ambiguous_functions
+        # assert attr not in ambiguous_functions
+        if attr in ambiguous_functions:
+            raise AttributeError("attr is part of ambiguous_functions")
+
         # Load the utility function to transform the args
         # TODO rename registry or use another one than for methods
         hook_args = hook_method_args_functions[attr]
@@ -230,7 +235,9 @@ def hook_response(attr, response, wrap_type, wrap_args={}, new_self=None):
     attr_id = f"{attr}@{wrap_type.__name__}.{response_is_tuple}.{hash_wrap_args}"
 
     try:
-        assert attr not in ambiguous_functions
+        # assert attr not in ambiguous_functions
+        if attr in ambiguous_functions:
+            raise AttributeError("attr is part of ambiguous_functions")
 
         # Load the utility function to transform the args
         response_hook_function = hook_method_response_functions[attr_id]
@@ -611,7 +618,9 @@ def typed_identity(a):
     if a is None:
 
         def none_identity(i):
-            assert i is None
+            # assert i is None
+            if i is not None:
+                raise ValueError("Supposed to be None")
             return i
 
         return none_identity
@@ -619,7 +628,9 @@ def typed_identity(a):
     elif type(a) in (int, float, bool):
 
         def number_identity(i):
-            assert isinstance(i, type(a))
+            # assert isinstance(i, type(a))
+            if not isinstance(i, type(a)):
+                raise TypeError("i is supposed to be type of a")
             return i
 
         return number_identity
@@ -664,8 +675,12 @@ def register_response(
     attr_id = f"{attr}"
 
     try:
-        assert attr not in ambiguous_functions
-        assert attr not in ambiguous_methods
+        # assert attr not in ambiguous_functions
+        if attr in ambiguous_functions:
+            raise AttributeError("attr is part of ambiguous_functions")
+        # assert attr not in ambiguous_methods
+        if attr in ambiguous_methods:
+            raise AttributeError("attr is part of ambiguous_methods")
 
         # Load the utility function to register the response and transform tensors with pointers
         register_response_function = register_response_functions[attr_id]

--- a/syft/generic/frameworks/hook/hook_args.py
+++ b/syft/generic/frameworks/hook/hook_args.py
@@ -115,7 +115,7 @@ def unwrap_args_from_method(attr, method_self, args_, kwargs_):
     try:
         # assert attr not in ambiguous_methods
         if attr in ambiguous_methods:
-            raise AttributeError("attr is part of ambiguous_methods")
+            raise AssertionError(f"{attr} is part of ambiguous_methods")
 
         # Load the utility function to transform the args
         hook_args = hook_method_args_functions[attr_id]
@@ -151,7 +151,7 @@ def unwrap_args_from_function(attr, args_, kwargs_, return_args_type=False):
     try:
         # assert attr not in ambiguous_functions
         if attr in ambiguous_functions:
-            raise AttributeError("attr is part of ambiguous_functions")
+            raise AssertionError(f"{attr} is part of ambiguous_functions")
 
         # Load the utility function to transform the args
         # TODO rename registry or use another one than for methods
@@ -237,7 +237,7 @@ def hook_response(attr, response, wrap_type, wrap_args={}, new_self=None):
     try:
         # assert attr not in ambiguous_functions
         if attr in ambiguous_functions:
-            raise AttributeError("attr is part of ambiguous_functions")
+            raise AssertionError(f"{attr} is part of ambiguous_functions")
 
         # Load the utility function to transform the args
         response_hook_function = hook_method_response_functions[attr_id]
@@ -630,7 +630,7 @@ def typed_identity(a):
         def number_identity(i):
             # assert isinstance(i, type(a))
             if not isinstance(i, type(a)):
-                raise TypeError("i is supposed to be type of a")
+                raise AssertionError(f"Check type: {type(a)}")
             return i
 
         return number_identity
@@ -676,11 +676,11 @@ def register_response(
 
     try:
         # assert attr not in ambiguous_functions
-        if attr in ambiguous_functions:
-            raise AttributeError("attr is part of ambiguous_functions")
         # assert attr not in ambiguous_methods
+        if attr in ambiguous_functions:
+            raise AssertionError(f"{attr} is part of ambiguous_functions")
         if attr in ambiguous_methods:
-            raise AttributeError("attr is part of ambiguous_methods")
+            raise AssertionError(f"{attr} is part of ambiguous_methods")
 
         # Load the utility function to register the response and transform tensors with pointers
         register_response_function = register_response_functions[attr_id]

--- a/syft/generic/frameworks/remote.py
+++ b/syft/generic/frameworks/remote.py
@@ -7,5 +7,7 @@ class Remote(object):
 
     @staticmethod
     def register_framework(cls):
-        assert cls.name not in Remote.frameworks
+        # assert cls.name not in Remote.frameworks
+        if cls.name in Remote.frameworks:
+            raise AttributeError("already registered")
         Remote.frameworks[cls.name] = cls

--- a/syft/generic/frameworks/remote.py
+++ b/syft/generic/frameworks/remote.py
@@ -7,7 +7,6 @@ class Remote(object):
 
     @staticmethod
     def register_framework(cls):
-        # assert cls.name not in Remote.frameworks
         if cls.name in Remote.frameworks:
-            raise AttributeError("already registered")
+            raise AttributeError(f"Error: {cls.name} is in Remote.Frameworks")
         Remote.frameworks[cls.name] = cls

--- a/syft/generic/pointers/multi_pointer.py
+++ b/syft/generic/pointers/multi_pointer.py
@@ -55,7 +55,9 @@ class MultiPointerTensor(AbstractTensor):
 
         self.child = {}
         for c in children:
-            assert c.shape == children[0].shape
+            # assert c.shape == children[0].shape
+            if c.shape != children[0].shape:
+                raise ValueError("Check the shape of children")
             self.child[c.location.id] = c
 
     def __str__(self):

--- a/syft/generic/pointers/multi_pointer.py
+++ b/syft/generic/pointers/multi_pointer.py
@@ -55,9 +55,8 @@ class MultiPointerTensor(AbstractTensor):
 
         self.child = {}
         for c in children:
-            # assert c.shape == children[0].shape
             if c.shape != children[0].shape:
-                raise ValueError("Check the shape of children")
+                raise ValueError("Each entry in children should be of same shape.")
             self.child[c.location.id] = c
 
     def __str__(self):

--- a/syft/generic/pointers/pointer_plan.py
+++ b/syft/generic/pointers/pointer_plan.py
@@ -107,9 +107,14 @@ class PointerPlan(ObjectPointer):
     def parameters(self) -> List:
         """Return a list of pointers to the plan parameters"""
 
-        assert (
-            len(self._locations) == 1
-        ), ".parameters() for PointerPlan with > 1 locations is currently not implemented."
+        # assert (
+        #     len(self._locations) == 1
+        # ), ".parameters() for PointerPlan with > 1 locations is currently not implemented."
+        if len(self._locations) != 1:
+            raise ValueError(
+                ".parameters() for PointerPlan with > 1 locations is currently not implemented."
+            )
+
         # TODO implement this feature using MultiPointerTensor
 
         location = self._locations[0]

--- a/syft/generic/pointers/pointer_plan.py
+++ b/syft/generic/pointers/pointer_plan.py
@@ -107,9 +107,6 @@ class PointerPlan(ObjectPointer):
     def parameters(self) -> List:
         """Return a list of pointers to the plan parameters"""
 
-        # assert (
-        #     len(self._locations) == 1
-        # ), ".parameters() for PointerPlan with > 1 locations is currently not implemented."
         if len(self._locations) != 1:
             raise ValueError(
                 ".parameters() for PointerPlan with > 1 locations is currently not implemented."

--- a/syft/serde/msgpack/native_serde.py
+++ b/syft/serde/msgpack/native_serde.py
@@ -360,7 +360,6 @@ def _detail_ndarray(
     arr_dtype = serde._detail(worker, arr_representation[2])
     res = numpy.frombuffer(arr_representation[0], dtype=arr_dtype).reshape(arr_shape)
 
-    # assert type(res) == numpy.ndarray
     if type(res) != numpy.ndarray:
         raise TypeError("res should be a numpy array.")
 
@@ -463,7 +462,6 @@ def _detail_numpy_number(
     nb_dtype = serde._detail(worker, nb_representation[1])
     nb = numpy.frombuffer(nb_representation[0], dtype=nb_dtype)[0]
 
-    # assert type(nb) in [numpy.float32, numpy.float64, numpy.int32, numpy.int64]
     if type(nb) not in [numpy.float32, numpy.float64, numpy.int32, numpy.int64]:
         raise TypeError(
             "Invalid type, nb_representation should be either of "

--- a/syft/serde/msgpack/native_serde.py
+++ b/syft/serde/msgpack/native_serde.py
@@ -360,7 +360,9 @@ def _detail_ndarray(
     arr_dtype = serde._detail(worker, arr_representation[2])
     res = numpy.frombuffer(arr_representation[0], dtype=arr_dtype).reshape(arr_shape)
 
-    assert type(res) == numpy.ndarray
+    # assert type(res) == numpy.ndarray
+    if type(res) != numpy.ndarray:
+        raise TypeError("res should be a numpy array.")
 
     return res
 
@@ -461,7 +463,12 @@ def _detail_numpy_number(
     nb_dtype = serde._detail(worker, nb_representation[1])
     nb = numpy.frombuffer(nb_representation[0], dtype=nb_dtype)[0]
 
-    assert type(nb) in [numpy.float32, numpy.float64, numpy.int32, numpy.int64]
+    # assert type(nb) in [numpy.float32, numpy.float64, numpy.int32, numpy.int64]
+    if type(nb) not in [numpy.float32, numpy.float64, numpy.int32, numpy.int64]:
+        raise TypeError(
+            "Invalid type, nb_representation should be either of "
+            "[numpy.float32, numpy.float64, numpy.int32, numpy.int64]"
+        )
 
     return nb
 

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -408,7 +408,12 @@ class BaseWorker(AbstractWorker):
         if not isinstance(workers, (list, tuple)):
             workers = [workers]
 
-        assert len(workers) > 0, "Please provide workers to receive the data"
+        # assert len(workers) > 0, "Please provide workers to receive the data"
+        if len(workers) <= 0:
+            raise RuntimeError(
+                "Please provide workers to receive the data, current size of workers: %d"
+                % len(workers)
+            )
 
         if len(workers) == 1:
             worker = workers[0]
@@ -859,7 +864,9 @@ class BaseWorker(AbstractWorker):
         """
         results = self.object_store.find_by_tag(tag)
         if results:
-            assert all(result.location.id == location.id for result in results)
+            # assert all(result.location.id == location.id for result in results)
+            if not all(result.location.id == location.id for result in results):
+                raise ValueError("All Tags are not of same location.")
             return results
         else:
             return self.request_search(tag, location=location)

--- a/syft/workers/base.py
+++ b/syft/workers/base.py
@@ -408,7 +408,6 @@ class BaseWorker(AbstractWorker):
         if not isinstance(workers, (list, tuple)):
             workers = [workers]
 
-        # assert len(workers) > 0, "Please provide workers to receive the data"
         if len(workers) <= 0:
             raise RuntimeError(
                 "Please provide workers to receive the data, current size of workers: %d"
@@ -864,7 +863,6 @@ class BaseWorker(AbstractWorker):
         """
         results = self.object_store.find_by_tag(tag)
         if results:
-            # assert all(result.location.id == location.id for result in results)
             if not all(result.location.id == location.id for result in results):
                 raise ValueError("All Tags are not of same location.")
             return results

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -83,9 +83,6 @@ class BaseMessageHandler(AbstractMessageHandler):
                     _self = self.worker
                 else:
                     res: list = self.worker.search(_self)
-                    # assert (
-                    #     len(res) == 1
-                    # ), f"Searching for {_self} on {self.worker.id}. /!\\ {len(res)} found"
                     if len(res) != 1:
                         raise ValueError(
                             f"Searching for {_self} on {self.worker.id}. /!\\ {len(res)} found"

--- a/syft/workers/message_handler.py
+++ b/syft/workers/message_handler.py
@@ -83,9 +83,13 @@ class BaseMessageHandler(AbstractMessageHandler):
                     _self = self.worker
                 else:
                     res: list = self.worker.search(_self)
-                    assert (
-                        len(res) == 1
-                    ), f"Searching for {_self} on {self.worker.id}. /!\\ {len(res)} found"
+                    # assert (
+                    #     len(res) == 1
+                    # ), f"Searching for {_self} on {self.worker.id}. /!\\ {len(res)} found"
+                    if len(res) != 1:
+                        raise ValueError(
+                            f"Searching for {_self} on {self.worker.id}. /!\\ {len(res)} found"
+                        )
                     _self = res[0]
             if sy.framework.is_inplace_method(op_name):
                 # TODO[jvmancuso]: figure out a good way to generalize the

--- a/test/generic/pointers/test_dataset_pointer.py
+++ b/test/generic/pointers/test_dataset_pointer.py
@@ -54,3 +54,10 @@ def test_get_data_targets(workers):
 
     assert torch.equal(remote_data, data) == 1
     assert torch.equal(remote_targets, target) == 1
+
+
+# adding this to increase test coverage of generic/pointers/pointer_dataset.py
+def test_simple_case(workers):
+    alice, _, _ = workers["alice"], workers["bob"], workers["me"]
+    dataset = PointerDataset(alice, tags=["test1", "test2"], description="test")
+    assert isinstance(dataset.__repr__(), str)

--- a/test/generic/test_string.py
+++ b/test/generic/test_string.py
@@ -68,3 +68,11 @@ def test_string_methods():
     bob = sy.VirtualWorker(id="bob", hook=sy.hook)
     out = x.send(bob)
     assert isinstance(out, sy.generic.pointers.string_pointer.StringPointer)
+
+    # adding this to increase test coverage of generic/string.py
+    test = "test"
+    x = String().simplify(worker=bob, string=String(test))
+    assert x is not None
+    x = String().detail(bob, x)
+    assert x is not None
+    assert x == test

--- a/test/generic/test_string.py
+++ b/test/generic/test_string.py
@@ -69,10 +69,9 @@ def test_string_methods():
     out = x.send(bob)
     assert isinstance(out, sy.generic.pointers.string_pointer.StringPointer)
 
-    # adding this to increase test coverage of generic/string.py
-    test = "test"
-    x = String().simplify(worker=bob, string=String(test))
-    assert x is not None
-    x = String().detail(bob, x)
-    assert x is not None
-    assert x == test
+    # adding these to increase test coverage of generic/string.py
+    test = String("test")
+    x = String().simplify(worker=bob, string=test)
+    assert String.add_string(test, String().detail(bob, x)) == "testtest"
+    assert isinstance(test.get_class_attributes()["owner"], sy.VirtualWorker)
+    assert test.on("on") == "on"

--- a/test/torch/nn/test_nn.py
+++ b/test/torch/nn/test_nn.py
@@ -1,4 +1,5 @@
 import copy
+import pytest
 
 import torch
 import torch.nn as nn
@@ -372,3 +373,11 @@ def test_LSTM():
     assert torch.all(torch.lt(torch.abs(output_syft - output_torch), 1e-6))
     assert torch.all(torch.lt(torch.abs(hidden_syft - hidden_torch), 1e-6))
     assert torch.all(torch.lt(torch.abs(cell_syft - cell_torch), 1e-6))
+
+
+# adding this to increase test coverage of syft/frameworks/torch/nn/conv.py
+def test_simple_case():
+    model = syft_nn.conv.Conv2d(1, 2, 3, bias=True)
+    assert not isinstance(model, torch.nn.Conv2d)
+    with pytest.raises(ValueError):
+        model.forward(torch.rand((1, 2)))

--- a/test/workers/test_virtual.py
+++ b/test/workers/test_virtual.py
@@ -233,6 +233,11 @@ def test_send_jit_scriptmodule(hook, workers):  # pragma: no cover
         return x + 2
 
     foo_wrapper = ObjectWrapper(obj=foo, id=99)
+    # adding this to increase test coverage of generic/pointers/object_wrapper.py
+    assert isinstance(foo_wrapper.__str__(), str)
+    assert isinstance(foo_wrapper.__repr__(), str)
+    assert foo_wrapper.__repr__() == foo_wrapper.__str__()
+
     foo_ptr = hook.local_worker.send(foo_wrapper, bob)
 
     res = foo_ptr(torch.tensor(4))


### PR DESCRIPTION
## Description
Changed all assert blocks to if/raise block. This is important as assert checks can be globally disabled with the -O and -OO flags, as well as the PYTHONOPTIMIZE env var. This PR is against an open issue, [Don't use `assert` for non-debugging data validation](https://github.com/OpenMined/PySyft/issues/3480) 

## Affected Dependencies
For now, commented out the assert blocks and wherever error statement wasn't present, added an error statement based on understanding I could make of it 

## How has this been tested?
- ran the standard `python setup.py test`, which was a success
