### PR TITLE
Move the generic update to util

### DIFF
--- a/src/syft/ast/globals.py
+++ b/src/syft/ast/globals.py
@@ -71,7 +71,7 @@ class Globals(Module):
     def register_updates(self, client: Any) -> None:
         # any previously loaded libs need to be applied
         for _, update_ast in self.loaded_lib_constructors.items():
-            update_ast(ast=client, client=client)
+            update_ast(ast_or_client=client)
 
         # make sure to get any future updates
         self.registered_clients[client.id] = client

--- a/src/syft/core/node/common/client.py
+++ b/src/syft/core/node/common/client.py
@@ -116,18 +116,6 @@ class Client(AbstractNodeClient):
         meta = _deserialize(blob=metadata)
         return meta.node, meta.name, meta.id
 
-    def add_attr(self, attr_name: str, attr: Any) -> None:
-        # this can be called any time after startup to add additional libs
-        # bind this client to the ast sub tree
-        attr.client = self
-
-        # attach this sub tree to the main ast tree
-        self.lib_ast.attrs[attr_name] = attr
-
-        # make sure that the lib attr_name is available at the top level of the client
-        # so you can do: client.package.class.method
-        setattr(self, attr_name, attr)
-
     def install_supported_frameworks(self) -> None:
         self.lib_ast = create_lib_ast(client=self)
 

--- a/src/syft/lib/__init__.py
+++ b/src/syft/lib/__init__.py
@@ -71,10 +71,10 @@ def load_lib(lib: str, options: TypeDict[str, TypeAny] = {}) -> None:
             update_ast = getattr(vendor_ast, "update_ast", None)
             if update_ast is not None:
                 global lib_ast
-                update_ast(ast=lib_ast)
+                update_ast(ast_or_client=lib_ast)
 
                 for _, client in lib_ast.registered_clients.items():
-                    update_ast(ast=client, client=client)
+                    update_ast(ast_or_client=client)
 
                 # cache the constructor for future created clients
                 lib_ast.loaded_lib_constructors[lib] = update_ast

--- a/src/syft/lib/opacus/__init__.py
+++ b/src/syft/lib/opacus/__init__.py
@@ -2,12 +2,13 @@
 from typing import Any as TypeAny
 from typing import List as TypeList
 from typing import Tuple as TypeTuple
-from typing import Union as TypeUnion
+import functools
 
 # third party
 import opacus
 
 # syft relative
+from ..util import generic_update_ast
 from ...ast import add_classes
 from ...ast import add_methods
 from ...ast import add_modules
@@ -15,11 +16,6 @@ from ...ast.globals import Globals
 
 LIB_NAME = "opacus"
 PACKAGE_SUPPORT = {"lib": LIB_NAME}
-
-
-def update_ast(ast: TypeUnion[Globals, TypeAny], client: TypeAny = None) -> None:
-    opacus_ast = create_ast(client)
-    ast.add_attr(attr_name=LIB_NAME, attr=opacus_ast.attrs[LIB_NAME])
 
 
 def create_ast(client: TypeAny = None) -> Globals:
@@ -62,3 +58,6 @@ def create_ast(client: TypeAny = None) -> Globals:
         klass.create_storable_object_attr_convenience_methods()
 
     return ast
+
+
+update_ast = functools.partial(generic_update_ast, LIB_NAME, create_ast)

--- a/src/syft/lib/openmined_psi/__init__.py
+++ b/src/syft/lib/openmined_psi/__init__.py
@@ -2,12 +2,13 @@
 from typing import Any as TypeAny
 from typing import List as TypeList
 from typing import Tuple as TypeTuple
-from typing import Union as TypeUnion
+import functools
 
 # third party
 import openmined_psi
 
 # syft relative
+from ..util import generic_update_ast
 from ...ast import add_classes
 from ...ast import add_methods
 from ...ast import add_modules
@@ -16,11 +17,6 @@ from ..python import GenerateProtobufWrapper
 
 LIB_NAME = "openmined_psi"
 PACKAGE_SUPPORT = {"lib": LIB_NAME}
-
-
-def update_ast(ast: TypeUnion[Globals, TypeAny], client: TypeAny = None) -> None:
-    psi_ast = create_ast(client)
-    ast.add_attr(attr_name=LIB_NAME, attr=psi_ast.attrs[LIB_NAME])
 
 
 def create_ast(client: TypeAny = None) -> Globals:
@@ -85,3 +81,6 @@ def create_ast(client: TypeAny = None) -> Globals:
         klass.create_storable_object_attr_convenience_methods()
 
     return ast
+
+
+update_ast = functools.partial(generic_update_ast, LIB_NAME, create_ast)

--- a/src/syft/lib/pydp/__init__.py
+++ b/src/syft/lib/pydp/__init__.py
@@ -2,7 +2,7 @@
 from typing import Any as TypeAny
 from typing import List as TypeList
 from typing import Tuple as TypeTuple
-from typing import Union as TypeUnion
+import functools
 
 # third party
 import pydp
@@ -17,6 +17,7 @@ from pydp.algorithms.laplacian import Min
 from pydp.algorithms.laplacian import Percentile
 
 # syft relative
+from ..util import generic_update_ast
 from ...ast import add_classes
 from ...ast import add_methods
 from ...ast import add_modules
@@ -25,11 +26,6 @@ from ..misc.union import UnionGenerator
 
 LIB_NAME = "pydp"
 PACKAGE_SUPPORT = {"lib": LIB_NAME}
-
-
-def update_ast(ast: TypeUnion[Globals, TypeAny], client: TypeAny = None) -> None:
-    dp_ast = create_ast(client)
-    ast.add_attr(attr_name=LIB_NAME, attr=dp_ast.attrs[LIB_NAME])
 
 
 def create_ast(client: TypeAny = None) -> Globals:
@@ -354,3 +350,6 @@ def create_ast(client: TypeAny = None) -> Globals:
         klass.create_storable_object_attr_convenience_methods()
 
     return ast
+
+
+update_ast = functools.partial(generic_update_ast, LIB_NAME, create_ast)

--- a/src/syft/lib/sympc/__init__.py
+++ b/src/syft/lib/sympc/__init__.py
@@ -2,22 +2,17 @@
 from typing import Any as TypeAny
 from typing import List as TypeList
 from typing import Tuple as TypeTuple
-from typing import Union as TypeUnion
+import functools
 
 # syft relative
+from ..util import generic_update_ast
 from ...ast import add_classes
 from ...ast import add_methods
 from ...ast import add_modules
 from ...ast.globals import Globals
 
-PACKAGE_SUPPORT = {"lib": "sympc", "torch": {"min_version": "1.6.0"}}
-
-
-# this gets called on global ast as well as clients
-# anything which wants to have its ast updated and has an add_attr method
-def update_ast(ast: TypeUnion[Globals, TypeAny], client: TypeAny = None) -> None:
-    sympc_ast = create_ast(client=client)
-    ast.add_attr(attr_name="sympc", attr=sympc_ast.attrs["sympc"])
+LIB_NAME = "sympc"
+PACKAGE_SUPPORT = {"lib": LIB_NAME, "torch": {"min_version": "1.6.0"}}
 
 
 def create_ast(client: TypeAny = None) -> Globals:
@@ -95,3 +90,6 @@ def create_ast(client: TypeAny = None) -> Globals:
         klass.create_storable_object_attr_convenience_methods()
 
     return ast
+
+
+update_ast = functools.partial(generic_update_ast, LIB_NAME, create_ast)

--- a/src/syft/lib/tenseal/__init__.py
+++ b/src/syft/lib/tenseal/__init__.py
@@ -2,7 +2,7 @@
 from typing import Any as TypeAny
 from typing import List as TypeList
 from typing import Tuple as TypeTuple
-from typing import Union as TypeUnion
+import functools
 
 # third party
 import tenseal as ts
@@ -11,6 +11,7 @@ import tenseal as ts
 from ...ast import add_classes
 from ...ast import add_methods
 from ...ast import add_modules
+from ..util import generic_update_ast
 from ...ast.globals import Globals
 from ..misc.union import UnionGenerator
 from .ckks_vector import CKKSVector  # noqa: 401
@@ -18,13 +19,6 @@ from .context import ContextWrapper  # noqa: 401
 
 LIB_NAME = "tenseal"
 PACKAGE_SUPPORT = {"lib": LIB_NAME}
-
-
-# this gets called on global ast as well as clients
-# anything which wants to have its ast updated and has an add_attr method
-def update_ast(ast: TypeUnion[Globals, TypeAny], client: TypeAny = None) -> None:
-    tenseal_ast = create_ast(client=client)
-    ast.add_attr(attr_name=LIB_NAME, attr=tenseal_ast.attrs[LIB_NAME])
 
 
 def create_ast(client: TypeAny) -> Globals:
@@ -79,3 +73,6 @@ def create_ast(client: TypeAny) -> Globals:
         klass.create_storable_object_attr_convenience_methods()
 
     return ast
+
+
+update_ast = functools.partial(generic_update_ast, LIB_NAME, create_ast)

--- a/src/syft/lib/util.py
+++ b/src/syft/lib/util.py
@@ -24,7 +24,7 @@ def generic_update_ast(
         ast = ast_or_client
         new_lib_ast = create_ast(None)
         ast.add_attr(attr_name=lib_name, attr=new_lib_ast.attrs[lib_name])
-    elif issubclass(ast_or_client, AbstractNodeClient):
+    elif isinstance(ast_or_client, AbstractNodeClient):
         client = ast_or_client
         new_lib_ast = create_ast(client)
         client.lib_ast.attrs[lib_name] = new_lib_ast.attrs[lib_name]

--- a/src/syft/lib/util.py
+++ b/src/syft/lib/util.py
@@ -24,7 +24,7 @@ def generic_update_ast(
         ast = ast_or_client
         new_lib_ast = create_ast(None)
         ast.add_attr(attr_name=lib_name, attr=new_lib_ast.attrs[lib_name])
-    elif isinstance(ast_or_client, AbstractNodeClient):
+    elif issubclass(ast_or_client, AbstractNodeClient):
         client = ast_or_client
         new_lib_ast = create_ast(client)
         client.lib_ast.attrs[lib_name] = new_lib_ast.attrs[lib_name]

--- a/tests/syft/ast/functionality_test.py
+++ b/tests/syft/ast/functionality_test.py
@@ -3,8 +3,8 @@ The following test suit serves as a set of examples of how to integrate differen
 into our AST and use them.
 """
 # stdlib
+from importlib import reload
 from typing import Union as TypeUnion
-import reload
 
 # third party
 import pytest

--- a/tests/syft/ast/functionality_test.py
+++ b/tests/syft/ast/functionality_test.py
@@ -4,6 +4,7 @@ into our AST and use them.
 """
 # stdlib
 from typing import Union as TypeUnion
+import reload
 
 # third party
 import pytest

--- a/tests/syft/ast/functionality_test.py
+++ b/tests/syft/ast/functionality_test.py
@@ -3,8 +3,6 @@ The following test suit serves as a set of examples of how to integrate differen
 into our AST and use them.
 """
 # stdlib
-from importlib import reload
-from typing import Any as TypeAny
 from typing import Union as TypeUnion
 
 # third party
@@ -13,6 +11,7 @@ import pytest
 # syft absolute
 import syft
 from syft.ast.globals import Globals
+from syft.core.node.abstract.node import AbstractNodeClient
 from syft.core.node.common.client import Client
 from syft.lib import lib_ast
 
@@ -20,9 +19,20 @@ from syft.lib import lib_ast
 from . import module_test
 
 
-def update_ast_test(ast: TypeUnion[Globals, TypeAny], client: TypeAny = None) -> None:
-    test_ast = create_ast_test(client=client)
-    ast.add_attr(attr_name="module_test", attr=test_ast.attrs["module_test"])
+def update_ast_test(ast_or_client: TypeUnion[Globals, AbstractNodeClient]) -> None:
+    if isinstance(ast_or_client, Globals):
+        ast = ast_or_client
+        test_ast = create_ast_test(None)
+        ast.add_attr(attr_name="module_test", attr=test_ast.attrs["module_test"])
+    elif isinstance(ast_or_client, AbstractNodeClient):
+        client = ast_or_client
+        test_ast = create_ast_test(client=client)
+        client.lib_ast.attrs["module_test"] = test_ast.attrs["module_test"]
+        setattr(client, "module_test", test_ast.attrs["module_test"])
+    else:
+        raise ValueError(
+            f"Expected param of type (Globals, AbstractNodeClient), but got {type(ast_or_client)}"
+        )
 
 
 def create_ast_test(client: Client) -> Globals:
@@ -57,7 +67,7 @@ def create_ast_test(client: Client) -> Globals:
 @pytest.fixture(autouse=True, scope="module")
 def registr_module_test() -> None:
     # Make lib_ast contain the specific methods/attributes
-    update_ast_test(ast=syft.lib_ast)
+    update_ast_test(ast_or_client=syft.lib_ast)
 
     # Make sure that when we register a new client it would update the specific AST
     lib_ast.loaded_lib_constructors["module_test"] = update_ast_test


### PR DESCRIPTION
## Description

What changes this PR introduces:
 * removes the ```add_attr``` from the client (I think only the things from ast should have the ```add_attr``` method)
 * create a ```generic_update_ast``` and the 3rd party libraries will only partially apply that generic function -- to bind the ```lib_name``` and the ```create_as```

## Affected Dependencies
* AST Part of our codebase

## How has this been tested?
- Library tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
