### PR TITLE
Add threadsafe stop

### DIFF
--- a/src/syft/core/common/event_loop.py
+++ b/src/syft/core/common/event_loop.py
@@ -74,8 +74,8 @@ class EventLoopThread:
     def shutdown(self) -> None:
         if "loop" in self.__shared_state:
             info("Stopping Event Loop")
-            loop.call_soon_threadsafe(loop.stop)  # type: ignore
             loop.run_until_complete(loop.shutdown_asyncgens())  # type: ignore
+            loop.call_soon_threadsafe(loop.stop)  # type: ignore
             del self.__shared_state["loop"]
 
         if "thread" in self.__shared_state:

--- a/src/syft/core/common/event_loop.py
+++ b/src/syft/core/common/event_loop.py
@@ -74,7 +74,7 @@ class EventLoopThread:
     def shutdown(self) -> None:
         if "loop" in self.__shared_state:
             info("Stopping Event Loop")
-            loop.stop()  # type: ignore
+            loop.call_soon_threadsafe(loop.stop)  # type: ignore
             loop.run_until_complete(loop.shutdown_asyncgens())  # type: ignore
             del self.__shared_state["loop"]
 


### PR DESCRIPTION
## Description
When running in a Python interactive console, pressing CTRL + D should cancel the interactive console.
This was not happening because the ```run_forever``` call was never stopped.
This was happening because the ```stop``` call should be done in a threadsafe manner ([reference](https://stackoverflow.com/questions/40143289/why-do-most-asyncio-examples-use-loop-run-until-complete)


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- ```python + import syft + CTRL-D``` (should close the console)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
