### PR TITLE
Don't start counter thread if stdout doesn't have parent_header

### DIFF
--- a/src/syft/grid/duet/__init__.py
+++ b/src/syft/grid/duet/__init__.py
@@ -134,7 +134,8 @@ def begin_duet_logger(my_domain: Domain) -> None:
                     sys.stdout.write("\r" + out)
                 iterator += 1
 
-    counterThread().start()
+    if hasattr(sys.stdout, "parent_header"):
+        counterThread().start()
 
 
 def launch_duet(


### PR DESCRIPTION
Don't start counter thread if stdout doesn't have parent_header

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
