### PR TITLE
CryptoStore no init in serialize function

### DIFF
--- a/src/syft/lib/sympc/session_util.py
+++ b/src/syft/lib/sympc/session_util.py
@@ -25,8 +25,6 @@ def protobuf_session_serializer(session: Session) -> MPCSession_PB:
         (length_nr_parties + 7) // 8, byteorder="big"
     )
 
-    session.crypto_store = CryptoStore()
-
     return MPCSession_PB(
         uuid=session.uuid.bytes,
         config=conf_proto,

--- a/src/syft/lib/tenseal/context.py
+++ b/src/syft/lib/tenseal/context.py
@@ -37,7 +37,7 @@ def context_proto2object(proto: VendorBytes_PB) -> ts.Context:
             log = f"Warning {lib_version} > local imported version {ts.__version__}"
             info(log)
 
-    return ts.context_from(proto.content)
+    return ts.context_from(proto.content, n_threads=1)
 
 
 GenerateWrapper(


### PR DESCRIPTION
## Description
When we send a session across multiple parties we should not create a new instance of the data store.
Fixes [this](https://github.com/OpenMined/SyMPC/issues/63) issue.


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
