### PR TITLE
Model get() not preserving parameters

### DIFF
--- a/src/syft/lib/torch/module.py
+++ b/src/syft/lib/torch/module.py
@@ -349,8 +349,8 @@ class Module:
                         timeout_secs=timeout_secs,
                         delete_obj=delete_obj,
                     )
+                    # We have to recreate the OrderedDict for load_state_dict to work
                     ordered_state_dict = OrderedDict()
-
                     for elem, item in state_dict.items():
                         ordered_state_dict[str(elem)] = item
                     # iterate through the key, values

--- a/src/syft/lib/torch/module.py
+++ b/src/syft/lib/torch/module.py
@@ -20,12 +20,12 @@ import torch
 from ...decorators import syft_decorator
 
 
-def debug(msg):
+def debug(msg: str) -> None:
     print(msg)
     logger.debug(msg)
 
 
-def critical(msg):
+def critical(msg: str) -> None:
     print(msg)
     logger.critical(msg)
 

--- a/tests/syft/lib/torch/module_test.py
+++ b/tests/syft/lib/torch/module_test.py
@@ -1,3 +1,9 @@
+# stdlib
+import copy
+import os
+import time
+from pathlib import Path
+
 # third party
 import torch
 import pytest
@@ -38,6 +44,94 @@ def dataloader() -> Tuple[torch.Tensor, torch.Tensor]:
     return torch.randn(size=(1, IN_DIM)), torch.randn(size=(1, OUT_DIM))
 
 
+def test_repr_to_kwargs() -> None:
+    assert sy.lib.util.full_name_with_qualname(klass=torch.Tensor) == "torch.Tensor"
+
+
+def test_module_setup(alice: sy.VirtualMachine, model: SyNet) -> None:
+    alice_client = alice.get_root_client()
+
+    remote = copy.copy(model)
+    remote.setup(torch_ref=alice_client.torch)
+    assert remote.is_local is False
+    assert remote.torch_ref == alice_client.torch
+    assert remote.training is False
+
+    remote.setup(torch_ref=torch)
+    assert remote.is_local is True
+
+
+def test_module_attr(model: SyNet) -> None:
+    model.__setattr__("fc1", torch.nn.Linear(1, 2))
+    assert model.__getattr__("fc1").in_features == 1
+    assert model.__getattr__("fc1").out_features == 2
+
+
+def test_module_modules(model: SyNet) -> None:
+    modules = model.modules
+    assert len(modules.items()) == 1
+    assert "fc1" in modules
+    assert modules["fc1"].in_features == IN_DIM
+
+
+def test_module_parameteres(alice: sy.VirtualMachine, model: SyNet) -> None:
+    model_ptr = model.send(alice.get_root_client())
+
+    assert len(model_ptr.parameters().get()) == 2
+    assert model_ptr.parameters().get()[0].shape == torch.Size([OUT_DIM, IN_DIM])
+    assert model_ptr.parameters().get()[1].shape == torch.Size([OUT_DIM])
+
+
+def test_module_cuda(model: SyNet) -> None:
+    model.cpu()
+    assert model.parameters()[-1].is_cuda is False
+
+
+def test_module_zero(model: SyNet) -> None:
+    model.zero_layers()
+    for _, m in model.modules.items():
+        for _, v in m.state_dict().items():
+            assert v.sum() == 0
+
+
+def test_module_state_dict(model: SyNet) -> None:
+    state = model.state_dict()
+
+    new_model = SyNet()
+    new_model.load_state_dict(state)
+
+    new_state = new_model.state_dict()
+    for k in state:
+        assert k in new_state
+        assert torch.all(torch.eq(new_state[k], state[k]))
+
+
+def test_module_load_save(model: SyNet) -> None:
+    state = model.state_dict()
+
+    folder = Path("tmp")
+    try:
+        os.mkdir(folder)
+    except FileExistsError:
+        pass
+
+    path = folder / str(time.time())
+    model.save(path)
+
+    new_model = SyNet()
+    new_model.load(path)
+    new_state = new_model.state_dict()
+
+    try:
+        os.remove(path)
+    except BaseException:
+        pass
+
+    for k in state:
+        assert k in new_state
+        assert torch.all(torch.eq(new_state[k], state[k]))
+
+
 def test_module_gradient_sanity(
     alice: sy.VirtualMachine,
     model: SyNet,
@@ -53,7 +147,7 @@ def test_module_gradient_sanity(
     assert model.parameters()[-1].grad is not None
 
 
-def test_module_remote_sanity(
+def test_module_send_get(
     alice: sy.VirtualMachine,
     model: SyNet,
     dataloader: Tuple[torch.Tensor, torch.Tensor],
@@ -74,5 +168,7 @@ def test_module_remote_sanity(
     model_parameter = model_ptr.get().parameters()
 
     for idx, param in enumerate(direct_param):
+        assert param.grad is not None
+        assert model_parameter[idx].grad is not None
         assert param.tolist() == model_parameter[idx].tolist()
         assert param.grad == model_parameter[idx].grad

--- a/tests/syft/lib/torch/module_test.py
+++ b/tests/syft/lib/torch/module_test.py
@@ -1,0 +1,78 @@
+# third party
+import torch
+import pytest
+from typing import Any, Tuple
+
+# syft absolute
+import syft as sy
+
+IN_DIM = 100
+OUT_DIM = 10
+
+
+class SyNet(sy.Module):
+    """
+    Simple test model
+    """
+
+    def __init__(self) -> None:
+        super(SyNet, self).__init__(torch_ref=torch)
+        self.fc1 = torch.nn.Linear(IN_DIM, OUT_DIM)
+
+    def forward(self, x: torch.Tensor) -> Any:
+        return self.fc1(x)
+
+
+@pytest.fixture(scope="function")
+def alice() -> sy.VirtualMachine:
+    return sy.VirtualMachine(name="alice")
+
+
+@pytest.fixture(scope="function")
+def model() -> SyNet:
+    return SyNet()
+
+
+@pytest.fixture(scope="function")
+def dataloader() -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.randn(size=(1, IN_DIM)), torch.randn(size=(1, OUT_DIM))
+
+
+def test_module_gradient_sanity(
+    alice: sy.VirtualMachine,
+    model: SyNet,
+    dataloader: Tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    data, labels = dataloader
+
+    result = model(data)
+    loss_func = torch.nn.L1Loss()
+    loss = loss_func(result, labels)
+    loss.backward()
+
+    assert model.parameters()[-1].grad is not None
+
+
+def test_module_remote_sanity(
+    alice: sy.VirtualMachine,
+    model: SyNet,
+    dataloader: Tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    alice_client = alice.get_root_client()
+
+    data, labels = dataloader
+
+    model_ptr = model.send(alice_client)
+    data_ptr = data.send(alice_client)
+    labels_ptr = labels.send(alice_client)
+    results_ptr = model_ptr(data_ptr)
+    remote_loss_func = alice_client.torch.nn.L1Loss()
+    remote_loss = remote_loss_func(results_ptr, labels_ptr)
+    remote_loss.backward()
+
+    direct_param = model_ptr.parameters().get()
+    model_parameter = model_ptr.get().parameters()
+
+    for idx, param in enumerate(direct_param):
+        assert param.tolist() == model_parameter[idx].tolist()
+        assert param.grad == model_parameter[idx].grad


### PR DESCRIPTION
## Description
 - syft.lib.torch.Module send was failing because load_state_dict was unable to load the result from sd_ptr.get.
 - added some tests for syft.lib.torch.Module.
 - the send/get flow cannot retrieve the gradients, since load_state_dict breaks the computational graph. ref: https://discuss.pytorch.org/t/loading-a-state-dict-seems-to-erase-grad/56676
 - removed some duplicate code.

fixes https://github.com/OpenMined/PySyft/issues/5002

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
