### PR TITLE
Test for 5033

### DIFF
--- a/src/syft/lib/torchvision/allowlist.py
+++ b/src/syft/lib/torchvision/allowlist.py
@@ -7,8 +7,7 @@ allowlist: Dict[str, Union[str, Dict[str, str]]] = {}  # (path: str, return_type
 # MNIST
 allowlist["torchvision.transforms.Compose"] = "torchvision.transforms.Compose"
 # allowlist["torchvision.transforms.Compose.__iter__"] = "torchvision.transforms.ToTensor"
-# TODO: Compose.transforms property only exists on the object not on the class?
-# allowlist["torchvision.transforms.Compose.transforms"] = "syft.lib.python.List"
+# TODO: Compose.transforms property only exists on the object not on the class? YES
 allowlist["torchvision.transforms.ToTensor"] = "torchvision.transforms.ToTensor"
 allowlist["torchvision.transforms.Normalize"] = "torchvision.transforms.Normalize"
 # TODO: Normalize properties only exists on the object not on the class?

--- a/src/syft/lib/torchvision/allowlist.py
+++ b/src/syft/lib/torchvision/allowlist.py
@@ -8,6 +8,7 @@ allowlist: Dict[str, Union[str, Dict[str, str]]] = {}  # (path: str, return_type
 allowlist["torchvision.transforms.Compose"] = "torchvision.transforms.Compose"
 # allowlist["torchvision.transforms.Compose.__iter__"] = "torchvision.transforms.ToTensor"
 # TODO: Compose.transforms property only exists on the object not on the class? YES
+allowlist["torchvision.transforms.Compose.transforms"] = "syft.lib.python.List"
 allowlist["torchvision.transforms.ToTensor"] = "torchvision.transforms.ToTensor"
 allowlist["torchvision.transforms.Normalize"] = "torchvision.transforms.Normalize"
 # TODO: Normalize properties only exists on the object not on the class?


### PR DESCRIPTION
## Description
Closes #5033 

## How has this been tested?
-below is  the tests that you ran to verify your changes.
- and instructions so we can reproduce.
- we can see that Compose.transforms property only exists on the object(cn) not on the class(Compose).
- 
![Screenshot from 2020-12-10 14-55-58](https://user-images.githubusercontent.com/56379013/105652031-611d6880-5ede-11eb-9639-15f915c5d573.png)


## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
