### PR TITLE
debug pointer.svd (OpenMined#4616)

### DIFF
--- a/syft/generic/object_storage.py
+++ b/syft/generic/object_storage.py
@@ -62,7 +62,7 @@ class ObjectStore:
                 more complex and needs to be explored. Is not supported at the
                 moment.
         """
-        if hasattr(obj, "id"):
+        if hasattr(obj, "_id"):
             self.rm_obj(obj.id)
         if hasattr(obj, "_owner"):
             del obj._owner

--- a/syft/generic/object_storage.py
+++ b/syft/generic/object_storage.py
@@ -6,6 +6,7 @@ from syft.generic.frameworks.types import FrameworkTensor
 from syft.generic.frameworks.types import FrameworkTensorType
 from syft.generic.abstract.tensor import AbstractTensor
 from syft.workers.abstract import AbstractWorker
+import torch
 
 
 class ObjectStore:
@@ -62,7 +63,8 @@ class ObjectStore:
                 more complex and needs to be explored. Is not supported at the
                 moment.
         """
-        if hasattr(obj, "_id"):
+        has_id = hasattr(obj, "_id") if isinstance(obj, torch.Tensor) else hasattr(obj, "id")
+        if has_id:
             self.rm_obj(obj.id)
         if hasattr(obj, "_owner"):
             del obj._owner

--- a/test/generic/pointers/test_pointer_tensor.py
+++ b/test/generic/pointers/test_pointer_tensor.py
@@ -398,6 +398,18 @@ def test_remote_T(workers):
     assert (bob_xT.get() == x.T).all()
 
 
+def test_remote_svd(workers):
+    """Test pointer.svd() functionality"""
+    bob = workers["bob"]
+    x = th.rand(5, 3)
+    local_u, local_s, local_v = x.svd()
+    bob_x = x.send(bob)
+    bob_u, bob_s, bob_v = bob_x.svd()
+    assert (local_u == bob_u.get()).all()
+    assert (local_s == bob_s.get()).all()
+    assert (local_v == bob_v.get()).all()
+
+
 def test_remote_function_with_multi_ouput(workers):
     """
     Functions like .split return several tensors, registration and response


### PR DESCRIPTION
## Description
Fixes #4616
When execute `pointer_tensor.svd()`, it returns 4 pointers, while what is expected is 3. And the 3rd one points to nothing. That's issue #4616.
I found that the reason is that there is bug in function `def de_register_obj()`. This function has a line `if hasattr(obj, "id")`, which is useless when `obj` is of type TorchTensor. Why it is useless is because a TorchTensor object always has `id` property, as you can see in it's definition. So I change the condition to be checking `has_attr = hasattr(obj, "_id") if isinstance(obj, torch.Tensor) else hasattr(obj, "id")`.
And why this bug is the key to #4616? Because `hasattr(obj,"id")` will run `obj.id()`. And in `obj.id()`, an `id` will be created for obj. And that `id` created is the 3rd poiner, which points to nothing.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Add a test unit `test_remote_svd`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
