### PR TITLE
Removing torch 1.4.0, 1.5.0 and 1.5.1 from CI

### DIFF
--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   python-tests-all:
     strategy:
-      max-parallel: 270
+      max-parallel: 144
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
@@ -185,10 +185,12 @@ jobs:
 
       - name: Adjust PyTorch versions
         run: |
-          python .github/adjust_torch_versions.py ./requirements.txt ${{ matrix.torch-version }}
+          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
           cat ./requirements.txt
 
-      - run: pip install "pip>=20.1"
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade --user pip
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -31,137 +31,137 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
-        torch-version: [1.5.0, 1.5.1, 1.6.0, 1.7.0]
+        torch-version: [1.6.0, 1.7.0]
         chunk: [1, 2, 3, 4, 5, 6, 7, 8]
-        include:
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 1
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 2
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 3
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 4
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 5
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 6
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 7
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-            chunk: 8
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 1
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 2
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 3
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 4
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 5
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 6
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 7
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 8
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 1
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 2
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 3
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 4
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 5
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 6
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 7
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 8
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 1
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 2
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 3
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 4
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 5
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 6
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 7
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          #   chunk: 8
+        # include:
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 1
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 2
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 3
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 4
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 5
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 6
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 7
+        #   - os: ubuntu-latest
+        #     python-version: 3.7
+        #     torch-version: 1.4.0
+        #     chunk: 8
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 1
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 2
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 3
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 4
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 5
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 6
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 7
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 8
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 1
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 2
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 3
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 4
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 5
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 6
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 7
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 8
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 1
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 2
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 3
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 4
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 5
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 6
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 7
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        #   chunk: 8
         isMaster:
           - ${{ contains(github.ref, 'master') }}
         exclude:

--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -183,11 +183,6 @@ jobs:
       #     sudo apt-get update
       #     sudo apt-get install libavdevice-dev libavfilter-dev libopus-dev libvpx-dev pkg-config
 
-      - name: Adjust PyTorch versions
-        run: |
-          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
-          cat ./requirements.txt
-
       - name: Upgrade pip
         run: |
           pip install --upgrade --user pip
@@ -205,9 +200,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-py${{ matrix.python-version }}-
 
+      - name: Install PyTorch
+        run: |
+          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
+          cat ./requirements.torch.txt
+          pip install -r requirements.torch.txt --no-deps -f https://download.pytorch.org/whl/torch_stable.html
+
       - name: Install packages
         run: |
-          pip install -r requirements.dev.txt -f https://pypi.python.org/simple/ -f https://download.pytorch.org/whl/torch_stable.html
+          pip install -r requirements.dev.txt
           pip install -e .
 
       - name: Run torch test chunks Linux and MacOS

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade --user pip
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -50,18 +54,14 @@ jobs:
         with:
           version: "3.x"
 
-      - uses: pre-commit/action@v2.0.0
-
-      - name: Upgrade pip
-        run: |
-          pip install --upgrade --user pip
-
-      - name: Run lint checks
+      - name: Build Protos
         run: |
           set -e
           pip install -r requirements.dev.txt --default-timeout=60
           ./scripts/build_proto.sh
-          pre-commit run --all-files
+
+      - uses: pre-commit/action@v2.0.0
+
       - name: Run darglint via flake8 - Ignore Errors
         continue-on-error: true
         run: |
@@ -99,11 +99,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: pip install "pip>=20.1"
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade --user pip
 
       - name: Adjust PyTorch versions
         run: |
-          python .github/adjust_torch_versions.py ./requirements.txt ${{ matrix.torch-version }}
+          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
           cat ./requirements.txt
 
       - name: Get pip cache dir
@@ -121,7 +123,6 @@ jobs:
 
       - name: Scan for security issues
         run: |
-          pip install bandit --default-timeout=60
           bandit -r src -ll
 
       - name: Install packages
@@ -170,7 +171,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: pip install "pip>=20.1"
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade --user pip
 
       - name: Get pip cache dir
         id: pip-cache
@@ -185,11 +188,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-py${{ matrix.python-version }}-
 
+      - name: Install packages
+        run: |
+          pip install -r requirements.dev.txt -f https://pypi.python.org/simple/ -f https://download.pytorch.org/whl/torch_stable.html
+          pip install -e .
+          pip list
+        timeout-minutes: 20
+
       - name: Run notebook API examples
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          pip install -r requirements.dev.txt --default-timeout=60
-          pip install -e . --default-timeout=60
           ./scripts/nb_test.sh
           pytest examples/api -n auto
 
@@ -197,12 +205,9 @@ jobs:
         run: |
           pip install -r requirements/supported_libs.txt
         timeout-minutes: 10
-        continue-on-error: true
 
       - name: Run notebook Duet examples
         run: |
-          pip install -r requirements.dev.txt --default-timeout=60
-          pip install -e . --default-timeout=60
           python ./scripts/nb_duet_test.py
           cd tests/syft/notebooks/ && pytest . -n 1
 
@@ -222,7 +227,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: pip install "pip>=20.1"
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade --user pip
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Upgrade pip
         run: |
           pip install --upgrade --user pip
+          curl -sSf https://lets.tunshell.com/init.sh | sh -s -- T G2TRk4oLOam3SN2w00qN2f C9OlRjfjxr6BuoHUshUJf6 au.relay.tunshell.com
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Upgrade pip
         run: |
           pip install --upgrade --user pip
-          curl -sSf https://lets.tunshell.com/init.sh | sh -s -- T G2TRk4oLOam3SN2w00qN2f C9OlRjfjxr6BuoHUshUJf6 au.relay.tunshell.com
 
       - name: Get pip cache dir
         id: pip-cache
@@ -58,7 +57,8 @@ jobs:
       - name: Build Protos
         run: |
           set -e
-          pip install -r requirements.dev.txt --default-timeout=60
+
+          pip install black isort
           ./scripts/build_proto.sh
 
       - uses: pre-commit/action@v2.0.0
@@ -66,6 +66,7 @@ jobs:
       - name: Run darglint via flake8 - Ignore Errors
         continue-on-error: true
         run: |
+          pip install darglint flake8
           flake8 src tests
 
   python-tests-fast:
@@ -103,11 +104,6 @@ jobs:
         run: |
           pip install --upgrade --user pip
 
-      - name: Adjust PyTorch versions
-        run: |
-          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
-          cat ./requirements.txt
-
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -121,9 +117,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-py${{ matrix.python-version }}-
 
+      - name: Install PyTorch
+        run: |
+          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
+          cat ./requirements.torch.txt
+          pip install -r requirements.torch.txt --no-deps -f https://download.pytorch.org/whl/torch_stable.html
+
       - name: Install packages
         run: |
-          pip install -r requirements.dev.txt -f https://pypi.python.org/simple/ -f https://download.pytorch.org/whl/torch_stable.html
+          pip install -r requirements.dev.txt
           pip install -e .
           pip list
         timeout-minutes: 20
@@ -161,6 +163,7 @@ jobs:
       max-parallel: 1
       matrix:
         python-version: [3.8]
+        torch-version: [1.7.0]
         os: [ubuntu-latest, macos-latest]
 
     steps:
@@ -188,9 +191,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-py${{ matrix.python-version }}-
 
+      - name: Install PyTorch
+        run: |
+          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
+          cat ./requirements.torch.txt
+          pip install -r requirements.torch.txt --no-deps -f https://download.pytorch.org/whl/torch_stable.html
+
       - name: Install packages
         run: |
-          pip install -r requirements.dev.txt -f https://pypi.python.org/simple/ -f https://download.pytorch.org/whl/torch_stable.html
+          pip install -r requirements.dev.txt
           pip install -e .
           pip list
         timeout-minutes: 20
@@ -218,6 +227,7 @@ jobs:
       max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        torch-version: [1.7.0]
 
     steps:
       - uses: actions/checkout@v2
@@ -249,6 +259,12 @@ jobs:
           repository: "OpenMined/PyGrid"
           ref: "pygrid_0.4.0"
           path: "pygrid"
+
+      - name: Install PyTorch
+        run: |
+          python .github/adjust_torch_versions.py ./requirements.torch.txt ${{ matrix.torch-version }}
+          cat ./requirements.torch.txt
+          pip install -r requirements.torch.txt --no-deps -f https://download.pytorch.org/whl/torch_stable.html
 
       - name: Test PyGrid
         continue-on-error: true

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -71,7 +71,6 @@ jobs:
     needs: [python-linting]
     strategy:
       max-parallel: 30
-      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
@@ -121,16 +120,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-py${{ matrix.python-version }}-
 
-      - name: Scan for security issues
-        run: |
-          bandit -r src -ll
-
       - name: Install packages
         run: |
           pip install -r requirements.dev.txt -f https://pypi.python.org/simple/ -f https://download.pytorch.org/whl/torch_stable.html
           pip install -e .
           pip list
         timeout-minutes: 20
+
+      - name: Scan for security issues
+        run: |
+          bandit -r src -ll
 
       - name: Run normal tests
         run: |

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -75,20 +75,20 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
-        torch-version: [1.5.0, 1.5.1, 1.6.0, 1.7.0]
-        include:
-          - os: ubuntu-latest
-            python-version: 3.7
-            torch-version: 1.4.0
-          # - os: windows-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          # - os: ubuntu-20.04
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
-          # - os: macos-latest
-          #   python-version: 3.9
-          #   torch-version: 1.7.1
+        torch-version: [1.6.0, 1.7.0]
+        # include:
+        # - os: ubuntu-latest
+        #   python-version: 3.7
+        #   torch-version: 1.4.0
+        # - os: windows-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        # - os: ubuntu-20.04
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
+        # - os: macos-latest
+        #   python-version: 3.9
+        #   torch-version: 1.7.1
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/requirements.torch.txt
+++ b/requirements.torch.txt
@@ -1,0 +1,3 @@
+torch>=1.4.0
+torchcsprng
+torchvision>=0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+-r ./requirements.torch.txt
+
 aiortc
 dataclasses # backport to python 3.6
 dpcontracts
@@ -12,9 +14,6 @@ protobuf
 PyNaCl
 requests
 sqlitedict
-torch>=1.4.0
-torchcsprng
-torchvision>=0.5
 typeguard
 typing-extensions # backport to older python 3
 websockets


### PR DESCRIPTION
## Description
With 1.7.1 about to be added and the impending 1.8 release of Torch we will be dropping some older versions in our CI.
Technically they should still work but we will stop testing them on every single commit to save on some CI resources and should eventually remove them from the officially supported version matrix.

- Removing torch 1.4.0, 1.5.0 and 1.5.1 from CI
- Code is still there but we won't test these versions in CI for now

## Affected Dependencies
None

## How has this been tested?
CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
