### PR TITLE
Fixing parallel threaded tests and nest_asyncio.apply()

### DIFF
--- a/src/syft/grid/duet/__init__.py
+++ b/src/syft/grid/duet/__init__.py
@@ -14,7 +14,11 @@ from .duet import Duet  # noqa: F401
 from .om_signaling_client import register
 from .webrtc_duet import Duet as WebRTCDuet  # noqa: F811
 
-nest_asyncio.apply()
+try:
+    nest_asyncio.apply()
+except RuntimeError as e:
+    # this happens when pytest-xdist parallel threaded tests are run on some systems
+    print("Nothing to patch", e)
 
 ADDR_REPOSITORY = (
     "https://raw.githubusercontent.com/OpenMined/OpenGridNodes/master/network_address"


### PR DESCRIPTION
## Description
The tests are sometimes breaking due to pytest-xdist and threaded parallel tests.
This PR is to fix the issue.

## Affected Dependencies
None

## How has this been tested?
CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
