### PR TITLE
Moved sympc back to main repo

### DIFF
--- a/requirements.libs.txt
+++ b/requirements.libs.txt
@@ -1,5 +1,5 @@
 opacus
 openmined.psi
 python-dp
-sympc @ git+https://github.com/madhavajay/SyMPC@madhava/torch_1_8
+sympc @ git+https://github.com/OpenMined/SyMPC@main
 tenseal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def pytest_collection_modifyitems(
     # the tests against that dynamic keyword
     vendor_tests = pytest.mark.libs  # note libs != vendor
     loaded_libs: TypeDict[str, bool] = {}
-    vendor_skip = pytest.mark.skip(reason="vendor requirements not  met")
+    vendor_skip = pytest.mark.skip(reason="vendor requirements not met")
     for item in items:
         # mark with: pytest.mark.vendor
         # run with: pytest -m libs -n auto 0
@@ -72,7 +72,8 @@ def pytest_collection_modifyitems(
                     try:
                         _load_lib(lib=lib_name)
                         loaded_libs[lib_name] = True
-                    except Exception:
+                    except Exception as e:
+                        print(f"Failed to load {lib_name}. {e}")
                         loaded_libs[lib_name] = False
                 if not loaded_libs[lib_name]:
                     item.add_marker(vendor_skip)


### PR DESCRIPTION
## Description
Moves back to main repo for the SyMPC library now that torch 1.8 and python 3.9 are working.

## Affected Dependencies
None

## How has this been tested?
CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
