### PR TITLE
Add tuple hash

### DIFF
--- a/src/syft/lib/python/tuple.py
+++ b/src/syft/lib/python/tuple.py
@@ -60,6 +60,10 @@ class Tuple(tuple, PyPrimitive):
     def __eq__(self, other: Any) -> SyPrimitiveRet:
         return PrimitiveFactory.generate_primitive(value=super().__eq__(other))
 
+    @syft_decorator(typechecking=True, prohibit_args=True)
+    def __hash__(self) -> SyPrimitiveRet:
+        return PrimitiveFactory.generate_primitive(value=super().__hash__())
+
     @syft_decorator(typechecking=True, prohibit_args=False)
     def __ne__(self, other: Any) -> SyPrimitiveRet:
         return PrimitiveFactory.generate_primitive(value=super().__ne__(other))

--- a/tests/syft/lib/python/tuple/tuple_test.py
+++ b/tests/syft/lib/python/tuple/tuple_test.py
@@ -52,12 +52,5 @@ def test_repr():
 
 def test_hash():
     assert hash(Tuple()) == hash(())
-    assert (
-        hash(
-            Tuple(
-                1,
-            )
-        )
-        == hash((1,))
-    )
-    assert hash(Tuple(-1, 0, 1)) == hash((-1, 0, 1))
+    assert hash(Tuple((1,))) == hash((1,))
+    assert hash(Tuple((-1, 0, 1))) == hash((-1, 0, 1))

--- a/tests/syft/lib/python/tuple/tuple_test.py
+++ b/tests/syft/lib/python/tuple/tuple_test.py
@@ -48,3 +48,8 @@ def test_repr():
     assert str(a2) == repr(l2)
     assert repr(a0) == "()"
     assert repr(a2), "(0, 1 ==  2)"
+
+def test_hash():
+    assert hash(Tuple()) == hash(())
+    assert hash(Tuple(1,)) == hash((1,))
+    assert hash(Tuple(-1,0,1)) == hash((-1,0,1))

--- a/tests/syft/lib/python/tuple/tuple_test.py
+++ b/tests/syft/lib/python/tuple/tuple_test.py
@@ -49,7 +49,15 @@ def test_repr():
     assert repr(a0) == "()"
     assert repr(a2), "(0, 1 ==  2)"
 
+
 def test_hash():
     assert hash(Tuple()) == hash(())
-    assert hash(Tuple(1,)) == hash((1,))
-    assert hash(Tuple(-1,0,1)) == hash((-1,0,1))
+    assert (
+        hash(
+            Tuple(
+                1,
+            )
+        )
+        == hash((1,))
+    )
+    assert hash(Tuple(-1, 0, 1)) == hash((-1, 0, 1))


### PR DESCRIPTION
## Description
Add the possibility to have the ```hash``` code over our own designed tuples.

## Affected Dependencies
The ```Tuple``` class from ```Python```.

## How has this been tested?
- Added a test in the Tuple test file

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
