### PR TITLE
Raise Reference error to prevent spurious network call

### DIFF
--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -155,6 +155,10 @@ class Pointer(AbstractPointer):
             description=description,
         )
         self.object_type = object_type
+        # _exhausted becomes True in get() call
+        # when delete_obj is True and network call
+        # has already been made
+        self._exhausted = False
 
     def _get(self, delete_obj: bool = True, verbose: bool = False) -> StorableObject:
         """Method to download a remote object from a pointer object if you have the right
@@ -259,9 +263,9 @@ class Pointer(AbstractPointer):
         # syft relative
         from ..node.domain.service import RequestStatus
 
-        if not self.gc_enabled:
+        if self._exhausted:
             raise ReferenceError(
-                "Object has already been deleted. This pointer isn't usable"
+                "Object has already been deleted. This pointer is exhausted"
             )
 
         if not request_block:
@@ -283,6 +287,7 @@ class Pointer(AbstractPointer):
 
         if result is not None and delete_obj:
             self.gc_enabled = False
+            self._exhausted = True
 
         return result
 

--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -259,6 +259,11 @@ class Pointer(AbstractPointer):
         # syft relative
         from ..node.domain.service import RequestStatus
 
+        if not self.gc_enabled:
+            raise ReferenceError(
+                "Object has already been deleted. This pointer isn't usable"
+            )
+
         if not request_block:
             result = self._get(delete_obj=delete_obj, verbose=verbose)
         else:

--- a/tests/syft/core/plan/plan_test.py
+++ b/tests/syft/core/plan/plan_test.py
@@ -213,7 +213,7 @@ def test_plan_batched_execution() -> None:
         plan_pointer(x=x, y=y)
 
         # checks if (model(x) == y) == [True, True]
-        assert all(result_tensor_pointer3.get())
+        assert all(result_tensor_pointer3.get(delete_obj=False))
 
 
 def test_make_plan() -> None:

--- a/tests/syft/core/pointer/pointer_test.py
+++ b/tests/syft/core/pointer/pointer_test.py
@@ -232,3 +232,15 @@ def test_printing_remote_creation() -> None:
     basic_client = bob.get_client()
     for idx, elem in enumerate(create_data_types(basic_client)):
         validate_permission_error(elem)
+
+
+def test_exhausted() -> None:
+    client = sy.VirtualMachine().get_root_client()
+
+    int_ptr = client.syft.lib.python.Int(0)
+    int_ptr.get()  # ptr gets exhausted after this call
+
+    with pytest.raises(ReferenceError) as e:
+        int_ptr.get()
+
+    assert str(e.value) == "Object has already been deleted. This pointer is exhausted"


### PR DESCRIPTION
## Description
Fixes issue #5364 
Pointer is invalidated if `.get()` is called once.

## Affected Dependencies
None

## How has this been tested?
``` python
import syft as sy
client = sy.VirtualMachine().get_root_client()

int_ptr = client.syft.lib.python.Int(0)
result = int_ptr.get() # delete_obj = True by default

# Does not make a network call and 
# Raises a ReferenceError
int_ptr.get()
```

Raises a reference Error in the second call and preventing a network call.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests 