### PR TITLE
Fix fixprecision operation with natural tensor.

### DIFF
--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -144,18 +144,21 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
             """
             Operate the hooking
             """
-            def match_natural2fixprec(t1,t2):
+            def match_natural2fixprec(t1, t2):
                 """
-                Wrap a natural tensor to match a FixedPrecisionTensor, with the same attribute values.
-                
+                Wrap a natural tensor to match a FixedPrecisionTensor, and with
+                the same attribute values.
+
                 Args:
                     t1: a natural tensor
                     t2: a FixedPrecisionTensor
                 Return:
                     a FixedPrecisionTensor
                 """
-                t1 = type(t2.child)(**t2.child.get_class_attributes()).on(t1,wrap=False).fix_precision()
-                if t2.is_wrapper: t1 = t1.wrap()
+                t1 = type(t2.child)(**t2.child.get_class_attributes()).on(t1, wrap=False)
+                t1 = t1.fix_precision()
+                if t2.is_wrapper:
+                    t1 = t1.wrap()
                 return t1
 
             if not hasattr(self, "child"):  # means that it's not a wrapper
@@ -168,7 +171,7 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
                     # that we could accidentally serialize and send a tensor in the
                     # arguments
                     if not isinstance(args[0].child, PointerTensor):
-                        self = match_natural2fixprec(self,args[0])
+                        self = match_natural2fixprec(self, args[0])
                         args = [args[0]]
                         return overloaded_native_method(self, *args, **kwargs)
 
@@ -204,7 +207,7 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
                             # a security class
 
                             _args = []
-                            arg0 = match_natural2fixprec(args[0],self)
+                            arg0 = match_natural2fixprec(args[0], self)
                             _args.append(arg0)
                             for a in args[1:]:
                                 _args.append(a)

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -144,6 +144,7 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
             """
             Operate the hooking
             """
+
             def match_natural2fixprec(t1, t2):
                 """
                 Wrap a natural tensor to match a FixedPrecisionTensor, and with

--- a/syft/generic/frameworks/hook/hook.py
+++ b/syft/generic/frameworks/hook/hook.py
@@ -144,6 +144,19 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
             """
             Operate the hooking
             """
+            def match_natural2fixprec(t1,t2):
+                """
+                Wrap a natural tensor to match a FixedPrecisionTensor, with the same attribute values.
+                
+                Args:
+                    t1: a natural tensor
+                    t2: a FixedPrecisionTensor
+                Return:
+                    a FixedPrecisionTensor
+                """
+                t1 = type(t2.child)(**t2.child.get_class_attributes()).on(t1,wrap=False).fix_precision()
+                if t2.is_wrapper: t1 = t1.wrap()
+                return t1
 
             if not hasattr(self, "child"):  # means that it's not a wrapper
 
@@ -155,7 +168,7 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
                     # that we could accidentally serialize and send a tensor in the
                     # arguments
                     if not isinstance(args[0].child, PointerTensor):
-                        self = type(args[0].child)().on(self, wrap=True)
+                        self = match_natural2fixprec(self,args[0])
                         args = [args[0]]
                         return overloaded_native_method(self, *args, **kwargs)
 
@@ -191,7 +204,8 @@ class FrameworkHook(TensorHook, PointerHook, StringHook, ABC):
                             # a security class
 
                             _args = []
-                            _args.append(type(self)().on(args[0], wrap=False))
+                            arg0 = match_natural2fixprec(args[0],self)
+                            _args.append(arg0)
                             for a in args[1:]:
                                 _args.append(a)
 

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -193,6 +193,13 @@ def test_torch_add(workers):
     z = x + y
     assert (z.float_prec() == torch.tensor([1.1, 2.2, 3.3])).all()
 
+def test_torch_add2():
+    x = torch.tensor(5).fix_prec()
+    y = torch.tensor(2)
+    z1 = (x + y).float_prec()
+    z2 = (y + x).float_prec()
+    assert z1==torch.tensor(7)
+    assert z2==torch.tensor(7)
 
 def test_torch_add_():
     x = torch.tensor([0.1, 0.2, 0.3]).fix_prec()
@@ -269,6 +276,13 @@ def test_torch_sub(workers):
     z = x - y
     assert (z.float_prec() == torch.tensor([0.9, 1.8, 2.7])).all()
 
+def test_torch_sub2():
+    x = torch.tensor(5).fix_prec()
+    y = torch.tensor(2)
+    z1 = (x - y).float_prec()
+    z2 = (y - x).float_prec()
+    assert z1==torch.tensor(3)
+    assert z2==torch.tensor(-3)
 
 def test_torch_sub_():
     x = torch.tensor([0.1, 0.2, 0.3]).fix_prec()
@@ -350,7 +364,14 @@ def test_torch_mul(workers):
     z = x * y
     assert (z.float_prec() == torch.tensor([0.1, 0.4, 0.9])).all()
 
-
+def test_torch_mul2():
+    x = torch.tensor(5).fix_prec()
+    y = torch.tensor(2)
+    z1 = (x * y).float_prec()
+    z2 = (y * x).float_prec()
+    assert z1==torch.tensor(10)
+    assert z2==torch.tensor(10)
+    
 def test_torch_div(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
 
@@ -385,6 +406,13 @@ def test_torch_div(workers):
     z = torch.div(x, y)
     assert (z.float_prec() == torch.tensor([[-3.0, -4.1], [1.0, 0.0]])).all()
 
+def test_torch_div2():
+    x = torch.tensor(5).fix_prec()
+    y = torch.tensor(2)
+    z1 = (x / y).float_prec()
+    z2 = (y / x).float_prec()
+    assert z1==torch.tensor(2.5)
+    assert z2==torch.tensor(0.4)    
 
 def test_inplace_operations():
     a = torch.tensor([5.0, 6.0]).fix_prec()

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -419,7 +419,7 @@ def test_torch_div2():
     z1 = (x / y).float_prec()
     z2 = (y / x).float_prec()
     assert z1 == torch.tensor(2.5)
-    assert z2 == torch.tensor(0.4)    
+    assert z2 == torch.tensor(0.4)
 
 
 def test_inplace_operations():

--- a/test/torch/tensors/test_precision.py
+++ b/test/torch/tensors/test_precision.py
@@ -193,13 +193,15 @@ def test_torch_add(workers):
     z = x + y
     assert (z.float_prec() == torch.tensor([1.1, 2.2, 3.3])).all()
 
+
 def test_torch_add2():
     x = torch.tensor(5).fix_prec()
     y = torch.tensor(2)
     z1 = (x + y).float_prec()
     z2 = (y + x).float_prec()
-    assert z1==torch.tensor(7)
-    assert z2==torch.tensor(7)
+    assert z1 == torch.tensor(7)
+    assert z2 == torch.tensor(7)
+
 
 def test_torch_add_():
     x = torch.tensor([0.1, 0.2, 0.3]).fix_prec()
@@ -276,13 +278,15 @@ def test_torch_sub(workers):
     z = x - y
     assert (z.float_prec() == torch.tensor([0.9, 1.8, 2.7])).all()
 
+
 def test_torch_sub2():
     x = torch.tensor(5).fix_prec()
     y = torch.tensor(2)
     z1 = (x - y).float_prec()
     z2 = (y - x).float_prec()
-    assert z1==torch.tensor(3)
-    assert z2==torch.tensor(-3)
+    assert z1 == torch.tensor(3)
+    assert z2 == torch.tensor(-3)
+
 
 def test_torch_sub_():
     x = torch.tensor([0.1, 0.2, 0.3]).fix_prec()
@@ -364,14 +368,16 @@ def test_torch_mul(workers):
     z = x * y
     assert (z.float_prec() == torch.tensor([0.1, 0.4, 0.9])).all()
 
+
 def test_torch_mul2():
     x = torch.tensor(5).fix_prec()
     y = torch.tensor(2)
     z1 = (x * y).float_prec()
     z2 = (y * x).float_prec()
-    assert z1==torch.tensor(10)
-    assert z2==torch.tensor(10)
-    
+    assert z1 == torch.tensor(10)
+    assert z2 == torch.tensor(10)
+
+
 def test_torch_div(workers):
     bob, alice, james = (workers["bob"], workers["alice"], workers["james"])
 
@@ -406,13 +412,15 @@ def test_torch_div(workers):
     z = torch.div(x, y)
     assert (z.float_prec() == torch.tensor([[-3.0, -4.1], [1.0, 0.0]])).all()
 
+
 def test_torch_div2():
     x = torch.tensor(5).fix_prec()
     y = torch.tensor(2)
     z1 = (x / y).float_prec()
     z2 = (y / x).float_prec()
-    assert z1==torch.tensor(2.5)
-    assert z2==torch.tensor(0.4)    
+    assert z1 == torch.tensor(2.5)
+    assert z2 == torch.tensor(0.4)    
+
 
 def test_inplace_operations():
     a = torch.tensor([5.0, 6.0]).fix_prec()


### PR DESCRIPTION
## Description 
Resoves #3950 
If there a natural tensor, say `t1`, and a FixPrecisionTensor, say `t2`, and you want to do operation with them, like:
- `t1 +(or -*/) t2`
- `t2 +(or -*/) t1`
then you need to wrap the natural tensor `t1` to match the FixPrecisionTensor `t2`.
I added this functionality by modifing `overloaded_native_method`. After that all the `+-*/` operations are correct. 
## Affected Dependencies
No affection.

## How has this been tested?
Test functions are added at test/torch/tensors/test_precision.py to test the +-*/ operation, and all are passed.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
