### PR TITLE
Use id_at_location

### DIFF
--- a/src/syft/ast/klass.py
+++ b/src/syft/ast/klass.py
@@ -164,10 +164,12 @@ class Class(Callable):
                 id_ = UID()
                 self.id = id_
 
+            id_at_location = UID()
+
             # Step 1: create pointer which will point to result
             ptr = getattr(outer_self, outer_self.pointer_name)(
                 client=client,
-                id_at_location=self.id,
+                id_at_location=id_at_location,
                 tags=self.tags if hasattr(self, "tags") else list(),
                 description=self.description if hasattr(self, "description") else "",
             )
@@ -184,6 +186,7 @@ class Class(Callable):
             client.send_immediate_msg_without_reply(msg=obj_msg)
 
             # STep 4: return pointer
+            # Step 4: return pointer
             return ptr
 
         def send_to(self: Any, client: Any, searchable: bool = False) -> Pointer:

--- a/src/syft/ast/klass.py
+++ b/src/syft/ast/klass.py
@@ -185,7 +185,6 @@ class Class(Callable):
             # Step 3: send message
             client.send_immediate_msg_without_reply(msg=obj_msg)
 
-            # STep 4: return pointer
             # Step 4: return pointer
             return ptr
 

--- a/src/syft/core/node/common/action/garbage_collect_object_action.py
+++ b/src/syft/core/node/common/action/garbage_collect_object_action.py
@@ -23,8 +23,6 @@ class GarbageCollectObjectAction(EventualActionWithoutReply):
         self.obj_id = obj_id
 
     def execute_action(self, node: AbstractNode, verify_key: VerifyKey) -> None:
-        # TODO: make lazy
-        # QUESTION: Where is delete_object defined
         try:
             del node.store[self.obj_id]
         except KeyError:

--- a/src/syft/core/node/common/action/get_object_action.py
+++ b/src/syft/core/node/common/action/get_object_action.py
@@ -158,6 +158,7 @@ class GetObjectAction(ImmediateActionWithReply):
         # TODO: send EventualActionWithoutReply to delete the object at the node's
         # convenience instead of definitely having to delete it now
         del node.store[self.obj_id]
+
         return msg
 
     @property

--- a/src/syft/core/node/common/action/save_object_action.py
+++ b/src/syft/core/node/common/action/save_object_action.py
@@ -37,36 +37,34 @@ class SaveObjectAction(ImmediateActionWithoutReply, Serializable):
 
     def execute_action(self, node: AbstractNode, verify_key: VerifyKey) -> None:
         # save the object to the store
-        node.store.store(
-            obj=StorableObject(
-                # ignoring this - the fundamental problem is that we can't force the classes
-                # we want to use to subclass from something without creating wrappers for
-                # everything which are mandatory for all operations. It's plausible that we
-                # will have to do this - but for now we aren't so we need to simply assume
-                # that we're adding ids to things. I don't like it though - wish there was a
-                # better way. But we want to support other frameworks so - gotta do it.
-                id=self.obj.id,  # type: ignore
-                data=self.obj,
-                tags=(
-                    # QUESTION: do we want None or an empty []
-                    self.obj.tags  # type: ignore
-                    if hasattr(self.obj, "tags")
-                    else None
-                ),
-                description=(
-                    self.obj.description  # type: ignore
-                    if hasattr(self.obj, "description")
-                    else ""
-                ),
-                search_permissions={All(): None}
-                if self.anyone_can_search_for_this
-                else {},
-                read_permissions={
-                    node.verify_key: node.id,
-                    verify_key: None,  # we dont have the passed in sender's UID
-                },
-            )
+        obj = StorableObject(
+            # ignoring this - the fundamental problem is that we can't force the classes
+            # we want to use to subclass from something without creating wrappers for
+            # everything which are mandatory for all operations. It's plausible that we
+            # will have to do this - but for now we aren't so we need to simply assume
+            # that we're adding ids to things. I don't like it though - wish there was a
+            # better way. But we want to support other frameworks so - gotta do it.
+            id=self.obj_id,
+            data=self.obj,
+            tags=(
+                # QUESTION: do we want None or an empty []
+                self.obj.tags  # type: ignore
+                if hasattr(self.obj, "tags")
+                else None
+            ),
+            description=(
+                self.obj.description  # type: ignore
+                if hasattr(self.obj, "description")
+                else ""
+            ),
+            search_permissions={All(): None} if self.anyone_can_search_for_this else {},
+            read_permissions={
+                node.verify_key: node.id,
+                verify_key: None,  # we dont have the passed in sender's UID
+            },
         )
+
+        node.store.store(obj=obj)
 
     @syft_decorator(typechecking=True)
     def _object2proto(self) -> SaveObjectAction_PB:

--- a/tests/stress/gc_test.py
+++ b/tests/stress/gc_test.py
@@ -1,0 +1,56 @@
+import syft as sy
+import torch
+
+import gc
+
+
+def test_same_var_for_ptr_gc() -> None:
+    """
+    Test for checking if the gc is correctly triggered
+    when the last reference to the ptr is overwritten
+    """
+    x = torch.tensor([1, 2, 3, 4])
+
+    alice = sy.VirtualMachine(name="alice")
+    alice_client = alice.get_client()
+
+    for _ in range(100):
+        """
+        Override the ptr multiple times to make sure we trigger
+        the gc
+        """
+        ptr = x.send(alice_client)
+
+    gc.collect()
+
+    assert len(alice.store) == 1
+
+    ptr.get()
+    gc.collect()
+
+    assert len(alice.store) == 0
+
+
+def test_send_same_obj_gc() -> None:
+    """
+    Test if sending the same object multiple times, register the
+    object multiple times - because each send generated another
+    remote object
+    """
+
+    x = torch.tensor([1, 2, 3, 4])
+    ptr = []
+
+    alice = sy.VirtualMachine(name="alice")
+    alice_client = alice.get_client()
+
+    for _ in range(100):
+        ptr.append(x.send(alice_client))
+
+    gc.collect()
+    assert len(alice.store) == 100
+
+    del ptr
+
+    gc.collect()
+    assert len(alice.store) == 0

--- a/tests/syft/core/common/serializable_test.py
+++ b/tests/syft/core/common/serializable_test.py
@@ -1,5 +1,21 @@
 # import uuid
-# import pytest
+import pytest
+
 # from syft.core.common.uid import UID
-# from syft.core.common.serde.serializable import Serializable
+from syft.core.common.serde.serializable import Serializable
+from syft.core.common.serde.serialize import _serialize
+
 # import syft as sy
+
+
+def test_object_with_no_serialize_wrapper() -> None:
+    """
+    Test if an object that is Serializable but does not implement the serializable_wrapper_type
+    throws an exception when trying to serialize.
+    """
+
+    class TestObject(Serializable):
+        pass
+
+    with pytest.raises(Exception):
+        _serialize(TestObject())

--- a/tests/syft/core/common/uid_test.py
+++ b/tests/syft/core/common/uid_test.py
@@ -110,6 +110,13 @@ def test_from_string() -> None:
     assert uid == uid_comp
 
 
+def test_from_string_exception() -> None:
+    """Tests that UID throws exception when invalid string is given. """
+
+    with pytest.raises(Exception):
+        UID.from_string(value="Hello world")
+
+
 # --------------------- SERDE ---------------------
 
 

--- a/tests/syft/grid/duet_test.py
+++ b/tests/syft/grid/duet_test.py
@@ -14,7 +14,7 @@ def test_duet_send_and_get() -> None:
     x = th.tensor([1, 2, 3])
     xp = x.send(duet)
 
-    assert xp.id_at_location == x.id
+    assert len(duet.store) == 1
 
     yp = xp + xp
 

--- a/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
+++ b/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
@@ -20,11 +20,11 @@ def test_torch_remote_tensor_register() -> None:
 
     assert len(alice.store) == 1
 
-    # TODO: Fix this from deleting the object in the store due to the variable
-    # ptr being assigned a second time and triggering __del__ on the old variable
-    # ptr used to be assigned to (Even though its new assignment is the same object)
-    # ptr = x.send(alice_client)
-    # assert len(alice.store) == 1  # Same id
+    ptr = x.send(alice_client)
+
+    # the previous objects get deleted because we overwrite
+    # ptr - we send a message to delete that object
+    assert len(alice.store) == 1
 
     ptr.get()
     assert len(alice.store) == 0  # Get removes the object

--- a/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
+++ b/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
@@ -21,6 +21,7 @@ def test_torch_remote_tensor_register() -> None:
     assert len(alice.store) == 1
 
     ptr = x.send(alice_client)
+    gc.collect()
 
     # the previous objects get deleted because we overwrite
     # ptr - we send a message to delete that object


### PR DESCRIPTION
## Description
Currently, we use the id of the object as a way to register an object as a remote location.
This brings some advantages, but also some downsides.
The advantage is that we will record only once if we send that item multiple times.
```
ptr = x.send(alice)
ptr = x.send(alice)
```
Since we send the same object, we keep only 1 instance of that object on alice.

The problem comes (in the above example) when we delete ```ptr``` - the second assignment will generate a call to the ```__del__``` method from ```PointerTensor``` (this call can come at any time).
If we have the same id, we might execute the second statement and after that, we delete the first ```ptr``` --> in this case we will delete the underlying data, where ```ptr``` points to.

With this PR we generate another UUID  for each sent item - in this scenario, we know that when the first ```ptr``` will get deleted it will delete an object that is identified with a UUID that is different than the second one


## Affected Dependencies
How the objects are kept at the destination

## How has this been tested?
- Added a test where we overwrite the ```ptr``` with the same object

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
