### PR TITLE
fix .tag and .describe

### DIFF
--- a/src/syft/ast/klass.py
+++ b/src/syft/ast/klass.py
@@ -291,6 +291,7 @@ class Class(Callable):
                 id_ = UID()
                 which_obj.id = id_
 
+            tags = sorted(set(tags), key=tags.index)  # keep order of original
             obj_tags = getattr(which_obj, "tags", [])
             # if `tags` is passed in, use it; else, use obj_tags
             tags = tags if tags else obj_tags
@@ -333,7 +334,7 @@ class Class(Callable):
 
     def create_storable_object_attr_convenience_methods(outer_self: Any) -> None:
         def tag(self: Any, *tags: Tuple[Any, ...]) -> object:
-            self.tags = list(tags)
+            self.tags = sorted(set(tags), key=tags.index)  # keep order of original
             return self
 
         def describe(self: Any, description: str) -> object:

--- a/src/syft/ast/klass.py
+++ b/src/syft/ast/klass.py
@@ -290,6 +290,15 @@ class Class(Callable):
             if id_ is None:
                 id_ = UID()
                 which_obj.id = id_
+
+            obj_tags = getattr(which_obj, "tags", [])
+            # if `tags` is passed in, use it; else, use obj_tags
+            tags = tags if tags else obj_tags
+
+            obj_description = getattr(which_obj, "description", "")
+            # if `description` is passed in, use it; else, use obj_description
+            description = description if description else obj_description
+
             which_obj.tags = tags
             which_obj.description = description
 

--- a/tests/syft/core/pointer/pointer_test.py
+++ b/tests/syft/core/pointer/pointer_test.py
@@ -69,3 +69,41 @@ def test_searchable_property() -> None:
 
     ptr.searchable = False
     assert len(client.store) == 0
+
+
+def test_tags() -> None:
+    bob = sy.VirtualMachine(name="Bob")
+    root_client = bob.get_root_client()
+
+    ten = th.tensor([1, 2])
+
+    ten = ten.tag("tag1")
+    assert ten.tags == ["tag1"]
+
+    # .send without `tags` passed in
+    ptr = ten.send(root_client)
+    assert ptr.tags == ["tag1"]
+
+    # .send with `tags` passed in
+    ptr = ten.send(root_client, tags=["tag2"])
+    assert ten.tags == ["tag2"]
+    assert ptr.tags == ["tag2"]
+
+
+def test_description() -> None:
+    bob = sy.VirtualMachine(name="Bob")
+    root_client = bob.get_root_client()
+
+    ten = th.tensor([1, 2])
+
+    ten = ten.describe("description 1")
+    assert ten.description == "description 1"
+
+    # .send without `description` passed in
+    ptr = ten.send(root_client)
+    assert ptr.description == "description 1"
+
+    # .send with `description` passed in
+    ptr = ten.send(root_client, description="description 2")
+    assert ten.description == "description 2"
+    assert ptr.description == "description 2"

--- a/tests/syft/core/pointer/pointer_test.py
+++ b/tests/syft/core/pointer/pointer_test.py
@@ -77,17 +77,17 @@ def test_tags() -> None:
 
     ten = th.tensor([1, 2])
 
-    ten = ten.tag("tag1")
-    assert ten.tags == ["tag1"]
+    ten = ten.tag("tag1", "tag1", "other")
+    assert ten.tags == ["tag1", "other"]
 
     # .send without `tags` passed in
     ptr = ten.send(root_client)
-    assert ptr.tags == ["tag1"]
+    assert ptr.tags == ["tag1", "other"]
 
     # .send with `tags` passed in
-    ptr = ten.send(root_client, tags=["tag2"])
-    assert ten.tags == ["tag2"]
-    assert ptr.tags == ["tag2"]
+    ptr = ten.send(root_client, tags=["tag2", "tag2", "other"])
+    assert ten.tags == ["tag2", "other"]
+    assert ptr.tags == ["tag2", "other"]
 
 
 def test_description() -> None:


### PR DESCRIPTION
## Description
This may close #5052 .

**Features this PR fix:**

- `.tag` can be used to attach tags to object
- call `.tag("tag1")`, then `.send` without `tags` passed in: "tag1" will be used.
- call `.tag("tag1")`, then `.send` with `tags=["tag2"]` passed in: "tag2" will be used.
- similar thing happens with `.describe`

## Affected Dependencies
No

## How has this been tested?
- test functions are added in `tests/syft/core/pointer/pointer_test.py`
    - `test_tags`
    - `test_description` 

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
