### PR TITLE
Reduce length of AST message

### DIFF
--- a/test/serde/serde_helpers.py
+++ b/test/serde/serde_helpers.py
@@ -557,7 +557,7 @@ def make_additivesharingtensor(**kwargs):
                     ast.dtype.encode("utf-8"),
                     (CODE[str], (ast.crypto_provider.id.encode("utf-8"),)),  # (str) worker_id
                     msgpack.serde._simplify(
-                        kwargs["workers"]["serde_worker"], ast.child
+                        kwargs["workers"]["serde_worker"], list(ast.child.values())
                     ),  # (dict of AbstractTensor) simplified chain
                     ast.get_garbage_collect_data(),
                 ),


### PR DESCRIPTION
## Description
Reduce the size of the AST message - when sending it.
Take advantage of the fact that the pointers already have the location -> no need to serialize the workers.
Also, take advantage of the fact that the garbage collect value is the same for all the shares.

How the serialization looked:
**Before**:
```
 (Pdb) p tensor_tuple
  (55209114651, (5, (b'18446744073709551616',)), (5, (b'snn',)), b'long', (5, (b'me',)), (0, (((5, (b'alice',)), (25, (50814691011, 47632598781, (5, (b'alice',)), None, (11, (3,)), False, None, None))), ((5, (b'  bob',)), (25, (64630107868, 8594578436, (5, (b'bob',)), None, (11, (3,)), False, None, None))), ((5, (b'charlie',)), (25, (5588846714, 53068487497, (5, (b'charlie',)), None, (11, (3,)), False, None, None))))),   {'alice': False, 'bob': False, 'charlie': False})
  Length: 468
```
**After**:
```
  (Pdb) p tensor_tuple
  (54647245112, (5, (b'18446744073709551616',)), (5, (b'snn',)), b'long', (5, (b'me',)), (1, ((25, (5808753007, 49435692954, (5, (b'alice',)), None, (11, (3,)), False, None, None)), (25, (95853045648, 9923638723  5, (5, (b'bob',)), None, (11, (3,)), False, None, None)), (25, (37769893179, 35243807859, (5, (b'charlie',)), None, (11, (3,)), False, None, None)))), False) 
  Length : 366
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- All the tests for AST are passing

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
