### PR TITLE
Issue 4527

### DIFF
--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -68,7 +68,7 @@ Example:
     requested_object = data_ptr_domain_1.id_at_location
 
     # getting the request id
-    message_request_id = domain_1_client.request_queue.get_request_id_from_object_id(
+    message_request_id = domain_1_client.requests.get_request_id_from_object_id(
         object_id=requested_object
     )
 

--- a/src/syft/grid/example_nodes/network.py
+++ b/src/syft/grid/example_nodes/network.py
@@ -85,7 +85,7 @@ def run() -> None:
     PORT = os.getenv("PORT", 5000)
     print(f"Starting Node on PORT: {PORT}")
     print(network.signing_key.encode(encoder=HexEncoder).decode("utf-8"), "\n")
-    app.run(host="0.0.0.0", port=int(PORT))  # nosec
+    app.run(host="::", port=int(PORT))  # nosec
 
 
 run()


### PR DESCRIPTION
## Description
There seemed to be a problem with the Flask server for IPv6 networks. I have made a change by replacing 0.0.0.0 with :: as host address. It will map the IPv4 addresses to IPv6 too. So the server now works for both the networks. This seems to be a temporary fix for now, and there maybe some problems even now for Mac OS and some Windows machines.

## Affected Dependencies
None

## How has this been tested?
My machine OS - Ubuntu 20.04
I tested this on Jupyter Notebooks by making a simple connection as follows:
Started the flask server 
![image](https://user-images.githubusercontent.com/52173002/103069219-ec0bfa00-45e4-11eb-98e5-8570f95abdf0.png)

![image](https://user-images.githubusercontent.com/52173002/103069037-8455af00-45e4-11eb-8d8a-31e0072ada8e.png)
![image](https://user-images.githubusercontent.com/52173002/103069071-98011580-45e4-11eb-8b27-8102a9976433.png)

The duet connection is successful.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
