### PR TITLE
Suppress spurious warning on google colab

### DIFF
--- a/src/syft/core/common/environment.py
+++ b/src/syft/core/common/environment.py
@@ -14,7 +14,8 @@ try:
     from packaging import version
 
     NOTEBOOK_VERSION = version.parse(notebook.__version__.split("+")[0])
-    if NOTEBOOK_VERSION < version.parse("6.0.0"):
+    if NOTEBOOK_VERSION < version.parse("6.0.0") and "google.colab" not in sys.modules:
+        # google.colab check to fix issue #5315
         raise Exception(
             "Your Jupyter Notebook is too old. Please upgrade to version 6 or higher."
         )


### PR DESCRIPTION
## Description
Suppress spurious warning on google colab, the warning was generated to check for notebook version being 6 or higher but is not required on google colab.
fixes #5315 

## Affected Dependencies
None

## How has this been tested?
This has been tested on a sample google colab notebook using the following code
``` python
%%capture
# This only runs in colab and clones the code sets it up and fixes a few issues, 
# you can skip this if you are running Jupyter Notebooks
import sys
if "google.colab" in sys.modules:
    branch = "fix-issue-#5315"    # change to the branch you want
    ! git clone --single-branch --branch $branch https://github.com/ArtistBanda/PySyft.git
    ! cd PySyft && ./scripts/colab.sh      # fixes some colab python issues
    sys.path.append("/content/PySyft/src") # prevents needing restart

! pip install syft

import syft as sy 
```

for the above code no warning will be generated but on the current dev branch it would throw the following warning 

```
Exception: Your Jupyter Notebook is too old. Please upgrade to version 6 or higher.
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
