### PR TITLE
Fixing issue with Windows in CI and pytest not available immediately

### DIFF
--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -116,8 +116,11 @@ jobs:
             pip install torchcsprng -f https://download.pytorch.org/whl/torch_stable.html
           }
 
-      - name: Run all tests
+      - name: Install packages
         run: |
           pip install -r requirements.txt
           pip install -e .
+
+      - name: Run all tests
+        run: |
           pytest -m 'all' --cov-fail-under 80 -n auto


### PR DESCRIPTION
## Description
Fixing issue with Windows in CI and pytest not available immediately
- See here: https://github.com/OpenMined/PySyft/runs/1603537525

## Affected Dependencies
None

## How has this been tested?
CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
