### PR TITLE
added location and locations printouts to remote and SMPC-encrypted nn.Module

### DIFF
--- a/syft/frameworks/torch/hook/hook.py
+++ b/syft/frameworks/torch/hook/hook.py
@@ -851,6 +851,26 @@ class TorchHook(FrameworkHook):
 
         self.torch.nn.Module.location = location
 
+        # print the location
+        native___str__ = self.torch.nn.Module.__str__
+
+        def model___str__(nn_self):
+            out = ""
+            # shared_encryption tensor doesn't have a location
+            first_data = next(iter(nn_self.state_dict().values()))
+            # child to get over FixedPrecisionTensor to AdditiveSharingTensor
+            if hasattr(first_data, "child"):
+                if hasattr(first_data.child, "location"):
+                    out = f"\n---\nlocation: {first_data.child.location}"
+                elif hasattr(first_data.child, "locations"):
+                    out = f"\n---\nlocations: {first_data.child.locations}"
+
+            out = native___str__(nn_self) + out
+
+            return out
+
+        self.torch.nn.Module.__str__ = model___str__
+
         def train(nn_self, mode=True):
             """
             This is a modification of nn.Module.train for BatchNorm, which stores the sqrt


### PR DESCRIPTION
## Description
This adds a new `__str__()` function to `torch.nn.Module` which adds a location printout to every shared model. In the case of an SMPC-encrypted model it outputs all the different locations. Should serve as a small convenience function.

## Affected Dependencies
None.

## How has this been tested?
- Tested the output of normal tensors, a remote tensor, a SMPC-encrypted tensor, a normal nn.Module, a nn.Module with FixedPrecisionTensor weights, a remote nn.Module and an SMPC-encrypted nn.Module.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
