### PR TITLE
changed get_root_data_path to use HOME dir

### DIFF
--- a/src/syft/util.py
+++ b/src/syft/util.py
@@ -589,10 +589,9 @@ def inherit_tags(
 
 def get_root_data_path() -> Path:
     # get the PySyft / data directory to share datasets between notebooks
-    here = Path(os.path.dirname(os.path.realpath("__file__")))
-    while os.path.basename(here).lower() != "pysyft" and here != here.parent:
-        here = here.parent
+    # directory is created as "/home/<username>/.syft/data" or "~/.syft/data"
 
-    data_dir = here / "data"
+    data_dir = Path.home() / ".syft" / "data"
+
     os.makedirs(data_dir, exist_ok=True)
     return data_dir

--- a/src/syft/util.py
+++ b/src/syft/util.py
@@ -589,7 +589,8 @@ def inherit_tags(
 
 def get_root_data_path() -> Path:
     # get the PySyft / data directory to share datasets between notebooks
-    # directory is created as "/home/<username>/.syft/data" or "~/.syft/data"
+    # on Linux and MacOS the directory is: ~/.syft/data"
+    # on Windows the directory is: C:/Users/$USER/.syft/data
 
     data_dir = Path.home() / ".syft" / "data"
 


### PR DESCRIPTION
## Description
Fixes #5304 
Changes `get_root_data_path` in utils to use `HOME` dir that should work cross-platform.
Changed the data directory previously created as `..pysyft/data` to `~/.syft/data`

## Affected Dependencies
None

## How has this been tested?
Ran the function independently and it accomplishes the required task. 
Tested on `Linux` and according to [this](https://docs.python.org/3/library/pathlib.html#concrete-paths) should work cross-platform.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
