### PR TITLE
Add admin and compliance officer to node's auth scheme

### DIFF
--- a/src/syft/core/node/abstract/node.py
+++ b/src/syft/core/node/abstract/node.py
@@ -27,6 +27,8 @@ class AbstractNode(Address):
     verify_key: Optional[VerifyKey]
     root_verify_key: VerifyKey
     guest_verify_key_registry: Set[VerifyKey]
+    admin_verify_key_registry: Set[VerifyKey]
+    cpl_ofcr_verify_key_registry: Set[VerifyKey]
 
     # TODO: remove hacky in_memory_client_registry
     in_memory_client_registry: Dict[Any, Any]

--- a/src/syft/core/node/common/node.py
+++ b/src/syft/core/node/common/node.py
@@ -249,6 +249,8 @@ class Node(AbstractNode):
         # PERMISSION REGISTRY:
         self.root_verify_key = self.verify_key  # TODO: CHANGE
         self.guest_verify_key_registry = set()
+        self.admin_verify_key_registry = set()
+        self.cpl_ofcr_verify_key_registry = set()
         self.in_memory_client_registry = {}
         # TODO: remove hacky signaling_msgs when SyftMessages become Storable.
         self.signaling_msgs = {}

--- a/src/syft/core/node/common/service/auth.py
+++ b/src/syft/core/node/common/service/auth.py
@@ -48,6 +48,7 @@ def service_auth(
                     verify_key not in node.admin_verify_key_registry
                     and verify_key != node.root_verify_key
                 ):
+                    logger.debug(f"> ❌ Auth FAILED {msg.pprint}")
                     raise AuthorizationException(
                         "User lacks Administrator credentials."
                     )
@@ -57,12 +58,14 @@ def service_auth(
                     verify_key not in node.cpl_ofcr_verify_key_registry
                     and verify_key != node.root_verify_key
                 ):
+                    logger.debug(f"> ❌ Auth FAILED {msg.pprint}")
                     raise AuthorizationException(
                         "User lacks Compliance Officer credentials."
                     )
 
             elif existing_users_only:
                 if verify_key not in node.guest_verify_key_registry:
+                    logger.debug(f"> ❌ Auth FAILED {msg.pprint}")
                     raise AuthorizationException("User not known.")
 
             elif guests_welcome:

--- a/src/syft/core/node/common/service/auth.py
+++ b/src/syft/core/node/common/service/auth.py
@@ -44,13 +44,19 @@ def service_auth(
                     logger.debug(f"> ✅ Auth Succeeded {msg.pprint} 🔑 == 🗝")
 
             elif admin_only:
-                if verify_key not in node.admin_verify_key_registry:
+                if (
+                    verify_key not in node.admin_verify_key_registry
+                    and verify_key != node.root_verify_key
+                ):
                     raise AuthorizationException(
                         "User lacks Administrator credentials."
                     )
 
             elif cpl_ofcr_only:
-                if verify_key not in node.cpl_ofcr_verify_key_registry:
+                if (
+                    verify_key not in node.cpl_ofcr_verify_key_registry
+                    and verify_key != node.root_verify_key
+                ):
                     raise AuthorizationException(
                         "User lacks Compliance Officer credentials."
                     )

--- a/src/syft/core/node/common/service/auth.py
+++ b/src/syft/core/node/common/service/auth.py
@@ -17,6 +17,8 @@ class AuthorizationException(Exception):
 
 def service_auth(
     root_only: bool = False,
+    admin_only: bool = False,
+    cpl_ofcr_only: bool = False,
     existing_users_only: bool = False,
     guests_welcome: bool = False,
     register_new_guests: bool = False,
@@ -40,6 +42,18 @@ def service_auth(
                     )
                 else:
                     logger.debug(f"> ✅ Auth Succeeded {msg.pprint} 🔑 == 🗝")
+
+            elif admin_only:
+                if verify_key not in node.admin_verify_key_registry:
+                    raise AuthorizationException(
+                        "User lacks Administrator credentials."
+                    )
+
+            elif cpl_ofcr_only:
+                if verify_key not in node.cpl_ofcr_verify_key_registry:
+                    raise AuthorizationException(
+                        "User lacks Compliance Officer credentials."
+                    )
 
             elif existing_users_only:
                 if verify_key not in node.guest_verify_key_registry:

--- a/tests/syft/core/node/common/service/auth_test.py
+++ b/tests/syft/core/node/common/service/auth_test.py
@@ -80,13 +80,14 @@ def test_service_auth_guests_succeeds() -> None:
     assert new_verify_key in node.guest_verify_key_registry
 
 
-def test_service_admin_fails() -> None:
+def test_service_auth_admin_fails() -> None:
     node = sy.Device()
     msg = sy.ReprMessage(address=node.address)
 
     random_signing_key = SigningKey.generate()
     random_verify_key = random_signing_key.verify_key
 
+    # Administrator only
     @service_auth(admin_only=True)
     def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
         pass
@@ -97,14 +98,14 @@ def test_service_admin_fails() -> None:
         process(node=node, msg=msg, verify_key=random_verify_key)
 
 
-def test_service_admin_success() -> None:
+def test_service_auth_admin_success() -> None:
     node = sy.Device()
     msg = sy.ReprMessage(address=node.address)
 
     random_signing_key = SigningKey.generate()
     random_verify_key = random_signing_key.verify_key
 
-    # admin
+    # Administrator only
     @service_auth(admin_only=True)
     def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
         pass
@@ -114,13 +115,14 @@ def test_service_admin_success() -> None:
     process(node=node, msg=msg, verify_key=random_verify_key)
 
 
-def test_service_cpl_ofcr_fails() -> None:
+def test_service_auth_cpl_ofcr_fails() -> None:
     node = sy.Device()
     msg = sy.ReprMessage(address=node.address)
 
     random_signing_key = SigningKey.generate()
     random_verify_key = random_signing_key.verify_key
 
+    # Compliance Officer only
     @service_auth(cpl_ofcr_only=True)
     def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
         pass
@@ -131,14 +133,14 @@ def test_service_cpl_ofcr_fails() -> None:
         process(node=node, msg=msg, verify_key=random_verify_key)
 
 
-def test_service_cpl_ofcr_success() -> None:
+def test_service_auth_cpl_ofcr_success() -> None:
     node = sy.Device()
     msg = sy.ReprMessage(address=node.address)
 
     random_signing_key = SigningKey.generate()
     random_verify_key = random_signing_key.verify_key
 
-    # admin
+    # Compliance Officer only
     @service_auth(cpl_ofcr_only=True)
     def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
         pass
@@ -146,3 +148,27 @@ def test_service_cpl_ofcr_success() -> None:
     # NOTE didn't find a method to add a key to cpl_ofcr_verify_key_registry
     node.cpl_ofcr_verify_key_registry.add(random_verify_key)
     process(node=node, msg=msg, verify_key=random_verify_key)
+
+
+def test_service_auth_admin_success_as_root() -> None:
+    node = sy.Device()
+    msg = sy.ReprMessage(address=node.address)
+
+    # Administrator only
+    @service_auth(admin_only=True)
+    def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
+        pass
+
+    process(node=node, msg=msg, verify_key=node.root_verify_key)
+
+
+def test_service_auth_cpl_ofcr_success_as_root() -> None:
+    node = sy.Device()
+    msg = sy.ReprMessage(address=node.address)
+
+    # Compliance Officer only
+    @service_auth(cpl_ofcr_only=True)
+    def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
+        pass
+
+    process(node=node, msg=msg, verify_key=node.root_verify_key)

--- a/tests/syft/core/node/common/service/auth_test.py
+++ b/tests/syft/core/node/common/service/auth_test.py
@@ -78,3 +78,71 @@ def test_service_auth_guests_succeeds() -> None:
     process(node=node, msg=msg, verify_key=new_verify_key)
 
     assert new_verify_key in node.guest_verify_key_registry
+
+
+def test_service_admin_fails() -> None:
+    node = sy.Device()
+    msg = sy.ReprMessage(address=node.address)
+
+    random_signing_key = SigningKey.generate()
+    random_verify_key = random_signing_key.verify_key
+
+    @service_auth(admin_only=True)
+    def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
+        pass
+
+    with pytest.raises(
+        AuthorizationException, match="User lacks Administrator credentials."
+    ):
+        process(node=node, msg=msg, verify_key=random_verify_key)
+
+
+def test_service_admin_success() -> None:
+    node = sy.Device()
+    msg = sy.ReprMessage(address=node.address)
+
+    random_signing_key = SigningKey.generate()
+    random_verify_key = random_signing_key.verify_key
+
+    # admin
+    @service_auth(admin_only=True)
+    def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
+        pass
+
+    # NOTE didn't find a method to add a key to admin_verify_key_registry
+    node.admin_verify_key_registry.add(random_verify_key)
+    process(node=node, msg=msg, verify_key=random_verify_key)
+
+
+def test_service_cpl_ofcr_fails() -> None:
+    node = sy.Device()
+    msg = sy.ReprMessage(address=node.address)
+
+    random_signing_key = SigningKey.generate()
+    random_verify_key = random_signing_key.verify_key
+
+    @service_auth(cpl_ofcr_only=True)
+    def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
+        pass
+
+    with pytest.raises(
+        AuthorizationException, match="User lacks Compliance Officer credentials."
+    ):
+        process(node=node, msg=msg, verify_key=random_verify_key)
+
+
+def test_service_cpl_ofcr_success() -> None:
+    node = sy.Device()
+    msg = sy.ReprMessage(address=node.address)
+
+    random_signing_key = SigningKey.generate()
+    random_verify_key = random_signing_key.verify_key
+
+    # admin
+    @service_auth(cpl_ofcr_only=True)
+    def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
+        pass
+
+    # NOTE didn't find a method to add a key to admin_verify_key_registry
+    node.cpl_ofcr_verify_key_registry.add(random_verify_key)
+    process(node=node, msg=msg, verify_key=random_verify_key)

--- a/tests/syft/core/node/common/service/auth_test.py
+++ b/tests/syft/core/node/common/service/auth_test.py
@@ -143,6 +143,6 @@ def test_service_cpl_ofcr_success() -> None:
     def process(node: sy.Device, msg: sy.ReprMessage, verify_key: VerifyKey) -> None:
         pass
 
-    # NOTE didn't find a method to add a key to admin_verify_key_registry
+    # NOTE didn't find a method to add a key to cpl_ofcr_verify_key_registry
     node.cpl_ofcr_verify_key_registry.add(random_verify_key)
     process(node=node, msg=msg, verify_key=random_verify_key)


### PR DESCRIPTION
## Description

Extend `/syft/core/node/common/node` and `syft/core/node/common/service/auth` to include the roles of Administrator and Compliance officer. This change is needed to make available the same fine-grained access control expected in PyGrid.

## How has this been tested?
- New unit tests in `tests/syft/core/node/common/service/auth_test.py`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
