### PR TITLE
Override __module__ for syft types

### DIFF
--- a/src/syft/lib/python/__init__.py
+++ b/src/syft/lib/python/__init__.py
@@ -22,6 +22,22 @@ from .tuple import Tuple
 from .none import SyNone  # NOQA
 
 
+for syft_type in [
+    Bool,
+    Complex,
+    Dict,
+    Float,
+    Int,
+    SyNone,
+    _SyNone,
+    Any,
+    PyPrimitive,
+    String,
+    Tuple,
+]:
+    syft_type.__module__ = __name__
+
+
 def get_parent(path: str, root: TypeAny) -> Module:
     parent = root
     for step in path.split(".")[:-1]:


### PR DESCRIPTION
## Description
There was an inconsistency between the string paths used for syft.python and the real __module__ of these types when building the ast.

I'm not sure this is the best way to do it. The other way I've thought about is to replace the paths from "syft.lib.python.Bool" to "syft.lib.python.bool.Bool" for instance.

## How has this been tested?
- This fixes an issue when trying to display the duet store when in contains a Bool in the MNIST duet notebooks.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
