### PR TITLE
Fix broken logging

### DIFF
--- a/src/syft/core/node/domain/domain.py
+++ b/src/syft/core/node/domain/domain.py
@@ -224,7 +224,7 @@ class Domain(Node):
 
         # We match a handler and a request when they have a same set of tags,
         # or if handler["tags"]=[], it matches with any request.
-        if tags != [] and not set(request.object_tags) == set(tags):
+        if len(tags) > 0 and not set(request.object_tags) == set(tags):
             debug(f"HANDLER Ignoring request handler {handler} against {request}")
             return False
 

--- a/src/syft/grid/duet/__init__.py
+++ b/src/syft/grid/duet/__init__.py
@@ -139,7 +139,10 @@ def begin_duet_logger(my_domain: Domain) -> None:
                         + str(n_request_handlers)
                     )
                     out += "                                "
-                    info("\r" + out, end="\r", print=True)
+                    # STOP changing this to logging, this happens every fraction of a
+                    # second to update the jupyter display, logging this creates
+                    # unnecessary noise, in addition the end= parameter broke logging
+                    print("\r" + out, end="\r")  # DO NOT change to log
                 iterator += 1
 
     if hasattr(sys.stdout, "parent_header"):

--- a/src/syft/logger.py
+++ b/src/syft/logger.py
@@ -66,12 +66,19 @@ def create_log_and_print_function(level: str) -> Callable:
             if "print" in kwargs and kwargs["print"] is True:
                 del kwargs["print"]
                 print(*args, **kwargs)
+                if "end" in kwargs:
+                    # clean up extra end for printing
+                    del kwargs["end"]
             if method is not None:
                 method(*args, **kwargs)
             else:
                 raise Exception(f"no method {level} on logger")
         except BaseException as e:
-            logger.debug("failed to log exception", e)
+            msg = f"failed to log exception. {e}"
+            try:
+                logger.debug(msg)
+            except Exception as e:
+                print(f"{msg}. {e}")
 
     return log_and_print
 


### PR DESCRIPTION
## Description
Logging was broken due to Duet print changing to log with `end` param.

## Affected Dependencies
None

## How has this been tested?
Locally

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
