### PR TITLE
adding docstrings for ast/klass.py

### DIFF
--- a/src/syft/ast/klass.py
+++ b/src/syft/ast/klass.py
@@ -294,6 +294,16 @@ class Class(Callable):
         return_type_name: Optional[str],
         client: Optional[Any],
     ):
+        """
+        >>> class Animal:
+                pass
+        >>> class Dog(Animal):
+                pass
+        >>> class Rat(Animal):
+                speak = 'squeak'
+                eats = 'cheese'
+        """
+
         super().__init__(
             path_and_name=path_and_name,
             object_ref=object_ref,


### PR DESCRIPTION
## Description
This is a pull request for improving docstrings in [PySyft/src/syft/ast/klass.py](https://docs.google.com/spreadsheets/d/1ExD1EQIQtLx03a_h7lBPlvasVsmb38S02Bfw5a7Q62Y/edit#gid=0) as mentioned by the issue #5279. I am a beginner to PySyft. 

## How has this been tested?
- using python ``doctest``

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

This is a sample code added. I want to get others opinions to be sure what I did is correct and I should proceed in that direction.