### PR TITLE
[WIP]  Testing #5033

### DIFF
--- a/src/syft/lib/torchvision/allowlist.py
+++ b/src/syft/lib/torchvision/allowlist.py
@@ -7,8 +7,7 @@ allowlist: Dict[str, Union[str, Dict[str, str]]] = {}  # (path: str, return_type
 # MNIST
 allowlist["torchvision.transforms.Compose"] = "torchvision.transforms.Compose"
 # allowlist["torchvision.transforms.Compose.__iter__"] = "torchvision.transforms.ToTensor"
-# TODO: Compose.transforms property only exists on the object not on the class?
-# allowlist["torchvision.transforms.Compose.transforms"] = "syft.lib.python.List"
+# TODO: Compose.transforms property only exists on the object not on the class? YES
 allowlist["torchvision.transforms.ToTensor"] = "torchvision.transforms.ToTensor"
 allowlist["torchvision.transforms.Normalize"] = "torchvision.transforms.Normalize"
 # TODO: Normalize properties only exists on the object not on the class?

--- a/src/syft/lib/torchvision/allowlist.py
+++ b/src/syft/lib/torchvision/allowlist.py
@@ -7,7 +7,7 @@ allowlist: Dict[str, Union[str, Dict[str, str]]] = {}  # (path: str, return_type
 # MNIST
 allowlist["torchvision.transforms.Compose"] = "torchvision.transforms.Compose"
 # allowlist["torchvision.transforms.Compose.__iter__"] = "torchvision.transforms.ToTensor"
-# TODO: Compose.transforms property only exists on the object not on the class? YES
+# TODO: Compose.transforms property only exists on the object not on the class? Yes
 allowlist["torchvision.transforms.Compose.transforms"] = "syft.lib.python.List"
 allowlist["torchvision.transforms.ToTensor"] = "torchvision.transforms.ToTensor"
 allowlist["torchvision.transforms.Normalize"] = "torchvision.transforms.Normalize"

--- a/src/syft/lib/torchvision/allowlist.py
+++ b/src/syft/lib/torchvision/allowlist.py
@@ -8,6 +8,7 @@ allowlist: Dict[str, Union[str, Dict[str, str]]] = {}  # (path: str, return_type
 allowlist["torchvision.transforms.Compose"] = "torchvision.transforms.Compose"
 # allowlist["torchvision.transforms.Compose.__iter__"] = "torchvision.transforms.ToTensor"
 # TODO: Compose.transforms property only exists on the object not on the class? YES
+allowlist["torchvision.transforms.Compose.transforms"] = "syft.lib.python.List"
 allowlist["torchvision.transforms.ToTensor"] = "torchvision.transforms.ToTensor"
 allowlist["torchvision.transforms.Normalize"] = "torchvision.transforms.Normalize"
 # TODO: Normalize properties only exists on the object not on the class?


### PR DESCRIPTION
## Description
try to closes #5033  
This PR hopes to solve Issue #5033  .

## How has this been tested?
-below is  the tests that you ran to verify the changes.
- and instructions so we can reproduce.
- we can see that Compose.transforms property only exists on the object(cn) not on the class(Compose).
![pysyft_dev #5033](https://user-images.githubusercontent.com/56379013/105653239-4bf60900-5ee1-11eb-8bba-189ff1f20674.png)
in above screenshot we can see that Compose takes list of transforms(i give two transforms above) so `allowlist["torchvision.transforms.Compose.transforms"] = "syft.lib.python.List"` must be true but I don't knowwhy test are failigs after removing comment before this command in allowlist.py

also need some help to create a test case from this one and  in which file we have to create a test for these



## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests 
