### PR TITLE
Add spdz mask SyMPC

### DIFF
--- a/src/syft/lib/sympc/__init__.py
+++ b/src/syft/lib/sympc/__init__.py
@@ -60,6 +60,7 @@ def create_ast(client: TypeAny = None) -> Globals:
         ("sympc.protocol.fss.fss.mask_builder", "sympc.tensor.ShareTensor"),
         ("sympc.protocol.fss.fss.evaluate", "sympc.tensor.ShareTensor"),
         ("sympc.protocol.spdz.spdz.mul_parties", "sympc.tensor.ShareTensor"),
+        ("sympc.protocol.spdz.spdz.spdz_mask", "syft.lib.python.Tuple"),
         ("sympc.protocol.spdz.spdz.div_wraps", "sympc.tensor.ShareTensor"),
         (
             "sympc.session.Session.przs_generate_random_share",


### PR DESCRIPTION
## Description
Hide both eps and delta using the ```spdz_mask``` function.
Don't return the primitives anymore.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- The tests are passing in SyMPC

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
