### PR TITLE
Test Coverage: Improve test coverage for syft.core.io.address

### DIFF
--- a/src/syft/core/io/address.py
+++ b/src/syft/core/io/address.py
@@ -1,6 +1,5 @@
 # stdlib
 from typing import Any
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -303,10 +302,6 @@ class Address(Serializable):
         if vm is not None:
             return vm.id
         return None
-
-    @property
-    def addressables(self) -> List[Optional[Location]]:
-        return [self.vm, self.device, self.domain, self.network]
 
     def target_emoji(self) -> str:
         output = ""

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -75,7 +75,6 @@ def _gen_address_kwargs_and_expected_values() -> list:
 def test_init_with_specific_id(address_kwargs: dict, expected_values: dict) -> None:
     """Test that Address will use the SpecificLocation you pass into the constructor"""
     addr = Address(**address_kwargs)
-    print(f'===> {addr.icon}')
 
     assert addr.network is expected_values['network']
     assert addr.domain is expected_values['domain']
@@ -132,6 +131,24 @@ def test_to_string() -> None:
 
     assert str(obj) == str_out
     assert obj.__repr__() == str_out
+
+
+@pytest.mark.parametrize(
+    'address_kwargs, expected_icon', list(zip(
+        _gen_address_kwargs(),
+        [
+            '💠 [🍰📱🏰]',
+            '💠 [🍰📱🔗]',
+            '💠 [🍰🏰🔗]',
+            '💠 [📱🏰🔗]',
+            '💠 [🍰📱🏰🔗]',
+        ]
+    ))
+)
+def test_icon(address_kwargs, expected_icon) -> None:
+    """Test that Address.icon property method returns the correct emojis."""
+    addr = Address(**address_kwargs)
+    assert addr.icon == expected_icon
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -147,13 +147,16 @@ def test_to_string() -> None:
     assert obj.__repr__() == str_out
 
 
+# --------------------- PROPERTY METHODS ---------------------
+
+
 @pytest.mark.parametrize(
     'address_kwargs, expected_icon', list(zip(
         _gen_address_kwargs(),
         _gen_icons(),
     ))
 )
-def test_icon(address_kwargs, expected_icon) -> None:
+def test_icon_property_method(address_kwargs, expected_icon) -> None:
     """Unit tests for Address.icon property method"""
     address = Address(**address_kwargs)
     assert address.icon == expected_icon
@@ -165,7 +168,7 @@ def test_icon(address_kwargs, expected_icon) -> None:
         _gen_icons(),
     ))
 )
-def test_pprint(address_kwargs, expected_icon) -> None:
+def test_pprint_property_method(address_kwargs, expected_icon) -> None:
     """Unit tests for Address.pprint property method"""
     named_address = Address(name="Sneaky Nahua", **address_kwargs)
     assert named_address.pprint == expected_icon + ' Sneaky Nahua (Address)'
@@ -209,6 +212,27 @@ def test_network_getter_and_setter() -> None:
     new_network = SpecificLocation(id=an_id)
     address.network = new_network
     assert address.network == new_network
+
+
+def test_network_id_property_method() -> None:
+    """Unit test for Address.network_id method"""
+    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
+    # Test getter
+    network = SpecificLocation(id=an_id)
+    address_with_network = Address(
+        network=network,
+        domain=SpecificLocation(id=an_id),
+        device=SpecificLocation(id=an_id),
+        vm=SpecificLocation(id=an_id),
+    )
+    address_without_network = Address(
+        domain=SpecificLocation(id=an_id),
+        device=SpecificLocation(id=an_id),
+        vm=SpecificLocation(id=an_id),
+    )
+
+    assert address_with_network.network_id == an_id
+    assert address_without_network.network_id is None
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -24,7 +24,7 @@ from syft.core.io.address import Address
 from syft.core.io.location.specific import SpecificLocation
 
 
-ARGUMENTS = ('vm', 'device', 'domain', 'network')
+ARGUMENTS = ("vm", "device", "domain", "network")
 
 # --------------------- INITIALIZATION ---------------------
 
@@ -50,20 +50,17 @@ def _gen_address_kwargs() -> list:
     There are at least 3 arguments, all taken from 'vm', 'device', 'domain', 'network'.
     """
     all_combos = list(combinations(ARGUMENTS, 3)) + [ARGUMENTS]
-    return [
-        {key: SpecificLocation(id=UID()) for key in combo}
-        for combo in all_combos
-    ]
+    return [{key: SpecificLocation(id=UID()) for key in combo} for combo in all_combos]
 
 
 def _gen_icons() -> list:
     """Helper method to return an pre-ordered list of icons."""
     return [
-        '💠 [🍰📱🏰]',
-        '💠 [🍰📱🔗]',
-        '💠 [🍰🏰🔗]',
-        '💠 [📱🏰🔗]',
-        '💠 [🍰📱🏰🔗]',
+        "💠 [🍰📱🏰]",
+        "💠 [🍰📱🔗]",
+        "💠 [🍰🏰🔗]",
+        "💠 [📱🏰🔗]",
+        "💠 [🍰📱🏰🔗]",
     ]
 
 
@@ -84,16 +81,16 @@ def _gen_address_kwargs_and_expected_values() -> list:
 
 
 @pytest.mark.parametrize(
-    'address_kwargs, expected_values', _gen_address_kwargs_and_expected_values()
+    "address_kwargs, expected_values", _gen_address_kwargs_and_expected_values()
 )
 def test_init_with_specific_id(address_kwargs: dict, expected_values: dict) -> None:
     """Test that Address will use the SpecificLocation you pass into the constructor"""
     address = Address(**address_kwargs)
 
-    assert address.network is expected_values['network']
-    assert address.domain is expected_values['domain']
-    assert address.device is expected_values['device']
-    assert address.vm is expected_values['vm']
+    assert address.network is expected_values["network"]
+    assert address.domain is expected_values["domain"]
+    assert address.device is expected_values["device"]
+    assert address.vm is expected_values["vm"]
 
 
 # --------------------- CLASS METHODS ---------------------
@@ -157,17 +154,20 @@ def test_target_emoji_method() -> None:
         device=SpecificLocation(id=an_id),
         vm=SpecificLocation(id=an_id),
     )
-    assert address.target_emoji() == '@<UID:🙍🛖>'
+    assert address.target_emoji() == "@<UID:🙍🛖>"
 
 
 # --------------------- PROPERTY METHODS ---------------------
 
 
 @pytest.mark.parametrize(
-    'address_kwargs, expected_icon', list(zip(
-        _gen_address_kwargs(),
-        _gen_icons(),
-    ))
+    "address_kwargs, expected_icon",
+    list(
+        zip(
+            _gen_address_kwargs(),
+            _gen_icons(),
+        )
+    )
 )
 def test_icon_property_method(address_kwargs, expected_icon) -> None:
     """Unit tests for Address.icon property method"""
@@ -176,19 +176,22 @@ def test_icon_property_method(address_kwargs, expected_icon) -> None:
 
 
 @pytest.mark.parametrize(
-    'address_kwargs, expected_icon', list(zip(
-        _gen_address_kwargs(),
-        _gen_icons(),
-    ))
+    "address_kwargs, expected_icon",
+    list(
+        zip(
+            _gen_address_kwargs(),
+            _gen_icons(),
+        )
+    )
 )
 def test_pprint_property_method(address_kwargs, expected_icon) -> None:
     """Unit tests for Address.pprint property method"""
     named_address = Address(name="Sneaky Nahua", **address_kwargs)
-    assert named_address.pprint == expected_icon + ' Sneaky Nahua (Address)'
+    assert named_address.pprint == expected_icon + " Sneaky Nahua (Address)"
 
     unnamed_address = Address(**address_kwargs)
     assert expected_icon in unnamed_address.pprint
-    assert '(Address)' in unnamed_address.pprint
+    assert "(Address)" in unnamed_address.pprint
 
 
 def test_address_property_method() -> None:

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -147,6 +147,19 @@ def test_to_string() -> None:
     assert obj.__repr__() == str_out
 
 
+def test_target_emoji_method() -> None:
+    """Unit test for Address.target_emoji method"""
+    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
+
+    address = Address(
+        network=SpecificLocation(id=an_id),
+        domain=SpecificLocation(id=an_id),
+        device=SpecificLocation(id=an_id),
+        vm=SpecificLocation(id=an_id),
+    )
+    assert address.target_emoji() == '@<UID:🙍🛖>'
+
+
 # --------------------- PROPERTY METHODS ---------------------
 
 
@@ -342,17 +355,26 @@ def test_target_id_property_method_with_a_return() -> None:
     assert address.target_id == network
 
 
-def test_target_emoji_method() -> None:
+def test_addressables_property_method() -> None:
     """Unit test for Address.target_emoji method"""
     an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
-
+    network = SpecificLocation(id=an_id)
+    domain = SpecificLocation(id=an_id)
+    device = SpecificLocation(id=an_id)
+    vm = SpecificLocation(id=an_id)
     address = Address(
-        network=SpecificLocation(id=an_id),
-        domain=SpecificLocation(id=an_id),
-        device=SpecificLocation(id=an_id),
-        vm=SpecificLocation(id=an_id),
+        network=network,
+        domain=domain,
+        device=device,
+        vm=vm,
     )
-    assert address.target_emoji() == '@<UID:🙍🛖>'
+    assert address.addressables == [vm, device, domain, network]
+    address.vm = None
+    assert address.addressables == [None, device, domain, network]
+    address.device = None
+    assert address.addressables == [None, None, domain, network]
+    address.domain = None
+    assert address.addressables == [None, None, None, network]
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -46,13 +46,24 @@ def test_init_without_arguments() -> None:
 
 def _gen_address_kwargs() -> list:
     """
-    Helper method to generate 3-4 arguments for initializing an Address instance.
-    Arguments are taken from 'vm', 'device', 'domain', 'network'.
+    Helper method to generate pre-ordered arguments for initializing an Address instance.
+    There are at least 3 arguments, all taken from 'vm', 'device', 'domain', 'network'.
     """
     all_combos = list(combinations(ARGUMENTS, 3)) + [ARGUMENTS]
     return [
         {key: SpecificLocation(id=UID()) for key in combo}
         for combo in all_combos
+    ]
+
+
+def _gen_icons() -> list:
+    """Helper method to return an pre-ordered list of icons."""
+    return [
+        '💠 [🍰📱🏰]',
+        '💠 [🍰📱🔗]',
+        '💠 [🍰🏰🔗]',
+        '💠 [📱🏰🔗]',
+        '💠 [🍰📱🏰🔗]',
     ]
 
 
@@ -139,13 +150,7 @@ def test_to_string() -> None:
 @pytest.mark.parametrize(
     'address_kwargs, expected_icon', list(zip(
         _gen_address_kwargs(),
-        [
-            '💠 [🍰📱🏰]',
-            '💠 [🍰📱🔗]',
-            '💠 [🍰🏰🔗]',
-            '💠 [📱🏰🔗]',
-            '💠 [🍰📱🏰🔗]',
-        ]
+        _gen_icons(),
     ))
 )
 def test_icon(address_kwargs, expected_icon) -> None:
@@ -157,13 +162,7 @@ def test_icon(address_kwargs, expected_icon) -> None:
 @pytest.mark.parametrize(
     'address_kwargs, expected_icon', list(zip(
         _gen_address_kwargs(),
-        [
-            '💠 [🍰📱🏰]',
-            '💠 [🍰📱🔗]',
-            '💠 [🍰🏰🔗]',
-            '💠 [📱🏰🔗]',
-            '💠 [🍰📱🏰🔗]',
-        ]
+        _gen_icons(),
     ))
 )
 def test_pprint(address_kwargs, expected_icon) -> None:
@@ -191,6 +190,25 @@ def test_address_property_method() -> None:
     assert returned_address.domain == address.domain
     assert returned_address.device == address.device
     assert returned_address.vm == address.vm
+
+
+def test_network_getter_and_setter() -> None:
+    """Unit tests for Address.network getter and setter"""
+    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
+    # Test getter
+    network = SpecificLocation(id=an_id)
+    address = Address(
+        network=network,
+        domain=SpecificLocation(id=an_id),
+        device=SpecificLocation(id=an_id),
+        vm=SpecificLocation(id=an_id),
+    )
+    assert address.network == network
+
+    # Test setter
+    new_network = SpecificLocation(id=an_id)
+    address.network = new_network
+    assert address.network == new_network
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -354,22 +354,6 @@ def test_target_id_property_method_with_a_return() -> None:
     assert address.target_id == network
 
 
-def test_addressables_property_method() -> None:
-    """Unit test for Address.target_emoji method"""
-    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
-    network = SpecificLocation(id=an_id)
-    domain = SpecificLocation(id=an_id)
-    device = SpecificLocation(id=an_id)
-    vm = SpecificLocation(id=an_id)
-    address = Address(
-        network=network,
-        domain=domain,
-        device=device,
-        vm=vm,
-    )
-    assert address.addressables == [vm, device, domain, network]
-
-
 # --------------------- SERDE ---------------------
 
 

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -12,6 +12,7 @@ Table of Contents:
 
 # stdlib
 import uuid
+from itertools import combinations
 
 # third party
 import pytest
@@ -23,7 +24,7 @@ from syft.core.io.address import Address
 from syft.core.io.location.specific import SpecificLocation
 
 # --------------------- INITIALIZATION ---------------------
-
+ARGUMENTS = ('vm', 'device', 'domain', 'network')
 
 def test_init_without_arguments() -> None:
     """Test that Address have all attributes as None if none are given"""
@@ -40,72 +41,46 @@ def test_init_without_arguments() -> None:
         assert addr.target_id is None
 
 
-def test_init_with_specific_id() -> None:
+def _gen_address_kwargs() -> list:
+    """
+    Helper method to generate 3-4 arguments for initializing an Address instance.
+    Arguments are taken from 'vm', 'device', 'domain', 'network'.
+    """
+    all_combos = list(combinations(ARGUMENTS, 3)) + [ARGUMENTS]
+    return [
+        {key: SpecificLocation(id=UID()) for key in combo}
+        for combo in all_combos
+    ]
+
+
+def _gen_address_kwargs_and_expected_values() -> list:
+    """
+    Helper method to generate kwargs for initializing Address as well as
+    the expected values thereof.
+    """
+    address_kwargs = _gen_address_kwargs()
+    expected_value_dict = [
+        {
+            key: kwargs.get(key, None)
+            for key in ARGUMENTS
+        }
+        for kwargs in address_kwargs
+    ]
+    return list(zip(address_kwargs, expected_value_dict))
+
+
+@pytest.mark.parametrize(
+    'address_kwargs, expected_values', _gen_address_kwargs_and_expected_values()
+)
+def test_init_with_specific_id(address_kwargs: dict, expected_values: dict) -> None:
     """Test that Address will use the SpecificLocation you pass into the constructor"""
+    addr = Address(**address_kwargs)
+    print(f'===> {addr.icon}')
 
-    # init works with arguments
-    addr = Address(
-        network=SpecificLocation(id=UID()),
-        domain=SpecificLocation(id=UID()),
-        device=SpecificLocation(id=UID()),
-        vm=SpecificLocation(id=UID()),
-    )
-
-    assert addr.network is not None
-    assert addr.domain is not None
-    assert addr.device is not None
-    assert addr.vm is not None
-
-    # init works without arguments
-    addr = Address(  # network=SpecificLocation(id=UID()),
-        domain=SpecificLocation(id=UID()),
-        device=SpecificLocation(id=UID()),
-        vm=SpecificLocation(id=UID()),
-    )
-
-    assert addr.network is None
-    assert addr.domain is not None
-    assert addr.device is not None
-    assert addr.vm is not None
-
-    # init works without arguments
-    addr = Address(
-        network=SpecificLocation(id=UID()),
-        # domain=SpecificLocation(id=UID()),
-        device=SpecificLocation(id=UID()),
-        vm=SpecificLocation(id=UID()),
-    )
-
-    assert addr.network is not None
-    assert addr.domain is None
-    assert addr.device is not None
-    assert addr.vm is not None
-
-    # init works without arguments
-    addr = Address(
-        network=SpecificLocation(id=UID()),
-        domain=SpecificLocation(id=UID()),
-        # device=SpecificLocation(id=UID()),
-        vm=SpecificLocation(id=UID()),
-    )
-
-    assert addr.network is not None
-    assert addr.domain is not None
-    assert addr.device is None
-    assert addr.vm is not None
-
-    # init works without arguments
-    addr = Address(
-        network=SpecificLocation(id=UID()),
-        domain=SpecificLocation(id=UID()),
-        device=SpecificLocation(id=UID()),
-        # vm=SpecificLocation(id=UID())
-    )
-
-    assert addr.network is not None
-    assert addr.domain is not None
-    assert addr.device is not None
-    assert addr.vm is None
+    assert addr.network is expected_values['network']
+    assert addr.domain is expected_values['domain']
+    assert addr.device is expected_values['device']
+    assert addr.vm is expected_values['vm']
 
 
 # --------------------- CLASS METHODS ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -218,9 +218,8 @@ def test_network_id_property_method() -> None:
     """Unit test for Address.network_id method"""
     an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     # Test getter
-    network = SpecificLocation(id=an_id)
     address_with_network = Address(
-        network=network,
+        network=SpecificLocation(id=an_id),
         domain=SpecificLocation(id=an_id),
         device=SpecificLocation(id=an_id),
         vm=SpecificLocation(id=an_id),
@@ -233,6 +232,35 @@ def test_network_id_property_method() -> None:
 
     assert address_with_network.network_id == an_id
     assert address_without_network.network_id is None
+
+
+def test_domain_and_domain_id_property_methods() -> None:
+    """Unit test for Address.network_id method"""
+    # Test getter
+    domain = SpecificLocation(id=UID())
+    address_with_domain = Address(
+        network=SpecificLocation(id=UID()),
+        domain=domain,
+        device=SpecificLocation(id=UID()),
+        vm=SpecificLocation(id=UID()),
+    )
+    # Test domain getter
+    assert address_with_domain.domain == domain
+
+    # Test domain setter
+    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
+    new_domain = SpecificLocation(id=an_id)
+    address_with_domain.domain = new_domain
+    assert address_with_domain.domain == new_domain
+
+    # Test domain_id getter
+    address_without_domain = Address(
+        network=SpecificLocation(id=UID()),
+        device=SpecificLocation(id=UID()),
+        vm=SpecificLocation(id=UID()),
+    )
+    assert address_with_domain.domain_id == an_id
+    assert address_without_domain.domain_id is None
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -321,6 +321,27 @@ def test_vm_and_vm_id_property_methods() -> None:
     assert address_without_vm.vm_id is None
 
 
+def test_target_id_property_method_with_a_return() -> None:
+    """Unit test for Address.target_emoji method"""
+    network = SpecificLocation(id=UID())
+    domain = SpecificLocation(id=UID())
+    device = SpecificLocation(id=UID())
+    vm = SpecificLocation(id=UID())
+    address = Address(
+        network=network,
+        domain=domain,
+        device=device,
+        vm=vm,
+    )
+    assert address.target_id == vm
+    address.vm = None
+    assert address.target_id == device
+    address.device = None
+    assert address.target_id == domain
+    address.domain = None
+    assert address.target_id == network
+
+
 # --------------------- SERDE ---------------------
 
 

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -235,7 +235,7 @@ def test_network_id_property_method() -> None:
 
 
 def test_domain_and_domain_id_property_methods() -> None:
-    """Unit test for Address.network_id method"""
+    """Unit test for Address.domain and Address.domain_id methods"""
     # Test getter
     domain = SpecificLocation(id=UID())
     address_with_domain = Address(
@@ -261,6 +261,35 @@ def test_domain_and_domain_id_property_methods() -> None:
     )
     assert address_with_domain.domain_id == an_id
     assert address_without_domain.domain_id is None
+
+
+def test_device_and_device_id_property_methods() -> None:
+    """Unit test for Address.device and Address.device_id methods"""
+    # Test getter
+    device = SpecificLocation(id=UID())
+    address_with_device = Address(
+        network=SpecificLocation(id=UID()),
+        domain=SpecificLocation(id=UID()),
+        device=device,
+        vm=SpecificLocation(id=UID()),
+    )
+    # Test device getter
+    assert address_with_device.device == device
+
+    # Test device setter
+    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
+    new_device = SpecificLocation(id=an_id)
+    address_with_device.device = new_device
+    assert address_with_device.device == new_device
+
+    # Test domain_id getter
+    address_without_device = Address(
+        network=SpecificLocation(id=UID()),
+        domain=SpecificLocation(id=UID()),
+        vm=SpecificLocation(id=UID()),
+    )
+    assert address_with_device.device_id == an_id
+    assert address_without_device.device_id is None
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -23,8 +23,11 @@ from syft.core.common.uid import UID
 from syft.core.io.address import Address
 from syft.core.io.location.specific import SpecificLocation
 
-# --------------------- INITIALIZATION ---------------------
+
 ARGUMENTS = ('vm', 'device', 'domain', 'network')
+
+# --------------------- INITIALIZATION ---------------------
+
 
 def test_init_without_arguments() -> None:
     """Test that Address have all attributes as None if none are given"""
@@ -74,12 +77,13 @@ def _gen_address_kwargs_and_expected_values() -> list:
 )
 def test_init_with_specific_id(address_kwargs: dict, expected_values: dict) -> None:
     """Test that Address will use the SpecificLocation you pass into the constructor"""
-    addr = Address(**address_kwargs)
+    address = Address(**address_kwargs)
+    print(f'=====> {address.pprint}')
 
-    assert addr.network is expected_values['network']
-    assert addr.domain is expected_values['domain']
-    assert addr.device is expected_values['device']
-    assert addr.vm is expected_values['vm']
+    assert address.network is expected_values['network']
+    assert address.domain is expected_values['domain']
+    assert address.device is expected_values['device']
+    assert address.vm is expected_values['vm']
 
 
 # --------------------- CLASS METHODS ---------------------
@@ -146,9 +150,31 @@ def test_to_string() -> None:
     ))
 )
 def test_icon(address_kwargs, expected_icon) -> None:
-    """Test that Address.icon property method returns the correct emojis."""
-    addr = Address(**address_kwargs)
-    assert addr.icon == expected_icon
+    """Unit tests for Address.icon property method"""
+    address = Address(**address_kwargs)
+    assert address.icon == expected_icon
+
+
+@pytest.mark.parametrize(
+    'address_kwargs, expected_icon', list(zip(
+        _gen_address_kwargs(),
+        [
+            '💠 [🍰📱🏰]',
+            '💠 [🍰📱🔗]',
+            '💠 [🍰🏰🔗]',
+            '💠 [📱🏰🔗]',
+            '💠 [🍰📱🏰🔗]',
+        ]
+    ))
+)
+def test_pprint(address_kwargs, expected_icon) -> None:
+    """Unit tests for Address.pprint property method"""
+    named_address = Address(name="Sneaky Nahua", **address_kwargs)
+    assert named_address.pprint == expected_icon + ' Sneaky Nahua (Address)'
+
+    unnamed_address = Address(**address_kwargs)
+    assert expected_icon in unnamed_address.pprint
+    assert '(Address)' in unnamed_address.pprint
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -71,11 +71,7 @@ def _gen_address_kwargs_and_expected_values() -> list:
     """
     address_kwargs = _gen_address_kwargs()
     expected_value_dict = [
-        {
-            key: kwargs.get(key, None)
-            for key in ARGUMENTS
-        }
-        for kwargs in address_kwargs
+        {key: kwargs.get(key, None) for key in ARGUMENTS} for kwargs in address_kwargs
     ]
     return list(zip(address_kwargs, expected_value_dict))
 
@@ -167,9 +163,9 @@ def test_target_emoji_method() -> None:
             _gen_address_kwargs(),
             _gen_icons(),
         )
-    )
+    ),
 )
-def test_icon_property_method(address_kwargs, expected_icon) -> None:
+def test_icon_property_method(address_kwargs: dict, expected_icon: str) -> None:
     """Unit tests for Address.icon property method"""
     address = Address(**address_kwargs)
     assert address.icon == expected_icon
@@ -182,9 +178,9 @@ def test_icon_property_method(address_kwargs, expected_icon) -> None:
             _gen_address_kwargs(),
             _gen_icons(),
         )
-    )
+    ),
 )
-def test_pprint_property_method(address_kwargs, expected_icon) -> None:
+def test_pprint_property_method(address_kwargs: dict, expected_icon: str) -> None:
     """Unit tests for Address.pprint property method"""
     named_address = Address(name="Sneaky Nahua", **address_kwargs)
     assert named_address.pprint == expected_icon + " Sneaky Nahua (Address)"

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -322,7 +322,7 @@ def test_vm_and_vm_id_property_methods() -> None:
 
 
 def test_target_id_property_method_with_a_return() -> None:
-    """Unit test for Address.target_emoji method"""
+    """Unit test for Address.target_id method"""
     network = SpecificLocation(id=UID())
     domain = SpecificLocation(id=UID())
     device = SpecificLocation(id=UID())
@@ -340,6 +340,19 @@ def test_target_id_property_method_with_a_return() -> None:
     assert address.target_id == domain
     address.domain = None
     assert address.target_id == network
+
+
+def test_target_emoji_method() -> None:
+    """Unit test for Address.target_emoji method"""
+    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
+
+    address = Address(
+        network=SpecificLocation(id=an_id),
+        domain=SpecificLocation(id=an_id),
+        device=SpecificLocation(id=an_id),
+        vm=SpecificLocation(id=an_id),
+    )
+    assert address.target_emoji() == '@<UID:🙍🛖>'
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -292,6 +292,35 @@ def test_device_and_device_id_property_methods() -> None:
     assert address_without_device.device_id is None
 
 
+def test_vm_and_vm_id_property_methods() -> None:
+    """Unit test for Address.vm and Address.vm_id methods"""
+    # Test getter
+    vm = SpecificLocation(id=UID())
+    address_with_vm = Address(
+        network=SpecificLocation(id=UID()),
+        domain=SpecificLocation(id=UID()),
+        device=SpecificLocation(id=UID()),
+        vm=vm,
+    )
+    # Test device getter
+    assert address_with_vm.vm == vm
+
+    # Test device setter
+    an_id = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
+    new_vm = SpecificLocation(id=an_id)
+    address_with_vm.vm = new_vm
+    assert address_with_vm.vm == new_vm
+
+    # Test domain_id getter
+    address_without_vm = Address(
+        network=SpecificLocation(id=UID()),
+        domain=SpecificLocation(id=UID()),
+        device=SpecificLocation(id=UID()),
+    )
+    assert address_with_vm.vm_id == an_id
+    assert address_without_vm.vm_id is None
+
+
 # --------------------- SERDE ---------------------
 
 

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -368,12 +368,6 @@ def test_addressables_property_method() -> None:
         vm=vm,
     )
     assert address.addressables == [vm, device, domain, network]
-    address.vm = None
-    assert address.addressables == [None, device, domain, network]
-    address.device = None
-    assert address.addressables == [None, None, domain, network]
-    address.domain = None
-    assert address.addressables == [None, None, None, network]
 
 
 # --------------------- SERDE ---------------------

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -78,7 +78,6 @@ def _gen_address_kwargs_and_expected_values() -> list:
 def test_init_with_specific_id(address_kwargs: dict, expected_values: dict) -> None:
     """Test that Address will use the SpecificLocation you pass into the constructor"""
     address = Address(**address_kwargs)
-    print(f'=====> {address.pprint}')
 
     assert address.network is expected_values['network']
     assert address.domain is expected_values['domain']
@@ -175,6 +174,23 @@ def test_pprint(address_kwargs, expected_icon) -> None:
     unnamed_address = Address(**address_kwargs)
     assert expected_icon in unnamed_address.pprint
     assert '(Address)' in unnamed_address.pprint
+
+
+def test_address_property_method() -> None:
+    """Unit tests for Address.address property method"""
+    address = Address(
+        network=SpecificLocation(id=UID()),
+        domain=SpecificLocation(id=UID()),
+        device=SpecificLocation(id=UID()),
+        vm=SpecificLocation(id=UID()),
+    )
+
+    returned_address = address.address
+    assert isinstance(returned_address, Address)
+    assert returned_address.network == address.network
+    assert returned_address.domain == address.domain
+    assert returned_address.device == address.device
+    assert returned_address.vm == address.vm
 
 
 # --------------------- SERDE ---------------------


### PR DESCRIPTION
## Description
This PR adds more unit tests for `src/syft/core/io/address.py` and is related to [Issue 4805](https://github.com/OpenMined/PySyft/issues/4805) for improving test coverage.

`address.py`'s coverage improved from 64% to 96%:
```
src/syft/core/io/address.py                         164      7    96%   25, 100, 104, 108, 118, 351-352
```

`src/syft/core/io`'s coverage improved from 70% to 82.27%:
```
----------- coverage: platform linux, python 3.8.6-final-0 -----------
Name                                              Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------
src/syft/core/io/__init__.py                          0      0   100%
src/syft/core/io/address.py                         164      7    96%   25, 100, 104, 108, 118, 351-352
src/syft/core/io/connection.py                       71     23    68%   16, 21, 26, 32, 38, 44, 48, 52, 56, 61, 67, 72, 77, 81, 85, 89, 94, 100, 106, 112, 116, 120, 124
src/syft/core/io/location/__init__.py                 6      0   100%
src/syft/core/io/location/group/__init__.py           0      0   100%
src/syft/core/io/location/group/group.py              5      1    80%   19
src/syft/core/io/location/group/registry.py           7      2    71%   21-22
src/syft/core/io/location/group/subscription.py       7      2    71%   11-12
src/syft/core/io/location/location.py                28      4    86%   27, 37, 55, 70
src/syft/core/io/location/specific.py                28      0   100%
src/syft/core/io/route.py                            61     21    66%   119, 124-128, 132, 136, 141, 146, 151, 160-161, 166-167, 172, 177, 181, 188-190, 206
src/syft/core/io/virtual.py                          63     18    71%   32, 38, 44, 50, 54, 58-59, 65, 72, 77, 83, 89, 93, 97, 103, 109-112
-------------------------------------------------------------------------------
TOTAL                                               440     78    82%
```

## Affected Dependencies
N/A

## How has this been tested?
`pytest tests/syft/core/io --cov-report term --cov=src/syft/core/io -m fast -n auto`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
