### PR TITLE
Fix for RNN training on websockets, added instructions for Windows workaround installation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -103,6 +103,10 @@ You can test your installation by running:
 
 ## Windows
 
+Currently, the PyTorch 1.4.0 package is not available in Windows, preventing an installation of PySyft from being
+completed successfully. A workaround is to grab an Ubuntu Submachine from the Windows store, and then following the instructions 
+for the Linux installation.
+
 ### 1. Install Python
 
 PySyft requires python version Python >= 3.6 < 3.8

--- a/examples/tutorials/advanced/Federated Recurrent Neural Network.ipynb
+++ b/examples/tutorials/advanced/Federated Recurrent Neural Network.ipynb
@@ -26,19 +26,19 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "predict(model_pointers[\"bob\"], \"Qing\", alice) #alice is our worker\n",
+    "predict(model_pointers[\"bob\"], \"Lu\", alice) #alice is our worker\n",
     "\n",
-    " Qing\n",
-    "(-1.43) Korean\n",
-    "(-1.74) Vietnamese\n",
-    "(-2.18) Arabic\n",
+    "> Lu\n",
+    "(-1.26) Korean\n",
+    "(-1.28) Chinese\n",
+    "(-3.18) English\n",
     "\n",
-    "predict(model_pointers[\"alice\"], \"Daniele\", alice)\n",
+    "predict(model_pointers[\"alice\"], \"Gadler\", alice)\n",
     "\n",
-    " Daniele\n",
-    "(-1.58) French\n",
-    "(-2.04) Scottish\n",
-    "(-2.07) Dutch\n",
+    "> Gadler\n",
+    "(-1.79) German\n",
+    "(-1.89) French\n",
+    "(-1.91) Dutch\n",
     "```"
    ]
   },
@@ -48,7 +48,7 @@
    "source": [
     "The present example is inspired by an official Pytorch [tutorial](https://pytorch.org/tutorials/intermediate/char_rnn_classification_tutorial.html), which I ported to PySyft with  the purpose of learning a Recurrent Neural Network in a federated way.The present tutorial is self-contained, so there are no dependencies on external pieces of code apart from a few Python libraries.\n",
     "\n",
-    "**RNN Tutorial's author**: Daniele Gadler. [@DanyEle](https://github.com/danyele) on Github.\n"
+    "**RNN Tutorial's author**: Daniele Gadler. [@DanyEle](https://github.com/danyele) on Github and [@DanieleGadler](https://twitter.com/danielegadler) on Twitter \n"
    ]
   },
   {
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,9 +117,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Not downloading the dataset because it was already downloaded\n"
+     ]
+    }
+   ],
    "source": [
     "#create a function for checking if the dataset does indeed exist\n",
     "def dataset_exists():\n",
@@ -164,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,9 +197,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "data/names/Arabic.txt\n",
+      "data/names/Chinese.txt\n",
+      "data/names/Czech.txt\n",
+      "data/names/Dutch.txt\n",
+      "data/names/English.txt\n",
+      "data/names/French.txt\n",
+      "data/names/German.txt\n",
+      "data/names/Greek.txt\n",
+      "data/names/Irish.txt\n",
+      "data/names/Italian.txt\n",
+      "data/names/Japanese.txt\n",
+      "data/names/Korean.txt\n",
+      "data/names/Polish.txt\n",
+      "data/names/Portuguese.txt\n",
+      "data/names/Russian.txt\n",
+      "data/names/Scottish.txt\n",
+      "data/names/Spanish.txt\n",
+      "data/names/Vietnamese.txt\n",
+      "Amount of categories:18\n"
+     ]
+    }
+   ],
    "source": [
     "all_letters = string.ascii_letters + \" .,;'\"\n",
     "n_letters = len(all_letters)\n",
@@ -223,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,9 +326,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "\n",
+       "\\begin{split}\n",
+       "names\\_list = [d_1,...,d_n]  \\\\\n",
+       "\n",
+       "category\\_list = [c_1,...,c_n] \n",
+       "\\end{split}\n",
+       "\n",
+       "\n",
+       "Where $n$ is the total amount of data points\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Latex object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%latex\n",
     "\n",
@@ -310,9 +365,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Nahas', 'Daher', 'Gerges', 'Nazari', 'Maalouf', 'Gerges', 'Naifeh', 'Guirguis', 'Baba', 'Sabbagh', 'Attia', 'Tahan', 'Haddad', 'Aswad', 'Najjar', 'Dagher', 'Maloof', 'Isa', 'Asghar']\n",
+      "['Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic', 'Arabic']\n",
+      "\n",
+      " \n",
+      " Amount of data points loaded: 20074\n"
+     ]
+    }
+   ],
    "source": [
     "#Set of names(X)\n",
     "names_list = []\n",
@@ -346,9 +413,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Said', 'Guirguis', 'Nader', 'Harb', 'Atiyeh', 'Zogby', 'Basara', 'Nassar', 'Kalb', 'Khoury']\n",
+      "[0 0 0 0 0 0 0 0 0 0]\n"
+     ]
+    }
+   ],
    "source": [
     "#Assign an integer to every category\n",
     "categories_numerical = pd.factorize(category_list)[0]\n",
@@ -384,9 +460,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Khoury\n",
+      "[[[0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]\n",
+      "\n",
+      " [[0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]\n",
+      "\n",
+      " [[0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]\n",
+      "\n",
+      " [[0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]\n",
+      "\n",
+      " [[0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 1. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]\n",
+      "\n",
+      " [[0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 1. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.\n",
+      "   0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]]\n",
+      "(6, 1, 57)\n"
+     ]
+    }
+   ],
    "source": [
     "def letterToIndex(letter):\n",
     "    return all_letters.find(letter)\n",
@@ -434,9 +542,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Khoury\n",
+      "tensor([[[0., 0., 0.,  ..., 0., 0., 0.]],\n",
+      "\n",
+      "        [[0., 0., 0.,  ..., 0., 0., 0.]],\n",
+      "\n",
+      "        [[0., 0., 0.,  ..., 0., 0., 0.]],\n",
+      "\n",
+      "        ...,\n",
+      "\n",
+      "        [[0., 0., 0.,  ..., 0., 0., 0.]],\n",
+      "\n",
+      "        [[0., 0., 0.,  ..., 0., 0., 0.]],\n",
+      "\n",
+      "        [[0., 0., 0.,  ..., 0., 0., 0.]]])\n",
+      "torch.Size([19, 1, 57])\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "max_line_size = max(len(x) for x in lines_tensors)\n",
@@ -466,9 +596,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(20074, 19, 1, 57)\n",
+      "(20074, 19, 57)\n"
+     ]
+    }
+   ],
    "source": [
     "#And finally, from a list, we can create a numpy array with all our word embeddings having the same shape:\n",
     "array_lines_tensors = np.stack(lines_tensors)\n",
@@ -490,9 +629,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Arabic': 0, 'Chinese': 2000, 'Czech': 2268, 'Dutch': 2787, 'English': 3084, 'French': 6752, 'German': 7029, 'Greek': 7753, 'Irish': 7956, 'Italian': 8188, 'Japanese': 8897, 'Korean': 9888, 'Polish': 9982, 'Portuguese': 10121, 'Russian': 10195, 'Scottish': 19603, 'Spanish': 19703, 'Vietnamese': 20001}\n"
+     ]
+    }
+   ],
    "source": [
     "def find_start_index_per_category(category_list):\n",
     "    categories_start_index = {}\n",
@@ -530,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,9 +707,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RNN(\n",
+      "  (i2h): Linear(in_features=185, out_features=128, bias=True)\n",
+      "  (i2o): Linear(in_features=185, out_features=18, bias=True)\n",
+      "  (softmax): LogSoftmax()\n",
+      ")\n"
+     ]
+    }
+   ],
    "source": [
     "#Two hidden layers, based on simple linear layers\n",
     "\n",
@@ -581,15 +740,14 @@
     "        output = self.softmax(output)\n",
     "        return output, hidden\n",
     "\n",
-    "    def initHidden(self):\n",
+    "    def init_hidden(self):\n",
     "        return torch.zeros(1, self.hidden_size)\n",
     "\n",
     "#Let's instantiate the neural network already:\n",
     "n_hidden = 128\n",
     "#Instantiate RNN\n",
     "\n",
-    "device = torch.device(\"cuda\" if args.use_cuda else \"cpu\")\n",
-    "model = RNN(n_letters, n_hidden, n_categories).to(device)\n",
+    "model = RNN(n_letters, n_hidden, n_categories)\n",
     "#The final softmax layer will produce a probability for each one of our 18 categories\n",
     "print(model)    \n",
     "    "
@@ -597,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -605,21 +763,21 @@
     "hook = sy.TorchHook(torch)  # <-- NEW: hook PyTorch ie add extra functionalities to support Federated Learning\n",
     "alice = sy.VirtualWorker(hook, id=\"alice\")  \n",
     "bob = sy.VirtualWorker(hook, id=\"bob\")  \n",
-    "#charlie = sy.VirtualWorker(hook, id=\"charlie\") \n",
+    "charlie = sy.VirtualWorker(hook, id=\"charlie\") \n",
     "\n",
     "workers_virtual = [alice, bob]\n",
     "\n",
     "#If you have your workers operating remotely, like on Raspberry PIs\n",
-    "#kwargs_websocket_alice = {\"host\": \"ip_alice\", \"hook\": hook}\n",
+    "#kwargs_websocket_alice = {\"host\": \"127.0.0.1\", \"hook\": hook}\n",
     "#alice = WebsocketClientWorker(id=\"alice\", port=8777, **kwargs_websocket_alice)\n",
-    "#kwargs_websocket_bob = {\"host\": \"ip_bob\", \"hook\": hook}\n",
+    "#kwargs_websocket_bob = {\"host\": \"127.0.0.1\", \"hook\": hook}\n",
     "#bob = WebsocketClientWorker(id=\"bob\", port=8778, **kwargs_websocket_bob)\n",
     "#workers_virtual = [alice, bob]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +826,7 @@
     "        \n",
     "        if(iter % args.federate_after_n_batches == 0):\n",
     "            for worker_name, model_pointer in model_pointers.items():\n",
-    "#                #need to assign the model to the worker it belongs to.\n",
+    "                #need to assign the model to the worker it belongs to.\n",
     "                models_local[worker_name] = model_pointer.copy().get()\n",
     "            model_avg = utils.federated_avg(models_local)\n",
     "           \n",
@@ -683,9 +841,8 @@
     "    #get the right initialized model\n",
     "    model_ptr = model_pointers[line_single.location.id]   \n",
     "    line_reshaped = line_single.reshape(max_line_size, 1, len(all_letters))\n",
-    "    line_reshaped, category_single = line_reshaped.to(device), category_single.to(device)\n",
     "    #Firstly, initialize hidden layer\n",
-    "    hidden_init = model_ptr.initHidden() \n",
+    "    hidden_init = model_ptr.init_hidden() \n",
     "    #And now zero grad the model\n",
     "    model_ptr.zero_grad()\n",
     "    hidden_ptr = hidden_init.send(line_single.location)\n",
@@ -731,7 +888,7 @@
     "        line_name = names_list[random_index]\n",
     "        model_pointers, loss, output = fw_bw_pass_model(model_pointers, line_single, category_single)\n",
     "        #model_pointers = fed_avg_every_n_iters(model_pointers, iter, args.federate_after_n_batches)\n",
-    "        #Update the current loss a\n",
+    "        #Update the current loss\n",
     "        loss_got = loss.get().item() \n",
     "        current_loss += loss_got\n",
     "        \n",
@@ -757,9 +914,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generating list of batches for the workers...\n"
+     ]
+    }
+   ],
    "source": [
     "#This may take a few seconds to complete.\n",
     "print(\"Generating list of batches for the workers...\")\n",
@@ -775,9 +940,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "200 2% (0m 4s) 2.8528 Pan / Irish ✗ (French)\n",
+      "400 4% (0m 8s) 2.7854 Gerges / Irish ✗ (Arabic)\n",
+      "600 6% (0m 12s) 2.6888 Muirchertach / Dutch ✗ (Irish)\n",
+      "800 8% (0m 16s) 2.9041 Yu / Irish ✗ (Korean)\n",
+      "1000 10% (0m 20s) 2.6636 Rumpade / French ✗ (Dutch)\n",
+      "1200 12% (0m 24s) 2.1188 Trukhachev / Russian ✓\n",
+      "1400 14% (0m 28s) 2.1301 Pinho / Russian ✗ (Portuguese)\n",
+      "1600 16% (0m 33s) 2.6266 Amari / Japanese ✗ (Arabic)\n",
+      "1800 18% (0m 37s) 2.3298 Cathasach / German ✗ (Irish)\n",
+      "2000 20% (0m 41s) 2.0159 Ogura / Japanese ✓\n",
+      "2200 22% (0m 45s) 1.6064 Cardona / Spanish ✓\n",
+      "2400 24% (0m 50s) 3.2761 Dziedzic / Greek ✗ (Polish)\n",
+      "2600 26% (0m 54s) 0.9767 Zhabsky / Russian ✓\n",
+      "2800 28% (0m 58s) 2.9497 Fakhoury / French ✗ (Arabic)\n",
+      "3000 30% (1m 3s) 0.5414 Alfionov / Russian ✓\n",
+      "3200 32% (1m 7s) 2.7879 Voss / English ✗ (German)\n",
+      "3400 34% (1m 12s) 2.3473 Ughi / Chinese ✗ (Italian)\n",
+      "3600 36% (1m 16s) 0.7153 Brisimitzakis / Greek ✓\n",
+      "3800 38% (1m 20s) 2.0650 Aitken / Russian ✗ (Scottish)\n",
+      "4000 40% (1m 24s) 1.7057 Rao / Chinese ✓\n",
+      "4200 42% (1m 28s) 3.1146 Macclelland / Greek ✗ (Irish)\n",
+      "4400 44% (1m 33s) 2.5295 Vann / Chinese ✗ (German)\n",
+      "4600 46% (1m 37s) 2.6828 Jaskolski / Greek ✗ (Polish)\n",
+      "4800 48% (1m 42s) 1.1059 Chu / Vietnamese ✓\n",
+      "5000 50% (1m 46s) 1.7006 Whyte / Spanish ✗ (Scottish)\n",
+      "5200 52% (1m 51s) 2.3312 Arian / English ✗ (Arabic)\n",
+      "5400 54% (1m 55s) 2.2386 Boucher / Dutch ✗ (French)\n",
+      "5600 56% (2m 0s) 0.3720 Patrianakos / Greek ✓\n",
+      "5800 57% (2m 4s) 1.7996 Markytan / English ✗ (Czech)\n",
+      "6000 60% (2m 9s) 1.6090 Iturburua / Russian ✗ (Spanish)\n",
+      "6200 62% (2m 13s) 2.3063 Molloy / French ✗ (Irish)\n",
+      "6400 64% (2m 18s) 1.4178 Lee / Chinese ✗ (Korean)\n",
+      "6600 66% (2m 22s) 3.1082 Tsoumada / Czech ✗ (Greek)\n",
+      "6800 68% (2m 27s) 2.8447 Downing / Dutch ✗ (English)\n",
+      "7000 70% (2m 31s) 3.1322 Adamczak / German ✗ (Polish)\n",
+      "7200 72% (2m 36s) 3.3061 Fux / Korean ✗ (German)\n",
+      "7400 74% (2m 40s) 1.1674 Asghar / Arabic ✓\n",
+      "7600 76% (2m 45s) 1.1927 Drivakis / Greek ✓\n",
+      "7800 78% (2m 49s) 1.1557 Moreno / Portuguese ✓\n",
+      "8000 80% (2m 54s) 1.3593 Vargas / Scottish ✗ (Portuguese)\n",
+      "8200 82% (2m 58s) 1.1932 Garcia / Portuguese ✓\n",
+      "8400 84% (3m 3s) 1.4476 Madeira / Scottish ✗ (Portuguese)\n",
+      "8600 86% (3m 7s) 2.5493 Bayliss / Greek ✗ (English)\n",
+      "8800 88% (3m 12s) 2.0805 Messana / Japanese ✗ (Italian)\n",
+      "9000 90% (3m 16s) 1.8588 Dreher / French ✗ (German)\n",
+      "9200 92% (3m 21s) 1.6711 Pesaro / Japanese ✗ (Italian)\n",
+      "9400 94% (3m 25s) 1.1560 Wyrzyk / Polish ✓\n",
+      "9600 96% (3m 30s) 1.4535 Stanek / Spanish ✗ (Polish)\n",
+      "9800 98% (3m 34s) 1.0348 Guo / Korean ✗ (Chinese)\n",
+      "10000 100% (3m 39s) 0.9083 White / Scottish ✓\n"
+     ]
+    }
+   ],
    "source": [
     "start = time.time()\n",
     "all_losses, model_pointers = train_RNN(args.epochs, args.print_every, args.plot_every, args.federate_after_n_batches, list_federated_train_loader)"
@@ -785,9 +1007,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f71c4a46610>]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAA8c0lEQVR4nO3dd3zbd5348ddb3kve244dO3FiZzWNSZN0Jd2UUgptKS2UTemgtNDjoBzHHT8O7lgFekChtKUUUo6OdFK60nQ3abMT25nO8t57S5/fH19J3ontWJZtvZ+Phx6RpY+kt1DRW5/1/ogxBqWUUv7L5usAlFJK+ZYmAqWU8nOaCJRSys9pIlBKKT+niUAppfxcoK8DGK+EhASTnZ3t6zCUUmpG2bZtW50xJnGk+2ZcIsjOzmbr1q2+DkMppWYUETk22n06NKSUUn5OE4FSSvk5TQRKKeXnNBEopZSf00SglFJ+ThOBUkr5OU0ESinl5/wmEdS3dfOD54ro6nX4OhSllJpW/CYRvFdaz5/eOcpXHtlKZ48mA6WUcvObRHDF0jR+fu0y3jlUx+ceep/Wrl5fh6SUUtOC3yQCgGtWZHDv9cvZfryRzzz4PsfrO3wdklJK+ZxfJQKwegb3fWYFB6paueieN/jRP4pp7tDegVLKf/ldIgC4uCCZ17+1lquWp/HA20c4/+eb2F3W5OuwlFLKJ/wyEQAk20P56TXLeOHr5xIWFMBdj+2iu08nkZVS/sdvE4FbfqqdH398CQdr2vjta4d8HY5SSk05v08EAOsWJvGJ5en87vXDFFe0+DocpZSaUpoIXL7/0QJiwoP51hO76HU4fR2OUkpNGa8lAhHJFJFNIlIsIkUicscIbaJF5DkR2eVq8wVvxXMqMeHB/NdViyiqaOH2R3fQ3t3nq1CUUmpKebNH0AfcZYwpAFYBt4lIwZA2twHFxphlwFrgFyIS7MWYTuqyxal87yP5vFxcxdX3vcuJBt1noJSa/byWCIwxlcaY7a7rrUAJkD60GRAlIgJEAg1YCcRnvnxuDg9/YSUVTZ189Ddvs+1Yoy/DUUopr5uSOQIRyQaWA1uG3PUbIB+oAPYAdxhjfD5Af15eIs9+7Ryiw4L4yiNbdQeyUmpW83oiEJFI4EngTmPM0CU5lwI7gTTgDOA3ImIf4TluEpGtIrK1trbWyxFbshMi+NPnP4TDafjinz+gRWsTKaVmKa8mAhEJwkoC640xG0Zo8gVgg7EcAo4AC4c2Msbcb4wpNMYUJiYmejPkQXISI7nvM2dytK6d29Zvp09XEymlZiFvrhoS4EGgxBhzzyjNjgMXutonAwuAUm/FNBFrchP40ccX89bBOu7deNDX4Sil1KTzZo/gbOBG4AIR2em6XC4iN4vIza42PwTWiMgeYCPwbWNMnRdjmpDrPjSHK5el8Yc3S6ls7vR1OEopNakCvfXExpi3ATlFmwrgEm/FMJm+dekCXtxbxc9fOsAvPrnM1+EopdSk0Z3FY5QZF87nz85mw44yLUOhlJpVNBGMw21r52EPDeK//1ni61CUUmrSaCIYh+jwIG6/YB5vHaxj0/4aX4ejlFKTQhPBON24OouchAhuf3QH7x2u93U4Sil12jQRjFNIYADrv3IWqdGhfO6h93lxb6WvQ1JKqdOiiWACUqPDePzm1SxOt3Pr+u387f3jvg5JKaUmTBPBBMWEB7P+y6s4Py+Ruzfs4f43D/s6JKWUmhBNBKchLDiAP9xYyEeWpvLjF/Zxz8v7Mcb4OiyllBoXr20o8xfBgTbu/dRyIoMDufe1Qxyt7+CWtbnkpw6rnaeUUtOSJoJJEGAT/ufqJSTZQ/jjW6U8u6uCldlxfPOSPFblxPs6PKWUOikdGpokIsJdlyxg890X8m+X51PW2MFNj2ylq9fh69CUUuqkNBFMspjwYL5yXg4/v3YZLV19vFRU5euQlFLqpDQReMmqnHgy48L4+wcnfB2KUkqdlCYCL7HZhE+uyOTdw/V61KVSalrTROBF1xRmYBN4fJv2CpRS05cmAi9KjQ7jvLxEHt9ahsOp+wuUUtOTJgIvu64wk6qWLt48UOvrUJRSakSaCLzswvxk4iOCddJYKTVtaSLwsuBAG9cUZvBycRWltW2+DkcppYbRRDAFvnJuDiGBAdy78aCvQ1FKqWE0EUyBhMgQPrcmm2d2VXCwutXX4Sil1CCaCKbITeflEB4UwK9e1V6BUmp60UQwReIigvniOXP5x55KiitafB2OUkp5eC0RiEimiGwSkWIRKRKRO0Zpt1ZEdrravOGteKaDL5+TQ1RoIL989YCvQ1FKKQ9v9gj6gLuMMQXAKuA2ESkY2EBEYoDfAVcaYxYB13oxHp+LDg/ii2fP5ZXiao7Wtfs6HKWUAryYCIwxlcaY7a7rrUAJkD6k2Q3ABmPMcVe7Gm/FM13ccNYcbAKPbdV9BUqp6WFK5ghEJBtYDmwZclceECsir4vINhH57CiPv0lEtorI1tramb1DN9keygULk3h8Wxm9Dqevw1FKKe8nAhGJBJ4E7jTGDJ0lDQRWAB8BLgX+XUTyhj6HMeZ+Y0yhMaYwMTHR2yF73XUfmkNtazeb9s36DpBSagbwaiIQkSCsJLDeGLNhhCZlwEvGmHZjTB3wJrDMmzFNB+sWJJIUFaJlJ5RS04I3Vw0J8CBQYoy5Z5RmzwDniEigiIQDZ2HNJcxqgQE2ri3MYNP+GiqbO30djlLKz3mzR3A2cCNwgWt56E4RuVxEbhaRmwGMMSXAi8Bu4H3gAWPMXi/GNG1cVzgHp4Entpb5OhSllJ8L9NYTG2PeBmQM7X4G/MxbcUxXc+LDOXtePH/ZfIzAABvzkyJZlG4nNTrM16EppfyM7iz2oTsuzCPQJvzkxX18+ZGtnPuTTVQ1d/k6LKWUn/Faj0Cd2sq5cbx794W0dPWysaSab/x9F7vLmkiJTvF1aEopP6I9gmnAHhrEJQUpiMC+Kq1OqpSaWpoIpomIkECy4sLZV6UF6ZRSU0sTwTSyMMXOvkrtESilppYmgmlkYWoUR+rb6exx+DoUpZQf0UQwjSxMsWMMHNBTzJRSU0gTwTSSnxoFQEmlzhMopaaOJoJpJDM2nPDgAF05pJSaUpoIphGbTViQEqU9AqXUlNJEMM3kp9rZV9WKMQaArl4H9795mPbuPh9HppSarTQRTDP5KVE0d/ZS1WKVmvjr5mP8+IV9bNhR7uPIlFKzlSaCaWZhqh2AfZWtdPc5+ONbpQBsLKn2ZVhKqVlMaw1NMwtSXCuHqlqoaumiuqWbxel23j1cT0dPH+HB+pEppSaX9gimGXtoEOkxYRSVt/D7Nw6zNCOauz+cT0+fk7cO1vk6PKXULKSJYBrKT43ixaIqjtV3cOvaXD6UHUdUSKAODymlvEITwTS0MMWOw2nITYzgkoIUggNtnLcgkdf21eJ0Gl+Hp5SaZTQRTEOL0qwJ41vWzsNmsw55uyg/ibq2bnaVNfkwMqXUbKSJYBq6uCCZP9y4gk8sT/fctjYvCZvAxpIaH0amlJqNNBFMQ4EBNi5dlOLpDQDERgRTmBXHqzpPoJSaZJoIZpAL85PYV9VKWWOHr0NRSs0imghmkAsWJgHw7qF6H0eilJpNvJYIRCRTRDaJSLGIFInIHSdp+yER6RORa7wVz2yQmxhJRHAAxVqUTik1iby5TbUPuMsYs11EooBtIvKKMaZ4YCMRCQB+ArzsxVhmBZtNyE+1U1TR7OtQlFKziNd6BMaYSmPMdtf1VqAESB+h6e3Ak4AuhxmDgjQ7JZWtup9AKTVppmSOQESygeXAliG3pwMfB+47xeNvEpGtIrK1trbWa3HOBAWpdtq6+zihE8ZKqUni9UQgIpFYv/jvNMYMHdz+FfBtY4zzZM9hjLnfGFNojClMTEz0UqQzw6K0aACKKnSeQCk1ObyaCEQkCCsJrDfGbBihSSHwfyJyFLgG+J2IXOXNmGa6+cmRBNiEYk0ESqlJ4rXJYhER4EGgxBhzz0htjDFzB7R/GHjeGPO0t2KaDUKDApiXGKkrh5RSk8abq4bOBm4E9ojITtdt3wXmABhjfu/F157VCtLsvHf49PYSdPY4cBhDZIieb6CUv/Pat4Ax5m1ATtmwv/3nvRXLbFOQauepHeXUt3UTHxky7sc7nYYbH7Tm7Z+4Zc1kh6eUmmF0Z/EM5K5OOtHhoce2nmDrsUZ2nGiiq9cxmaEppWYgTQQzUL7rXOOJTBg3tvfwkxf3ER0WhMNpdPWRUkoTwUwUGxFMWnTohHoEP31pPy1dffzv9csB2HWiaZKjU0rNNJoIZqiCNLvn1/zh2jYuuucNntpRdtLH7DzRxP99cJzPr8nmvLxEku0h7B5y0E2fw0lrV6+3wlZKTUOaCGaogrRoSmvb2HWiiev+sJlDNW2nPNz+Fy/vJzEyhDsvmg/A0owYdpcNrlt0zysHuPieNzFGS1go5S80EcxQBal2nAau/cN7BNhgflIkh2vbR23vcBq2HWvk8iWpRIUGAXBGZgylde00d1o9AGMMz+ysoKqli8YO7RUo5S80EcxQ7pVDiZEhPPbV1azOjae0pm3UX/KHatro6HGwLDPac9vSDOv6HlevoKiihfKmTgA9/EYpP6KJYIbKjAvn/htX8OQta8iKjyA3MZLW7j5qW7tHbO8+9H5pRozntqXpMYPue7moynPfiYZOb4StlJqGNBHMYJcsSiElOhSAnMQIAA7Vto3YdteJJqJCApkbH+G5LTo8iLkJEZ4J45eKqilwLU3VHoFS/kMTwSyRmxgJMOo8we6yZpZkRGOzDd7svTQjml0nmjla187+6lauXpFBdFiQlrlWyo+MKRGISISI2FzX80TkSldlUTVNpNhDCQ8OoHSEHkF3n4N9VS2DhoXclmbEUNXSxV83HwPgkoJkMmLDKGvUoSGl/MVYewRvAqGug2Rexiom97C3glLjZ7MJOYkRI/YISipb6XUYzhgwUey2zDVh/MjmYyxKs5MZF05mbDgnGrRHoJS/GGsiEGNMB/AJ4HfGmGuBRd4LS01EbmIkh2uG9wjcu4dH6hEsSosmwCb09Dm5pCAFwNMj0L0ESvmHMScCEVkNfBr4h+u2AO+EpCYqNzGS8qZOOnsGF5LbVdZEQmQIqa6J5YHCggPIS44C4NLFyYC1Iqm7z0lt28grkJRSs8tYE8GdwN3AU8aYIhHJATZ5LSo1Ie4J49K6wb2C3WXNLMuIxjoraLi1CxJZnG5ngSshZMSGAeg8gVJ+YkyJwBjzhjHmSmPMT1yTxnXGmK97OTY1TrlJ1tLQgfMErV29HK5tY1lmzKiP+/ZlC3n2tnM8iSIzLhxA5wmU8hNjXTX0qIjYRSQC2AsUi8i3vBuaGq/s+AhEGDRPsKe8GWP6dxGPZuCy0vQY7REo5U/GOjRUYIxpAa4C/gnMxVo5pKaR0KAAMmPDOTxgCam7qNxIE8WjiQgJJD4ieNCmMmOMViVVapYaayIIcu0buAp41hjTC+iSkmkod8gS0t1lTWTGhREXETyu58mICx/UI3h6ZzmF//Uqx+pHL2ynlJqZxpoI/gAcBSKAN0UkC9Cjraah3MRISmvbcDoNR+raeWN/LYVZceN+nqGbyp7bVUl3n5OH3j4ymeEqpaaBsU4W32uMSTfGXG4sx4B1Xo5NTUBuUiTdfU5K69q45a/bCAq08S+XLhj382TGhlPe2InTaejo6ePtQ3UEBQiPbS2jqaPnlI93OA2/fvUgFU06z6DUdDfWyeJoEblHRLa6Lr/A6h2oaca9hPS29TvYV9XKL687wzP5Ox4ZsWH0OJzUtHbz9sE6evqcfOfD+XT2Oli/5binXXefg9f31+B0Dh4pfP9IA7989QAbtp/81DSllO+NdWjoIaAV+KTr0gL8yVtBqYnLdVUh3V/dym3rclm3IGlCz+NZQtrYwcaSGqJCArlxVRbn5SXy8LtH6e5z0N3n4Na/bufzf/qA5/dUDnr8a/uqASZ0rrJSamqNNRHkGmP+wxhT6rr8AMg52QNEJFNENolIsYgUicgdI7T5tIjsFpE9IvKuiCybyJtQ/eIigkmxh7IqJ45vXJQ34edxbyo7Xt/Bxn01nLcgkeBAG185dy61rd08sa2M29ZvZ+O+GsKCAnh+V8Wgx2/cVwNAcYUmAqWmu8AxtusUkXOMMW8DiMjZwKkGf/uAu4wx20UkCtgmIq8YY4oHtDkCnG+MaRSRDwP3A2eN8z2oAUSEZ752NtFhQQQGTLzKuHs46YU9ldS1dXNxvlV+4px5CSxMieLfn96L08APr1rM4Zo2Hn3/OK1dvUSFBnGkrp3S2nZSo0M5Wt9BW3cfkSFj/U9NKTXVxvpNcTPwWxE5KiJHgd8AXz3ZA4wxlcaY7a7rrUAJkD6kzbvGmEbXn5uBjHHErkaRbA8lNOj0SkGFBgWQFBXCa/trCLAJaxckAlaiuXXdPJwG/t/HFnHjqiyuWJpKT5+TjSVWL+A1V2/gpvOsTuM+HR5Salob66qhXcaYZcBSYKkxZjlwwVhfRESygeXAlpM0+xLWZrWRHn+Te6K6trZ2rC+rTlNmXDjGwIqsWGLC+/chXLksjV3fv4TPrs4G4Mw5saRGh/L8bmt46LV91cxPiuSyxVY10xJNBEpNa+MaOzDGtLh2GAN8cyyPEZFI4EngzgGPHdpmHVYi+PYor3u/MabQGFOYmJg4npDVaXDPE7iHhQaKDu8/l8hmEy5fksqbB+oob+pkS2kDF+QnkWIPJTY8SCeMlZrmTueoypFLWQ5sYO1GfhJYb4zZMEqbpcADwMeMMfWnEY+aZHNcK4cuzD/1yqOPLE2lx+Hk+0/vpc9puCg/GRGhIM2uE8ZKTXOnM4N30hITYpWyfBAoMcbcM0qbOcAG4EZjzIHTiEV5wfUr55AVH0GOa2/CySzPjCE9JoyN+2qICQ9iuavaaX6Knb9sPkafw3lak9dKKe856f8zRaRVRFpGuLQCaad47rOxCtNdICI7XZfLReRmEbnZ1eb7QDzwO9f9W0/7HalJkxYTxjUrxjZ/LyJ8ZGkqAGvzEj1f+gVpdrr7nBzVGkVKTVsn7REYY6Im+sSupaYnHT4yxnwZ+PJEX0NNL1cuS+OPb5Vy2eJUz20FaXYAiipamJc0/D+nzaX1pEaHkhWvG9WV8hXtq6tJszg9mne/cwGXLuqfXM5NjCQ4wDbihHFFUyefffB9PvfQ+3T3OYbdr5SaGpoI1KRKjQ4bdCRmUICNvJTIESeMf7vpEH1OJ0frO3jo7aNTGKVSaiBNBMrr8lPslFS2DrqtrLGDx7ae4Iaz5nBRfjL/+9pBqpq7fBShUv5NE4HyuoI0O3Vt3dS09n/R/3bTIQThtnXz+P4VBfQ5Df/9z5IRH2+MwRg9B0kpb9FEoLyuILV/whjgREMHj28t41MrM0mNDmNOfDhfPS+HZ3ZW8MHRhkGP7XM4uekv27j+j5unPG6l/IVWAlNel59mJ8AmfPUv2zhzTgy9DoPNJty6dp6nza1r5/Gkq6LpI19aycIUO8YYfvBcMa8UWyWtG9t7iB3DkZtdvQ4OVrexJCPaa+9JqdlEewTK6+yhQfz1S2dx46osWrv62H68kc+vySYlOtTTJiw4gD99YSUi8Mnfv8cHRxt46J2j/GXzMc6dnwDAliOn3nhe1tjB1fe9y0d/8zYHq1tP2V4ppT0CNUVW58azOjcegI6ePkIDh1dHXZASxZO3rOGzD73Ppx/YQq/DyWWLUvjVp85g+f97hc2lDYP2KAz13uF6bnt0Ox09fQDsONHE/OQJb4VRym9oj0BNufDgQGy2kfcaZsSG88TNa1iaHk1hViy/vO4MQoMCKMyOZXPp6D2CV4qr+cyDW4gND+L5288lMiSQPWXN3noLSs0q2iNQ005cRDCP37wawLMnYVVOPD97aT/1bd3ER4YMat/c2ct3n9rDguQo/v7VVUSFBrE43c7uck0ESo2F9gjUtCQigzamrcqxhpXeP9IwrO1PXtxHfVs3P71mKVGhVnnspRkxlFS20OtwTk3ASs1gmgjUjLA0I5qwoIBhw0MfHG3g0S3H+eLZc1mc3r9KaEl6ND19Tg7ohLFSp6RDQ2pGCAqwUZgdy3sDEkF3n4O7N+whPSaMb1ycN6j9EldS2FPWzKK04ctIjTE8taOc/VWtlDd1UtPazZ0XzWdNboJ334hS05D2CNSMsTo3ngPVbdS1dWOM4Uf/KOFQTRv/ddViIkIG/6bJig8nKjRw1HmCD4428s3HdvGnd46yt7yZwzVtfOvx3Z4VR0r5E+0RqBnDPU+wpbSBPeXNPPLeMb58zlzWLRx+gpqIsDQjetSVQ8/tqiA0yMa2711MREgg7x9p4JN/eI9fv3qQuy/P9+r7UGq60R6BmjGWpEcTHhzAj/5RzO/fOMynz5rDv31k9C/tJekx7KtqGVbius/h5J97K7kwP9nTk1g5N45PfSiTB94+QlGFrjZS/kUTgZoxrHmCOCqau7j6zAx++LHFg1YWDbU0I5peh2F/1eAJ482lDdS19fDRpYM3p33nwwuJDQ/iu0/txeHUInfKf2giUDPKHRfO466L8/jpNUtH3ZTm5p4w3j1keOi5XRVEhgSydsHgIaWY8GD+/YoCdp1o4oltJyY3cKWmMU0EakZZkRXH7RfOJ+AUSQAgIzaM2PCgQfMEPX1OXiyq4pKCZEKDhpe5uHJZGnMTInhxb9Wkxq3UdKaJQM1aIsKSjBj2DFg59PahWpo7e/nosrRRH3P2vHjeP9IwIzajvVxUxbH6dl+HoWY4TQRqVluaHs3+6lY6e6wJ4+d2VRIdFsTZ80bfL3B2bgLtPQ52nWiaoignpqvXwa3rt/PQ20d8HYqa4XT5qJrVzsiMweE0fOhHr7J8TgzbjjVy5bI0ggNH/w20OjceEXjnUD2F2XETfu2Kpk72V7eybsHw5a2T4VBNG31OQ11bj1eeX/kPr/UIRCRTRDaJSLGIFInIHSO0ERG5V0QOichuETnTW/Eo/7RuYRK/uWE5Vy1Po7a1m16Hk2sLM0/6mJjwYBal2XnncN1pvfZ9rx/mpke2DhtiMsbQ1esY5VFjV1xpnfhW39592s+l/Js3ewR9wF3GmO0iEgVsE5FXjDHFA9p8GJjvupwF3Of6V6lJEWATrliaxhVLrTkBp9OccrURWMNDD71zhI6ePsKDJ/Z/k0M1bfQ6DBVNnWTFR3huf7m4mm/8fSdvfGsdiVEhJ3mGkytxJwLtEajT5LUegTGm0hiz3XW9FSgB0oc0+xjwiLFsBmJEZPSTR5Q6TWNJAgBr5iXQ6zB8cLRxwq91uLYNgKP1HYNu33G8iY4ex7DzmcfLnQga2jURqNMzJZPFIpINLAe2DLkrHRi4YLuM4ckCEblJRLaKyNba2lqvxamU24eyYwkKEN49NLHhoZauXmparSGb40NW9RypsxLEtmMTTzLGGIorrETQ2NGDUzfAqdPg9UQgIpHAk8CdxpiWiTyHMeZ+Y0yhMaYwMTFxcgNUagThwYEsnxM74XmC0tr+L/+hPYKjddbfp5MIKpq7aOnqIzcxAqeBps7eCT+XUl5NBCIShJUE1htjNozQpBwYOHOX4bpNKZ9bkxtPUUULTR3jH3o5XGP96g8PDuDYgETgdBqO1LcTYBOKKponPGlc4uoNnDvf+mHUoBPG6jR4c9WQAA8CJcaYe0Zp9izwWdfqoVVAszGm0lsxKTUeZ89LwBhOelbyaA7XthFoE1blxA/a8FXR3ElPn5O1eYn0Osyw8hdj5Z4fWJ1rVWTVCWN1OrzZIzgbuBG4QER2ui6Xi8jNInKzq80LQClwCPgjcKsX41FqXM7IjCEiOGBC5SYO17aRFR9ObmIExxs6PGP4R+qspHD1igxg4sNDxZUtZMWHkxkbDkC9Thir0+C15aPGmLeBky7RMMYY4DZvxaDU6QgKsHHDWXN48O0j3LpuHnnJUWN+bGltOzmJkWTFR9Dd56SmtZuU6FCOuhLBiqxYchIj2HasAcgdd2wllS0UpNpJiAwGNBGo06MlJpQ6iVvXziMiOJCfv7R/zI/pczg5Wt9ObmIkWfHWL/ajruGh0rp2woMDSIoKYcWcWLYda8T6PTR27d19HGvoID/VTmyElQgadGhInQZNBEqdRGxEMF85L4eXi6vZcdwaxjHG8PzuCt4ZZWnpicZOeh2G3MQIsuKsjWTHXRPGR+rayY6PQEQozI6lsaPXM1w0VvuqWjEG8lPtBAXYsIcGTvlk8bH6dlb88BV2TvN6TGpsNBEodQpfPGcu8RHB/PTF/TR39vK1v+3ga4/u4Pa/7Rhx1Y97xVBuUiRpMaEE2sTTIzhS187cRCs5rMiKBWDrOOcJ3KUl8lOtoar4yJApHxr6594q6tt7eHqHLvKbDTQRKHUKkSGBfO2CebxXWs+Fv3idF/dWcfWZGTSM8kXo3lGcmxBJYICNjNgwjjV00NPnpKyxk5wEKxHkJEQSHRbE9nEmgpLKFuyhgaTHhAEQFxE85auGXiupAWDjvupxD22p6UcTgVJjcMNZc8iODyc0KIDHb17Nz69dSkGqnQffPjLsi/BwbRsJkSFEhwcBkBUfwbH6dk40duBwGrJddYdsNmFFVuy4Vw6VVLaQn2r3HNMZHxHstTITJxo6+OZjO2nr7vPc1tTRw9ZjDaTHhHGioZNDrh6Qmrk0ESg1BiGBATz/9XPZeNf5nDknFhHhS+fM5WBNG28eHDxXUFrbTm5if5G5rPhwjtV3eHYbzx1w34qsWA7WtI1505rTaZ3BnJ9q99wWHxnstaGhl4qq2LC9nMc+6K8E88aBWpwGvveRfABedfUO3BrbeyZ85nNPn9NzdoSaOpoIlBqjyJBAQgL7j7f86LI0kqJCeHDIwTCHa9vITYr0/J0VH0FrV59nstk9NASwNMM6V9k97n8qFc2ddPQ4Bi1ljYsIPu16Q8/uquBjv31n2Bf4gepWAP783lHP87+2r4b4iGAuXZTCojQ7G0uqPe1La9tY9d8b+fsHEzvz+XtP7+HaP7yrw01TTBOBUhMUHGjjs6uzePNALQddX5gN7T00dvSSmzggEcRZS0hf319LbHgQMeHBnvvmuRLG4dqxrRxy9ypyBvQq4iJCcDgNLV0Trzf09I5ydp1oGnbs5YHqNkKDbByr7+D1AzX0OZy8vr+WtQuSsNmECxcmsf14o2do6scv7KO7z8nOExPbKLevqpW95S3sLZ9QWTI1QZoIlDoNN5yVRWiQjXteOUB3n8MzUTzwizo7wUoExZUtzB3QGwBIsYcSERzgWWl0KqUjPH98xOltKutzOHn/SIMnRjdjDIdq2vjEmRmk2EP50ztH2XGiiebOXi7Mt05duzA/GaeB1/fX8M6hOl4tqSbAJhyonti8QUVTJwAbdpRN6PFqYjQRKHUa4iKCuem8XP65t4pLf/mmZyx93oAeQUZsOK55XbKHJAIRITcp0pNATqW0rp3IkEASI/sPtIlzJ4IJrhwqqmjxTAaXDEgElc1dtHX3kZ9q58bVWbx1sI4/vFFKoE04Z7515vOS9GgSo0J4uaiaHz5fTEZsGJ8szOBQTdu4h3e6eh2eYzef21VB35CT3ZT3aCJQ6jR98+I8HvniSkSEx7eVERJoI821tBMgNCiAFHsoMHh+wC03MXLMPYIjde3kJEZ4VgyBNVkME69A+p6rqF6yPYSSylbP7e75gbykSK5fOYfgQBuvllSzcm4c9lBrRZR7eOjFoir2VbXy3cvzWZQWTVt3HxXNXeOKo9LV/tJFydS19fDWBM+CUOOniUCpSXBeXiIv3nku375sIXdcNJ+AISehuUtNzE2IHPbY3MQIKpq7aB+wRHM0pbXtw5JJfITVO5jo0NDm0nrmJUWyOid+UI/goGt4Z35yFHERwVx1hnXc5wULkwY93v33yuw4Prw4xTOR7U4kY+UeFrrhrCxiwoN4artuVpsqmgiUmiQhgQHcsjaXW9fOG3afu9TE0DkC6J8wPlWpic4eB+VNncOSSWyE9et8IvWGeh1OPjjSwKqcOPJT7VQ2d9HoSigHqltJiAz2DD199fxczpwTw0eWDj5N9ry8RK5dkcGPPr4YESEv2Yrv0DjnCdyJIDs+nCuWpvJycdWg/QvKezQRKDUFFqXbiQwJ9EwcD+ReYTRwY5Yxhg3bywaVsHAnioETxWAloKiQwAn1CPaWN9Pe42B1TgIFadbeBHev4GBNG/OT+pep5iZGsuHWs0mNDhv0HKFBAfzs2mXMd/UEYsKDSYwKmUCPwBoaSokO5ePL0+nqdU6oBLgaP00ESk2BG1bOYdO/rCU8eHjl96z4CAJsMmjC+L3D9XzzsV08vrV/Pf5oiQAgboKbytzzA2e5egRgrRxyrxhy/7ofr7zkSA6Mc8dxRVMniVEhhAQGcOacWLLiw3lKVw9NCU0ESk2BwAAbiVEhI94XHGgjKy58UCJwT5S+e7j/dDT30tGRhpfiIoInNFm8ubSBvORIEiJDSIgMITEqhOLKFipcK4bmj+MMhoHmJ0VxqLp1XCuHKpo7PZPsIsLavER2n5jYCW5qfDQRKDUN5CRGDhoaeutgLWD9Ynfv6C2tayc1OnTEXkV8RMi4l4/2OpxsPdrA6px4z20FqXZKKls9wzrzkybWI5ifHEm7a05jrMqbOkmLDvX8nRIdRmt3Hx09Ok/gbZoIlJoGcpMiOFrXQZ/DSUN7D0UVLeQmRtDU0UtJlTVmX+paOjqSiRSe213WTEePg1UDEkF+qp1DNa0UV1ivOZ5T2QZyP+7gGCeMjTFUNHUOWnab5OpB1bRM7VkL/shrR1UqpcYuNzGSHodVpnpPeTPGwL9csoBb1m/nvcP1FKTaKa1t46oz0kd8fFykVW/IGDNojwFYheqO1rezp7yZPWXNlDV20tXn4ESDdVjOWYMSQRS9DsOLe6tIiAzxnIA2XnlJ/UtI1y1MwhjDT17cT15yJJ84M2NY+6aOXrp6nYMSQbJr70V1S9ewjXhqcmkiUGoa6K851MbbB+uICg3k4oJkchIieO9wPR87I53Wrr6T9gh6HYaWrj6iw4Koau7ihT2VbC6t5/2jDTR1WHWIQgJtzIkLJzw4gITIEC4qSPYsDwVY5Fo5tKe8mTW58SO+1lhEhweRFBXiKTXxzqF6fv/GYUSsOZErlqYNau8eQkqP6R8aSrZbPYLqVu0ReJsmAqWmgdyE/iWkbx+qY01uPIEBNlbnxvPMzgpPUbuRJophYJmJbkKDbFx937uUN3UyJy6ci/OTKcyOZWlGDPOTrMNyRpMdH0FIoI3uPueE5wfc8pKjOFhjTRj/7OX9pMeEkRodyjf/vou4iGDW5CZ42rr3EAwaGnL1CGpaxrdD2Rf+uvkYT+0o5/GvrsY2ZDPhTKBzBEpNA9HhQSREhvBqSTXlTZ2cMz8RgDW5CbR19/HsrgqAQVVNB4p31R5qaO/h0S3HKW/q5KHPF/Lmv67jZ9cu47oPzSE/1X7SJADW6qYFKdawzkRXDLnNT47kYHUbrxRXs+tEE1+/cB4PfK6QrPhwbnpkG0UV/SuCRkoE9tBAQoNs1MyAHsEbB2rZdqxx3MeOThdeSwQi8pCI1IjI3lHujxaR50Rkl4gUicgXvBWLUjNBbmIEHxy1vkjOnWf9Wl6VEwfAMzsrCB5Sw2ggdwXSssZOfrvpEKty4li3IGnEtqdS4NpPMNGJYre85Cg6ex38x7NFZMeH84kzM4gJD+bPX1xJWHAA//3CPk/biuYuggNtnvcB1hLSpKhQqmdAj8C9tPeZnTOzLIY3ewQPA5ed5P7bgGJjzDJgLfALEZnYzJRSs4B7niAzLsxTmyg+MoSFKdYXanZ8+LAaRm7uoaF7XztIXVsP37p0wbBJ47FaOTeOiOAAT89gotyb0Sqbu7jzojyCXL2RtJgwPrE8nS1H6j0lJNxLR4fGnGwPmfaJoM/h5Lhr4v2FPZX0zsCqqV5LBMaYN4GGkzUBosT65CNdbXXBsPJb7mGfc+YlDvpCXO2atM0ZoWCdmzsRlNa2c8HCJFZkxU04jo8vT2fzdy8kOixows8BMM+1cigvOZKPLhs8Obx2QRK9DsM7ro1zlUOWjrol2UMntHy0ob2HLz78wZQkkRONnfQ6DJcuSqaxo5e3Z2DVVF/OEfwGyAcqgD3AHcaYmZdKlZok7l/g581PGHS7e1J1tBVDYNX7iQi2jtG865K804pDRIgKPb0kABAdFsRdF+fxP1cvHdaTKcyOJSokkE37rPOOK5q6RkwEyVGhE5oj2Haskdf21Xie/1TctZ0OjrM+EvQPC33h7LnYQwN5dmfFuJ/D13y5auhSYCdwAZALvCIibxljhp1RJyI3ATcBzJkzZypjVGrKrM6J58HPFQ4b21+VE8eC5CjOmZcwyiMt85KjyE2IYFFatDfDHJfbL5w/4u1BATbOzUtg0/4aevqcVLeOnAiS7CG0dffR1t1HZMjwrytjDJXNwx/rnnwuqhjbkZe/evUgv954kDlx4bx053mEBQec+kEu7uNDF6ZEcfmSVJ7bVUFnj2Ncz+FrvuwRfAHYYCyHgCPAwpEaGmPuN8YUGmMKExMTpzRIpaaKzSZcmJ88bPlhVGgQL33jPNacIhE8/tXV/PSapd4McVKtW5BEdUs3m/bXYMzgPQRu7r0Eoy0hfXZXBef/bNOw+yua3Yng1LWK7n/zML/eeJBz5iVwvKGDX756YFzvo7SujbiIYGLCg7lyWRrtPQ5eG2NPZLrwZSI4DlwIICLJwAKg1IfxKDWjBQfaTrk8dDo5f4H1o279luMAow4NAVSPMk/w/pEGeh2Gw7WDz3Jwl7QuqWzF4Ry98N36Lcf48Qv7uGJpKn/+4kpuOGsOD7xVyq4TTWN+H4cHHBZ0Vk48SVEhM271kDeXj/4NeA9YICJlIvIlEblZRG52NfkhsEZE9gAbgW8bY2beLItSakKSokJZmhHNmwesAntDzzmAAZvKWkfuEex1Df2caOwYdHula2ios9cx6oE/nT0O/vPZIs7PS+SX151BgE34zocXkhQVyref3E1P39imLEtr+2tABdiEy5ek8vr+2jE/fjrw5qqh640xqcaYIGNMhjHmQWPM740xv3fdX2GMucQYs8QYs9gY81dvxaKUmp7WDpgPSRthaCjJPnrhuV6H03OITlnj4CqnFU2dnv0Qow0PHa5to9dh+GRhpmdpqz00iP+6ajH7qlr5zobdNLtKc4ympauXurZucgZs9CtIs9PjcFI1zjObfWnm9COVUrOO+7zj2PCgEctrR4UEEhYUMOIy0EM1bZ5f3WUN/T2CPoeT6tZuzstLJDjQNuqEsfv8h3lDSmlcVJDMLWtzeWpHOet+8TrrtxwbdXjJPVE88BzpjFirZ1M2pJcynWkiUEr5zNL0aOIjgkfdMS0i1qayEZaQ7i23fuknRoUMGhqqae3G4TTMiQtnQXLUqD2CQzVt2IQRjw/99mULef72c5iXFMm/PbWX7z8zYoEEz9LRgT2CzFjr+YYOV01nmgiUUj5jswl3X57Pl8+dO2qbJPvIZSb2ljcTERzAOfMSBg0NVbpWDKXGhLIozU5RRcuIJ6UdqmkjKz6CkMCRl3kuSovm7zet4uKCZF7fXztim9LadgJswpy4/mSSGh1KgE2GDVdNZ5oIlFI+dc2KDD6+fPgZBW5JUSEjLh/dW9HCorRo5sSFU9XSRXefA4By14qh9JgwFqXZaeropWKE8fpDNW2jFvFzExFWZMVS3tRJ4wgH/5TWtZEZG0ZwYP9XaWCAjRR7qCYCpZSaLMl2a3fxwF/1DqehuKKFRel2MuPCMaZ/yah7xVBqdCgFrs11ReWDh4f6HE6O1rcPmx8YyWLXcxRXDp9rsFYMDX+OzLgwz8E/M4EmAqXUtJZsD6Gjx+EpUAfW2Hxnr4PFadGeyVn3F29FUydRoYFEhQaRnxqFyPAdxscaOuh1mDElAvdhPXuHJBOn03Ckrn3QRLFbRmz4iD2Ck+1p8CVNBEqpaa3/yMr+CeO9rgngJRnRZLrG591fvBXNXaS7Jp/DgwPJSYgYlggO1Yy8YmgksRHBpMeEefYsuJU3ddLd5xyxR5ARG0Z1a/9wFcC7h+tY9oOX2XF88JkFRRXNrPv56/x187FTxuItmgiUUtNaUtTwk8r2lrcQGmQjJyGCFHsoQQHiWaVT0dRJanT/noTF6dHDVg65E0HuSQr5DbQ43T5seKnUtVFtpGKAGbGDh6sA3jtsld2+8+87Pb2b9u4+bn90B8fq2/ne03v596f3espYn2jo4C/vHZ2SE9r0qEql1LTm2VQ2YAnpnvLmQSeupcX0j8lXNndxRmaMp+2iNDvP7Kygob3HU677cE0bKfbQMVdZXZQWzUtF1bR29Xoe0790dHgiyBywl8B9vGhxRQsx4UGcaOjgP58t4ufXLuM/ni3iSH076790Fm8cqOUPb5ZSXNmC0xh2HG8CoKSqlR9/fMmY4pwo7REopaa1/qEh65ex0zVRvCS9v8pqRmwYZY2ddPY4aGjvGbQvwV2Ndc+AX/SHatvGNCzktjjdmicoqewvU32opo2okEASXceEDpQxZLgKrHmKtXmJfG3dPJ7YVsY3H9vJE9vKuH3dPNbMS+Duy/P5xbXL2FfZQmePg3+9bAEX5Sfz/K4Kunodw15jMmkiUEpNa5EhgUQEB3jmCI41dNDW3edZzQPWJq6yxg7PHoKB5SrOyIwhPDiA513nPhtjOFwzzkTgei33hHGvw8lLRdWsnBs34klwKfZQAm3i6aXUt3VT1dLForRobr9wPmdkxrBhezmFWbF8fUCp7qtXZLDnPy/lxTvP49a18/jcmixauvq8Xs1UE4FSatpLtodS7So898FR6+DDRa5f6QCZceHUtfV4qpAOLGAXERLIx85I47ndFbR09VLZ3EV7j4PccSSCJHsoiVEhnknnV4qrqWvr5tOrRj4fJcAmpMWEeXoE7qWnBWl2ggJs/O/1y7n6zAx+ff3yYRVjB5YhX5ObQIo9lA3by8Yc60RoIlBKTXuJrk1lj31wgu89vZechAjykvvPVHYvIX3/SD2AZ9WQ2/Ur59DV6+SZHeX9K4ZOsZlsKGuXstUjWL/lGOkxYZyflzRqe2u4yuoRFLsSiLsQXmZcOL/45LJhcQ4VYBOuWp7O6/trqWsb/0ltY6WJQCk17SXbQ9l+vIl/fXI3K7PjePKWNZ6KoWCt0gHrfAKR/nkFtyXp0SxKs7N+y/FxLR0daHFaNAdr2thX1cI7h+q5fmXmsCM4B8qIDeNEY/9JaWnRocS6JqvH4xNnptPnNF49AlMTgVJq2psTF47DafjqeTk8/IUPDftCzYyzflnvrWghMTJkUMkHsEpF3HDWHPZVtbJhRxnRYUEkRI7vS3lxuh2H0/D9Z4oItAmfLMw8afuM2HBqW7vp6nVQXNni2eU8XnnJUSxJj2bDDu8ND2kiUEpNe189P4cXvn4ud1+eP+IpbImRIYQE2nA4DamjDLdcuSyN8OAA9pa3MC8pcsRJ3pNxrz56/0gDFxckew7NGY07OR2qaaO0to2CNPtJ25/MJ85MZ295C/urWk/deAI0ESilpr2o0KCTfpGKiGeeYKSzj93P8bEz0oDxzw+ANdQTHWbtIfj0WVljaG8NV20sqcFp+ucHJuKjy9IItInXegWaCJRSs4K71ETaCEdeul2/0lrlsyAlatQ2oxERls+JISchgjW58ads705MLxVVAf01iyYiITKE/7l66SmHoyZKdxYrpWYF94Ewow0NASzNiOHRr5zFsoyYCb3GL65dhsNpBi3xHE1ylFX6oriyBXtooCcxTNQ1K0Yv1X26NBEopWYF95j8aENDbmtyEyb8GvEj7CIejc0mpMeEcbS+g4I0+7jnJKaSDg0ppWYF9yEzWfFjKyQ3FdzzBAWpE1sxNFU0ESilZoV1C5J46tY15J/GpOxkc/dSTmd+YCpoIlBKzQo2m7B8TqyvwxjE0yOY5onAa3MEIvIQcAVQY4xZPEqbtcCvgCCgzhhzvrfiUUqpqXblsjS6eh0sSB7/KqWp5M0ewcPAZaPdKSIxwO+AK40xi4BrvRiLUkpNucy4cO66ZMGYVhn5ktcSgTHmTaDhJE1uADYYY4672nu3zqpSSqkR+XKOIA+IFZHXRWSbiHx2tIYicpOIbBWRrbW1tVMYolJKzX6+TASBwArgI8ClwL+LSN5IDY0x9xtjCo0xhYmJiVMZo1JKzXq+3FBWBtQbY9qBdhF5E1gGHPBhTEop5Xd82SN4BjhHRAJFJBw4CyjxYTxKKeWXvLl89G/AWiBBRMqA/8BaJoox5vfGmBIReRHYDTiBB4wxe70Vj1JKqZF5LREYY64fQ5ufAT/zVgxKKaVOTXcWK6WUnxNjjK9jGBcRqQWOTfDhCUDdJIYzU/jj+/bH9wz++b798T3D+N93ljFmxGWXMy4RnA4R2WqMKfR1HFPNH9+3P75n8M/37Y/vGSb3fevQkFJK+TlNBEop5ef8LRHc7+sAfMQf37c/vmfwz/ftj+8ZJvF9+9UcgVJKqeH8rUeglFJqCE0ESinl5/wmEYjIZSKyX0QOich3fB2PN4hIpohsEpFiESkSkTtct8eJyCsictD17/Q6z2+SiEiAiOwQkeddf88VkS2uz/zvIhLs6xgnk4jEiMgTIrJPREpEZLU/fNYi8g3Xf997ReRvIhI6Gz9rEXlIRGpEZO+A20b8fMVyr+v97xaRM8fzWn6RCEQkAPgt8GGgALheRAp8G5VX9AF3GWMKgFXAba73+R1gozFmPrDR9fdsdAeDCxf+BPilMWYe0Ah8ySdRec+vgReNMQuxKveWMMs/axFJB74OFLqOwA0APsXs/KwfZvgpj6N9vh8G5rsuNwH3jeeF/CIRACuBQ8aYUmNMD/B/wMd8HNOkM8ZUGmO2u663Yn0xpGO91z+7mv0ZuMonAXqRiGRgnW3xgOtvAS4AnnA1mVXvW0SigfOABwGMMT3GmCb84LPGqpEWJiKBQDhQySz8rEc55XG0z/djwCPGshmIEZHUsb6WvySCdODEgL/LXLfNWiKSDSwHtgDJxphK111VQLKv4vKiXwH/ilXJFiAeaDLG9Ln+nm2f+VygFviTazjsARGJYJZ/1saYcuDnwHGsBNAMbGN2f9YDjfb5ntZ3nL8kAr8iIpHAk8CdxpiWgfcZa73wrFozLCJXADXGmG2+jmUKBQJnAvcZY5YD7QwZBpqln3Us1q/fuUAaEMHw4RO/MJmfr78kgnIgc8DfGa7bZh0RCcJKAuuNMRtcN1e7u4muf2t8FZ+XnA1cKSJHsYb9LsAaP49xDR/A7PvMy4AyY8wW199PYCWG2f5ZXwQcMcbUGmN6gQ1Yn/9s/qwHGu3zPa3vOH9JBB8A810rC4KxJpee9XFMk841Lv4gUGKMuWfAXc8Cn3Nd/xzW6XCzhjHmbmNMhjEmG+uzfc0Y82lgE3CNq9mset/GmCrghIgscN10IVDMLP+ssYaEVolIuOu/d/f7nrWf9RCjfb7PAp91rR5aBTQPGEI6NWOMX1yAy7HOQz4M/Juv4/HSezwHq6u4G9jpulyONV6+ETgIvArE+TpWL/5vsBZ43nU9B3gfOAQ8DoT4Or5Jfq9nAFtdn/fTQKw/fNbAD4B9wF7gL0DIbPysgb9hzYP0YvUAvzTa5wsI1srIw8AerFVVY34tLTGhlFJ+zl+GhpRSSo1CE4FSSvk5TQRKKeXnNBEopZSf00SglFJ+ThOBmvFExCEiOwdcJq3QmohkD6z+OIHHLxeRB13XF4rIeyLSLSL/MqTdiNVxx1NVU0SWiMjDE41V+S9NBGo26DTGnDHg8j++DmiA7wL3uq43YFXO/PnABqeojjvmqprGmD1AhojMmdR3oGY9TQRq1hKRoyLyUxHZIyLvi8g81+3ZIvKaq277RvcXp4gki8hTIrLLdVnjeqoAEfmjqwb+yyIS5mr/dbHOftgtIv83wutHAUuNMbsAjDE1xpgPsDYIDTRiddyTVVAVkWtd9fh3icibA57rOazd1UqNmSYCNRuEDRkaum7Afc3GmCXAb7AqlAL8L/BnY8xSYD39v9jvBd4wxizDqttT5Lp9PvBbY8wioAm42nX7d4Dlrue5eYS4CrF2v57KaJUjT1ZB9fvApa5Yrxzw2K3AuWN4TaU8NBGo2WDo0NDfB9z3twH/rnZdXw086rr+F6zSHGD9+r4PwBjjMMY0u24/YozZ6bq+Dch2Xd8NrBeRz2AdCjRUKlapaG94B3hYRL6CdTiLWw1WVU6lxkwTgZrtzCjXx6N7wHUHVglosA7C+S1W7+GDAdUv3TqB0DE8/2iVI+sZpaqmMeZm4Huux20TkXhXm1DX6yo1ZpoI1Gx33YB/33Ndf5f+cfRPA2+5rm8EbgHP+cfRoz2piNiATGPMJuDbQDQQOaRZCTBvDDGOWB3XWIXARqyqKSK5xpgtxpjvY/U63Ikkj7ENRynlMfQXjFIzUZiI7Bzw94vGGPcSzFgR2Y31q/561223Y53s9S2sL9EvuG6/A7hfRL6E9cv/FqzqjyMJAP7qShYC3GusoyI9jDH7RCRaRKKMMa0ikoI1hm8HnCJyJ1BgjGkRka8BL7me9yFjjHt+4tvA/4nIfwE7cB1NCfxMROa7XnsjsMt1+zrgH6f430upQbT6qJq1XAfVFBpj6nwYwzeAVmPMA1PwWiHAG8A5AyaYlTolHRpSyrvuY/AcgzfNAb6jSUCNl/YIlFLKz2mPQCml/JwmAqWU8nOaCJRSys9pIlBKKT+niUAppfzc/wfNkXJ7kv5uGQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "#Let's plot the loss we got during the training procedure\n",
     "plt.figure()\n",
@@ -806,7 +1051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -819,7 +1064,7 @@
     "    #line_tensor = lineToTensor(input_line)\n",
     "    #output = evaluate(model, line_remote)\n",
     "    # Get top N categories\n",
-    "    hidden = model_remote.initHidden()\n",
+    "    hidden = model_remote.init_hidden()\n",
     "    hidden_remote = hidden.copy().send(worker)\n",
     "        \n",
     "    with torch.no_grad():\n",
@@ -846,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,15 +1101,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "> Lu\n",
+      "(-1.26) Korean\n",
+      "(-1.28) Chinese\n",
+      "(-3.18) English\n",
+      "\n",
+      "> Gadler\n",
+      "(-1.79) German\n",
+      "(-1.89) French\n",
+      "(-1.91) Dutch\n",
+      "\n",
+      "> Lu\n",
+      "(-0.51) Vietnamese\n",
+      "(-2.84) Spanish\n",
+      "(-2.88) Scottish\n",
+      "\n",
+      "> Gadler\n",
+      "(-0.87) Scottish\n",
+      "(-1.50) Portuguese\n",
+      "(-1.72) Spanish\n"
+     ]
+    }
+   ],
    "source": [
-    "predict(model_alice.copy(), \"Qing\", alice) \n",
-    "predict(model_alice.copy(), \"Daniele\", alice) \n",
+    "predict(model_alice.copy(), \"Lu\", alice) \n",
+    "predict(model_alice.copy(), \"Gadler\", alice) \n",
     "\n",
-    "predict(model_bob.copy(), \"Qing\", alice) \n",
-    "predict(model_bob.copy(), \"Daniele\", alice) "
+    "predict(model_bob.copy(), \"Lu\", alice) \n",
+    "predict(model_bob.copy(), \"Gadler\", alice) "
    ]
   },
   {
@@ -930,7 +1202,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

- Fixed Recurrent Neural Network training on local and remote websockets in response to issue #4656 
- Currently, it is impossible to install PySyft in Windows because PyTorch 1.4.0 is not available. Added a workaround to install PySyft on Windows machines in INSTALLATION.md.


## Affected Dependencies
No additional dependencies affected

## How has this been tested?
- Working locally with websockets
- Test cases passing


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
