### PR TITLE
Order dict __getitem__ fix

### DIFF
--- a/src/syft/lib/python/__init__.py
+++ b/src/syft/lib/python/__init__.py
@@ -493,7 +493,7 @@ def create_python_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ),
         ("syft.lib.python.collections.OrderedDict.items", "syft.lib.python.List"),
         (
-            "syft.lib.python.collections.OrderedDict.dict_get",
+            "syft.lib.python.collections.OrderedDict.get",
             "syft.lib.python.Any",
         ),
     ]

--- a/src/syft/lib/python/__init__.py
+++ b/src/syft/lib/python/__init__.py
@@ -275,7 +275,7 @@ def create_python_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ("syft.lib.python.Dict.__str__", "syft.lib.python.String"),
         ("syft.lib.python.Dict.copy", "syft.lib.python.Dict"),
         ("syft.lib.python.Dict.fromkeys", "syft.lib.python.Dict"),
-        # Renam get to dict_get because of conflict
+        # Rename get to dict_get because of conflict
         ("syft.lib.python.Dict.dict_get", "syft.lib.python.Any"),
         ("syft.lib.python.Dict.items", "syft.lib.python.List"),
         ("syft.lib.python.Dict.keys", "syft.lib.python.List"),

--- a/src/syft/lib/python/__init__.py
+++ b/src/syft/lib/python/__init__.py
@@ -275,8 +275,8 @@ def create_python_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ("syft.lib.python.Dict.__str__", "syft.lib.python.String"),
         ("syft.lib.python.Dict.copy", "syft.lib.python.Dict"),
         ("syft.lib.python.Dict.fromkeys", "syft.lib.python.Dict"),
-        # TODO: name conflict with syft.get()
-        # ("syft.lib.python.Dict.get", "syft.lib.python.Any"),
+        # Renam get to dict_get because of conflict
+        ("syft.lib.python.Dict.dict_get", "syft.lib.python.Any"),
         ("syft.lib.python.Dict.items", "syft.lib.python.List"),
         ("syft.lib.python.Dict.keys", "syft.lib.python.List"),
         ("syft.lib.python.Dict.pop", "syft.lib.python.Any"),

--- a/src/syft/lib/python/__init__.py
+++ b/src/syft/lib/python/__init__.py
@@ -493,7 +493,7 @@ def create_python_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ),
         ("syft.lib.python.collections.OrderedDict.items", "syft.lib.python.List"),
         (
-            "syft.lib.python.collections.OrderedDict.get",
+            "syft.lib.python.collections.OrderedDict.dict_get",
             "syft.lib.python.Any",
         ),
     ]

--- a/src/syft/lib/python/collections/ordered_dict.py
+++ b/src/syft/lib/python/collections/ordered_dict.py
@@ -94,7 +94,7 @@ class OrderedDict(PyOrderedDict, PyPrimitive):
         res = super().fromkeys(iterable, value)
         return PrimitiveFactory.generate_primitive(value=res)
 
-    def get(self, other: Any) -> SyPrimitiveRet:
+    def dict_get(self, other: Any) -> SyPrimitiveRet:
         res = super().get(other)
         if isprimitive(value=res):
             return PrimitiveFactory.generate_primitive(value=res)

--- a/src/syft/lib/python/collections/ordered_dict.py
+++ b/src/syft/lib/python/collections/ordered_dict.py
@@ -94,7 +94,7 @@ class OrderedDict(PyOrderedDict, PyPrimitive):
         res = super().fromkeys(iterable, value)
         return PrimitiveFactory.generate_primitive(value=res)
 
-    def dict_get(self, other: Any) -> SyPrimitiveRet:
+    def dict_get(self, other: Any) -> Any:
         res = super().get(other)
         if isprimitive(value=res):
             return PrimitiveFactory.generate_primitive(value=res)

--- a/src/syft/lib/python/collections/ordered_dict.py
+++ b/src/syft/lib/python/collections/ordered_dict.py
@@ -94,9 +94,13 @@ class OrderedDict(PyOrderedDict, PyPrimitive):
         res = super().fromkeys(iterable, value)
         return PrimitiveFactory.generate_primitive(value=res)
 
-    def dict_get(self, other: Any) -> SyPrimitiveRet:
+    def get(self, other: Any) -> SyPrimitiveRet:
         res = super().get(other)
-        return PrimitiveFactory.generate_primitive(value=res)
+        if isprimitive(value=res):
+            return PrimitiveFactory.generate_primitive(value=res)
+        else:
+            # we can have torch.Tensor and other types
+            return res
 
     def items(self) -> SyPrimitiveRet:
         res = list(super().items())

--- a/src/syft/lib/python/collections/ordered_dict.py
+++ b/src/syft/lib/python/collections/ordered_dict.py
@@ -15,6 +15,7 @@ from ....proto.lib.python.collections.ordered_dict_pb2 import (
     OrderedDict as OrderedDict_PB,
 )
 from ..primitive_factory import PrimitiveFactory
+from ..primitive_factory import isprimitive
 from ..primitive_interface import PyPrimitive
 from ..types import SyPrimitiveRet
 from ..util import downcast
@@ -52,7 +53,11 @@ class OrderedDict(PyOrderedDict, PyPrimitive):
 
     def __getitem__(self, other: Any) -> SyPrimitiveRet:
         res = super().__getitem__(other)
-        return PrimitiveFactory.generate_primitive(value=res)
+        if isprimitive(value=res):
+            return PrimitiveFactory.generate_primitive(value=res)
+        else:
+            # we can have torch.Tensor and other types
+            return res
 
     def __len__(self) -> SyPrimitiveRet:
         res = super().__len__()

--- a/src/syft/lib/python/dict.py
+++ b/src/syft/lib/python/dict.py
@@ -151,7 +151,7 @@ class Dict(UserDict, PyPrimitive):
         res = super().fromkeys(iterable, value)
         return PrimitiveFactory.generate_primitive(value=res)
 
-    def get(self, key: Any, default: Any = None) -> SyPrimitiveRet:
+    def dict_get(self, key: Any, default: Any = None) -> SyPrimitiveRet:
         res = super().get(key, default)
         if isprimitive(value=res):
             return PrimitiveFactory.generate_primitive(value=res)

--- a/src/syft/lib/python/dict.py
+++ b/src/syft/lib/python/dict.py
@@ -151,7 +151,7 @@ class Dict(UserDict, PyPrimitive):
         res = super().fromkeys(iterable, value)
         return PrimitiveFactory.generate_primitive(value=res)
 
-    def dict_get(self, key: Any, default: Any = None) -> SyPrimitiveRet:
+    def dict_get(self, key: Any, default: Any = None) -> Any:
         res = super().get(key, default)
         if isprimitive(value=res):
             return PrimitiveFactory.generate_primitive(value=res)

--- a/src/syft/lib/python/dict.py
+++ b/src/syft/lib/python/dict.py
@@ -153,7 +153,11 @@ class Dict(UserDict, PyPrimitive):
 
     def get(self, key: Any, default: Any = None) -> SyPrimitiveRet:
         res = super().get(key, default)
-        return PrimitiveFactory.generate_primitive(value=res)
+        if isprimitive(value=res):
+            return PrimitiveFactory.generate_primitive(value=res)
+        else:
+            # we can have torch.Tensor and other types
+            return res
 
     def items(self, max_len: Optional[int] = None) -> Iterator:  # type: ignore
         return Iterator(ItemsView(self), max_len=max_len)

--- a/tests/syft/lib/python/dict/dict_test.py
+++ b/tests/syft/lib/python/dict/dict_test.py
@@ -374,14 +374,16 @@ class DictTest(unittest.TestCase):
         self.assertEqual(d2, d)
 
     def test_get(self):
+        # We call dict_get because of the conflict with our "get" method
+        # from pointers
         d = Dict()
-        self.assertIs(d.get("c"), SyNone)
-        self.assertEqual(d.get("c", 3), 3)
+        self.assertIs(d.dict_get("c"), SyNone)
+        self.assertEqual(d.dict_get("c", 3), 3)
         d = Dict({"a": 1, "b": 2})
-        self.assertEqual(d.get("c"), SyNone)
-        self.assertEqual(d.get("c", 3), 3)
-        self.assertEqual(d.get("a"), 1)
-        self.assertEqual(d.get("a", 3), 1)
+        self.assertEqual(d.dict_get("c"), SyNone)
+        self.assertEqual(d.dict_get("c", 3), 3)
+        self.assertEqual(d.dict_get("a"), 1)
+        self.assertEqual(d.dict_get("a", 3), 1)
         self.assertRaises(TypeError, d.get)
         self.assertRaises(TypeError, d.get, None, None, None)
 
@@ -852,7 +854,7 @@ class DictTest(unittest.TestCase):
             "d[x2] = 2",
             "z = d[x2]",
             "x2 in d",
-            "d.get(x2)",
+            "d.dict_get(x2)",
             "d.setdefault(x2, 42)",
             "d.pop(x2)",
             "d.update({x2: 2})",


### PR DESCRIPTION
## Description
Treat the case when we have a Tensor in the Ordered Dict (is the same fix as the one with the Dict).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Create a remote OrderedDict with a tensor as a value

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
