### PR TITLE
Re-enabled windows on merge test CI and added -p no:benchmark

### DIFF
--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       max-parallel: 36
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
         torch-version: [1.5.0, 1.5.1, 1.6.0, 1.7.0]
         isMaster:
@@ -123,4 +123,4 @@ jobs:
 
       - name: Run all tests
         run: |
-          pytest -m 'all' --cov-fail-under 80 -n auto
+          pytest -m 'all' --cov-fail-under 80 -n auto -p no:benchmark


### PR DESCRIPTION
## Description
- Benchmark plugin on the slow tests is probably causing the $? 137 OOM

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
