### PR TITLE
Added pytest-xdist to setup.cfg testing and updated CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,8 +241,10 @@ $ which python
 
 Okay, any time we are inside the virtualenv every python and pip command we run will use this isolated version that we defined and will not effect the rest of the system or other projects.
 
-### Install Python Packages
+### Install Python Dependencies
 Once you are inside the virtualenv you can do this with pip or pipenv.
+
+**NOTE** this is required for several `dev` packages like pytest-xdist etc.
 ```
 $ pip install -r requirements.txt
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ testing =
     PyNaCl
     pytest
     pytest-cov
+    pytest-xdist[psutil]
     sqlitedict
     typing-extensions
     websockets


### PR DESCRIPTION
## Description
Makes the need for pytest-xdist package more clear to resolve the following error:
```
$ pytest -m fast -n auto
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: -n
  inifile: /mnt/d/github/PySyft/setup.cfg
  rootdir: /mnt/d/github/PySyft
```

## Affected Dependencies
None

## How has this been tested?
Locally and CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
