### PR TITLE
Expose dataset module within package

### DIFF
--- a/src/syft/core/store/__init__.py
+++ b/src/syft/core/store/__init__.py
@@ -2,5 +2,6 @@
 from .store_disk import DiskObjectStore
 from .store_interface import ObjectStore
 from .store_memory import MemoryStore
+from .dataset import Dataset
 
-__all__ = ["DiskObjectStore", "ObjectStore", "MemoryStore"]
+__all__ = ["DiskObjectStore", "ObjectStore", "MemoryStore", "Dataset"]


### PR DESCRIPTION
## Description

Minor patch to ensure the Dataset class is made available once the syft package has been built.

## How has this been tested?

- Built syft and made sure the class can now be imported.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
