### PR TITLE
Private attr API refactor

### DIFF
--- a/examples/api/start.ipynb
+++ b/examples/api/start.ipynb
@@ -975,7 +975,7 @@
     }
    ],
    "source": [
-    "assert serialize(repr_msg, to_bytes=True) == sig_msg.serialized_message\n",
+    "assert sy.serialize(repr_msg, to_bytes=True) == sig_msg.serialized_message\n",
     "print(repr_msg.pprint, \" ⬅️ \", sig_msg.pprint)"
    ]
   },

--- a/examples/api/start.ipynb
+++ b/examples/api/start.ipynb
@@ -735,7 +735,7 @@
     "# repr_service.py\n",
     "def _object2proto(self) -> ReprMessage_PB:\n",
     "    return ReprMessage_PB(\n",
-    "        msg_id=self.id._sy_serialize(), address=self.address._sy_serialize(),\n",
+    "        msg_id=serialize(self.id), address=serialize(self.address),\n",
     "    )\n",
     "```"
    ]
@@ -975,7 +975,7 @@
     }
    ],
    "source": [
-    "assert repr_msg._sy_serialize(to_bytes=True) == sig_msg.serialized_message\n",
+    "assert serialize(repr_msg, to_bytes=True) == sig_msg.serialized_message\n",
     "print(repr_msg.pprint, \" ⬅️ \", sig_msg.pprint)"
    ]
   },

--- a/examples/api/start.ipynb
+++ b/examples/api/start.ipynb
@@ -735,7 +735,7 @@
     "# repr_service.py\n",
     "def _object2proto(self) -> ReprMessage_PB:\n",
     "    return ReprMessage_PB(\n",
-    "        msg_id=self.id.serialize(), address=self.address.serialize(),\n",
+    "        msg_id=self.id._sy_serialize(), address=self.address._sy_serialize(),\n",
     "    )\n",
     "```"
    ]
@@ -975,7 +975,7 @@
     }
    ],
    "source": [
-    "assert repr_msg.serialize(to_bytes=True) == sig_msg.serialized_message\n",
+    "assert repr_msg._sy_serialize(to_bytes=True) == sig_msg.serialized_message\n",
     "print(repr_msg.pprint, \" ⬅️ \", sig_msg.pprint)"
    ]
   },

--- a/examples/experimental/trask/Early Dev.ipynb
+++ b/examples/experimental/trask/Early Dev.ipynb
@@ -787,7 +787,7 @@
    "source": [
     "x = th.tensor([1,2,3,4])\n",
     "\n",
-    "blob = x._sy_serialize()\n",
+    "blob = serialize(x)\n",
     "\n",
     "x2 = sy.deserialize(blob=blob)\n",
     "\n",
@@ -953,7 +953,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x._sy_serialize()"
+    serialize("x)"
    ]
   },
   {

--- a/examples/experimental/trask/Early Dev.ipynb
+++ b/examples/experimental/trask/Early Dev.ipynb
@@ -787,7 +787,7 @@
    "source": [
     "x = th.tensor([1,2,3,4])\n",
     "\n",
-    "blob = x.serialize()\n",
+    "blob = x._sy_serialize()\n",
     "\n",
     "x2 = sy.deserialize(blob=blob)\n",
     "\n",
@@ -953,7 +953,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x.serialize()"
+    "x._sy_serialize()"
    ]
   },
   {

--- a/examples/experimental/trask/Untitled1.ipynb
+++ b/examples/experimental/trask/Untitled1.ipynb
@@ -590,7 +590,7 @@
        " 'scatter_add_',\n",
        " 'select',\n",
        " 'send',\n",
-       " 'serializable_wrapper_type',\n",
+       " '_sy_serializable_wrapper_type',\n",
        " 'serialize',\n",
        " 'set_',\n",
        " 'shape',\n",

--- a/examples/mock_apis/duet/Data Owner Mock.ipynb
+++ b/examples/mock_apis/duet/Data Owner Mock.ipynb
@@ -686,7 +686,7 @@
     }
    ],
    "source": [
-    "blob = x._sy_serialize()"
+    "blob = serialize(x)"
    ]
   },
   {
@@ -1243,7 +1243,7 @@
     }
    ],
    "source": [
-    "blob = msg._sy_serialize()"
+    "blob = serialize(msg)"
    ]
   },
   {

--- a/examples/mock_apis/duet/Data Owner Mock.ipynb
+++ b/examples/mock_apis/duet/Data Owner Mock.ipynb
@@ -686,7 +686,7 @@
     }
    ],
    "source": [
-    "blob = x.serialize()"
+    "blob = x._sy_serialize()"
    ]
   },
   {
@@ -1009,7 +1009,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "th.Tensor.serializable_wrapper_type = "
+    "th.Tensor._sy_serializable_wrapper_type = "
    ]
   },
   {
@@ -1019,7 +1019,7 @@
    "outputs": [
     {
      "ename": "Exception",
-     "evalue": "Object <class 'torch.Tensor'> has no serializable_wrapper_type",
+     "evalue": "Object <class 'torch.Tensor'> has no _sy_serializable_wrapper_type",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
@@ -1028,8 +1028,8 @@
       "\u001b[0;32m~/Dropbox/Laboratory/openmined/PySyft/PySyft/src/syft/decorators/syft_decorator_impl.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     22\u001b[0m         \u001b[0;32mdef\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 24\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     25\u001b[0m             \u001b[0;31m# try:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m             \u001b[0;31m#     return function(*args, **kwargs)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m~/Dropbox/Laboratory/openmined/PySyft/PySyft/src/syft/decorators/typecheck.py\u001b[0m in \u001b[0;36mdecorator\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mprohibit_args\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m             \u001b[0mcheck_args\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mtypechecked\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdecorated\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     80\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m     \u001b[0mdecorator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__annotations__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdecorated\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__annotations__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m~/opt/anaconda3/envs/syft/lib/python3.8/site-packages/typeguard/__init__.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    838\u001b[0m         \u001b[0mmemo\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_CallMemo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpython_func\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_localns\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    839\u001b[0m         \u001b[0mcheck_argument_types\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmemo\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 840\u001b[0;31m         \u001b[0mretval\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    841\u001b[0m         \u001b[0mcheck_return_type\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mretval\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemo\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    842\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Dropbox/Laboratory/openmined/PySyft/PySyft/src/syft/core/common/serde/serialize.py\u001b[0m in \u001b[0;36m_serialize\u001b[0;34m(obj, to_proto, to_bytes)\u001b[0m\n\u001b[1;32m     52\u001b[0m             \u001b[0mis_serializable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mserializable_wrapper_type\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mas_wrapper\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 54\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Object {type(obj)} has no serializable_wrapper_type\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     55\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m         \u001b[0mis_serializable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mException\u001b[0m: Object <class 'torch.Tensor'> has no serializable_wrapper_type"
+      "\u001b[0;32m~/Dropbox/Laboratory/openmined/PySyft/PySyft/src/syft/core/common/serde/serialize.py\u001b[0m in \u001b[0;36m_serialize\u001b[0;34m(obj, to_proto, to_bytes)\u001b[0m\n\u001b[1;32m     52\u001b[0m             \u001b[0mis_serializable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sy_serializable_wrapper_type\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mas_wrapper\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 54\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Object {type(obj)} has no _sy_serializable_wrapper_type\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     55\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m         \u001b[0mis_serializable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mException\u001b[0m: Object <class 'torch.Tensor'> has no _sy_serializable_wrapper_type"
      ]
     }
    ],
@@ -1243,7 +1243,7 @@
     }
    ],
    "source": [
-    "blob = msg.serialize()"
+    "blob = msg._sy_serialize()"
    ]
   },
   {

--- a/src/syft/core/common/message.py
+++ b/src/syft/core/common/message.py
@@ -168,7 +168,7 @@ class SignedMessage(SyftMessage):
 
         # obj_type will be the final subclass callee for example ReprMessage
         return SignedMessage_PB(
-            msg_id=self.id._sy_proto(),
+            msg_id=self.id._sy_serialize(to_proto=True),
             obj_type=self.obj_type,
             signature=bytes(self.signature),
             verify_key=bytes(self.verify_key),

--- a/src/syft/core/common/message.py
+++ b/src/syft/core/common/message.py
@@ -87,7 +87,7 @@ class SyftMessage(AbstractMessage):
 
         """
         debug(f"> Signing with {self.address.key_emoji(key=signing_key.verify_key)}")
-        signed_message = signing_key.sign(self.serialize(to_bytes=True))
+        signed_message = signing_key.sign(self._sy_serialize(to_bytes=True))
 
         # signed_type will be the final subclass callee's closest parent signed_type
         # for example ReprMessage -> ImmediateSyftMessageWithoutReply.signed_type
@@ -168,7 +168,7 @@ class SignedMessage(SyftMessage):
 
         # obj_type will be the final subclass callee for example ReprMessage
         return SignedMessage_PB(
-            msg_id=self.id.proto(),
+            msg_id=self.id._sy_proto(),
             obj_type=self.obj_type,
             signature=bytes(self.signature),
             verify_key=bytes(self.verify_key),

--- a/src/syft/core/common/message.py
+++ b/src/syft/core/common/message.py
@@ -13,6 +13,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ...core.common.object import ObjectWithID
+from ...core.common.serde.serialize import _serialize as serialize
 from ...core.common.uid import UID
 from ...core.io.address import Address
 from ...logger import debug
@@ -87,7 +88,7 @@ class SyftMessage(AbstractMessage):
 
         """
         debug(f"> Signing with {self.address.key_emoji(key=signing_key.verify_key)}")
-        signed_message = signing_key.sign(self._sy_serialize(to_bytes=True))
+        signed_message = signing_key.sign(serialize(self, to_bytes=True))
 
         # signed_type will be the final subclass callee's closest parent signed_type
         # for example ReprMessage -> ImmediateSyftMessageWithoutReply.signed_type
@@ -168,7 +169,7 @@ class SignedMessage(SyftMessage):
 
         # obj_type will be the final subclass callee for example ReprMessage
         return SignedMessage_PB(
-            msg_id=self.id._sy_serialize(to_proto=True),
+            msg_id=serialize(self.id, to_proto=True),
             obj_type=self.obj_type,
             signature=bytes(self.signature),
             verify_key=bytes(self.verify_key),

--- a/src/syft/core/common/object.py
+++ b/src/syft/core/common/object.py
@@ -119,11 +119,11 @@ class ObjectWithID(Serializable):
             a protobuf object that is the serialization of self.
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
-        return ObjectWithID_PB(id=self.id.serialize())
+        return ObjectWithID_PB(id=self.id._sy_serialize())
 
     @staticmethod
     def _proto2object(proto: ObjectWithID_PB) -> "ObjectWithID":

--- a/src/syft/core/common/object.py
+++ b/src/syft/core/common/object.py
@@ -11,6 +11,7 @@ from ...util import validate_type
 from ..common.serde.deserialize import _deserialize
 from ..common.serde.serializable import Serializable
 from ..common.serde.serializable import bind_protobuf
+from ..common.serde.serialize import _serialize as serialize
 from .uid import UID
 
 
@@ -119,11 +120,11 @@ class ObjectWithID(Serializable):
             a protobuf object that is the serialization of self.
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
-        return ObjectWithID_PB(id=self.id._sy_serialize())
+        return ObjectWithID_PB(id=serialize(self.id))
 
     @staticmethod
     def _proto2object(proto: ObjectWithID_PB) -> "ObjectWithID":

--- a/src/syft/core/common/serde/__init__.py
+++ b/src/syft/core/common/serde/__init__.py
@@ -60,8 +60,8 @@ on the object for your convenience::
     print(my_object)
     # >>> <ObjectWithID:fb1bb067-5bb7-4c49-bece-e700ab0a1514>
 
-    # by default, .serialize() will serialize it to a protobuf Message object
-    proto_obj = my_object.serialize()
+    # by default, ._sy_serialize() will serialize it to a protobuf Message object
+    proto_obj = my_object._sy_serialize()
 
     print(proto_obj)
     # >>> obj_type: "syft.core.common.object.ObjectWithID"
@@ -91,9 +91,9 @@ Protobuf
 
 .. code::
 
-    proto_obj = obj.serialize(to_proto=True)
-    proto_obj = obj.to_proto()
-    proto_obj = obj.proto()
+    proto_obj = obj._sy_serialize(to_proto=True)
+    proto_obj = obj._sy_to_proto()
+    proto_obj = obj._sy_proto()
 
     print(proto_obj)
     # >>> obj_type: "syft.core.common.object.ObjectWithID"
@@ -109,8 +109,8 @@ Binary
 
 .. code::
 
-    binary_obj = obj.serialize(to_bytes=True)
-    binary_obj = obj.to_bytes()
+    binary_obj = obj._sy_serialize(to_bytes=True)
+    binary_obj = obj._sy_to_bytes()
     binary_obj = obj.binary()
 
     # print(binary_obj)

--- a/src/syft/core/common/serde/__init__.py
+++ b/src/syft/core/common/serde/__init__.py
@@ -92,8 +92,8 @@ Protobuf
 .. code::
 
     proto_obj = obj._sy_serialize(to_proto=True)
-    proto_obj = obj._sy_to_proto()
-    proto_obj = obj._sy_proto()
+    proto_obj = obj._sy_serialize(to_proto=True)
+    proto_obj = obj._sy_serialize(to_proto=True)
 
     print(proto_obj)
     # >>> obj_type: "syft.core.common.object.ObjectWithID"
@@ -110,8 +110,8 @@ Binary
 .. code::
 
     binary_obj = obj._sy_serialize(to_bytes=True)
-    binary_obj = obj._sy_to_bytes()
-    binary_obj = obj.binary()
+    binary_obj = obj._sy_serialize(to_bytes=True)
+    binary_obj = obj._sy_serialize(to_bytes=True)
 
     # print(binary_obj)
     # >>> b'{  "objType": "syft.core.common.object.ObjectWithID",

--- a/src/syft/core/common/serde/__init__.py
+++ b/src/syft/core/common/serde/__init__.py
@@ -60,8 +60,8 @@ on the object for your convenience::
     print(my_object)
     # >>> <ObjectWithID:fb1bb067-5bb7-4c49-bece-e700ab0a1514>
 
-    # by default, ._sy_serialize() will serialize it to a protobuf Message object
-    proto_obj = my_object._sy_serialize()
+    # by default, serialize() will serialize it to a protobuf Message object
+    proto_obj = serialize(my_object)
 
     print(proto_obj)
     # >>> obj_type: "syft.core.common.object.ObjectWithID"
@@ -91,9 +91,9 @@ Protobuf
 
 .. code::
 
-    proto_obj = obj._sy_serialize(to_proto=True)
-    proto_obj = obj._sy_serialize(to_proto=True)
-    proto_obj = obj._sy_serialize(to_proto=True)
+    proto_obj = serialize(obj, to_proto=True)
+    proto_obj = serialize(obj, to_proto=True)
+    proto_obj = serialize(obj, to_proto=True)
 
     print(proto_obj)
     # >>> obj_type: "syft.core.common.object.ObjectWithID"
@@ -109,9 +109,9 @@ Binary
 
 .. code::
 
-    binary_obj = obj._sy_serialize(to_bytes=True)
-    binary_obj = obj._sy_serialize(to_bytes=True)
-    binary_obj = obj._sy_serialize(to_bytes=True)
+    binary_obj = serialize(obj, to_bytes=True)
+    binary_obj = serialize(obj, to_bytes=True)
+    binary_obj = serialize(obj, to_bytes=True)
 
     # print(binary_obj)
     # >>> b'{  "objType": "syft.core.common.object.ObjectWithID",

--- a/src/syft/core/common/serde/deserialize.py
+++ b/src/syft/core/common/serde/deserialize.py
@@ -78,7 +78,7 @@ def _deserialize(
         if obj_type is None:
             traceback_and_raise(deserialization_error)
         obj_type = pydoc.locate(obj_type)  # type: ignore
-        obj_type = getattr(obj_type, "serializable_wrapper_type", obj_type)
+        obj_type = getattr(obj_type, "_sy_serializable_wrapper_type", obj_type)
 
     if not isinstance(obj_type, type):
         traceback_and_raise(deserialization_error)
@@ -88,7 +88,4 @@ def _deserialize(
         traceback_and_raise(deserialization_error)
 
     res = _proto2object(proto=blob)
-    # XTY >>>
-    # if type(res).__name__.endswith("Wrapper"):
-    #     res = res.obj
     return res

--- a/src/syft/core/common/serde/serializable.py
+++ b/src/syft/core/common/serde/serializable.py
@@ -127,7 +127,7 @@ class Serializable:
         """This methods converts self into a protobuf object
 
         This method must be implemented by all subclasses so that generic high-level functions
-        implemented here (such as .binary(), etc) know how to convert the object into
+        implemented here (such as ._sy_serialize(to_bytes=True), etc) know how to convert the object into
         a protobuf object before further converting it into the requested format.
 
         :return: a protobuf message
@@ -167,38 +167,6 @@ class Serializable:
         """
         traceback_and_raise(NotImplementedError)
 
-    def _sy_to_proto(self) -> Message:
-        """A convenience method to convert any subclass of Serializable into a protobuf object.
-
-        :return: a protobuf message
-        :rtype: Message
-        """
-        return validate_type(self._sy_serialize(to_proto=True), Message)
-
-    def _sy_proto(self) -> Message:
-        """A convenience method to convert any subclass of Serializable into a protobuf object.
-
-        :return: a protobuf message
-        :rtype: Message
-        """
-        return validate_type(self._sy_serialize(to_proto=True), Message)
-
-    def _sy_to_bytes(self) -> bytes:
-        """A convenience method to convert any subclass of Serializable into a binary object.
-
-        :return: a binary string
-        :rtype: bytes
-        """
-        return validate_type(self._sy_serialize(to_bytes=True), bytes)
-
-    def binary(self) -> bytes:
-        """A convenience method to convert any subclass of Serializable into a binary object.
-
-        :return: a binary string
-        :rtype: bytes
-        """
-        return validate_type(self._sy_serialize(to_bytes=True), bytes)
-
     def _sy_serialize(
         self,
         to_proto: bool = True,
@@ -237,15 +205,15 @@ class Serializable:
             blob: Message = DataMessage(
                 obj_type=get_fully_qualified_name(obj=self), content=serialized_data
             )
-            return blob.SerializeToString()
+            return validate_type(blob.SerializeToString(), bytes)
 
         elif to_proto:
-            return self._object2proto()
+            return validate_type(self._object2proto(), Message)
         else:
             traceback_and_raise(
                 Exception(
                     """You must specify at least one deserialization format using
-                            one of the arguments of the serialize() method such as:
+                            one of the arguments of the _sy_serialize() method such as:
                             to_proto, to_bytes."""
                 )
             )

--- a/src/syft/core/common/serde/serializable.py
+++ b/src/syft/core/common/serde/serializable.py
@@ -167,29 +167,29 @@ class Serializable:
         """
         traceback_and_raise(NotImplementedError)
 
-    def to_proto(self) -> Message:
+    def _sy_to_proto(self) -> Message:
         """A convenience method to convert any subclass of Serializable into a protobuf object.
 
         :return: a protobuf message
         :rtype: Message
         """
-        return validate_type(self.serialize(to_proto=True), Message)
+        return validate_type(self._sy_serialize(to_proto=True), Message)
 
-    def proto(self) -> Message:
+    def _sy_proto(self) -> Message:
         """A convenience method to convert any subclass of Serializable into a protobuf object.
 
         :return: a protobuf message
         :rtype: Message
         """
-        return validate_type(self.serialize(to_proto=True), Message)
+        return validate_type(self._sy_serialize(to_proto=True), Message)
 
-    def to_bytes(self) -> bytes:
+    def _sy_to_bytes(self) -> bytes:
         """A convenience method to convert any subclass of Serializable into a binary object.
 
         :return: a binary string
         :rtype: bytes
         """
-        return validate_type(self.serialize(to_bytes=True), bytes)
+        return validate_type(self._sy_serialize(to_bytes=True), bytes)
 
     def binary(self) -> bytes:
         """A convenience method to convert any subclass of Serializable into a binary object.
@@ -197,9 +197,9 @@ class Serializable:
         :return: a binary string
         :rtype: bytes
         """
-        return validate_type(self.serialize(to_bytes=True), bytes)
+        return validate_type(self._sy_serialize(to_bytes=True), bytes)
 
-    def serialize(
+    def _sy_serialize(
         self,
         to_proto: bool = True,
         to_bytes: bool = False,

--- a/src/syft/core/common/serde/serializable.py
+++ b/src/syft/core/common/serde/serializable.py
@@ -1,19 +1,14 @@
 # stdlib
 from typing import Any
 from typing import Type
-from typing import Union
 
 # third party
 from google.protobuf.message import Message
 from google.protobuf.reflection import GeneratedProtocolMessageType
 
 # syft relative
-from ....logger import debug
 from ....logger import traceback_and_raise
-from ....proto.util.data_message_pb2 import DataMessage
-from ....util import get_fully_qualified_name
 from ....util import random_name
-from ....util import validate_type
 
 
 def bind_protobuf(cls: Any) -> Any:
@@ -127,7 +122,7 @@ class Serializable:
         """This methods converts self into a protobuf object
 
         This method must be implemented by all subclasses so that generic high-level functions
-        implemented here (such as ._sy_serialize(to_bytes=True), etc) know how to convert the object into
+        implemented here (such as serialize(, to_bytes=True), etc) know how to convert the object into
         a protobuf object before further converting it into the requested format.
 
         :return: a protobuf message
@@ -166,57 +161,6 @@ class Serializable:
         :rtype: type
         """
         traceback_and_raise(NotImplementedError)
-
-    def _sy_serialize(
-        self,
-        to_proto: bool = True,
-        to_bytes: bool = False,
-    ) -> Union[str, bytes, Message]:
-        """Serialize the object according to the parameters.
-
-        This is the primary serialization method, which processes the above
-        flags in a particular order. In general, it is not expected that people
-        will set multiple to_<type> flags to True at the same time. We don't
-        currently have logic which prevents this, because this may affect
-        runtime performance, but if several flags are True, then we will simply
-        take return the type of latest supported flag from the following list:
-
-            - proto
-            - json
-            - binary
-            - hex
-
-        TODO: we could also add "dict" to this list but it's not clear if it would be used.
-
-        :param to_proto: set this flag to TRUE if you want to return a protobuf object
-        :type to_proto: bool
-        :param to_bytes: set this flag to TRUE if you want to return a binary object
-        :type to_bytes: bool
-        :return: a serialized form of the object on which serialize() is called.
-        :rtype: Union[str, bytes, Message]
-
-        """
-
-        if to_bytes:
-            debug(f"Serializing {type(self)}")
-            # indent=None means no white space or \n in the serialized version
-            # this is compatible with json.dumps(x, indent=None)
-            serialized_data = self._object2proto().SerializeToString()
-            blob: Message = DataMessage(
-                obj_type=get_fully_qualified_name(obj=self), content=serialized_data
-            )
-            return validate_type(blob.SerializeToString(), bytes)
-
-        elif to_proto:
-            return validate_type(self._object2proto(), Message)
-        else:
-            traceback_and_raise(
-                Exception(
-                    """You must specify at least one deserialization format using
-                            one of the arguments of the _sy_serialize() method such as:
-                            to_proto, to_bytes."""
-                )
-            )
 
     @staticmethod
     def random_name() -> str:

--- a/src/syft/core/common/serde/serialize.py
+++ b/src/syft/core/common/serde/serialize.py
@@ -5,7 +5,11 @@ from typing import Union
 from google.protobuf.message import Message
 
 # syft relative
+from ....logger import debug
 from ....logger import traceback_and_raise
+from ....proto.util.data_message_pb2 import DataMessage
+from ....util import get_fully_qualified_name
+from ....util import validate_type
 from .serializable import Serializable
 
 
@@ -54,8 +58,23 @@ def _serialize(
     else:
         is_serializable = obj
 
-    serialize_method = getattr(is_serializable, "_sy_serialize", None)
-    if serialize_method is None:
-        raise Exception(f"Object {type(obj)} has no _sy_serialize method")
-
-    return serialize_method(to_proto=to_proto, to_bytes=to_bytes)
+    if to_bytes:
+        debug(f"Serializing {type(is_serializable)}")
+        # indent=None means no white space or \n in the serialized version
+        # this is compatible with json.dumps(x, indent=None)
+        serialized_data = is_serializable._object2proto().SerializeToString()
+        blob: Message = DataMessage(
+            obj_type=get_fully_qualified_name(obj=is_serializable),
+            content=serialized_data,
+        )
+        return validate_type(blob.SerializeToString(), bytes)
+    elif to_proto:
+        return validate_type(is_serializable._object2proto(), Message)
+    else:
+        traceback_and_raise(
+            Exception(
+                """You must specify at least one deserialization format using
+                        one of the arguments of the serialize() method such as:
+                        to_proto, to_bytes."""
+            )
+        )

--- a/src/syft/core/common/serde/serialize.py
+++ b/src/syft/core/common/serde/serialize.py
@@ -43,21 +43,19 @@ def _serialize(
 
     is_serializable: Serializable
     if not isinstance(obj, Serializable):
-        if hasattr(obj, "serializable_wrapper_type"):
-            is_serializable = obj.serializable_wrapper_type(value=obj)  # type: ignore
+        if hasattr(obj, "_sy_serializable_wrapper_type"):
+            is_serializable = obj._sy_serializable_wrapper_type(value=obj)  # type: ignore
         else:
             traceback_and_raise(
                 Exception(
-                    f"Object {type(obj)} is not serializable and has no serializable_wrapper_type"
+                    f"Object {type(obj)} is not serializable and has no _sy_serializable_wrapper_type"
                 )
             )
     else:
         is_serializable = obj
 
-    serialize_method = getattr(is_serializable, "sy_serialize", None)
+    serialize_method = getattr(is_serializable, "_sy_serialize", None)
     if serialize_method is None:
-        serialize_method = getattr(is_serializable, "serialize", None)
-    if serialize_method is None:
-        raise Exception(f"Object {type(obj)} has no serialize method")
+        raise Exception(f"Object {type(obj)} has no _sy_serialize method")
 
     return serialize_method(to_proto=to_proto, to_bytes=to_bytes)

--- a/src/syft/core/common/uid.py
+++ b/src/syft/core/common/uid.py
@@ -167,7 +167,7 @@ class UID(Serializable):
         :rtype: ProtoUID
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """

--- a/src/syft/core/common/uid.py
+++ b/src/syft/core/common/uid.py
@@ -167,7 +167,7 @@ class UID(Serializable):
         :rtype: ProtoUID
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """

--- a/src/syft/core/io/address.py
+++ b/src/syft/core/io/address.py
@@ -16,6 +16,7 @@ from ...util import key_emoji as key_emoji_util
 from ..common.serde.deserialize import _deserialize
 from ..common.serde.serializable import Serializable
 from ..common.serde.serializable import bind_protobuf
+from ..common.serde.serialize import _serialize as serialize
 from ..common.uid import UID
 from ..io.location import Location
 
@@ -137,20 +138,20 @@ class Address(Serializable):
         :rtype: Address_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return Address_PB(
             name=self.name,
             has_network=self.network is not None,
-            network=self.network._sy_serialize() if self.network is not None else None,
+            network=serialize(self.network) if self.network is not None else None,
             has_domain=self.domain is not None,
-            domain=self.domain._sy_serialize() if self.domain is not None else None,
+            domain=serialize(self.domain) if self.domain is not None else None,
             has_device=self.device is not None,
-            device=self.device._sy_serialize() if self.device is not None else None,
+            device=serialize(self.device) if self.device is not None else None,
             has_vm=self.vm is not None,
-            vm=self.vm._sy_serialize() if self.vm is not None else None,
+            vm=serialize(self.vm) if self.vm is not None else None,
         )
 
     @staticmethod

--- a/src/syft/core/io/address.py
+++ b/src/syft/core/io/address.py
@@ -137,20 +137,20 @@ class Address(Serializable):
         :rtype: Address_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return Address_PB(
             name=self.name,
             has_network=self.network is not None,
-            network=self.network.serialize() if self.network is not None else None,
+            network=self.network._sy_serialize() if self.network is not None else None,
             has_domain=self.domain is not None,
-            domain=self.domain.serialize() if self.domain is not None else None,
+            domain=self.domain._sy_serialize() if self.domain is not None else None,
             has_device=self.device is not None,
-            device=self.device.serialize() if self.device is not None else None,
+            device=self.device._sy_serialize() if self.device is not None else None,
             has_vm=self.vm is not None,
-            vm=self.vm.serialize() if self.vm is not None else None,
+            vm=self.vm._sy_serialize() if self.vm is not None else None,
         )
 
     @staticmethod

--- a/src/syft/core/io/location/location.py
+++ b/src/syft/core/io/location/location.py
@@ -57,7 +57,7 @@ class Location(Serializable):
         """This methods converts self into a protobuf object
 
         This method must be implemented by all subclasses so that generic high-level functions
-        implemented here (such as ._sy_serialize(to_bytes=True), etc) know how to convert the object into
+        implemented here (such as serialize(, to_bytes=True), etc) know how to convert the object into
         a protobuf object before further converting it into the requested format.
 
         :return: a protobuf message

--- a/src/syft/core/io/location/location.py
+++ b/src/syft/core/io/location/location.py
@@ -57,7 +57,7 @@ class Location(Serializable):
         """This methods converts self into a protobuf object
 
         This method must be implemented by all subclasses so that generic high-level functions
-        implemented here (such as .binary(), etc) know how to convert the object into
+        implemented here (such as ._sy_serialize(to_bytes=True), etc) know how to convert the object into
         a protobuf object before further converting it into the requested format.
 
         :return: a protobuf message

--- a/src/syft/core/io/location/specific.py
+++ b/src/syft/core/io/location/specific.py
@@ -10,6 +10,7 @@ from ....util import validate_type
 from ...common.object import ObjectWithID
 from ...common.serde.deserialize import _deserialize
 from ...common.serde.serializable import bind_protobuf
+from ...common.serde.serialize import _serialize as serialize
 from ...common.uid import UID
 from .location import Location
 
@@ -44,11 +45,11 @@ class SpecificLocation(ObjectWithID, Location):
         :rtype: SpecificLocation_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
-        return SpecificLocation_PB(id=self.id._sy_serialize(), name=self.name)
+        return SpecificLocation_PB(id=serialize(self.id), name=self.name)
 
     @staticmethod
     def _proto2object(proto: SpecificLocation_PB) -> "SpecificLocation":

--- a/src/syft/core/io/location/specific.py
+++ b/src/syft/core/io/location/specific.py
@@ -44,11 +44,11 @@ class SpecificLocation(ObjectWithID, Location):
         :rtype: SpecificLocation_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
-        return SpecificLocation_PB(id=self.id.serialize(), name=self.name)
+        return SpecificLocation_PB(id=self.id._sy_serialize(), name=self.name)
 
     @staticmethod
     def _proto2object(proto: SpecificLocation_PB) -> "SpecificLocation":

--- a/src/syft/core/node/common/action/exception_action.py
+++ b/src/syft/core/node/common/action/exception_action.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft relative
+from ..... import serialize
 from .....proto.core.node.common.action.exception_action_pb2 import (
     ExceptionMessage as ExceptionMessage_PB,
 )
@@ -51,7 +52,7 @@ class ExceptionMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ExceptionMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
@@ -64,9 +65,9 @@ class ExceptionMessage(ImmediateSyftMessageWithoutReply):
         fqn = ".".join(module_parts)
 
         return ExceptionMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
-            msg_id_causing_exception=self.msg_id_causing_exception._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
+            msg_id_causing_exception=serialize(self.msg_id_causing_exception),
             exception_type=fqn,
             exception_msg=self.exception_msg,
         )

--- a/src/syft/core/node/common/action/exception_action.py
+++ b/src/syft/core/node/common/action/exception_action.py
@@ -51,7 +51,7 @@ class ExceptionMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ExceptionMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
@@ -64,9 +64,9 @@ class ExceptionMessage(ImmediateSyftMessageWithoutReply):
         fqn = ".".join(module_parts)
 
         return ExceptionMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
-            msg_id_causing_exception=self.msg_id_causing_exception.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
+            msg_id_causing_exception=self.msg_id_causing_exception._sy_serialize(),
             exception_type=fqn,
             exception_msg=self.exception_msg,
         )

--- a/src/syft/core/node/common/action/function_or_constructor_action.py
+++ b/src/syft/core/node/common/action/function_or_constructor_action.py
@@ -12,6 +12,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ..... import lib
+from ..... import serialize
 from .....logger import traceback_and_raise
 from .....proto.core.node.common.action.run_function_or_constructor_pb2 import (
     RunFunctionOrConstructorAction as RunFunctionOrConstructorAction_PB,
@@ -165,17 +166,17 @@ class RunFunctionOrConstructorAction(ImmediateActionWithoutReply):
         :rtype: RunFunctionOrConstructorAction_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RunFunctionOrConstructorAction_PB(
             path=self.path,
-            args=[x._sy_serialize() for x in self.args],
-            kwargs={k: v._sy_serialize() for k, v in self.kwargs.items()},
-            id_at_location=self.id_at_location._sy_serialize(),
-            address=self.address._sy_serialize(),
-            msg_id=self.id._sy_serialize(),
+            args=[serialize(x) for x in self.args],
+            kwargs={k: serialize(v) for k, v in self.kwargs.items()},
+            id_at_location=serialize(self.id_at_location),
+            address=serialize(self.address),
+            msg_id=serialize(self.id),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/action/function_or_constructor_action.py
+++ b/src/syft/core/node/common/action/function_or_constructor_action.py
@@ -165,17 +165,17 @@ class RunFunctionOrConstructorAction(ImmediateActionWithoutReply):
         :rtype: RunFunctionOrConstructorAction_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RunFunctionOrConstructorAction_PB(
             path=self.path,
-            args=[x.serialize() for x in self.args],
-            kwargs={k: v.serialize() for k, v in self.kwargs.items()},
-            id_at_location=self.id_at_location.serialize(),
-            address=self.address.serialize(),
-            msg_id=self.id.serialize(),
+            args=[x._sy_serialize() for x in self.args],
+            kwargs={k: v._sy_serialize() for k, v in self.kwargs.items()},
+            id_at_location=self.id_at_location._sy_serialize(),
+            address=self.address._sy_serialize(),
+            msg_id=self.id._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/action/garbage_collect_object_action.py
+++ b/src/syft/core/node/common/action/garbage_collect_object_action.py
@@ -6,6 +6,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from nacl.signing import VerifyKey
 
 # syft relative
+from ..... import serialize
 from .....logger import critical
 from .....proto.core.node.common.action.garbage_collect_object_pb2 import (
     GarbageCollectObjectAction as GarbageCollectObjectAction_PB,
@@ -37,8 +38,8 @@ class GarbageCollectObjectAction(EventualActionWithoutReply):
 
     def _object2proto(self) -> GarbageCollectObjectAction_PB:
 
-        id_pb = self.id_at_location._sy_serialize()
-        addr = self.address._sy_serialize()
+        id_pb = serialize(self.id_at_location)
+        addr = serialize(self.address)
 
         return GarbageCollectObjectAction_PB(
             id_at_location=id_pb,

--- a/src/syft/core/node/common/action/garbage_collect_object_action.py
+++ b/src/syft/core/node/common/action/garbage_collect_object_action.py
@@ -37,8 +37,8 @@ class GarbageCollectObjectAction(EventualActionWithoutReply):
 
     def _object2proto(self) -> GarbageCollectObjectAction_PB:
 
-        id_pb = self.id_at_location.serialize()
-        addr = self.address.serialize()
+        id_pb = self.id_at_location._sy_serialize()
+        addr = self.address._sy_serialize()
 
         return GarbageCollectObjectAction_PB(
             id_at_location=id_pb,

--- a/src/syft/core/node/common/action/get_enum_attribute_action.py
+++ b/src/syft/core/node/common/action/get_enum_attribute_action.py
@@ -61,16 +61,16 @@ class EnumAttributeAction(ImmediateActionWithoutReply):
         :return: returns a protobuf object
         :rtype: GetOrSetPropertyAction_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return GetEnumAttributeAction_PB(
             path=self.path,
-            id_at_location=self.id_at_location.serialize(),
-            address=self.address.serialize(),
-            msg_id=self.id.serialize(),
+            id_at_location=self.id_at_location._sy_serialize(),
+            address=self.address._sy_serialize(),
+            msg_id=self.id._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/action/get_enum_attribute_action.py
+++ b/src/syft/core/node/common/action/get_enum_attribute_action.py
@@ -8,6 +8,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ..... import lib
+from ..... import serialize
 from .....proto.core.node.common.action.get_enum_attribute_pb2 import (
     GetEnumAttributeAction as GetEnumAttributeAction_PB,
 )
@@ -61,16 +62,16 @@ class EnumAttributeAction(ImmediateActionWithoutReply):
         :return: returns a protobuf object
         :rtype: GetOrSetPropertyAction_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return GetEnumAttributeAction_PB(
             path=self.path,
-            id_at_location=self.id_at_location._sy_serialize(),
-            address=self.address._sy_serialize(),
-            msg_id=self.id._sy_serialize(),
+            id_at_location=serialize(self.id_at_location),
+            address=serialize(self.address),
+            msg_id=serialize(self.id),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/action/get_object_action.py
+++ b/src/syft/core/node/common/action/get_object_action.py
@@ -6,6 +6,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from nacl.signing import VerifyKey
 
 # syft relative
+from ..... import serialize
 from .....logger import critical
 from .....logger import debug
 from .....logger import traceback_and_raise
@@ -55,15 +56,15 @@ class GetObjectResponseMessage(ImmediateSyftMessageWithoutReply):
         :rtype: GetObjectResponseMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
-        ser = self.obj._sy_serialize()
+        ser = serialize(self.obj)
 
         return GetObjectResponseMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             obj=ser,
         )
 
@@ -214,15 +215,15 @@ class GetObjectAction(ImmediateActionWithReply):
         :rtype: ObjectWithID_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetObjectAction_PB(
-            id_at_location=self.id_at_location._sy_serialize(to_proto=True),
-            msg_id=self.id._sy_serialize(to_proto=True),
-            address=self.address._sy_serialize(to_proto=True),
-            reply_to=self.reply_to._sy_serialize(to_proto=True),
+            id_at_location=serialize(self.id_at_location, to_proto=True),
+            msg_id=serialize(self.id, to_proto=True),
+            address=serialize(self.address, to_proto=True),
+            reply_to=serialize(self.reply_to, to_proto=True),
             delete_obj=self.delete_obj,
         )
 

--- a/src/syft/core/node/common/action/get_object_action.py
+++ b/src/syft/core/node/common/action/get_object_action.py
@@ -55,15 +55,15 @@ class GetObjectResponseMessage(ImmediateSyftMessageWithoutReply):
         :rtype: GetObjectResponseMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
-        ser = self.obj.serialize()
+        ser = self.obj._sy_serialize()
 
         return GetObjectResponseMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             obj=ser,
         )
 
@@ -214,15 +214,15 @@ class GetObjectAction(ImmediateActionWithReply):
         :rtype: ObjectWithID_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetObjectAction_PB(
-            id_at_location=self.id_at_location.proto(),
-            msg_id=self.id.proto(),
-            address=self.address.proto(),
-            reply_to=self.reply_to.proto(),
+            id_at_location=self.id_at_location._sy_proto(),
+            msg_id=self.id._sy_proto(),
+            address=self.address._sy_proto(),
+            reply_to=self.reply_to._sy_proto(),
             delete_obj=self.delete_obj,
         )
 

--- a/src/syft/core/node/common/action/get_object_action.py
+++ b/src/syft/core/node/common/action/get_object_action.py
@@ -219,10 +219,10 @@ class GetObjectAction(ImmediateActionWithReply):
             object.
         """
         return GetObjectAction_PB(
-            id_at_location=self.id_at_location._sy_proto(),
-            msg_id=self.id._sy_proto(),
-            address=self.address._sy_proto(),
-            reply_to=self.reply_to._sy_proto(),
+            id_at_location=self.id_at_location._sy_serialize(to_proto=True),
+            msg_id=self.id._sy_serialize(to_proto=True),
+            address=self.address._sy_serialize(to_proto=True),
+            reply_to=self.reply_to._sy_serialize(to_proto=True),
             delete_obj=self.delete_obj,
         )
 

--- a/src/syft/core/node/common/action/get_or_set_property_action.py
+++ b/src/syft/core/node/common/action/get_or_set_property_action.py
@@ -14,6 +14,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ..... import lib
+from ..... import serialize
 from .....proto.core.node.common.action.get_set_property_pb2 import (
     GetOrSetPropertyAction as GetOrSetPropertyAction_PB,
 )
@@ -151,18 +152,18 @@ class GetOrSetPropertyAction(ImmediateActionWithoutReply):
         :return: returns a protobuf object
         :rtype: GetOrSetPropertyAction_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetOrSetPropertyAction_PB(
             path=self.path,
-            id_at_location=self.id_at_location._sy_serialize(),
-            args=list(map(lambda x: x._sy_serialize(), self.args)),
-            kwargs={k: v._sy_serialize() for k, v in self.kwargs.items()},
-            address=self.address._sy_serialize(),
-            _self=self._self._sy_serialize(),
-            msg_id=self.id._sy_serialize(),
+            id_at_location=serialize(self.id_at_location),
+            args=list(map(lambda x: serialize(x), self.args)),
+            kwargs={k: serialize(v) for k, v in self.kwargs.items()},
+            address=serialize(self.address),
+            _self=serialize(self._self),
+            msg_id=serialize(self.id),
             action=self.action.value,
         )
 

--- a/src/syft/core/node/common/action/get_or_set_property_action.py
+++ b/src/syft/core/node/common/action/get_or_set_property_action.py
@@ -151,18 +151,18 @@ class GetOrSetPropertyAction(ImmediateActionWithoutReply):
         :return: returns a protobuf object
         :rtype: GetOrSetPropertyAction_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetOrSetPropertyAction_PB(
             path=self.path,
-            id_at_location=self.id_at_location.serialize(),
-            args=list(map(lambda x: x.serialize(), self.args)),
-            kwargs={k: v.serialize() for k, v in self.kwargs.items()},
-            address=self.address.serialize(),
-            _self=self._self.serialize(),
-            msg_id=self.id.serialize(),
+            id_at_location=self.id_at_location._sy_serialize(),
+            args=list(map(lambda x: x._sy_serialize(), self.args)),
+            kwargs={k: v._sy_serialize() for k, v in self.kwargs.items()},
+            address=self.address._sy_serialize(),
+            _self=self._self._sy_serialize(),
+            msg_id=self.id._sy_serialize(),
             action=self.action.value,
         )
 

--- a/src/syft/core/node/common/action/get_or_set_static_attribute_action.py
+++ b/src/syft/core/node/common/action/get_or_set_static_attribute_action.py
@@ -98,7 +98,7 @@ class GetSetStaticAttributeAction(ImmediateActionWithoutReply):
         :return: returns a protobuf object
         :rtype: GetOrSetPropertyAction_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
@@ -107,18 +107,18 @@ class GetSetStaticAttributeAction(ImmediateActionWithoutReply):
         if self.set_arg is not None:
             return GetSetStaticAttributeAction_PB(
                 path=self.path,
-                id_at_location=self.id_at_location.serialize(),
-                address=self.address.serialize(),
-                msg_id=self.id.serialize(),
+                id_at_location=self.id_at_location._sy_serialize(),
+                address=self.address._sy_serialize(),
+                msg_id=self.id._sy_serialize(),
                 action=self.action.value,
-                set_arg=self.set_arg.serialize(),
+                set_arg=self.set_arg._sy_serialize(),
             )
         else:
             return GetSetStaticAttributeAction_PB(
                 path=self.path,
-                id_at_location=self.id_at_location.serialize(),
-                address=self.address.serialize(),
-                msg_id=self.id.serialize(),
+                id_at_location=self.id_at_location._sy_serialize(),
+                address=self.address._sy_serialize(),
+                msg_id=self.id._sy_serialize(),
                 action=self.action.value,
             )
 

--- a/src/syft/core/node/common/action/get_or_set_static_attribute_action.py
+++ b/src/syft/core/node/common/action/get_or_set_static_attribute_action.py
@@ -10,6 +10,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ..... import lib
+from ..... import serialize
 from .....proto.core.node.common.action.get_set_static_attribute_pb2 import (
     GetSetStaticAttributeAction as GetSetStaticAttributeAction_PB,
 )
@@ -98,7 +99,7 @@ class GetSetStaticAttributeAction(ImmediateActionWithoutReply):
         :return: returns a protobuf object
         :rtype: GetOrSetPropertyAction_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
@@ -107,18 +108,18 @@ class GetSetStaticAttributeAction(ImmediateActionWithoutReply):
         if self.set_arg is not None:
             return GetSetStaticAttributeAction_PB(
                 path=self.path,
-                id_at_location=self.id_at_location._sy_serialize(),
-                address=self.address._sy_serialize(),
-                msg_id=self.id._sy_serialize(),
+                id_at_location=serialize(self.id_at_location),
+                address=serialize(self.address),
+                msg_id=serialize(self.id),
                 action=self.action.value,
-                set_arg=self.set_arg._sy_serialize(),
+                set_arg=serialize(self.set_arg),
             )
         else:
             return GetSetStaticAttributeAction_PB(
                 path=self.path,
-                id_at_location=self.id_at_location._sy_serialize(),
-                address=self.address._sy_serialize(),
-                msg_id=self.id._sy_serialize(),
+                id_at_location=serialize(self.id_at_location),
+                address=serialize(self.address),
+                msg_id=serialize(self.id),
                 action=self.action.value,
             )
 

--- a/src/syft/core/node/common/action/run_class_method_action.py
+++ b/src/syft/core/node/common/action/run_class_method_action.py
@@ -213,19 +213,19 @@ class RunClassMethodAction(ImmediateActionWithoutReply):
         :rtype: RunClassMethodAction_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return RunClassMethodAction_PB(
             path=self.path,
-            _self=self._self.serialize(),
-            args=list(map(lambda x: x.serialize(), self.args)),
-            kwargs={k: v.serialize() for k, v in self.kwargs.items()},
-            id_at_location=self.id_at_location.serialize(),
-            address=self.address.serialize(),
-            msg_id=self.id.serialize(),
+            _self=self._self._sy_serialize(),
+            args=list(map(lambda x: x._sy_serialize(), self.args)),
+            kwargs={k: v._sy_serialize() for k, v in self.kwargs.items()},
+            id_at_location=self.id_at_location._sy_serialize(),
+            address=self.address._sy_serialize(),
+            msg_id=self.id._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/action/run_class_method_action.py
+++ b/src/syft/core/node/common/action/run_class_method_action.py
@@ -12,6 +12,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ..... import lib
+from ..... import serialize
 from .....logger import critical
 from .....logger import traceback_and_raise
 from .....proto.core.node.common.action.run_class_method_pb2 import (
@@ -213,19 +214,19 @@ class RunClassMethodAction(ImmediateActionWithoutReply):
         :rtype: RunClassMethodAction_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return RunClassMethodAction_PB(
             path=self.path,
-            _self=self._self._sy_serialize(),
-            args=list(map(lambda x: x._sy_serialize(), self.args)),
-            kwargs={k: v._sy_serialize() for k, v in self.kwargs.items()},
-            id_at_location=self.id_at_location._sy_serialize(),
-            address=self.address._sy_serialize(),
-            msg_id=self.id._sy_serialize(),
+            _self=serialize(self._self),
+            args=list(map(lambda x: serialize(x), self.args)),
+            kwargs={k: serialize(v) for k, v in self.kwargs.items()},
+            id_at_location=serialize(self.id_at_location),
+            address=serialize(self.address),
+            msg_id=serialize(self.id),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/action/save_object_action.py
+++ b/src/syft/core/node/common/action/save_object_action.py
@@ -39,7 +39,7 @@ class SaveObjectAction(ImmediateActionWithoutReply, Serializable):
 
     def _object2proto(self) -> SaveObjectAction_PB:
         obj = self.obj._object2proto()
-        addr = self.address.serialize()
+        addr = self.address._sy_serialize()
         return SaveObjectAction_PB(obj=obj, address=addr)
 
     @staticmethod

--- a/src/syft/core/node/common/action/save_object_action.py
+++ b/src/syft/core/node/common/action/save_object_action.py
@@ -6,6 +6,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from nacl.signing import VerifyKey
 
 # syft relative
+from ..... import serialize
 from .....proto.core.node.common.action.save_object_pb2 import (
     SaveObjectAction as SaveObjectAction_PB,
 )
@@ -39,7 +40,7 @@ class SaveObjectAction(ImmediateActionWithoutReply, Serializable):
 
     def _object2proto(self) -> SaveObjectAction_PB:
         obj = self.obj._object2proto()
-        addr = self.address._sy_serialize()
+        addr = serialize(self.address)
         return SaveObjectAction_PB(obj=obj, address=addr)
 
     @staticmethod

--- a/src/syft/core/node/common/client.py
+++ b/src/syft/core/node/common/client.py
@@ -14,6 +14,7 @@ from nacl.signing import VerifyKey
 import pandas as pd
 
 # syft relative
+from .... import serialize
 from ....core.pointer.pointer import Pointer
 from ....lib import create_lib_ast
 from ....logger import critical
@@ -282,7 +283,7 @@ class Client(AbstractNodeClient):
     def _object2proto(self) -> Client_PB:
         obj_type = get_fully_qualified_name(obj=self)
 
-        routes = [route._sy_serialize() for route in self.routes]
+        routes = [serialize(route) for route in self.routes]
 
         network = self.network._object2proto() if self.network is not None else None
 
@@ -294,7 +295,7 @@ class Client(AbstractNodeClient):
 
         client_pb = Client_PB(
             obj_type=obj_type,
-            id=self.id._sy_serialize(),
+            id=serialize(self.id),
             name=self.name,
             routes=routes,
             has_network=self.network is not None,

--- a/src/syft/core/node/common/client.py
+++ b/src/syft/core/node/common/client.py
@@ -282,7 +282,7 @@ class Client(AbstractNodeClient):
     def _object2proto(self) -> Client_PB:
         obj_type = get_fully_qualified_name(obj=self)
 
-        routes = [route.serialize() for route in self.routes]
+        routes = [route._sy_serialize() for route in self.routes]
 
         network = self.network._object2proto() if self.network is not None else None
 
@@ -294,7 +294,7 @@ class Client(AbstractNodeClient):
 
         client_pb = Client_PB(
             obj_type=obj_type,
-            id=self.id.serialize(),
+            id=self.id._sy_serialize(),
             name=self.name,
             routes=routes,
             has_network=self.network is not None,

--- a/src/syft/core/node/common/metadata.py
+++ b/src/syft/core/node/common/metadata.py
@@ -5,6 +5,7 @@ from typing import Optional
 from google.protobuf.reflection import GeneratedProtocolMessageType
 
 # syft relative
+from .... import serialize
 from ....proto.core.node.common.metadata_pb2 import Metadata as Metadata_PB
 from ....util import validate_type
 from ...common.serde.deserialize import _deserialize
@@ -41,12 +42,12 @@ class Metadata(Serializable):
         :rtype: Metadata_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return Metadata_PB(
-            name=self.name, id=self.id._sy_serialize(), node=self.node._sy_serialize()
+            name=self.name, id=serialize(self.id), node=serialize(self.node)
         )
 
     @staticmethod

--- a/src/syft/core/node/common/metadata.py
+++ b/src/syft/core/node/common/metadata.py
@@ -41,12 +41,12 @@ class Metadata(Serializable):
         :rtype: Metadata_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return Metadata_PB(
-            name=self.name, id=self.id.serialize(), node=self.node.serialize()
+            name=self.name, id=self.id._sy_serialize(), node=self.node._sy_serialize()
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/child_node_lifecycle_service.py
+++ b/src/syft/core/node/common/service/child_node_lifecycle_service.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from nacl.signing import VerifyKey
 
 # syft relative
+from ..... import serialize
 from .....logger import debug
 from .....logger import error
 from .....proto.core.node.common.service.child_node_lifecycle_service_pb2 import (
@@ -41,10 +42,12 @@ class RegisterChildNodeMessage(ImmediateSyftMessageWithoutReply):
     def _object2proto(self) -> RegisterChildNodeMessage_PB:
         debug(f"> {self.icon} -> Proto 🔢")
         return RegisterChildNodeMessage_PB(
-            lookup_id=self.lookup_id._sy_serialize(),  # TODO: not sure if this is needed anymore
-            child_node_client_address=self.child_node_client_address._sy_serialize(),
-            address=self.address._sy_serialize(),
-            msg_id=self.id._sy_serialize(),
+            lookup_id=serialize(
+                self.lookup_id
+            ),  # TODO: not sure if this is needed anymore
+            child_node_client_address=serialize(self.child_node_client_address),
+            address=serialize(self.address),
+            msg_id=serialize(self.id),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/child_node_lifecycle_service.py
+++ b/src/syft/core/node/common/service/child_node_lifecycle_service.py
@@ -41,10 +41,10 @@ class RegisterChildNodeMessage(ImmediateSyftMessageWithoutReply):
     def _object2proto(self) -> RegisterChildNodeMessage_PB:
         debug(f"> {self.icon} -> Proto 🔢")
         return RegisterChildNodeMessage_PB(
-            lookup_id=self.lookup_id.serialize(),  # TODO: not sure if this is needed anymore
-            child_node_client_address=self.child_node_client_address.serialize(),
-            address=self.address.serialize(),
-            msg_id=self.id.serialize(),
+            lookup_id=self.lookup_id._sy_serialize(),  # TODO: not sure if this is needed anymore
+            child_node_client_address=self.child_node_client_address._sy_serialize(),
+            address=self.address._sy_serialize(),
+            msg_id=self.id._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/heritage_update_service.py
+++ b/src/syft/core/node/common/service/heritage_update_service.py
@@ -13,6 +13,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from nacl.signing import VerifyKey
 
 # syft relative
+from ..... import serialize
 from .....logger import debug
 from .....logger import traceback
 from .....proto.core.node.common.service.heritage_update_service_pb2 import (
@@ -44,9 +45,9 @@ class HeritageUpdateMessage(ImmediateSyftMessageWithoutReply):
 
     def _object2proto(self) -> HeritageUpdateMessage_PB:
         return HeritageUpdateMessage_PB(
-            new_ancestry_address=self.new_ancestry_address._sy_serialize(),
-            address=self.address._sy_serialize(),
-            msg_id=self.id._sy_serialize(),
+            new_ancestry_address=serialize(self.new_ancestry_address),
+            address=serialize(self.address),
+            msg_id=serialize(self.id),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/heritage_update_service.py
+++ b/src/syft/core/node/common/service/heritage_update_service.py
@@ -44,9 +44,9 @@ class HeritageUpdateMessage(ImmediateSyftMessageWithoutReply):
 
     def _object2proto(self) -> HeritageUpdateMessage_PB:
         return HeritageUpdateMessage_PB(
-            new_ancestry_address=self.new_ancestry_address.serialize(),
-            address=self.address.serialize(),
-            msg_id=self.id.serialize(),
+            new_ancestry_address=self.new_ancestry_address._sy_serialize(),
+            address=self.address._sy_serialize(),
+            msg_id=self.id._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/obj_search_permission_service.py
+++ b/src/syft/core/node/common/service/obj_search_permission_service.py
@@ -58,17 +58,17 @@ class ObjectSearchPermissionUpdateMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ObjectSearchPermissionUpdateMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ObjectSearchPermissionUpdateMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             target_verify_key=bytes(self.target_verify_key)
             if self.target_verify_key
             else None,
-            target_object_id=self.target_object_id.serialize(),
+            target_object_id=self.target_object_id._sy_serialize(),
             add_instead_of_remove=self.add_instead_of_remove,
         )
 

--- a/src/syft/core/node/common/service/obj_search_permission_service.py
+++ b/src/syft/core/node/common/service/obj_search_permission_service.py
@@ -15,6 +15,7 @@ from nacl.signing import VerifyKey
 from typing_extensions import final
 
 # syft relative
+from ..... import serialize
 from .....proto.core.node.common.service.object_search_permission_update_message_pb2 import (
     ObjectSearchPermissionUpdateMessage as ObjectSearchPermissionUpdateMessage_PB,
 )
@@ -58,17 +59,17 @@ class ObjectSearchPermissionUpdateMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ObjectSearchPermissionUpdateMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ObjectSearchPermissionUpdateMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             target_verify_key=bytes(self.target_verify_key)
             if self.target_verify_key
             else None,
-            target_object_id=self.target_object_id._sy_serialize(),
+            target_object_id=serialize(self.target_object_id),
             add_instead_of_remove=self.add_instead_of_remove,
         )
 

--- a/src/syft/core/node/common/service/obj_search_service.py
+++ b/src/syft/core/node/common/service/obj_search_service.py
@@ -58,14 +58,14 @@ class ObjectSearchMessage(ImmediateSyftMessageWithReply):
         :rtype: ObjectSearchMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ObjectSearchMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
-            reply_to=self.reply_to.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -136,14 +136,14 @@ class ObjectSearchReplyMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ObjectSearchReplyMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ObjectSearchReplyMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
-            results=list(map(lambda x: x.serialize(), self.results)),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
+            results=list(map(lambda x: x._sy_serialize(), self.results)),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/obj_search_service.py
+++ b/src/syft/core/node/common/service/obj_search_service.py
@@ -15,6 +15,7 @@ from nacl.signing import VerifyKey
 from typing_extensions import final
 
 # syft relative
+from ..... import serialize
 from .....core.common.serde.serializable import bind_protobuf
 from .....logger import error
 from .....proto.core.node.common.service.object_search_message_pb2 import (
@@ -58,14 +59,14 @@ class ObjectSearchMessage(ImmediateSyftMessageWithReply):
         :rtype: ObjectSearchMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ObjectSearchMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
-            reply_to=self.reply_to._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -136,14 +137,14 @@ class ObjectSearchReplyMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ObjectSearchReplyMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ObjectSearchReplyMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
-            results=list(map(lambda x: x._sy_serialize(), self.results)),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
+            results=list(map(lambda x: serialize(x), self.results)),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/repr_service.py
+++ b/src/syft/core/node/common/service/repr_service.py
@@ -15,6 +15,7 @@ from nacl.signing import VerifyKey
 from typing_extensions import final
 
 # syft relative
+from ..... import serialize
 from .....logger import critical
 from .....proto.core.node.common.service.repr_service_pb2 import (
     ReprMessage as ReprMessage_PB,
@@ -46,14 +47,14 @@ class ReprMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ReprMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return ReprMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
         )
 
     @staticmethod

--- a/src/syft/core/node/common/service/repr_service.py
+++ b/src/syft/core/node/common/service/repr_service.py
@@ -46,14 +46,14 @@ class ReprMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ReprMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return ReprMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/core/node/domain/service/accept_or_deny_request_service.py
+++ b/src/syft/core/node/domain/service/accept_or_deny_request_service.py
@@ -15,6 +15,7 @@ from nacl.signing import VerifyKey
 from typing_extensions import final
 
 # syft relative
+from ..... import serialize
 from .....logger import debug
 from .....logger import traceback_and_raise
 from .....proto.core.node.domain.service.accept_or_deny_request_message_pb2 import (
@@ -58,15 +59,15 @@ class AcceptOrDenyRequestMessage(ImmediateSyftMessageWithoutReply):
         :rtype: AcceptOrDenyRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return AcceptOrDenyRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             accept=self.accept,
-            request_id=self.request_id._sy_serialize(),
+            request_id=serialize(self.request_id),
         )
 
     @staticmethod

--- a/src/syft/core/node/domain/service/accept_or_deny_request_service.py
+++ b/src/syft/core/node/domain/service/accept_or_deny_request_service.py
@@ -58,15 +58,15 @@ class AcceptOrDenyRequestMessage(ImmediateSyftMessageWithoutReply):
         :rtype: AcceptOrDenyRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return AcceptOrDenyRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             accept=self.accept,
-            request_id=self.request_id.serialize(),
+            request_id=self.request_id._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/core/node/domain/service/get_all_requests_service.py
+++ b/src/syft/core/node/domain/service/get_all_requests_service.py
@@ -8,6 +8,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ..... import deserialize
+from ..... import serialize
 from .....logger import traceback_and_raise
 from .....proto.core.node.domain.service.get_all_requests_message_pb2 import (
     GetAllRequestsMessage as GetAllRequestsMessage_PB,
@@ -43,14 +44,14 @@ class GetAllRequestsMessage(ImmediateSyftMessageWithReply):
         :rtype: GetAllRequestsMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAllRequestsMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
-            reply_to=self.reply_to._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -117,14 +118,14 @@ class GetAllRequestsResponseMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ReprMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAllRequestsResponseMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
-            requests=list(map(lambda x: x._sy_serialize(), self.requests)),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
+            requests=list(map(lambda x: serialize(x), self.requests)),
         )
 
     @staticmethod

--- a/src/syft/core/node/domain/service/get_all_requests_service.py
+++ b/src/syft/core/node/domain/service/get_all_requests_service.py
@@ -43,14 +43,14 @@ class GetAllRequestsMessage(ImmediateSyftMessageWithReply):
         :rtype: GetAllRequestsMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAllRequestsMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
-            reply_to=self.reply_to.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -117,14 +117,14 @@ class GetAllRequestsResponseMessage(ImmediateSyftMessageWithoutReply):
         :rtype: ReprMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAllRequestsResponseMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
-            requests=list(map(lambda x: x.serialize(), self.requests)),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
+            requests=list(map(lambda x: x._sy_serialize(), self.requests)),
         )
 
     @staticmethod

--- a/src/syft/core/node/domain/service/request_handler_service.py
+++ b/src/syft/core/node/domain/service/request_handler_service.py
@@ -11,6 +11,7 @@ from nacl.signing import VerifyKey
 
 # syft relative
 from ..... import deserialize
+from ..... import serialize
 from .....lib.python import Dict
 from .....lib.python.util import downcast
 from .....lib.python.util import upcast
@@ -59,14 +60,14 @@ class UpdateRequestHandlerMessage(ImmediateSyftMessageWithoutReply):
         :rtype: UpdateRequestHandlerMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return UpdateRequestHandlerMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             handler=downcast(value=self.handler)._object2proto(),
             keep=self.keep,
         )
@@ -133,14 +134,14 @@ class GetAllRequestHandlersMessage(ImmediateSyftMessageWithReply):
         :rtype: GetAllRequestHandlersMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAllRequestHandlersMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
-            reply_to=self.reply_to._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -208,7 +209,7 @@ class GetAllRequestHandlersResponseMessage(ImmediateSyftMessageWithoutReply):
         :rtype: GetAllRequestHandlersResponseMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
@@ -220,8 +221,8 @@ class GetAllRequestHandlersResponseMessage(ImmediateSyftMessageWithoutReply):
                 handler["created_time"] = str(handler["created_time"])
 
         return GetAllRequestHandlersResponseMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             handlers=list(map(lambda x: downcast(value=x)._object2proto(), handlers)),
         )
 

--- a/src/syft/core/node/domain/service/request_handler_service.py
+++ b/src/syft/core/node/domain/service/request_handler_service.py
@@ -59,14 +59,14 @@ class UpdateRequestHandlerMessage(ImmediateSyftMessageWithoutReply):
         :rtype: UpdateRequestHandlerMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return UpdateRequestHandlerMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             handler=downcast(value=self.handler)._object2proto(),
             keep=self.keep,
         )
@@ -133,14 +133,14 @@ class GetAllRequestHandlersMessage(ImmediateSyftMessageWithReply):
         :rtype: GetAllRequestHandlersMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAllRequestHandlersMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
-            reply_to=self.reply_to.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -208,7 +208,7 @@ class GetAllRequestHandlersResponseMessage(ImmediateSyftMessageWithoutReply):
         :rtype: GetAllRequestHandlersResponseMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
@@ -220,8 +220,8 @@ class GetAllRequestHandlersResponseMessage(ImmediateSyftMessageWithoutReply):
                 handler["created_time"] = str(handler["created_time"])
 
         return GetAllRequestHandlersResponseMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             handlers=list(map(lambda x: downcast(value=x)._object2proto(), handlers)),
         )
 

--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -245,15 +245,15 @@ class Pointer(AbstractPointer):
         :rtype: Pointer_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return Pointer_PB(
             points_to_object_with_path=self.path_and_name,
             pointer_name=type(self).__name__,
-            id_at_location=self.id_at_location.serialize(),
-            location=self.client.address.serialize(),
+            id_at_location=self.id_at_location._sy_serialize(),
+            location=self.client.address._sy_serialize(),
             tags=self.tags,
             description=self.description,
             object_type=self.object_type,

--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -245,15 +245,15 @@ class Pointer(AbstractPointer):
         :rtype: Pointer_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use sy.serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return Pointer_PB(
             points_to_object_with_path=self.path_and_name,
             pointer_name=type(self).__name__,
-            id_at_location=self.id_at_location._sy_serialize(),
-            location=self.client.address._sy_serialize(),
+            id_at_location=sy.serialize(self.id_at_location),
+            location=sy.serialize(self.client.address),
             tags=self.tags,
             description=self.description,
             object_type=self.object_type,

--- a/src/syft/core/store/dataset.py
+++ b/src/syft/core/store/dataset.py
@@ -9,6 +9,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 import syft as sy
 
 # syft relative
+from ... import serialize
 from ...proto.core.store.dataset_pb2 import Dataset as Dataset_PB
 from ...util import get_fully_qualified_name
 from ..common.serde.deserialize import _deserialize
@@ -100,7 +101,7 @@ class Dataset(Serializable):
         proto = Dataset_PB()
 
         # Step 1: Serialize the id to protobuf and copy into protobuf
-        id = self.id._sy_serialize()
+        id = serialize(self.id)
         proto.id.CopyFrom(id)
 
         # Step 2: Save the type of wrapper to use to deserialize
@@ -129,14 +130,14 @@ class Dataset(Serializable):
             permission_data = sy.lib.python.Dict()
             for k, v in self.read_permissions.items():
                 permission_data[k] = v
-            proto.read_permissions = permission_data._sy_serialize(to_bytes=True)
+            proto.read_permissions = serialize(permission_data, to_bytes=True)
 
         # Step 7: save search permissions
         if len(self.search_permissions.keys()) > 0:
             permission_data = sy.lib.python.Dict()
             for k, v in self.search_permissions.items():
                 permission_data[k] = v
-            proto.search_permissions = permission_data._sy_serialize(to_bytes=True)
+            proto.search_permissions = serialize(permission_data, to_bytes=True)
 
         return proto
 

--- a/src/syft/core/store/dataset.py
+++ b/src/syft/core/store/dataset.py
@@ -100,7 +100,7 @@ class Dataset(Serializable):
         proto = Dataset_PB()
 
         # Step 1: Serialize the id to protobuf and copy into protobuf
-        id = self.id.serialize()
+        id = self.id._sy_serialize()
         proto.id.CopyFrom(id)
 
         # Step 2: Save the type of wrapper to use to deserialize
@@ -129,14 +129,14 @@ class Dataset(Serializable):
             permission_data = sy.lib.python.Dict()
             for k, v in self.read_permissions.items():
                 permission_data[k] = v
-            proto.read_permissions = permission_data.serialize(to_bytes=True)
+            proto.read_permissions = permission_data._sy_serialize(to_bytes=True)
 
         # Step 7: save search permissions
         if len(self.search_permissions.keys()) > 0:
             permission_data = sy.lib.python.Dict()
             for k, v in self.search_permissions.items():
                 permission_data[k] = v
-            proto.search_permissions = permission_data.serialize(to_bytes=True)
+            proto.search_permissions = permission_data._sy_serialize(to_bytes=True)
 
         return proto
 

--- a/src/syft/core/store/store_disk.py
+++ b/src/syft/core/store/store_disk.py
@@ -56,7 +56,7 @@ class DiskObjectStore(ObjectStore):
 
     def __setitem__(self, key: UID, value: StorableObject) -> None:
         try:
-            blob = value.serialize(to_bytes=True)
+            blob = value._sy_serialize(to_bytes=True)
             self.db[str(key.value)] = blob
             self.db.commit(blocking=False)
         except Exception as e:

--- a/src/syft/core/store/store_disk.py
+++ b/src/syft/core/store/store_disk.py
@@ -9,6 +9,7 @@ from sqlitedict import SqliteDict
 from typing_extensions import Final
 
 # syft relative
+from ... import serialize
 from ...logger import critical
 from ...logger import trace
 from ...logger import traceback_and_raise
@@ -56,7 +57,7 @@ class DiskObjectStore(ObjectStore):
 
     def __setitem__(self, key: UID, value: StorableObject) -> None:
         try:
-            blob = value._sy_serialize(to_bytes=True)
+            blob = serialize(value, to_bytes=True)
             self.db[str(key.value)] = blob
             self.db.commit(blocking=False)
         except Exception as e:

--- a/src/syft/core/store/storeable_object.py
+++ b/src/syft/core/store/storeable_object.py
@@ -94,8 +94,8 @@ class StorableObject(AbstractStorableObject):
 
     @data.setter
     def data(self, value: Any) -> Any:
-        if hasattr(value, "serializable_wrapper_type"):
-            self._data = value.serializable_wrapper_type(value=value)
+        if hasattr(value, "_sy_serializable_wrapper_type"):
+            self._data = value._sy_serializable_wrapper_type(value=value)
         else:
             self._data = value
 
@@ -119,7 +119,7 @@ class StorableObject(AbstractStorableObject):
         proto = StorableObject_PB()
 
         # Step 1: Serialize the id to protobuf and copy into protobuf
-        id = self.id.serialize()
+        id = self.id._sy_serialize()
         proto.id.CopyFrom(id)
 
         # Step 2: Save the type of wrapper to use to deserialize
@@ -146,14 +146,14 @@ class StorableObject(AbstractStorableObject):
             permission_data = sy.lib.python.Dict()
             for k, v in self.read_permissions.items():
                 permission_data[k] = v
-            proto.read_permissions = permission_data.serialize(to_bytes=True)
+            proto.read_permissions = permission_data._sy_serialize(to_bytes=True)
 
         # Step 7: save search permissions
         if len(self.search_permissions.keys()) > 0:
             permission_data = sy.lib.python.Dict()
             for k, v in self.search_permissions.items():
                 permission_data[k] = v
-            proto.search_permissions = permission_data.serialize(to_bytes=True)
+            proto.search_permissions = permission_data._sy_serialize(to_bytes=True)
 
         return proto
 

--- a/src/syft/core/store/storeable_object.py
+++ b/src/syft/core/store/storeable_object.py
@@ -119,7 +119,7 @@ class StorableObject(AbstractStorableObject):
         proto = StorableObject_PB()
 
         # Step 1: Serialize the id to protobuf and copy into protobuf
-        id = self.id._sy_serialize()
+        id = sy.serialize(self.id)
         proto.id.CopyFrom(id)
 
         # Step 2: Save the type of wrapper to use to deserialize
@@ -146,14 +146,14 @@ class StorableObject(AbstractStorableObject):
             permission_data = sy.lib.python.Dict()
             for k, v in self.read_permissions.items():
                 permission_data[k] = v
-            proto.read_permissions = permission_data._sy_serialize(to_bytes=True)
+            proto.read_permissions = sy.serialize(permission_data, to_bytes=True)
 
         # Step 7: save search permissions
         if len(self.search_permissions.keys()) > 0:
             permission_data = sy.lib.python.Dict()
             for k, v in self.search_permissions.items():
                 permission_data[k] = v
-            proto.search_permissions = permission_data._sy_serialize(to_bytes=True)
+            proto.search_permissions = sy.serialize(permission_data, to_bytes=True)
 
         return proto
 

--- a/src/syft/generate_wrapper.py
+++ b/src/syft/generate_wrapper.py
@@ -11,7 +11,6 @@ import syft
 # syft relative
 from .core.common.serde.serializable import Serializable
 from .core.common.serde.serializable import bind_protobuf
-from .core.common.serde.serialize import _serialize
 from .util import aggressive_set_attr
 
 module_type = type(syft)
@@ -65,8 +64,6 @@ def GenerateWrapper(
     aggressive_set_attr(
         obj=wrapped_type, name="_sy_serializable_wrapper_type", attr=Wrapper
     )
-
-    aggressive_set_attr(obj=wrapped_type, name="_sy_serialize", attr=_serialize)
 
 
 def GenerateProtobufWrapper(

--- a/src/syft/generate_wrapper.py
+++ b/src/syft/generate_wrapper.py
@@ -67,13 +67,6 @@ def GenerateWrapper(
     )
 
     aggressive_set_attr(obj=wrapped_type, name="_sy_serialize", attr=_serialize)
-    aggressive_set_attr(
-        obj=wrapped_type, name="_sy_to_proto", attr=Serializable._sy_to_proto
-    )
-    aggressive_set_attr(obj=wrapped_type, name="_sy_proto", attr=Serializable._sy_proto)
-    aggressive_set_attr(
-        obj=wrapped_type, name="_sy_to_bytes", attr=Serializable._sy_to_bytes
-    )
 
 
 def GenerateProtobufWrapper(

--- a/src/syft/generate_wrapper.py
+++ b/src/syft/generate_wrapper.py
@@ -1,10 +1,8 @@
 # stdlib
 from typing import Any
 from typing import Callable as CallableT
-from typing import Union
 
 # third party
-from google.protobuf.message import Message
 from google.protobuf.reflection import GeneratedProtocolMessageType
 
 # syft absolute
@@ -19,7 +17,7 @@ from .util import aggressive_set_attr
 module_type = type(syft)
 
 
-# this will overwrite the .serializable_wrapper_type with an auto generated
+# this will overwrite the ._sy_serializable_wrapper_type with an auto generated
 # wrapper which will basically just hold the object being wrapped.
 def GenerateWrapper(
     wrapped_type: type,
@@ -65,35 +63,16 @@ def GenerateWrapper(
     parent.__dict__[Wrapper.__name__] = Wrapper
 
     aggressive_set_attr(
-        obj=wrapped_type, name="serializable_wrapper_type", attr=Wrapper
+        obj=wrapped_type, name="_sy_serializable_wrapper_type", attr=Wrapper
     )
 
-    def serialize(  # type: ignore
-        self,
-        to_proto: bool = True,
-        to_bytes: bool = False,
-    ) -> Union[str, bytes, Message]:
-        return _serialize(
-            obj=self,
-            to_proto=to_proto,
-            to_bytes=to_bytes,
-        )
-
-    serialize_attr = "serialize"
-    if not hasattr(wrapped_type, serialize_attr):
-        aggressive_set_attr(obj=wrapped_type, name=serialize_attr, attr=serialize)
-    else:
-        serialize_attr = "sy_serialize"
-        aggressive_set_attr(obj=wrapped_type, name=serialize_attr, attr=serialize)
-
-    aggressive_set_attr(obj=wrapped_type, name="to_proto", attr=Serializable.to_proto)
-    aggressive_set_attr(obj=wrapped_type, name="proto", attr=Serializable.proto)
-    to_bytes_attr = "to_bytes"
-    # int has a to_bytes already, so we can use _to_bytes internally
-    if hasattr(wrapped_type, to_bytes_attr):
-        to_bytes_attr = "_to_bytes"
+    aggressive_set_attr(obj=wrapped_type, name="_sy_serialize", attr=_serialize)
     aggressive_set_attr(
-        obj=wrapped_type, name=to_bytes_attr, attr=Serializable.to_bytes
+        obj=wrapped_type, name="_sy_to_proto", attr=Serializable._sy_to_proto
+    )
+    aggressive_set_attr(obj=wrapped_type, name="_sy_proto", attr=Serializable._sy_proto)
+    aggressive_set_attr(
+        obj=wrapped_type, name="_sy_to_bytes", attr=Serializable._sy_to_bytes
     )
 
 

--- a/src/syft/grid/connections/http_connection.py
+++ b/src/syft/grid/connections/http_connection.py
@@ -2,6 +2,7 @@
 import requests
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import SignedEventualSyftMessageWithoutReply
 from syft.core.common.message import SignedImmediateSyftMessageWithReply
 from syft.core.common.message import SignedImmediateSyftMessageWithoutReply
@@ -77,7 +78,7 @@ class HTTPConnection(ClientConnection):
         # Perform HTTP request using base_url as a root address
         r = requests.post(
             url=self.base_url,
-            data=msg._sy_serialize(to_bytes=True),
+            data=serialize(msg, to_bytes=True),
             headers={"Content-Type": "application/octet-stream"},
         )
 

--- a/src/syft/grid/connections/http_connection.py
+++ b/src/syft/grid/connections/http_connection.py
@@ -77,7 +77,7 @@ class HTTPConnection(ClientConnection):
         # Perform HTTP request using base_url as a root address
         r = requests.post(
             url=self.base_url,
-            data=msg.binary(),
+            data=msg._sy_serialize(to_bytes=True),
             headers={"Content-Type": "application/octet-stream"},
         )
 

--- a/src/syft/grid/connections/webrtc.py
+++ b/src/syft/grid/connections/webrtc.py
@@ -345,7 +345,7 @@ class WebRTCConnection(BidirectionalConnection):
 
                 # If self.producer_pool.get() returns a message
                 # send it as a binary using the RTCDataChannel.
-                data = msg._sy_to_bytes()
+                data = msg._sy_serialize(to_bytes=True)
                 data_len = len(data)
 
                 if DC_CHUNKING_ENABLED and data_len > DC_MAX_CHUNK_SIZE:
@@ -391,7 +391,9 @@ class WebRTCConnection(BidirectionalConnection):
             # Build Close Message to warn the other peer
             bye_msg = CloseConnectionMessage(address=Address())
 
-            self.channel.send(OrderedChunk(0, bye_msg._sy_to_bytes()).save())
+            self.channel.send(
+                OrderedChunk(0, bye_msg._sy_serialize(to_bytes=True)).save()  # type: ignore
+            )
 
             # Finish async tasks related with this connection
             self._finish_coroutines()

--- a/src/syft/grid/connections/webrtc.py
+++ b/src/syft/grid/connections/webrtc.py
@@ -94,6 +94,7 @@ from aiortc.contrib.signaling import object_from_string
 from aiortc.contrib.signaling import object_to_string
 
 # syft relative
+from ... import serialize
 from ...core.common.event_loop import loop
 from ...core.common.message import SignedEventualSyftMessageWithoutReply
 from ...core.common.message import SignedImmediateSyftMessageWithReply
@@ -345,7 +346,7 @@ class WebRTCConnection(BidirectionalConnection):
 
                 # If self.producer_pool.get() returns a message
                 # send it as a binary using the RTCDataChannel.
-                data = msg._sy_serialize(to_bytes=True)
+                data = serialize(msg, to_bytes=True)
                 data_len = len(data)
 
                 if DC_CHUNKING_ENABLED and data_len > DC_MAX_CHUNK_SIZE:
@@ -391,9 +392,7 @@ class WebRTCConnection(BidirectionalConnection):
             # Build Close Message to warn the other peer
             bye_msg = CloseConnectionMessage(address=Address())
 
-            self.channel.send(
-                OrderedChunk(0, bye_msg._sy_serialize(to_bytes=True)).save()  # type: ignore
-            )
+            self.channel.send(OrderedChunk(0, serialize(bye_msg, to_bytes=True)).save())
 
             # Finish async tasks related with this connection
             self._finish_coroutines()

--- a/src/syft/grid/connections/webrtc.py
+++ b/src/syft/grid/connections/webrtc.py
@@ -345,7 +345,7 @@ class WebRTCConnection(BidirectionalConnection):
 
                 # If self.producer_pool.get() returns a message
                 # send it as a binary using the RTCDataChannel.
-                data = msg.to_bytes()
+                data = msg._sy_to_bytes()
                 data_len = len(data)
 
                 if DC_CHUNKING_ENABLED and data_len > DC_MAX_CHUNK_SIZE:
@@ -391,7 +391,7 @@ class WebRTCConnection(BidirectionalConnection):
             # Build Close Message to warn the other peer
             bye_msg = CloseConnectionMessage(address=Address())
 
-            self.channel.send(OrderedChunk(0, bye_msg.to_bytes()).save())
+            self.channel.send(OrderedChunk(0, bye_msg._sy_to_bytes()).save())
 
             # Finish async tasks related with this connection
             self._finish_coroutines()

--- a/src/syft/grid/duet/webrtc_duet.py
+++ b/src/syft/grid/duet/webrtc_duet.py
@@ -134,7 +134,7 @@ class Duet(DomainClient):
                     name,
                     _,
                 ) = DomainClient.deserialize_client_metadata_from_node(
-                    metadata=self._client_metadata.serialize()
+                    metadata=self._client_metadata._sy_serialize()
                 )
 
                 # Create a SoloRoute

--- a/src/syft/grid/duet/webrtc_duet.py
+++ b/src/syft/grid/duet/webrtc_duet.py
@@ -35,6 +35,7 @@ from typing import Optional
 from nacl.signing import SigningKey
 
 # syft relative
+from ... import serialize
 from ...core.io.route import SoloRoute
 from ...core.node.common.metadata import Metadata
 from ...core.node.domain.client import DomainClient
@@ -134,7 +135,7 @@ class Duet(DomainClient):
                     name,
                     _,
                 ) = DomainClient.deserialize_client_metadata_from_node(
-                    metadata=self._client_metadata._sy_serialize()
+                    metadata=serialize(self._client_metadata)
                 )
 
                 # Create a SoloRoute

--- a/src/syft/grid/example_nodes/network.py
+++ b/src/syft/grid/example_nodes/network.py
@@ -18,6 +18,7 @@ from flask import Response
 from nacl.encoding import HexEncoder
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import SignedImmediateSyftMessageWithReply
 from syft.core.common.message import SignedImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -40,7 +41,7 @@ network._register_services()  # re-register all services including SignalingServ
 @app.route("/metadata")
 def get_metadata() -> flask.Response:
     metadata = network.get_metadata_for_client()
-    metadata_proto = metadata._sy_serialize()
+    metadata_proto = serialize(metadata)
     r = Response(
         response=metadata_proto.SerializeToString(),
         status=200,
@@ -58,7 +59,7 @@ def process_network_msgs() -> flask.Response:
             f"Signaling server SignedImmediateSyftMessageWithReply: {obj_msg.message} watch"
         )
         reply = network.recv_immediate_msg_with_reply(msg=obj_msg)
-        r = Response(response=reply._sy_serialize(to_bytes=True), status=200)
+        r = Response(response=serialize(reply, to_bytes=True), status=200)
         r.headers["Content-Type"] = "application/octet-stream"
         return r
     elif isinstance(obj_msg, SignedImmediateSyftMessageWithoutReply):

--- a/src/syft/grid/example_nodes/network.py
+++ b/src/syft/grid/example_nodes/network.py
@@ -40,7 +40,7 @@ network._register_services()  # re-register all services including SignalingServ
 @app.route("/metadata")
 def get_metadata() -> flask.Response:
     metadata = network.get_metadata_for_client()
-    metadata_proto = metadata.serialize()
+    metadata_proto = metadata._sy_serialize()
     r = Response(
         response=metadata_proto.SerializeToString(),
         status=200,
@@ -58,7 +58,7 @@ def process_network_msgs() -> flask.Response:
             f"Signaling server SignedImmediateSyftMessageWithReply: {obj_msg.message} watch"
         )
         reply = network.recv_immediate_msg_with_reply(msg=obj_msg)
-        r = Response(response=reply.serialize(to_bytes=True), status=200)
+        r = Response(response=reply._sy_serialize(to_bytes=True), status=200)
         r.headers["Content-Type"] = "application/octet-stream"
         return r
     elif isinstance(obj_msg, SignedImmediateSyftMessageWithoutReply):

--- a/src/syft/grid/messages/association_messages.py
+++ b/src/syft/grid/messages/association_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -75,15 +76,15 @@ class SendAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: SendAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SendAssociationRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -147,13 +148,13 @@ class SendAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SendAssociationRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -218,15 +219,15 @@ class ReceiveAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: ReceiveAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ReceiveAssociationRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -290,13 +291,13 @@ class ReceiveAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ReceiveAssociationRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -361,15 +362,15 @@ class RespondAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: RespondAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RespondAssociationRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -433,13 +434,13 @@ class RespondAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RespondAssociationRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -504,15 +505,15 @@ class GetAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -576,13 +577,13 @@ class GetAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -647,15 +648,15 @@ class GetAssociationRequestsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetAssociationRequestsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestsMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -719,13 +720,13 @@ class GetAssociationRequestsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestsResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -790,15 +791,15 @@ class DeleteAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteAssociationRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -862,13 +863,13 @@ class DeleteAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteAssociationRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/association_messages.py
+++ b/src/syft/grid/messages/association_messages.py
@@ -75,15 +75,15 @@ class SendAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: SendAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SendAssociationRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -147,13 +147,13 @@ class SendAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SendAssociationRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -218,15 +218,15 @@ class ReceiveAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: ReceiveAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ReceiveAssociationRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -290,13 +290,13 @@ class ReceiveAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return ReceiveAssociationRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -361,15 +361,15 @@ class RespondAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: RespondAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RespondAssociationRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -433,13 +433,13 @@ class RespondAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RespondAssociationRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -504,15 +504,15 @@ class GetAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -576,13 +576,13 @@ class GetAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -647,15 +647,15 @@ class GetAssociationRequestsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetAssociationRequestsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestsMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -719,13 +719,13 @@ class GetAssociationRequestsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetAssociationRequestsResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -790,15 +790,15 @@ class DeleteAssociationRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteAssociationRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteAssociationRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -862,13 +862,13 @@ class DeleteAssociationRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteAssociationRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/dataset_messages.py
+++ b/src/syft/grid/messages/dataset_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -67,15 +68,15 @@ class CreateDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateDatasetMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -139,13 +140,13 @@ class CreateDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateDatasetResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +211,15 @@ class GetDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -282,13 +283,13 @@ class GetDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +354,15 @@ class GetDatasetsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetDatasetsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetsMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -425,13 +426,13 @@ class GetDatasetsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetsResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +497,15 @@ class UpdateDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateDatasetMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -568,13 +569,13 @@ class UpdateDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateDatasetResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +640,15 @@ class DeleteDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteDatasetMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -711,13 +712,13 @@ class DeleteDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteDatasetResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/dataset_messages.py
+++ b/src/syft/grid/messages/dataset_messages.py
@@ -67,15 +67,15 @@ class CreateDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateDatasetMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -139,13 +139,13 @@ class CreateDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateDatasetResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +210,15 @@ class GetDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -282,13 +282,13 @@ class GetDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +353,15 @@ class GetDatasetsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetDatasetsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetsMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -425,13 +425,13 @@ class GetDatasetsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetDatasetsResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +496,15 @@ class UpdateDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateDatasetMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -568,13 +568,13 @@ class UpdateDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateDatasetResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +639,15 @@ class DeleteDatasetMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteDatasetMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteDatasetMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -711,13 +711,13 @@ class DeleteDatasetResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteDatasetResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/group_messages.py
+++ b/src/syft/grid/messages/group_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -67,15 +68,15 @@ class CreateGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateGroupMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -139,13 +140,13 @@ class CreateGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateGroupResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +211,15 @@ class GetGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -282,13 +283,13 @@ class GetGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +354,15 @@ class GetGroupsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetGroupsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupsMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -425,13 +426,13 @@ class GetGroupsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupsResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +497,15 @@ class UpdateGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateGroupMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -568,13 +569,13 @@ class UpdateGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateGroupResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +640,15 @@ class DeleteGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteGroupMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -711,13 +712,13 @@ class DeleteGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteGroupResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/group_messages.py
+++ b/src/syft/grid/messages/group_messages.py
@@ -67,15 +67,15 @@ class CreateGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateGroupMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -139,13 +139,13 @@ class CreateGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateGroupResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +210,15 @@ class GetGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -282,13 +282,13 @@ class GetGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +353,15 @@ class GetGroupsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetGroupsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupsMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -425,13 +425,13 @@ class GetGroupsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetGroupsResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +496,15 @@ class UpdateGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateGroupMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -568,13 +568,13 @@ class UpdateGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateGroupResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +639,15 @@ class DeleteGroupMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteGroupMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteGroupMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -711,13 +711,13 @@ class DeleteGroupResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteGroupResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/infra_messages.py
+++ b/src/syft/grid/messages/infra_messages.py
@@ -73,15 +73,15 @@ class CreateWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateWorkerMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -145,13 +145,13 @@ class CreateWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateWorkerResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -216,15 +216,15 @@ class CheckWorkerDeploymentMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CheckWorkerDeploymentMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CheckWorkerDeploymentMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -288,13 +288,13 @@ class CheckWorkerDeploymentResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CheckWorkerDeploymentResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -359,15 +359,15 @@ class GetWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkerMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -431,13 +431,13 @@ class GetWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkerResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -502,15 +502,15 @@ class GetWorkersMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetWorkersMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkersMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -574,13 +574,13 @@ class GetWorkersResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkersResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -645,15 +645,15 @@ class UpdateWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateWorkerMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -717,13 +717,13 @@ class UpdateWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateWorkerResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -788,15 +788,15 @@ class DeleteWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteWorkerMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -860,13 +860,13 @@ class DeleteWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteWorkerResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/infra_messages.py
+++ b/src/syft/grid/messages/infra_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -73,15 +74,15 @@ class CreateWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateWorkerMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -145,13 +146,13 @@ class CreateWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateWorkerResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -216,15 +217,15 @@ class CheckWorkerDeploymentMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CheckWorkerDeploymentMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CheckWorkerDeploymentMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -288,13 +289,13 @@ class CheckWorkerDeploymentResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CheckWorkerDeploymentResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -359,15 +360,15 @@ class GetWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkerMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -431,13 +432,13 @@ class GetWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkerResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -502,15 +503,15 @@ class GetWorkersMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetWorkersMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkersMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -574,13 +575,13 @@ class GetWorkersResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetWorkersResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -645,15 +646,15 @@ class UpdateWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateWorkerMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -717,13 +718,13 @@ class UpdateWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateWorkerResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -788,15 +789,15 @@ class DeleteWorkerMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteWorkerMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteWorkerMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -860,13 +861,13 @@ class DeleteWorkerResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteWorkerResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/request_messages.py
+++ b/src/syft/grid/messages/request_messages.py
@@ -67,15 +67,15 @@ class CreateRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -139,13 +139,13 @@ class CreateRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +210,15 @@ class GetRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -282,13 +282,13 @@ class GetRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +353,15 @@ class GetRequestsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRequestsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestsMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -425,13 +425,13 @@ class GetRequestsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestsResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +496,15 @@ class UpdateRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -568,13 +568,13 @@ class UpdateRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +639,15 @@ class DeleteRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -711,13 +711,13 @@ class DeleteRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRequestResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/request_messages.py
+++ b/src/syft/grid/messages/request_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -67,15 +68,15 @@ class CreateRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -139,13 +140,13 @@ class CreateRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +211,15 @@ class GetRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -282,13 +283,13 @@ class GetRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +354,15 @@ class GetRequestsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRequestsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestsMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -425,13 +426,13 @@ class GetRequestsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRequestsResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +497,15 @@ class UpdateRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -568,13 +569,13 @@ class UpdateRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +640,15 @@ class DeleteRequestMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteRequestMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -711,13 +712,13 @@ class DeleteRequestResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRequestResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/role_messages.py
+++ b/src/syft/grid/messages/role_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -67,15 +68,15 @@ class CreateRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRoleMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -139,13 +140,13 @@ class CreateRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRoleResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +211,15 @@ class GetRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRoleMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -282,13 +283,13 @@ class GetRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRoleResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +354,15 @@ class GetRolesMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRolesMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRolesMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -425,13 +426,13 @@ class GetRolesResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRolesResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +497,15 @@ class UpdateRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRoleMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -568,13 +569,13 @@ class UpdateRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRoleResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +640,15 @@ class DeleteRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRoleMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -711,13 +712,13 @@ class DeleteRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRoleResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/role_messages.py
+++ b/src/syft/grid/messages/role_messages.py
@@ -67,15 +67,15 @@ class CreateRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRoleMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -139,13 +139,13 @@ class CreateRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateRoleResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +210,15 @@ class GetRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRoleMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -282,13 +282,13 @@ class GetRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRoleResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +353,15 @@ class GetRolesMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetRolesMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRolesMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -425,13 +425,13 @@ class GetRolesResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetRolesResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +496,15 @@ class UpdateRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRoleMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -568,13 +568,13 @@ class UpdateRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateRoleResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +639,15 @@ class DeleteRoleMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteRoleMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRoleMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -711,13 +711,13 @@ class DeleteRoleResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteRoleResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/setup_messages.py
+++ b/src/syft/grid/messages/setup_messages.py
@@ -49,15 +49,15 @@ class GetSetUpMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetSetUpMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetSetUpMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -121,13 +121,13 @@ class GetSetUpResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetSetUpResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -192,15 +192,15 @@ class CreateInitialSetUpMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateInitialSetUpMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateInitialSetUpMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -264,13 +264,13 @@ class CreateInitialSetUpResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateInitialSetUpResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/setup_messages.py
+++ b/src/syft/grid/messages/setup_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -49,15 +50,15 @@ class GetSetUpMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetSetUpMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetSetUpMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -121,13 +122,13 @@ class GetSetUpResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetSetUpResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -192,15 +193,15 @@ class CreateInitialSetUpMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateInitialSetUpMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateInitialSetUpMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -264,13 +265,13 @@ class CreateInitialSetUpResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateInitialSetUpResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/tensor_messages.py
+++ b/src/syft/grid/messages/tensor_messages.py
@@ -67,15 +67,15 @@ class CreateTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateTensorMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -139,13 +139,13 @@ class CreateTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateTensorResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +210,15 @@ class GetTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -282,13 +282,13 @@ class GetTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +353,15 @@ class GetTensorsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetTensorsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorsMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -425,13 +425,13 @@ class GetTensorsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorsResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +496,15 @@ class UpdateTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateTensorMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -568,13 +568,13 @@ class UpdateTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateTensorResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +639,15 @@ class DeleteTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteTensorMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -711,13 +711,13 @@ class DeleteTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteTensorResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/tensor_messages.py
+++ b/src/syft/grid/messages/tensor_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -67,15 +68,15 @@ class CreateTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateTensorMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -139,13 +140,13 @@ class CreateTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateTensorResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -210,15 +211,15 @@ class GetTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -282,13 +283,13 @@ class GetTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +354,15 @@ class GetTensorsMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetTensorsMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorsMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -425,13 +426,13 @@ class GetTensorsResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetTensorsResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -496,15 +497,15 @@ class UpdateTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateTensorMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -568,13 +569,13 @@ class UpdateTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateTensorResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -639,15 +640,15 @@ class DeleteTensorMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteTensorMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteTensorMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -711,13 +712,13 @@ class DeleteTensorResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteTensorResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/user_messages.py
+++ b/src/syft/grid/messages/user_messages.py
@@ -71,15 +71,15 @@ class CreateUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateUserMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -142,13 +142,13 @@ class CreateUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateUserResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -212,15 +212,15 @@ class GetUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUserMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -283,13 +283,13 @@ class GetUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUserResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +353,15 @@ class GetUsersMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetUsersMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUsersMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -424,13 +424,13 @@ class GetUsersResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUsersResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -494,15 +494,15 @@ class UpdateUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateUserMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -565,13 +565,13 @@ class UpdateUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateUserResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -635,15 +635,15 @@ class DeleteUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteUserMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -706,13 +706,13 @@ class DeleteUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteUserResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -776,15 +776,15 @@ class SearchUsersMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: SearchUsersMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SearchUsersMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             content=json.dumps(self.content),
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -847,13 +847,13 @@ class SearchUsersResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SearchUsersResponse_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/messages/user_messages.py
+++ b/src/syft/grid/messages/user_messages.py
@@ -8,6 +8,7 @@ from google.protobuf.reflection import GeneratedProtocolMessageType
 from typing_extensions import final
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import ImmediateSyftMessageWithReply
 from syft.core.common.message import ImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -71,15 +72,15 @@ class CreateUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: CreateUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateUserMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -142,13 +143,13 @@ class CreateUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CreateUserResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -212,15 +213,15 @@ class GetUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUserMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -283,13 +284,13 @@ class GetUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUserResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -353,15 +354,15 @@ class GetUsersMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: GetUsersMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUsersMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -424,13 +425,13 @@ class GetUsersResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return GetUsersResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -494,15 +495,15 @@ class UpdateUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: UpdateUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateUserMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -565,13 +566,13 @@ class UpdateUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return UpdateUserResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -635,15 +636,15 @@ class DeleteUserMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: DeleteUserMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteUserMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -706,13 +707,13 @@ class DeleteUserResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return DeleteUserResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )
@@ -776,15 +777,15 @@ class SearchUsersMessage(ImmediateSyftMessageWithReply):
         :return: returns a protobuf object
         :rtype: SearchUsersMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SearchUsersMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             content=json.dumps(self.content),
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -847,13 +848,13 @@ class SearchUsersResponse(ImmediateSyftMessageWithoutReply):
         :return: returns a protobuf object
         :rtype: SignalingOfferMessage_PB
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SearchUsersResponse_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             status_code=self.status_code,
             content=json.dumps(self.content),
         )

--- a/src/syft/grid/services/signaling_service.py
+++ b/src/syft/grid/services/signaling_service.py
@@ -78,16 +78,16 @@ class OfferPullRequestMessage(ImmediateSyftMessageWithReply):
         :rtype: OfferPullRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return OfferPullRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -161,16 +161,16 @@ class AnswerPullRequestMessage(ImmediateSyftMessageWithReply):
         :rtype: AnswerPullRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return AnswerPullRequestMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
-            reply_to=self.reply_to.serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -240,14 +240,14 @@ class RegisterNewPeerMessage(ImmediateSyftMessageWithReply):
         :rtype: AnswerPullRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RegisterNewPeerMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
-            reply_to=self.reply_to.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
+            reply_to=self.reply_to._sy_serialize(),
         )
 
     @staticmethod
@@ -316,13 +316,13 @@ class PeerSuccessfullyRegistered(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingOfferMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return PeerSuccessfullyRegistered_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             peer_id=self.peer_id,
         )
 
@@ -400,15 +400,15 @@ class SignalingOfferMessage(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingOfferMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SignalingOfferMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             payload=self.payload,
-            host_metadata=self.host_metadata.serialize(),
+            host_metadata=self.host_metadata._sy_serialize(),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
         )
@@ -488,16 +488,16 @@ class SignalingAnswerMessage(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingAnswerMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return SignalingAnswerMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
             payload=self.payload,
-            host_metadata=self.host_metadata.serialize(),
+            host_metadata=self.host_metadata._sy_serialize(),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
         )
@@ -568,13 +568,13 @@ class SignalingRequestsNotFound(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingRequestsNotFound_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SignalingRequestsNotFound_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
         )
 
     @staticmethod
@@ -641,13 +641,13 @@ class InvalidLoopBackRequest(ImmediateSyftMessageWithoutReply):
         :rtype: InvalidLoopBackRequest_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return InvalidLoopBackRequest_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
         )
 
     @staticmethod
@@ -713,13 +713,13 @@ class CloseConnectionMessage(ImmediateSyftMessageWithoutReply):
         :rtype: CloseConnectionMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object.serialize() or one of
+            This method is purely an internal method. Please use object._sy_serialize() or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CloseConnectionMessage_PB(
-            msg_id=self.id.serialize(),
-            address=self.address.serialize(),
+            msg_id=self.id._sy_serialize(),
+            address=self.address._sy_serialize(),
         )
 
     @staticmethod

--- a/src/syft/grid/services/signaling_service.py
+++ b/src/syft/grid/services/signaling_service.py
@@ -11,6 +11,7 @@ from nacl.signing import VerifyKey
 from typing_extensions import final
 
 # syft relative
+from ... import serialize
 from ...core.common.message import ImmediateSyftMessageWithReply
 from ...core.common.message import ImmediateSyftMessageWithoutReply
 from ...core.common.message import SyftMessage
@@ -78,16 +79,16 @@ class OfferPullRequestMessage(ImmediateSyftMessageWithReply):
         :rtype: OfferPullRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return OfferPullRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -161,16 +162,16 @@ class AnswerPullRequestMessage(ImmediateSyftMessageWithReply):
         :rtype: AnswerPullRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return AnswerPullRequestMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
-            reply_to=self.reply_to._sy_serialize(),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -240,14 +241,14 @@ class RegisterNewPeerMessage(ImmediateSyftMessageWithReply):
         :rtype: AnswerPullRequestMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return RegisterNewPeerMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
-            reply_to=self.reply_to._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
+            reply_to=serialize(self.reply_to),
         )
 
     @staticmethod
@@ -316,13 +317,13 @@ class PeerSuccessfullyRegistered(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingOfferMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return PeerSuccessfullyRegistered_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             peer_id=self.peer_id,
         )
 
@@ -400,15 +401,15 @@ class SignalingOfferMessage(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingOfferMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SignalingOfferMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             payload=self.payload,
-            host_metadata=self.host_metadata._sy_serialize(),
+            host_metadata=serialize(self.host_metadata),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
         )
@@ -488,16 +489,16 @@ class SignalingAnswerMessage(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingAnswerMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
 
         return SignalingAnswerMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
             payload=self.payload,
-            host_metadata=self.host_metadata._sy_serialize(),
+            host_metadata=serialize(self.host_metadata),
             target_peer=self.target_peer,
             host_peer=self.host_peer,
         )
@@ -568,13 +569,13 @@ class SignalingRequestsNotFound(ImmediateSyftMessageWithoutReply):
         :rtype: SignalingRequestsNotFound_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return SignalingRequestsNotFound_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
         )
 
     @staticmethod
@@ -641,13 +642,13 @@ class InvalidLoopBackRequest(ImmediateSyftMessageWithoutReply):
         :rtype: InvalidLoopBackRequest_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return InvalidLoopBackRequest_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
         )
 
     @staticmethod
@@ -713,13 +714,13 @@ class CloseConnectionMessage(ImmediateSyftMessageWithoutReply):
         :rtype: CloseConnectionMessage_PB
 
         .. note::
-            This method is purely an internal method. Please use object._sy_serialize() or one of
+            This method is purely an internal method. Please use serialize(object) or one of
             the other public serialization methods if you wish to serialize an
             object.
         """
         return CloseConnectionMessage_PB(
-            msg_id=self.id._sy_serialize(),
-            address=self.address._sy_serialize(),
+            msg_id=serialize(self.id),
+            address=serialize(self.address),
         )
 
     @staticmethod

--- a/src/syft/lib/python/bool.py
+++ b/src/syft/lib/python/bool.py
@@ -264,15 +264,3 @@ class Bool(int, PyPrimitive):
     @staticmethod
     def get_protobuf_schema() -> GeneratedProtocolMessageType:
         return Bool_PB
-
-    # method signature override
-    def to_bytes(
-        self,
-        length: Optional[int] = None,
-        byteorder: Optional[str] = None,
-        signed: Optional[bool] = True,
-    ) -> bytes:
-        if length is not None and byteorder is not None and signed is not None:
-            return int.to_bytes(self, length=length, byteorder=byteorder, signed=signed)
-        else:
-            return PyPrimitive.to_bytes(self)

--- a/src/syft/lib/python/int.py
+++ b/src/syft/lib/python/int.py
@@ -317,15 +317,3 @@ class Int(int, PyPrimitive):
     def conjugate(self) -> SyPrimitiveRet:
         res = super().conjugate()
         return PrimitiveFactory.generate_primitive(value=res)
-
-    # method signature override
-    def to_bytes(
-        self,
-        length: Optional[int] = None,
-        byteorder: Optional[str] = None,
-        signed: Optional[bool] = True,
-    ) -> bytes:
-        if length is not None and byteorder is not None and signed is not None:
-            return int.to_bytes(self, length=length, byteorder=byteorder, signed=signed)
-        else:
-            return PyPrimitive.to_bytes(self)

--- a/src/syft/lib/python/int.py
+++ b/src/syft/lib/python/int.py
@@ -297,6 +297,14 @@ class Int(int, PyPrimitive):
         res = super().denominator
         return PrimitiveFactory.generate_primitive(value=res)
 
+    def to_bytes(
+        self,
+        length: int,
+        byteorder: str,
+        signed: bool = False,
+    ) -> bytes:
+        return int.to_bytes(self, length=length, byteorder=byteorder, signed=signed)
+
     @staticmethod
     def from_bytes(bytes: Any, byteorder: str, *, signed: Any = True) -> SyPrimitiveRet:
         res = int.from_bytes(bytes, byteorder, signed=signed)

--- a/src/syft/lib/python/namedtuple.py
+++ b/src/syft/lib/python/namedtuple.py
@@ -49,7 +49,7 @@ ValuesIndices = namedtuple("ValuesIndices", all_attrs)  # type: ignore
 
 
 def object2proto(obj: object) -> ValuesIndices_PB:
-    obj_type = full_name_with_name(klass=obj.serializable_wrapper_type)  # type: ignore
+    obj_type = full_name_with_name(klass=obj._sy_serializable_wrapper_type)  # type: ignore
     keys = get_keys(klass_name=obj_type)
 
     values = []

--- a/tests/syft/core/common/message_test.py
+++ b/tests/syft/core/common/message_test.py
@@ -5,6 +5,7 @@ from nacl.signing import VerifyKey
 # syft absolute
 import syft as sy
 from syft import ReprMessage
+from syft import serialize
 from syft.core.common.message import SignedImmediateSyftMessageWithoutReply
 from syft.util import get_fully_qualified_name
 
@@ -71,7 +72,7 @@ def test_create_signed_message() -> None:
     assert len(sig_msg.signature) > 0
     assert sig_msg.verify_key == get_verify_key()
     assert sig_msg.message == msg
-    assert sig_msg.serialized_message == msg._sy_serialize(to_bytes=True)
+    assert sig_msg.serialized_message == serialize(msg, to_bytes=True)
 
 
 def test_deserialize_signed_message() -> None:
@@ -110,7 +111,7 @@ def test_serde_matches() -> None:
     assert type(sig_msg) == SignedImmediateSyftMessageWithoutReply
 
     # reserial should be same as original fixture
-    comp_blob = sig_msg._sy_serialize(to_bytes=True)
+    comp_blob = serialize(sig_msg, to_bytes=True)
     assert type(comp_blob) == bytes
     assert comp_blob == sig_msg_blob
 

--- a/tests/syft/core/common/message_test.py
+++ b/tests/syft/core/common/message_test.py
@@ -71,7 +71,7 @@ def test_create_signed_message() -> None:
     assert len(sig_msg.signature) > 0
     assert sig_msg.verify_key == get_verify_key()
     assert sig_msg.message == msg
-    assert sig_msg.serialized_message == msg.serialize(to_bytes=True)
+    assert sig_msg.serialized_message == msg._sy_serialize(to_bytes=True)
 
 
 def test_deserialize_signed_message() -> None:
@@ -110,7 +110,7 @@ def test_serde_matches() -> None:
     assert type(sig_msg) == SignedImmediateSyftMessageWithoutReply
 
     # reserial should be same as original fixture
-    comp_blob = sig_msg.serialize(to_bytes=True)
+    comp_blob = sig_msg._sy_serialize(to_bytes=True)
     assert type(comp_blob) == bytes
     assert comp_blob == sig_msg_blob
 

--- a/tests/syft/core/common/object_test.py
+++ b/tests/syft/core/common/object_test.py
@@ -90,9 +90,9 @@ def test_object_with_id_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = obj._sy_serialize(to_proto=True)
+    blob = sy.serialize(obj, to_proto=True)
 
-    assert obj._sy_serialize() == blob
+    assert sy.serialize(obj) == blob
 
 
 def test_object_with_id_default_deserialization() -> None:
@@ -101,7 +101,7 @@ def test_object_with_id_default_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = ObjectWithID.get_protobuf_schema()(id=uid._sy_serialize())
+    blob = ObjectWithID.get_protobuf_schema()(id=sy.serialize(uid))
 
     obj2 = sy.deserialize(blob=blob)
     assert obj == obj2
@@ -113,11 +113,11 @@ def test_object_with_id_proto_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = ObjectWithID.get_protobuf_schema()(id=uid._sy_serialize())
+    blob = ObjectWithID.get_protobuf_schema()(id=sy.serialize(uid))
 
-    assert obj._sy_serialize(to_proto=True) == blob
-    assert obj._sy_serialize(to_proto=True) == blob
-    assert obj._sy_serialize(to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
 
 
 def test_object_with_id_proto_deserialization() -> None:
@@ -126,7 +126,7 @@ def test_object_with_id_proto_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = ObjectWithID.get_protobuf_schema()(id=uid._sy_serialize())
+    blob = ObjectWithID.get_protobuf_schema()(id=sy.serialize(uid))
 
     obj2 = sy.deserialize(blob=blob, from_proto=True)
     assert obj == obj2
@@ -143,9 +143,9 @@ def test_object_with_id_binary_serialization() -> None:
         + b"g[\xb7LI\xbe\xce\xe7\x00\xab\n\x15\x14"
     )
 
-    assert obj._sy_serialize(to_bytes=True) == blob
-    assert obj._sy_serialize(to_bytes=True) == blob
-    assert obj._sy_serialize(to_bytes=True) == blob
+    assert sy.serialize(obj, to_bytes=True) == blob
+    assert sy.serialize(obj, to_bytes=True) == blob
+    assert sy.serialize(obj, to_bytes=True) == blob
 
 
 def test_object_with_id_binary_deserialization() -> None:

--- a/tests/syft/core/common/object_test.py
+++ b/tests/syft/core/common/object_test.py
@@ -90,9 +90,9 @@ def test_object_with_id_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = obj.to_proto()
+    blob = obj._sy_to_proto()
 
-    assert obj.serialize() == blob
+    assert obj._sy_serialize() == blob
 
 
 def test_object_with_id_default_deserialization() -> None:
@@ -101,7 +101,7 @@ def test_object_with_id_default_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = ObjectWithID.get_protobuf_schema()(id=uid.serialize())
+    blob = ObjectWithID.get_protobuf_schema()(id=uid._sy_serialize())
 
     obj2 = sy.deserialize(blob=blob)
     assert obj == obj2
@@ -113,11 +113,11 @@ def test_object_with_id_proto_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = ObjectWithID.get_protobuf_schema()(id=uid.serialize())
+    blob = ObjectWithID.get_protobuf_schema()(id=uid._sy_serialize())
 
-    assert obj.proto() == blob
-    assert obj.to_proto() == blob
-    assert obj.serialize(to_proto=True) == blob
+    assert obj._sy_proto() == blob
+    assert obj._sy_to_proto() == blob
+    assert obj._sy_serialize(to_proto=True) == blob
 
 
 def test_object_with_id_proto_deserialization() -> None:
@@ -126,7 +126,7 @@ def test_object_with_id_proto_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = ObjectWithID.get_protobuf_schema()(id=uid.serialize())
+    blob = ObjectWithID.get_protobuf_schema()(id=uid._sy_serialize())
 
     obj2 = sy.deserialize(blob=blob, from_proto=True)
     assert obj == obj2
@@ -144,8 +144,8 @@ def test_object_with_id_binary_serialization() -> None:
     )
 
     assert obj.binary() == blob
-    assert obj.to_bytes() == blob
-    assert obj.serialize(to_bytes=True) == blob
+    assert obj._sy_to_bytes() == blob
+    assert obj._sy_serialize(to_bytes=True) == blob
 
 
 def test_object_with_id_binary_deserialization() -> None:

--- a/tests/syft/core/common/object_test.py
+++ b/tests/syft/core/common/object_test.py
@@ -90,7 +90,7 @@ def test_object_with_id_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = ObjectWithID(id=uid)
 
-    blob = obj._sy_to_proto()
+    blob = obj._sy_serialize(to_proto=True)
 
     assert obj._sy_serialize() == blob
 
@@ -115,8 +115,8 @@ def test_object_with_id_proto_serialization() -> None:
 
     blob = ObjectWithID.get_protobuf_schema()(id=uid._sy_serialize())
 
-    assert obj._sy_proto() == blob
-    assert obj._sy_to_proto() == blob
+    assert obj._sy_serialize(to_proto=True) == blob
+    assert obj._sy_serialize(to_proto=True) == blob
     assert obj._sy_serialize(to_proto=True) == blob
 
 
@@ -143,8 +143,8 @@ def test_object_with_id_binary_serialization() -> None:
         + b"g[\xb7LI\xbe\xce\xe7\x00\xab\n\x15\x14"
     )
 
-    assert obj.binary() == blob
-    assert obj._sy_to_bytes() == blob
+    assert obj._sy_serialize(to_bytes=True) == blob
+    assert obj._sy_serialize(to_bytes=True) == blob
     assert obj._sy_serialize(to_bytes=True) == blob
 
 

--- a/tests/syft/core/common/serializable_test.py
+++ b/tests/syft/core/common/serializable_test.py
@@ -12,7 +12,7 @@ from syft.core.common.serde.serialize import _serialize
 
 def test_object_with_no_serialize_wrapper() -> None:
     """
-    Test if an object that is Serializable but does not implement the serializable_wrapper_type
+    Test if an object that is Serializable but does not implement the _sy_serializable_wrapper_type
     throws an exception when trying to serialize.
     """
 

--- a/tests/syft/core/common/uid_test.py
+++ b/tests/syft/core/common/uid_test.py
@@ -130,8 +130,8 @@ def test_uid_proto_serialization() -> None:
 
     blob = _serialize(obj=uid)
 
-    assert uid._sy_proto() == blob
-    assert uid._sy_to_proto() == blob
+    assert uid._sy_serialize(to_proto=True) == blob
+    assert uid._sy_serialize(to_proto=True) == blob
     assert uid._sy_serialize(to_proto=True) == blob
 
 
@@ -154,8 +154,8 @@ def test_uid_binary_serialization() -> None:
         + b"g[\xb7LI\xbe\xce\xe7\x00\xab\n\x15\x14"
     )
 
-    assert uid.binary() == blob
-    assert uid._sy_to_bytes() == blob
+    assert uid._sy_serialize(to_bytes=True) == blob
+    assert uid._sy_serialize(to_bytes=True) == blob
     assert uid._sy_serialize(to_bytes=True) == blob
 
 

--- a/tests/syft/core/common/uid_test.py
+++ b/tests/syft/core/common/uid_test.py
@@ -111,7 +111,7 @@ def test_uid_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     blob = _serialize(obj=uid)
     _ = _deserialize(blob=blob)
-    assert uid.serialize() == blob
+    assert uid._sy_serialize() == blob
 
 
 def test_uid_default_deserialization() -> None:
@@ -130,9 +130,9 @@ def test_uid_proto_serialization() -> None:
 
     blob = _serialize(obj=uid)
 
-    assert uid.proto() == blob
-    assert uid.to_proto() == blob
-    assert uid.serialize(to_proto=True) == blob
+    assert uid._sy_proto() == blob
+    assert uid._sy_to_proto() == blob
+    assert uid._sy_serialize(to_proto=True) == blob
 
 
 def test_uid_proto_deserialization() -> None:
@@ -155,8 +155,8 @@ def test_uid_binary_serialization() -> None:
     )
 
     assert uid.binary() == blob
-    assert uid.to_bytes() == blob
-    assert uid.serialize(to_bytes=True) == blob
+    assert uid._sy_to_bytes() == blob
+    assert uid._sy_serialize(to_bytes=True) == blob
 
 
 def test_uid_binary_deserialization() -> None:

--- a/tests/syft/core/common/uid_test.py
+++ b/tests/syft/core/common/uid_test.py
@@ -111,7 +111,7 @@ def test_uid_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     blob = _serialize(obj=uid)
     _ = _deserialize(blob=blob)
-    assert uid._sy_serialize() == blob
+    assert sy.serialize(uid) == blob
 
 
 def test_uid_default_deserialization() -> None:
@@ -130,9 +130,9 @@ def test_uid_proto_serialization() -> None:
 
     blob = _serialize(obj=uid)
 
-    assert uid._sy_serialize(to_proto=True) == blob
-    assert uid._sy_serialize(to_proto=True) == blob
-    assert uid._sy_serialize(to_proto=True) == blob
+    assert sy.serialize(uid, to_proto=True) == blob
+    assert sy.serialize(uid, to_proto=True) == blob
+    assert sy.serialize(uid, to_proto=True) == blob
 
 
 def test_uid_proto_deserialization() -> None:
@@ -154,9 +154,9 @@ def test_uid_binary_serialization() -> None:
         + b"g[\xb7LI\xbe\xce\xe7\x00\xab\n\x15\x14"
     )
 
-    assert uid._sy_serialize(to_bytes=True) == blob
-    assert uid._sy_serialize(to_bytes=True) == blob
-    assert uid._sy_serialize(to_bytes=True) == blob
+    assert sy.serialize(uid, to_bytes=True) == blob
+    assert sy.serialize(uid, to_bytes=True) == blob
+    assert sy.serialize(uid, to_bytes=True) == blob
 
 
 def test_uid_binary_deserialization() -> None:

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -372,9 +372,9 @@ def test_default_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj.to_proto()
+    blob = obj._sy_to_proto()
 
-    assert obj.serialize() == blob
+    assert obj._sy_serialize() == blob
     assert obj == sy.deserialize(blob=blob)
 
 
@@ -389,7 +389,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    assert obj == sy.deserialize(blob=obj.serialize())
+    assert obj == sy.deserialize(blob=obj._sy_serialize())
 
     obj = Address(
         network=SpecificLocation(id=an_id),
@@ -398,7 +398,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj.to_proto()
+    blob = obj._sy_to_proto()
     assert obj == sy.deserialize(blob=blob)
 
     obj = Address(
@@ -408,7 +408,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj.to_proto()
+    blob = obj._sy_to_proto()
     assert obj == sy.deserialize(blob=blob)
 
     obj = Address(
@@ -418,7 +418,7 @@ def test_partial_serialization_and_deserialization() -> None:
         # vm=SpecificLocation(id=an_id)
     )
 
-    blob = obj.to_proto()
+    blob = obj._sy_to_proto()
     assert obj == sy.deserialize(blob=blob)
 
 
@@ -441,15 +441,15 @@ def test_proto_serialization() -> None:
         has_domain=True,
         has_device=True,
         has_vm=True,
-        network=loc.serialize(),
-        domain=loc.serialize(),
-        device=loc.serialize(),
-        vm=loc.serialize(),
+        network=loc._sy_serialize(),
+        domain=loc._sy_serialize(),
+        device=loc._sy_serialize(),
+        vm=loc._sy_serialize(),
     )
 
-    assert obj.proto() == blob
-    assert obj.to_proto() == blob
-    assert obj.serialize(to_proto=True) == blob
+    assert obj._sy_proto() == blob
+    assert obj._sy_to_proto() == blob
+    assert obj._sy_serialize(to_proto=True) == blob
 
 
 def test_proto_deserialization() -> None:
@@ -470,10 +470,10 @@ def test_proto_deserialization() -> None:
         has_domain=True,
         has_device=True,
         has_vm=True,
-        network=loc.serialize(),
-        domain=loc.serialize(),
-        device=loc.serialize(),
-        vm=loc.serialize(),
+        network=loc._sy_serialize(),
+        domain=loc._sy_serialize(),
+        device=loc._sy_serialize(),
+        vm=loc._sy_serialize(),
     )
 
     obj2 = sy.deserialize(blob=blob, from_proto=True)

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -372,7 +372,7 @@ def test_default_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj._sy_to_proto()
+    blob = obj._sy_serialize(to_proto=True)
 
     assert obj._sy_serialize() == blob
     assert obj == sy.deserialize(blob=blob)
@@ -398,7 +398,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj._sy_to_proto()
+    blob = obj._sy_serialize(to_proto=True)
     assert obj == sy.deserialize(blob=blob)
 
     obj = Address(
@@ -408,7 +408,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj._sy_to_proto()
+    blob = obj._sy_serialize(to_proto=True)
     assert obj == sy.deserialize(blob=blob)
 
     obj = Address(
@@ -418,7 +418,7 @@ def test_partial_serialization_and_deserialization() -> None:
         # vm=SpecificLocation(id=an_id)
     )
 
-    blob = obj._sy_to_proto()
+    blob = obj._sy_serialize(to_proto=True)
     assert obj == sy.deserialize(blob=blob)
 
 
@@ -447,8 +447,8 @@ def test_proto_serialization() -> None:
         vm=loc._sy_serialize(),
     )
 
-    assert obj._sy_proto() == blob
-    assert obj._sy_to_proto() == blob
+    assert obj._sy_serialize(to_proto=True) == blob
+    assert obj._sy_serialize(to_proto=True) == blob
     assert obj._sy_serialize(to_proto=True) == blob
 
 

--- a/tests/syft/core/io/address_test.py
+++ b/tests/syft/core/io/address_test.py
@@ -372,9 +372,9 @@ def test_default_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj._sy_serialize(to_proto=True)
+    blob = sy.serialize(obj, to_proto=True)
 
-    assert obj._sy_serialize() == blob
+    assert sy.serialize(obj) == blob
     assert obj == sy.deserialize(blob=blob)
 
 
@@ -389,7 +389,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    assert obj == sy.deserialize(blob=obj._sy_serialize())
+    assert obj == sy.deserialize(blob=sy.serialize(obj))
 
     obj = Address(
         network=SpecificLocation(id=an_id),
@@ -398,7 +398,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj._sy_serialize(to_proto=True)
+    blob = sy.serialize(obj, to_proto=True)
     assert obj == sy.deserialize(blob=blob)
 
     obj = Address(
@@ -408,7 +408,7 @@ def test_partial_serialization_and_deserialization() -> None:
         vm=SpecificLocation(id=an_id),
     )
 
-    blob = obj._sy_serialize(to_proto=True)
+    blob = sy.serialize(obj, to_proto=True)
     assert obj == sy.deserialize(blob=blob)
 
     obj = Address(
@@ -418,7 +418,7 @@ def test_partial_serialization_and_deserialization() -> None:
         # vm=SpecificLocation(id=an_id)
     )
 
-    blob = obj._sy_serialize(to_proto=True)
+    blob = sy.serialize(obj, to_proto=True)
     assert obj == sy.deserialize(blob=blob)
 
 
@@ -441,15 +441,15 @@ def test_proto_serialization() -> None:
         has_domain=True,
         has_device=True,
         has_vm=True,
-        network=loc._sy_serialize(),
-        domain=loc._sy_serialize(),
-        device=loc._sy_serialize(),
-        vm=loc._sy_serialize(),
+        network=sy.serialize(loc),
+        domain=sy.serialize(loc),
+        device=sy.serialize(loc),
+        vm=sy.serialize(loc),
     )
 
-    assert obj._sy_serialize(to_proto=True) == blob
-    assert obj._sy_serialize(to_proto=True) == blob
-    assert obj._sy_serialize(to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
 
 
 def test_proto_deserialization() -> None:
@@ -470,10 +470,10 @@ def test_proto_deserialization() -> None:
         has_domain=True,
         has_device=True,
         has_vm=True,
-        network=loc._sy_serialize(),
-        domain=loc._sy_serialize(),
-        device=loc._sy_serialize(),
-        vm=loc._sy_serialize(),
+        network=sy.serialize(loc),
+        domain=sy.serialize(loc),
+        device=sy.serialize(loc),
+        vm=sy.serialize(loc),
     )
 
     obj2 = sy.deserialize(blob=blob, from_proto=True)

--- a/tests/syft/core/io/location/specific_test.py
+++ b/tests/syft/core/io/location/specific_test.py
@@ -86,9 +86,9 @@ def test_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid, name="Test")
 
-    blob = obj.to_proto()
+    blob = obj._sy_to_proto()
 
-    assert obj.serialize() == blob
+    assert obj._sy_serialize() == blob
 
 
 def test_default_deserialization() -> None:
@@ -97,7 +97,7 @@ def test_default_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid, name="Test")
 
-    blob = SpecificLocation.get_protobuf_schema()(id=uid.serialize())
+    blob = SpecificLocation.get_protobuf_schema()(id=uid._sy_serialize())
 
     obj2 = sy.deserialize(blob=blob)
     assert obj == obj2
@@ -109,11 +109,11 @@ def test_proto_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid, name="Test")
 
-    blob = SpecificLocation.get_protobuf_schema()(id=uid.serialize(), name="Test")
+    blob = SpecificLocation.get_protobuf_schema()(id=uid._sy_serialize(), name="Test")
 
-    assert obj.proto() == blob
-    assert obj.to_proto() == blob
-    assert obj.serialize(to_proto=True) == blob
+    assert obj._sy_proto() == blob
+    assert obj._sy_to_proto() == blob
+    assert obj._sy_serialize(to_proto=True) == blob
 
 
 def test_proto_deserialization() -> None:
@@ -122,7 +122,7 @@ def test_proto_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid)
 
-    blob = SpecificLocation.get_protobuf_schema()(id=uid.serialize())
+    blob = SpecificLocation.get_protobuf_schema()(id=uid._sy_serialize())
 
     obj2 = sy.deserialize(blob=blob, from_proto=True)
     assert obj == obj2
@@ -140,8 +140,8 @@ def test_binary_serialization() -> None:
     )
 
     assert obj.binary() == blob
-    assert obj.to_bytes() == blob
-    assert obj.serialize(to_bytes=True) == blob
+    assert obj._sy_to_bytes() == blob
+    assert obj._sy_serialize(to_bytes=True) == blob
 
 
 def test_binary_deserialization() -> None:

--- a/tests/syft/core/io/location/specific_test.py
+++ b/tests/syft/core/io/location/specific_test.py
@@ -86,9 +86,9 @@ def test_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid, name="Test")
 
-    blob = obj._sy_serialize(to_proto=True)
+    blob = sy.serialize(obj, to_proto=True)
 
-    assert obj._sy_serialize() == blob
+    assert sy.serialize(obj) == blob
 
 
 def test_default_deserialization() -> None:
@@ -97,7 +97,7 @@ def test_default_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid, name="Test")
 
-    blob = SpecificLocation.get_protobuf_schema()(id=uid._sy_serialize())
+    blob = SpecificLocation.get_protobuf_schema()(id=sy.serialize(uid))
 
     obj2 = sy.deserialize(blob=blob)
     assert obj == obj2
@@ -109,11 +109,11 @@ def test_proto_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid, name="Test")
 
-    blob = SpecificLocation.get_protobuf_schema()(id=uid._sy_serialize(), name="Test")
+    blob = SpecificLocation.get_protobuf_schema()(id=sy.serialize(uid), name="Test")
 
-    assert obj._sy_serialize(to_proto=True) == blob
-    assert obj._sy_serialize(to_proto=True) == blob
-    assert obj._sy_serialize(to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
+    assert sy.serialize(obj, to_proto=True) == blob
 
 
 def test_proto_deserialization() -> None:
@@ -122,7 +122,7 @@ def test_proto_deserialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid)
 
-    blob = SpecificLocation.get_protobuf_schema()(id=uid._sy_serialize())
+    blob = SpecificLocation.get_protobuf_schema()(id=sy.serialize(uid))
 
     obj2 = sy.deserialize(blob=blob, from_proto=True)
     assert obj == obj2
@@ -139,9 +139,9 @@ def test_binary_serialization() -> None:
         + b"\xfb\x1b\xb0g[\xb7LI\xbe\xce\xe7\x00\xab\n\x15\x14\x12\x04Test"
     )
 
-    assert obj._sy_serialize(to_bytes=True) == blob
-    assert obj._sy_serialize(to_bytes=True) == blob
-    assert obj._sy_serialize(to_bytes=True) == blob
+    assert sy.serialize(obj, to_bytes=True) == blob
+    assert sy.serialize(obj, to_bytes=True) == blob
+    assert sy.serialize(obj, to_bytes=True) == blob
 
 
 def test_binary_deserialization() -> None:

--- a/tests/syft/core/io/location/specific_test.py
+++ b/tests/syft/core/io/location/specific_test.py
@@ -86,7 +86,7 @@ def test_default_serialization() -> None:
     uid = UID(value=uuid.UUID(int=333779996850170035686993356951732753684))
     obj = SpecificLocation(id=uid, name="Test")
 
-    blob = obj._sy_to_proto()
+    blob = obj._sy_serialize(to_proto=True)
 
     assert obj._sy_serialize() == blob
 
@@ -111,8 +111,8 @@ def test_proto_serialization() -> None:
 
     blob = SpecificLocation.get_protobuf_schema()(id=uid._sy_serialize(), name="Test")
 
-    assert obj._sy_proto() == blob
-    assert obj._sy_to_proto() == blob
+    assert obj._sy_serialize(to_proto=True) == blob
+    assert obj._sy_serialize(to_proto=True) == blob
     assert obj._sy_serialize(to_proto=True) == blob
 
 
@@ -139,8 +139,8 @@ def test_binary_serialization() -> None:
         + b"\xfb\x1b\xb0g[\xb7LI\xbe\xce\xe7\x00\xab\n\x15\x14\x12\x04Test"
     )
 
-    assert obj.binary() == blob
-    assert obj._sy_to_bytes() == blob
+    assert obj._sy_serialize(to_bytes=True) == blob
+    assert obj._sy_serialize(to_bytes=True) == blob
     assert obj._sy_serialize(to_bytes=True) == blob
 
 

--- a/tests/syft/core/node/client_test.py
+++ b/tests/syft/core/node/client_test.py
@@ -13,7 +13,7 @@ async def test_client_from_metadata() -> None:
     client_metadata = domain.get_metadata_for_client()
 
     spec_location, name, id = sy.DomainClient.deserialize_client_metadata_from_node(
-        metadata=client_metadata.serialize()
+        metadata=client_metadata._sy_serialize()
     )
 
     assert domain.domain == spec_location

--- a/tests/syft/core/node/client_test.py
+++ b/tests/syft/core/node/client_test.py
@@ -3,6 +3,7 @@ import pytest
 
 # syft absolute
 import syft as sy
+from syft import serialize
 
 
 @pytest.mark.asyncio
@@ -13,7 +14,7 @@ async def test_client_from_metadata() -> None:
     client_metadata = domain.get_metadata_for_client()
 
     spec_location, name, id = sy.DomainClient.deserialize_client_metadata_from_node(
-        metadata=client_metadata._sy_serialize()
+        metadata=serialize(client_metadata)
     )
 
     assert domain.domain == spec_location

--- a/tests/syft/core/node/common/action/function_or_constructor_action_test.py
+++ b/tests/syft/core/node/common/action/function_or_constructor_action_test.py
@@ -29,7 +29,7 @@ def test_run_function_or_constructor_action_serde() -> None:
         msg_id=UID(),
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
 
     msg2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/core/node/common/action/function_or_constructor_action_test.py
+++ b/tests/syft/core/node/common/action/function_or_constructor_action_test.py
@@ -29,7 +29,7 @@ def test_run_function_or_constructor_action_serde() -> None:
         msg_id=UID(),
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
 
     msg2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/core/node/common/action/garbage_collection_object_action_test.py
+++ b/tests/syft/core/node/common/action/garbage_collection_object_action_test.py
@@ -14,7 +14,7 @@ def test_garbage_collection_object_action_serde() -> None:
 
     msg = GarbageCollectObjectAction(id_at_location=uid, address=addr)
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
 
     msg2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/core/node/common/action/garbage_collection_object_action_test.py
+++ b/tests/syft/core/node/common/action/garbage_collection_object_action_test.py
@@ -1,5 +1,6 @@
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.common.uid import UID
 from syft.core.io.address import Address
 from syft.core.io.location import SpecificLocation
@@ -14,7 +15,7 @@ def test_garbage_collection_object_action_serde() -> None:
 
     msg = GarbageCollectObjectAction(id_at_location=uid, address=addr)
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
 
     msg2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/core/node/common/action/get_object_action_test.py
+++ b/tests/syft/core/node/common/action/get_object_action_test.py
@@ -1,5 +1,6 @@
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.common.uid import UID
 from syft.core.io.address import Address
 from syft.core.node.common.action.get_object_action import GetObjectAction
@@ -9,7 +10,7 @@ def test_get_object_action_serde() -> None:
     msg = GetObjectAction(
         id_at_location=UID(), address=Address(), reply_to=Address(), msg_id=UID()
     )
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/core/node/common/action/get_object_action_test.py
+++ b/tests/syft/core/node/common/action/get_object_action_test.py
@@ -9,7 +9,7 @@ def test_get_object_action_serde() -> None:
     msg = GetObjectAction(
         id_at_location=UID(), address=Address(), reply_to=Address(), msg_id=UID()
     )
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/core/node/common/action/save_object_action_test.py
+++ b/tests/syft/core/node/common/action/save_object_action_test.py
@@ -3,6 +3,7 @@ import torch as th
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.common.uid import UID
 from syft.core.io.address import Address
 from syft.core.io.location import SpecificLocation
@@ -17,7 +18,7 @@ def test_save_object_action_serde() -> None:
     storable = StorableObject(id=UID(), data=obj)
     msg = SaveObjectAction(obj=storable, address=addr)
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
 
     msg2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/core/node/common/action/save_object_action_test.py
+++ b/tests/syft/core/node/common/action/save_object_action_test.py
@@ -17,7 +17,7 @@ def test_save_object_action_serde() -> None:
     storable = StorableObject(id=UID(), data=obj)
     msg = SaveObjectAction(obj=storable, address=addr)
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
 
     msg2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/core/node/common/service/child_node_lifecycle_service_test.py
+++ b/tests/syft/core/node/common/service/child_node_lifecycle_service_test.py
@@ -24,7 +24,7 @@ def test_child_node_lifecycle_message_serde() -> None:
         address=bob_phone_client.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/core/node/common/service/child_node_lifecycle_service_test.py
+++ b/tests/syft/core/node/common/service/child_node_lifecycle_service_test.py
@@ -3,6 +3,7 @@ import pytest
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.node.common.service.child_node_lifecycle_service import (
     RegisterChildNodeMessage,
 )
@@ -24,7 +25,7 @@ def test_child_node_lifecycle_message_serde() -> None:
         address=bob_phone_client.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/core/node/common/service/obj_search_permission_service_test.py
+++ b/tests/syft/core/node/common/service/obj_search_permission_service_test.py
@@ -24,7 +24,7 @@ def test_object_search_permissons_update_message_serde() -> None:
         address=bob_phone_client.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/core/node/common/service/obj_search_permission_service_test.py
+++ b/tests/syft/core/node/common/service/obj_search_permission_service_test.py
@@ -24,7 +24,7 @@ def test_object_search_permissons_update_message_serde() -> None:
         address=bob_phone_client.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/core/store/dataset_object_test.py
+++ b/tests/syft/core/store/dataset_object_test.py
@@ -255,7 +255,7 @@ def test_serde_storable_obj_2() -> None:
     tags = ["dummy", "dataset"]
     obj = Dataset(id=id, data=data, description=description, tags=tags)
 
-    blob = obj.serialize()
+    blob = obj._sy_serialize()
     ds_obj = sy.deserialize(blob=blob)
 
     assert obj.id == ds_obj.id

--- a/tests/syft/core/store/dataset_object_test.py
+++ b/tests/syft/core/store/dataset_object_test.py
@@ -3,6 +3,7 @@ import torch as th
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.common import UID
 from syft.core.store.dataset import Dataset
 from syft.core.store.storeable_object import StorableObject
@@ -255,7 +256,7 @@ def test_serde_storable_obj_2() -> None:
     tags = ["dummy", "dataset"]
     obj = Dataset(id=id, data=data, description=description, tags=tags)
 
-    blob = obj._sy_serialize()
+    blob = serialize(obj)
     ds_obj = sy.deserialize(blob=blob)
 
     assert obj.id == ds_obj.id

--- a/tests/syft/core/store/storable_object_test.py
+++ b/tests/syft/core/store/storable_object_test.py
@@ -3,6 +3,7 @@ import torch as th
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.common import UID
 from syft.core.store.storeable_object import StorableObject
 
@@ -33,7 +34,7 @@ def test_serde_storable_obj_2() -> None:
     description = "This is a dummy test"
     tags = ["dummy", "test"]
     obj = StorableObject(id=id, data=data, description=description, tags=tags)
-    blob = obj._sy_serialize()
+    blob = serialize(obj)
     ds_obj = sy.deserialize(blob=blob)
     assert obj.id == ds_obj.id
     assert (obj.data == ds_obj.data).all()

--- a/tests/syft/core/store/storable_object_test.py
+++ b/tests/syft/core/store/storable_object_test.py
@@ -33,7 +33,7 @@ def test_serde_storable_obj_2() -> None:
     description = "This is a dummy test"
     tags = ["dummy", "test"]
     obj = StorableObject(id=id, data=data, description=description, tags=tags)
-    blob = obj.serialize()
+    blob = obj._sy_serialize()
     ds_obj = sy.deserialize(blob=blob)
     assert obj.id == ds_obj.id
     assert (obj.data == ds_obj.data).all()

--- a/tests/syft/grid/connections/webrtc_test.py
+++ b/tests/syft/grid/connections/webrtc_test.py
@@ -290,6 +290,6 @@ async def test_consumer_request() -> None:
     test_domain.root_verify_key = signing_key.verify_key
     signed_msg = msg.sign(signing_key=signing_key)
 
-    msg_bin = signed_msg._sy_to_bytes()
+    msg_bin = signed_msg._sy_serialize(to_bytes=True)
 
     await webrtc_node.consumer(msg=msg_bin)

--- a/tests/syft/grid/connections/webrtc_test.py
+++ b/tests/syft/grid/connections/webrtc_test.py
@@ -15,6 +15,7 @@ import pytest
 from pytest import MonkeyPatch
 
 # syft absolute
+from syft import serialize
 from syft.core.node.common.service.repr_service import ReprMessage
 from syft.core.node.domain.domain import Domain
 from syft.grid.connections.webrtc import DC_CHUNK_START_SIGN
@@ -290,6 +291,6 @@ async def test_consumer_request() -> None:
     test_domain.root_verify_key = signing_key.verify_key
     signed_msg = msg.sign(signing_key=signing_key)
 
-    msg_bin = signed_msg._sy_serialize(to_bytes=True)
+    msg_bin = serialize(signed_msg, to_bytes=True)
 
     await webrtc_node.consumer(msg=msg_bin)

--- a/tests/syft/grid/connections/webrtc_test.py
+++ b/tests/syft/grid/connections/webrtc_test.py
@@ -290,6 +290,6 @@ async def test_consumer_request() -> None:
     test_domain.root_verify_key = signing_key.verify_key
     signed_msg = msg.sign(signing_key=signing_key)
 
-    msg_bin = signed_msg.to_bytes()
+    msg_bin = signed_msg._sy_to_bytes()
 
     await webrtc_node.consumer(msg=msg_bin)

--- a/tests/syft/grid/duet/signaling_server_test.py
+++ b/tests/syft/grid/duet/signaling_server_test.py
@@ -8,6 +8,7 @@ from flask import Flask
 from flask import Response
 
 # syft absolute
+from syft import serialize
 from syft.core.common.message import SignedImmediateSyftMessageWithReply
 from syft.core.common.message import SignedImmediateSyftMessageWithoutReply
 from syft.core.common.serde.deserialize import _deserialize
@@ -31,7 +32,7 @@ network._register_services()  # re-register all services including SignalingServ
 @app.route("/metadata")
 def metadata() -> flask.Response:
     metadata = network.get_metadata_for_client()
-    metadata_proto = metadata._sy_serialize()
+    metadata_proto = serialize(metadata)
     r = Response(
         response=metadata_proto.SerializeToString(),
         status=200,
@@ -46,7 +47,7 @@ def post() -> flask.Response:
     obj_msg = _deserialize(blob=data, from_bytes=True)
     if isinstance(obj_msg, SignedImmediateSyftMessageWithReply):
         reply = network.recv_immediate_msg_with_reply(msg=obj_msg)
-        r = Response(response=reply._sy_serialize(to_bytes=True), status=200)
+        r = Response(response=serialize(reply, to_bytes=True), status=200)
         r.headers["Content-Type"] = "application/octet-stream"
         return r
     elif isinstance(obj_msg, SignedImmediateSyftMessageWithoutReply):

--- a/tests/syft/grid/duet/signaling_server_test.py
+++ b/tests/syft/grid/duet/signaling_server_test.py
@@ -31,7 +31,7 @@ network._register_services()  # re-register all services including SignalingServ
 @app.route("/metadata")
 def metadata() -> flask.Response:
     metadata = network.get_metadata_for_client()
-    metadata_proto = metadata.serialize()
+    metadata_proto = metadata._sy_serialize()
     r = Response(
         response=metadata_proto.SerializeToString(),
         status=200,
@@ -46,7 +46,7 @@ def post() -> flask.Response:
     obj_msg = _deserialize(blob=data, from_bytes=True)
     if isinstance(obj_msg, SignedImmediateSyftMessageWithReply):
         reply = network.recv_immediate_msg_with_reply(msg=obj_msg)
-        r = Response(response=reply.serialize(to_bytes=True), status=200)
+        r = Response(response=reply._sy_serialize(to_bytes=True), status=200)
         r.headers["Content-Type"] = "application/octet-stream"
         return r
     elif isinstance(obj_msg, SignedImmediateSyftMessageWithoutReply):

--- a/tests/syft/grid/messages/asc_req_msg_test.py
+++ b/tests/syft/grid/messages/asc_req_msg_test.py
@@ -30,7 +30,7 @@ def test_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -49,7 +49,7 @@ def test_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -69,7 +69,7 @@ def test_receive_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -88,7 +88,7 @@ def test_receive_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -108,7 +108,7 @@ def test_respond_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -127,7 +127,7 @@ def test_respond_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -147,7 +147,7 @@ def test_delete_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -166,7 +166,7 @@ def test_delete_association_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -186,7 +186,7 @@ def test_get_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -210,7 +210,7 @@ def test_get_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -230,7 +230,7 @@ def test_get_all_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -270,7 +270,7 @@ def test_get_all_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/asc_req_msg_test.py
+++ b/tests/syft/grid/messages/asc_req_msg_test.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.io.address import Address
 from syft.grid.messages.association_messages import DeleteAssociationRequestMessage
 from syft.grid.messages.association_messages import DeleteAssociationRequestResponse
@@ -30,7 +31,7 @@ def test_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -49,7 +50,7 @@ def test_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -69,7 +70,7 @@ def test_receive_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -88,7 +89,7 @@ def test_receive_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -108,7 +109,7 @@ def test_respond_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -127,7 +128,7 @@ def test_respond_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -147,7 +148,7 @@ def test_delete_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -166,7 +167,7 @@ def test_delete_association_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -186,7 +187,7 @@ def test_get_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -210,7 +211,7 @@ def test_get_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -230,7 +231,7 @@ def test_get_all_association_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -270,7 +271,7 @@ def test_get_all_association_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/dataset_msg_test.py
+++ b/tests/syft/grid/messages/dataset_msg_test.py
@@ -35,7 +35,7 @@ def test_create_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -54,7 +54,7 @@ def test_create_dataset_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -74,7 +74,7 @@ def test_delete_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -93,7 +93,7 @@ def test_delete_dataset_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -120,7 +120,7 @@ def test_update_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -139,7 +139,7 @@ def test_update_dataset_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -159,7 +159,7 @@ def test_get_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -186,7 +186,7 @@ def test_get_dataset_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -206,7 +206,7 @@ def test_get_all_datasets_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -245,7 +245,7 @@ def test_get_all_datasets_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/dataset_msg_test.py
+++ b/tests/syft/grid/messages/dataset_msg_test.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.io.address import Address
 from syft.grid.messages.dataset_messages import CreateDatasetMessage
 from syft.grid.messages.dataset_messages import CreateDatasetResponse
@@ -35,7 +36,7 @@ def test_create_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -54,7 +55,7 @@ def test_create_dataset_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -74,7 +75,7 @@ def test_delete_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -93,7 +94,7 @@ def test_delete_dataset_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -120,7 +121,7 @@ def test_update_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -139,7 +140,7 @@ def test_update_dataset_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -159,7 +160,7 @@ def test_get_dataset_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -186,7 +187,7 @@ def test_get_dataset_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -206,7 +207,7 @@ def test_get_all_datasets_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -245,7 +246,7 @@ def test_get_all_datasets_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/group_msg_test.py
+++ b/tests/syft/grid/messages/group_msg_test.py
@@ -36,7 +36,7 @@ def test_create_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -55,7 +55,7 @@ def test_create_group_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -75,7 +75,7 @@ def test_delete_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -94,7 +94,7 @@ def test_delete_group_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -123,7 +123,7 @@ def test_update_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -142,7 +142,7 @@ def test_update_group_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -162,7 +162,7 @@ def test_get_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -191,7 +191,7 @@ def test_get_group_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -211,7 +211,7 @@ def test_get_all_groups_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -252,7 +252,7 @@ def test_get_all_groups_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/group_msg_test.py
+++ b/tests/syft/grid/messages/group_msg_test.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.io.address import Address
 from syft.grid.messages.group_messages import CreateGroupMessage
 from syft.grid.messages.group_messages import CreateGroupResponse
@@ -36,7 +37,7 @@ def test_create_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -55,7 +56,7 @@ def test_create_group_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -75,7 +76,7 @@ def test_delete_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -94,7 +95,7 @@ def test_delete_group_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -123,7 +124,7 @@ def test_update_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -142,7 +143,7 @@ def test_update_group_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -162,7 +163,7 @@ def test_get_group_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -191,7 +192,7 @@ def test_get_group_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -211,7 +212,7 @@ def test_get_all_groups_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -252,7 +253,7 @@ def test_get_all_groups_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/infra_msg_test.py
+++ b/tests/syft/grid/messages/infra_msg_test.py
@@ -35,7 +35,7 @@ def test_create_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -54,7 +54,7 @@ def test_create_worker_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -74,7 +74,7 @@ def test_delete_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -93,7 +93,7 @@ def test_delete_worker_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -121,7 +121,7 @@ def test_update_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -140,7 +140,7 @@ def test_update_worker_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -160,7 +160,7 @@ def test_get_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -185,7 +185,7 @@ def test_get_worker_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -205,7 +205,7 @@ def test_get_all_workers_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -239,7 +239,7 @@ def test_get_all_workers_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/infra_msg_test.py
+++ b/tests/syft/grid/messages/infra_msg_test.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.io.address import Address
 from syft.grid.messages.infra_messages import CreateWorkerMessage
 from syft.grid.messages.infra_messages import CreateWorkerResponse
@@ -35,7 +36,7 @@ def test_create_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -54,7 +55,7 @@ def test_create_worker_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -74,7 +75,7 @@ def test_delete_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -93,7 +94,7 @@ def test_delete_worker_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -121,7 +122,7 @@ def test_update_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -140,7 +141,7 @@ def test_update_worker_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -160,7 +161,7 @@ def test_get_worker_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -185,7 +186,7 @@ def test_get_worker_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -205,7 +206,7 @@ def test_get_all_workers_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -239,7 +240,7 @@ def test_get_all_workers_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/roles_msg_test.py
+++ b/tests/syft/grid/messages/roles_msg_test.py
@@ -35,7 +35,7 @@ def test_create_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -54,7 +54,7 @@ def test_create_role_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -74,7 +74,7 @@ def test_delete_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -93,7 +93,7 @@ def test_delete_role_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -121,7 +121,7 @@ def test_update_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -140,7 +140,7 @@ def test_update_role_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -160,7 +160,7 @@ def test_get_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -187,7 +187,7 @@ def test_get_role_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -207,7 +207,7 @@ def test_get_all_roles_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -246,7 +246,7 @@ def test_get_all_roles_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/roles_msg_test.py
+++ b/tests/syft/grid/messages/roles_msg_test.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.io.address import Address
 from syft.grid.messages.role_messages import CreateRoleMessage
 from syft.grid.messages.role_messages import CreateRoleResponse
@@ -35,7 +36,7 @@ def test_create_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -54,7 +55,7 @@ def test_create_role_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -74,7 +75,7 @@ def test_delete_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -93,7 +94,7 @@ def test_delete_role_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -121,7 +122,7 @@ def test_update_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -140,7 +141,7 @@ def test_update_role_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -160,7 +161,7 @@ def test_get_role_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -187,7 +188,7 @@ def test_get_role_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -207,7 +208,7 @@ def test_get_all_roles_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -246,7 +247,7 @@ def test_get_all_roles_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/setup_msg_test.py
+++ b/tests/syft/grid/messages/setup_msg_test.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.io.address import Address
 from syft.grid.messages.setup_messages import CreateInitialSetUpMessage
 from syft.grid.messages.setup_messages import CreateInitialSetUpResponse
@@ -28,7 +29,7 @@ def test_create_initial_setup_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -47,7 +48,7 @@ def test_create_initial_setup_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -67,7 +68,7 @@ def test_get_initial_setup_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -92,7 +93,7 @@ def test_delete_worker_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/setup_msg_test.py
+++ b/tests/syft/grid/messages/setup_msg_test.py
@@ -28,7 +28,7 @@ def test_create_initial_setup_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -47,7 +47,7 @@ def test_create_initial_setup_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -67,7 +67,7 @@ def test_get_initial_setup_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -92,7 +92,7 @@ def test_delete_worker_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/tensor_msg_test.py
+++ b/tests/syft/grid/messages/tensor_msg_test.py
@@ -33,7 +33,7 @@ def test_create_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -52,7 +52,7 @@ def test_create_tensor_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -72,7 +72,7 @@ def test_delete_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -91,7 +91,7 @@ def test_delete_tensor_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -117,7 +117,7 @@ def test_update_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -136,7 +136,7 @@ def test_update_tensor_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -156,7 +156,7 @@ def test_get_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -179,7 +179,7 @@ def test_get_tensor_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -199,7 +199,7 @@ def test_get_all_tensors_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -234,7 +234,7 @@ def test_get_all_tensors_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/tensor_msg_test.py
+++ b/tests/syft/grid/messages/tensor_msg_test.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.io.address import Address
 from syft.grid.messages.tensor_messages import CreateTensorMessage
 from syft.grid.messages.tensor_messages import CreateTensorResponse
@@ -33,7 +34,7 @@ def test_create_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -52,7 +53,7 @@ def test_create_tensor_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -72,7 +73,7 @@ def test_delete_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -91,7 +92,7 @@ def test_delete_tensor_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -117,7 +118,7 @@ def test_update_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -136,7 +137,7 @@ def test_update_tensor_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -156,7 +157,7 @@ def test_get_tensor_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -179,7 +180,7 @@ def test_get_tensor_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -199,7 +200,7 @@ def test_get_all_tensors_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -234,7 +235,7 @@ def test_get_all_tensors_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/tensor_req_test.py
+++ b/tests/syft/grid/messages/tensor_req_test.py
@@ -32,7 +32,7 @@ def test_create_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -51,7 +51,7 @@ def test_create_data_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -71,7 +71,7 @@ def test_delete_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -90,7 +90,7 @@ def test_delete_data_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -115,7 +115,7 @@ def test_update_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -134,7 +134,7 @@ def test_update_data_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -154,7 +154,7 @@ def test_get_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -179,7 +179,7 @@ def test_get_data_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -199,7 +199,7 @@ def test_get_all_data_requests_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -232,7 +232,7 @@ def test_get_all_data_requests_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/messages/tensor_req_test.py
+++ b/tests/syft/grid/messages/tensor_req_test.py
@@ -32,7 +32,7 @@ def test_create_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -51,7 +51,7 @@ def test_create_data_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -71,7 +71,7 @@ def test_delete_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -90,7 +90,7 @@ def test_delete_data_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -115,7 +115,7 @@ def test_update_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -134,7 +134,7 @@ def test_update_data_request_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -154,7 +154,7 @@ def test_get_data_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -179,7 +179,7 @@ def test_get_data_request_response_serde() -> None:
         content=content,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -199,7 +199,7 @@ def test_get_all_data_requests_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -232,7 +232,7 @@ def test_get_all_data_requests_response_serde() -> None:
         content=request_content,
     )
 
-    blob = msg._sy_serialize()
+    blob = sy.serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/services/signaling_service_test.py
+++ b/tests/syft/grid/services/signaling_service_test.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 # syft absolute
 import syft as sy
+from syft import serialize
 from syft.core.common.message import SyftMessage
 from syft.core.io.address import Address
 from syft.core.node.common.node import Node
@@ -45,7 +46,7 @@ def test_signaling_offer_message_serde() -> None:
         host_peer=host_id,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     msg_metadata = bob_vm.get_metadata_for_client()
@@ -79,7 +80,7 @@ def test_signaling_answer_message_serde() -> None:
     )
     msg_metadata = bob_vm.get_metadata_for_client()
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
     msg2_metadata = msg2.host_metadata
 
@@ -110,7 +111,7 @@ def test_signaling_answer_pull_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -134,7 +135,7 @@ def test_signaling_offer_pull_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg._sy_serialize()
+    blob = serialize(msg)
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/grid/services/signaling_service_test.py
+++ b/tests/syft/grid/services/signaling_service_test.py
@@ -45,7 +45,7 @@ def test_signaling_offer_message_serde() -> None:
         host_peer=host_id,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     msg_metadata = bob_vm.get_metadata_for_client()
@@ -79,7 +79,7 @@ def test_signaling_answer_message_serde() -> None:
     )
     msg_metadata = bob_vm.get_metadata_for_client()
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
     msg2_metadata = msg2.host_metadata
 
@@ -110,7 +110,7 @@ def test_signaling_answer_pull_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id
@@ -134,7 +134,7 @@ def test_signaling_offer_pull_request_message_serde() -> None:
         reply_to=bob_vm.address,
     )
 
-    blob = msg.serialize()
+    blob = msg._sy_serialize()
     msg2 = sy.deserialize(blob=blob)
 
     assert msg.id == msg2.id

--- a/tests/syft/lib/python/namedtuple/namedtuple_test.py
+++ b/tests/syft/lib/python/namedtuple/namedtuple_test.py
@@ -2,6 +2,7 @@
 import torch
 
 # syft absolute
+from syft import serialize
 from syft.core.common.serde.deserialize import _deserialize
 from syft.lib.python import ValuesIndices
 
@@ -12,7 +13,7 @@ def test_torch_valuesindices_serde() -> None:
     values = y.values
     indices = y.indices
 
-    ser = y._sy_serialize()
+    ser = serialize(y)
     # horrible hack, we shouldnt be constructing these right now anyway
     params = [None] * 17
     params[0] = values

--- a/tests/syft/lib/python/namedtuple/namedtuple_test.py
+++ b/tests/syft/lib/python/namedtuple/namedtuple_test.py
@@ -12,7 +12,7 @@ def test_torch_valuesindices_serde() -> None:
     values = y.values
     indices = y.indices
 
-    ser = y.serialize()
+    ser = y._sy_serialize()
     # horrible hack, we shouldnt be constructing these right now anyway
     params = [None] * 17
     params[0] = values

--- a/tests/syft/lib/python/namedtuple/namedtuple_test.py
+++ b/tests/syft/lib/python/namedtuple/namedtuple_test.py
@@ -33,7 +33,7 @@ def test_torch_qr_serde() -> None:
     values = y.Q
     indices = y.R
 
-    ser = y.serialize()
+    ser = serialize(y)
     # horrible hack, we shouldnt be constructing these right now anyway
     params = [None] * 17
     params[8] = values

--- a/tests/syft/lib/torch/parameter_test.py
+++ b/tests/syft/lib/torch/parameter_test.py
@@ -63,7 +63,7 @@ def test_parameter_serde() -> None:
     # Setting grad manually to check it is passed through serialization
     param.grad = th.randn_like(param)
 
-    blob = param._sy_serialize()
+    blob = sy.serialize(param)
 
     param2 = sy.deserialize(blob=blob)
 
@@ -86,7 +86,7 @@ def test_linear_grad_serde() -> None:
     # out.backward()
     # assert param.grad is not None
 
-    blob = param._sy_serialize()
+    blob = sy.serialize(param)
 
     param2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/lib/torch/parameter_test.py
+++ b/tests/syft/lib/torch/parameter_test.py
@@ -63,7 +63,7 @@ def test_parameter_serde() -> None:
     # Setting grad manually to check it is passed through serialization
     param.grad = th.randn_like(param)
 
-    blob = param.serialize()
+    blob = param._sy_serialize()
 
     param2 = sy.deserialize(blob=blob)
 
@@ -86,7 +86,7 @@ def test_linear_grad_serde() -> None:
     # out.backward()
     # assert param.grad is not None
 
-    blob = param.serialize()
+    blob = param._sy_serialize()
 
     param2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
+++ b/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
@@ -60,7 +60,7 @@ def test_torch_serde() -> None:
     # But pretend we have .grad
     x.grad = th.randn_like(x)
 
-    blob = x.serialize()
+    blob = x._sy_serialize()
 
     x2 = sy.deserialize(blob=blob)
 

--- a/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
+++ b/tests/syft/lib/torch/tensor/tensor_remote_and_serde_test.py
@@ -60,7 +60,7 @@ def test_torch_serde() -> None:
     # But pretend we have .grad
     x.grad = th.randn_like(x)
 
-    blob = x._sy_serialize()
+    blob = sy.serialize(x)
 
     x2 = sy.deserialize(blob=blob)
 


### PR DESCRIPTION
## Description
This may close #5172 .

There are some new attrs we attach to object, including
- `serialize`
- `to_bytes`
- `binary`
- `to_proto`
- `proto`
- `serializable_wrapper_type`

These attrs are intented to be used by developers and not by end-users. We want to refacor them, so that they don't confuse end-users.

This work is done in three steps:
1. prefix `_sy_` to their names. Make it clear that they should be used inside by developers.  
2. remove `_sy_to_bytes/binary/to_proto/proto` methods, use `_sy_serialize(...)`.
3. remove `_sy_serialize`, use `sy.serialize`

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- pytest -m fast/libs still all pass

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
