### PR TITLE
Issue 5075 - Investigate pytest warnings

### DIFF
--- a/tests/syft/lib/python/dict/dict_test.py
+++ b/tests/syft/lib/python/dict/dict_test.py
@@ -481,9 +481,9 @@ class DictTest(unittest.TestCase):
                     b = a.copy()
                 for i in range(size):
                     ka, va = ta = a.popitem()
-                    self.assertEqual(va, int(ka))
+                    self.assertEqual(va, ka.__int__())
                     kb, vb = tb = b.popitem()
-                    self.assertEqual(vb, int(kb))
+                    self.assertEqual(vb, kb.__int__())
                     self.assertFalse(copymode < 0 and ta != tb)
                 self.assertFalse(a)
                 self.assertFalse(b)


### PR DESCRIPTION
## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

## Summary
This time I run: 

`pytest -m 'fast or slow' --no-cov -n auto`

as @madhavajay suggest, and was raised 4116 warnings, with this smalls changes that I made the warnings decreased to 24 warnings.

What I did was to change the direct casting using int(), for using the built-in function __int__().

I'll open issues for this 24 warnings that I couldn't solve.

Closes #5075 