### PR TITLE
Fixed Sample Code

### DIFF
--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -68,7 +68,7 @@ Example:
     requested_object = data_ptr_domain_1.id_at_location
 
     # getting the request id
-    message_request_id = domain_1_client.request_queue.get_request_id_from_object_id(
+    message_request_id = domain_1_client.requests.get_request_id_from_object_id(
         object_id=requested_object
     )
 


### PR DESCRIPTION
**Description**
Fixes #4913 
I replaced the word 'request_queue' from sample code with 'requests'. The sample code now **does not throw** the Attribute Error:
AttributeError: 'DomainClient' object has no attribute 'request_queue'

**Affected Dependencies**
None

**How has this been tested?**
I ran the updated code on jupyter notebook
![image](https://user-images.githubusercontent.com/52173002/102330341-6cac7400-3faf-11eb-9a24-8fff30c736eb.png)

