### PR TITLE
Skip benchmarks on slow and fast tests on merge

### DIFF
--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       max-parallel: 36
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
         torch-version: [1.5.0, 1.5.1, 1.6.0, 1.7.0]
         isMaster:
@@ -79,4 +79,5 @@ jobs:
 
       - name: Run all tests
         run: |
-          pytest -m 'all' --cov-fail-under 80 -n auto -p no:benchmark
+          pytest -m fast --cov-fail-under 0 -n auto -p no:benchmark
+          pytest -m slow --cov-fail-under 0 -n auto -p no:benchmark

--- a/tests/benchmarks/pytest_benchmarks/bench_test.py
+++ b/tests/benchmarks/pytest_benchmarks/bench_test.py
@@ -4,10 +4,14 @@ Define benchmark tests
 # stdlib
 from typing import Any
 
+# third party
+import pytest
+
 # syft relative
 from ..pytest_benchmarks.benchmarks_functions_test import string_serde
 
 
+@pytest.mark.benchmark
 def test_string_serde(benchmark: Any) -> None:
     """
     Test sigmoid approximation with chebyshev method and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ def pytest_configure(config: _pytest.config.Config) -> None:
     config.addinivalue_line("markers", "asyncio: mark test as asyncio")
     config.addinivalue_line("markers", "vendor: mark test as vendor library")
     config.addinivalue_line("markers", "libs: runs valid vendor tests")
+    config.addinivalue_line("markers", "benchmark: runs benchmark tests")
 
 
 def pytest_collection_modifyitems(
@@ -65,6 +66,9 @@ def pytest_collection_modifyitems(
                 print(e)
             except Exception as e:
                 print(f"Unable to check vendor library: {vendor_requirements}. {e}")
+            continue
+
+        if "benchmark" in item.keywords:
             continue
 
         item.add_marker(all_tests)


### PR DESCRIPTION
## Description
- Skip benchmarks on slow and fast tests on merge
- Disabled Windows again

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
