### PR TITLE
Fixing issue with namedtuple type resolution

### DIFF
--- a/src/syft/lib/python/namedtuple.py
+++ b/src/syft/lib/python/namedtuple.py
@@ -50,7 +50,9 @@ ValuesIndices = namedtuple("ValuesIndices", all_attrs)  # type: ignore
 
 def object2proto(obj: object) -> ValuesIndices_PB:
     obj_type = full_name_with_name(klass=obj.serializable_wrapper_type)  # type: ignore
-    keys = get_keys(klass_name=obj_type)
+    torch_type = full_name_with_name(klass=type(obj))
+
+    keys = get_keys(klass_name=torch_type)
 
     values = []
     for key in keys:
@@ -154,7 +156,9 @@ def make_namedtuple(
     module_parts = obj_type.split(".")
     klass = module_parts.pop().replace("Wrapper", "")
     module_name = ".".join(module_parts[2:])
-    keys = get_keys(klass_name=obj_type)
+    torch_type = f"{module_name}.{klass}"
+
+    keys = get_keys(klass_name=torch_type)
     tuple_klass = namedtuple(  # type: ignore
         klass, (*keys, "tags", "description", "id")
     )

--- a/tests/syft/lib/python/namedtuple/namedtuple_test.py
+++ b/tests/syft/lib/python/namedtuple/namedtuple_test.py
@@ -24,3 +24,23 @@ def test_torch_valuesindices_serde() -> None:
     assert (de.indices == y.indices).all()
     assert (vi.values == de.values).all()
     assert (vi.indices == de.indices).all()
+
+
+def test_torch_qr_serde() -> None:
+    x = torch.Tensor([[1, 2], [1, 2]])
+    y = x.qr()
+    values = y.Q
+    indices = y.R
+
+    ser = y.serialize()
+    # horrible hack, we shouldnt be constructing these right now anyway
+    params = [None] * 17
+    params[8] = values
+    params[9] = indices
+    vi = ValuesIndices(*params)
+    de = _deserialize(blob=ser)
+
+    assert (de.Q == y.Q).all()
+    assert (de.R == y.R).all()
+    assert (vi.Q == de.Q).all()
+    assert (vi.R == de.R).all()


### PR DESCRIPTION
## Description
- Fixing issue with namedtuple type resolution
- Added a test for .qr which would have failed before this fix

## Affected Dependencies
None

## How has this been tested?
Locally and CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
