### PR TITLE
Quick Fix:  discontinued support for Continuous benchmark actions for pull_requests

### DIFF
--- a/.github/workflows/benchmark_actions.yml
+++ b/.github/workflows/benchmark_actions.yml
@@ -1,11 +1,5 @@
 name: Pytest-benchmark
 on:
-  pull_request:
-    branches:
-      - dev
-    paths:
-      - "**.py"
-      - ".github/workflows/**.yml"
   push:
     branches:
       - dev


### PR DESCRIPTION
## Description
Discontinued support for Continuous benchmark actions for pull_requests.
Currently, as the new PRs are failing this is a quick fix for #4927

## Affected Dependencies
None

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
