### PR TITLE
Fixed issue with AST Cache on python types directly using add_attr

### DIFF
--- a/src/syft/ast/__init__.py
+++ b/src/syft/ast/__init__.py
@@ -27,9 +27,9 @@ def add_modules(ast: globals.Globals, modules: TypeList[str]) -> None:
         parent.add_attr(
             attr_name=attr_name,
             attr=module.Module(
-                attr_name,
-                target_module,
-                None,
+                name=attr_name,
+                path_and_name=target_module,
+                ref=None,
                 return_type_name="",
             ),
         )
@@ -41,13 +41,12 @@ def add_classes(
     for path, return_type, ref in paths:
         parent = get_parent(path, ast)
         attr_name = path.rsplit(".", 1)[-1]
-
         parent.add_attr(
             attr_name=attr_name,
             attr=klass.Class(
-                attr_name,
-                path,
-                ref,
+                name=attr_name,
+                path_and_name=path,
+                ref=ref,
                 return_type_name=return_type,
             ),
         )

--- a/src/syft/ast/module.py
+++ b/src/syft/ast/module.py
@@ -31,6 +31,12 @@ class Module(ast.attribute.Attribute):
         if attr is not None:
             self.attrs[attr_name] = attr
 
+            # if add_attr is called directly we need to cache the path as well
+            attr_ref = getattr(attr, "ref", None)
+            path = getattr(attr, "path_and_name", None)
+            if attr_ref not in self.lookup_cache and path is not None:
+                self.lookup_cache[attr_ref] = path
+
     def __call__(
         self,
         path: Union[str, List[str]] = [],

--- a/tests/syft/ast/util_test.py
+++ b/tests/syft/ast/util_test.py
@@ -1,4 +1,5 @@
 # syft absolute
+import syft as sy
 from syft.ast.util import unsplit
 
 
@@ -6,3 +7,26 @@ def test_util_unsplit() -> None:
     fqn_list = unsplit(["syft", "lib", "python", "List"])
 
     assert fqn_list == "syft.lib.python.List"
+
+
+def test_path_cache() -> None:
+    short_fqn_list = "syft.lib.python.List"
+    long_fqn_list = "syft.lib.python.list.List"
+
+    list_ref1 = sy.lib_ast(
+        short_fqn_list, return_callable=True, obj_type=sy.lib.python.List
+    )
+
+    list_ref2 = sy.lib_ast(
+        long_fqn_list, return_callable=True, obj_type=sy.lib.python.List
+    )
+
+    assert list_ref1.ref == sy.lib.python.List
+    assert list_ref1.name == "List"
+    assert list_ref1.path_and_name == short_fqn_list
+
+    assert list_ref2.ref == sy.lib.python.List
+    assert list_ref2.name == "List"
+    assert list_ref2.path_and_name == short_fqn_list
+
+    assert list_ref1 == list_ref2

--- a/tests/syft/lib/torch/client_torch_test.py
+++ b/tests/syft/lib/torch/client_torch_test.py
@@ -1,3 +1,7 @@
+# stdlib
+from typing import List as TypeList
+from typing import Type as TypeType
+
 # third party
 import torch as th
 
@@ -15,3 +19,21 @@ def test_torch_function() -> None:
     res = ptr_res.get()
 
     assert (res == th.tensor([[0.0, 0.0], [0.0, 0.0]])).all()
+
+
+def test_path_cache() -> None:
+    short_fqn = "torch.nn.Conv2d"
+    conv2d_paths = [
+        "torch.nn.modules.conv.Conv2d",
+        "torch.nn.modules.Conv2d",
+        "torch.nn.Conv2d",
+    ]
+
+    refs: TypeList[TypeType] = []
+    for path in conv2d_paths:
+        klass = sy.lib_ast(path, return_callable=True, obj_type=th.nn.Conv2d)
+        assert klass == sy.lib_ast.torch.nn.Conv2d
+        assert klass.name == "Conv2d"
+        assert klass.path_and_name == short_fqn
+        assert all(klass == ref for ref in refs)
+        refs.append(klass)


### PR DESCRIPTION
## Description
- Fixed issue with AST Cache on python types directly using add_attr
- Added tests for torch and SyPrimitive cache types to prevent this

## Affected Dependencies
None

## How has this been tested?
Locally and CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
