### PR TITLE
Fixed issue with untested torch.Tensor ops

### DIFF
--- a/tests/syft/lib/allowlist_test.json
+++ b/tests/syft/lib/allowlist_test.json
@@ -976,6 +976,11 @@
           }
         ]
       },
+      "__len__": {
+        "profile": "tensor_method_input",
+        "inputs": [],
+        "return_type": "syft.lib.python.Int"
+      },
       "__rsub__": {
         "profile": "default",
         "data_types": ["common"],
@@ -10226,6 +10231,24 @@
             "data_types": ["bool", "uint8", "int8", "int16", "int32", "int64"],
             "lte_version": "1.8.0",
             "gte_version": "1.8.0"
+          }
+        ]
+      },
+      "size": {
+        "profile": "tensor_method_noinput",
+        "skip": [
+          {
+            "lte_version": "1.8.0",
+            "reason": "untested"
+          }
+        ]
+      },
+      "shape": {
+        "profile": "tensor_method_noinput",
+        "skip": [
+          {
+            "lte_version": "1.8.0",
+            "reason": "untested"
           }
         ]
       }


### PR DESCRIPTION
## Description
- Fixed issue with untested torch.Tensor ops
- __len__ added
- size and shape ignored for now as they are used remotely until serde

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
