### PR TITLE
Updated pip cache in merge_tests.yml thanks to @Borda

### DIFF
--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -186,9 +186,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ matrix.torch-version }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ matrix.torch-version }}-
 
       - name: Install aiortc native dependencies
         if: startsWith(runner.os, 'Linux') == true


### PR DESCRIPTION
## Description
Using the same improved cache hash for python and torch versions in the `merge_tests.py`.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
