### PR TITLE
[WIP] Serialize FL model old way, update FL grid integration test

### DIFF
--- a/src/syft/federated/fl_job.py
+++ b/src/syft/federated/fl_job.py
@@ -44,6 +44,7 @@ class FLJob(EventEmitter):
         self.grid_worker = grid_worker
         self.model_name = model_name
         self.model_version = model_version
+        self.plan_type = ModelCentricFLWorker.PLAN_TYPE_LIST
 
         self.model: Optional[ListType[TypeAny]] = None
         self.plans: JSONDict = {}
@@ -76,7 +77,7 @@ class FLJob(EventEmitter):
                 self.worker_id,
                 request_key,
                 plan_id,
-                ModelCentricFLWorker.PLAN_TYPE_LIST,
+                self.plan_type,
             )
 
     def start(self) -> None:

--- a/src/syft/federated/model_centric_fl_client.py
+++ b/src/syft/federated/model_centric_fl_client.py
@@ -6,7 +6,8 @@ from ..federated import JSONDict
 from ..federated.model_centric_fl_base import ModelCentricFLBase
 from ..lib.python import List
 from ..lib.torch.module import Module as SyModule
-from ..proto.lib.python.list_pb2 import List as ListPB
+from .model_serialization import deserialize_model_params
+from .model_serialization import wrap_model_params
 
 
 class ModelCentricFLClient(ModelCentricFLBase):
@@ -20,7 +21,11 @@ class ModelCentricFLClient(ModelCentricFLBase):
         server_config: JSONDict,
     ) -> JSONDict:
 
-        serialized_model = self.hex_serialize(List(model.parameters()))
+        # store raw tensors only (not nn.Parameters, no grad)
+        # TODO migrate to syft-core protobufs
+        params = [p.data for p in model.parameters()]
+        serialized_model = self.hex_serialize(wrap_model_params(params))
+
         serialized_plans = self._serialize_dict_values(client_plans)
         serialized_protocols = self._serialize_dict_values(client_protocols)
         serialized_avg_plan = self.hex_serialize(server_averaging_plan)
@@ -51,4 +56,5 @@ class ModelCentricFLClient(ModelCentricFLBase):
         serialized_model = self._send_http_req(
             "GET", "/model-centric/retrieve-model", params
         )
-        return self._unserialize(serialized_model, ListPB)
+        # TODO migrate to syft-core protobufs
+        return deserialize_model_params(serialized_model)

--- a/src/syft/federated/model_centric_fl_worker.py
+++ b/src/syft/federated/model_centric_fl_worker.py
@@ -10,13 +10,15 @@ from typing import Union
 
 # third party
 import requests
+from syft_proto.execution.v1.plan_pb2 import Plan as PlanTorchscriptPB
 
 # syft relative
 from ..core.plan import Plan
+from ..core.plan.translation.torchscript.plan import PlanTorchscript
 from ..federated.model_centric_fl_base import ModelCentricFLBase
-from ..lib.python.list import List
 from ..proto.core.plan.plan_pb2 import Plan as PlanPB
-from ..proto.lib.python.list_pb2 import List as ListPB
+from .model_serialization import deserialize_model_params
+from .model_serialization import wrap_model_params
 
 CHUNK_SIZE = 655360  # 640KB
 SPEED_MULT_FACTOR = 10
@@ -155,7 +157,9 @@ class ModelCentricFLWorker(ModelCentricFLBase):
         serialized_model = self._send_http_req(
             "GET", "/model-centric/get-model", params
         )
-        return self._unserialize(serialized_model, ListPB).upcast()
+        # TODO migrate to syft-core protobufs
+        params = deserialize_model_params(serialized_model)
+        return params.upcast()
 
     def get_plan(
         self, worker_id: str, request_key: str, plan_id: int, receive_operations_as: str
@@ -167,12 +171,19 @@ class ModelCentricFLWorker(ModelCentricFLBase):
             "receive_operations_as": receive_operations_as,
         }
         serialized_plan = self._send_http_req("GET", "/model-centric/get-plan", params)
-        return self._unserialize(serialized_plan, PlanPB)
+        if receive_operations_as == ModelCentricFLWorker.PLAN_TYPE_TORCHSCRIPT:
+            # TODO migrate to syft-core protobufs
+            pb = PlanTorchscriptPB()
+            pb.ParseFromString(serialized_plan)
+            return PlanTorchscript._proto2object(pb)
+        else:
+            return self._unserialize(serialized_plan, PlanPB)
 
     def report(
         self, worker_id: str, request_key: str, diff: TypeList
     ) -> TypeDict[str, TypeAny]:
-        diff_serialized = self._serialize(List(diff))
+        # TODO migrate to syft-core protobufs
+        diff_serialized = self._serialize(wrap_model_params(diff))
         diff_base64 = base64.b64encode(diff_serialized).decode("ascii")
         params = {
             "type": "model-centric/report",

--- a/src/syft/federated/model_serialization/__init__.py
+++ b/src/syft/federated/model_serialization/__init__.py
@@ -1,0 +1,31 @@
+# stdlib
+from typing import List as TypeList
+from typing import Union
+
+# syft relative
+from ...lib.python.list import List
+from .placeholder import PlaceHolder
+from .state import State
+from .state import StatePB
+
+
+def wrap_model_params(parameters: Union[List, TypeList]) -> State:
+    """
+    Wraps list of tensors in State object.
+    """
+    state = State(
+        state_placeholders=[
+            PlaceHolder(id=n).instantiate(p) for n, p in enumerate(parameters)
+        ]
+    )
+    return state
+
+
+def deserialize_model_params(proto: bin) -> List:
+    """
+    Deserializes binary string (State protobuf) to List of tensors.
+    """
+    state_pb = StatePB()
+    state_pb.ParseFromString(proto)
+    state: State = State._proto2object(state_pb)
+    return List(state.tensors())

--- a/src/syft/federated/model_serialization/common.py
+++ b/src/syft/federated/model_serialization/common.py
@@ -1,0 +1,112 @@
+# third party
+from syft_proto.types.torch.v1.tensor_data_pb2 import TensorData as TensorData_PB
+from syft_proto.types.torch.v1.tensor_pb2 import TorchTensor as TorchTensor_PB
+import torch as th
+
+# Torch dtypes to string (and back) mappers
+TORCH_DTYPE_STR = {
+    th.uint8: "uint8",
+    th.int8: "int8",
+    th.int16: "int16",
+    th.int32: "int32",
+    th.int64: "int64",
+    th.float16: "float16",
+    th.float32: "float32",
+    th.float64: "float64",
+    th.complex32: "complex32",
+    th.complex64: "complex64",
+    th.complex128: "complex128",
+    th.bool: "bool",
+    th.qint8: "qint8",
+    th.quint8: "quint8",
+    th.qint32: "qint32",
+    th.bfloat16: "bfloat16",
+}
+TORCH_STR_DTYPE = {name: cls for cls, name in TORCH_DTYPE_STR.items()}
+
+
+def set_protobuf_id(field, id):
+    if isinstance(id, str):
+        field.id_str = id
+    else:
+        field.id_int = id
+
+
+def get_protobuf_id(field):
+    return getattr(field, field.WhichOneof("id"))
+
+
+def serialize_tensor(tensor: th.Tensor) -> TorchTensor_PB:
+    """
+    This method converts a Torch tensor into a serialized tensor
+    using Protobuf.
+
+    Args:
+        tensor (th.Tensor): an input tensor to be serialized
+
+    Returns:
+        protobuf_obj: Protobuf version of torch tensor.
+    """
+    dtype = TORCH_DTYPE_STR[tensor.dtype]
+
+    tensor_data = TensorData_PB()
+
+    if tensor.is_quantized:
+        tensor_data.is_quantized = True
+        tensor_data.scale = tensor.q_scale()
+        tensor_data.zero_point = tensor.q_zero_point()
+        data = th.flatten(tensor).int_repr().tolist()
+    else:
+        data = th.flatten(tensor).tolist()
+
+    tensor_data.dtype = dtype
+    tensor_data.shape.dims.extend(tensor.size())
+    getattr(tensor_data, "contents_" + dtype).extend(data)
+
+    protobuf_tensor = TorchTensor_PB()
+    set_protobuf_id(protobuf_tensor.id, getattr(tensor, "id", 1))
+
+    protobuf_tensor.serializer = TorchTensor_PB.Serializer.SERIALIZER_ALL
+    protobuf_tensor.contents_data.CopyFrom(tensor_data)
+    protobuf_tensor.tags.extend(getattr(tensor, "tags", []))
+    return protobuf_tensor
+
+
+def deserialize_tensor(protobuf_tensor: TorchTensor_PB) -> th.Tensor:
+    """
+    This method converts a Protobuf torch tensor back into a
+    Torch tensor.
+
+    Args:
+        protobuf_tensor (bin): Protobuf message of torch tensor.
+
+    Returns:
+        tensor (th.Tensor): a torch tensor converted from Protobuf
+    """
+    tensor_id = get_protobuf_id(protobuf_tensor.id)
+    tags = protobuf_tensor.tags
+    description = protobuf_tensor.description
+
+    contents_type = protobuf_tensor.WhichOneof("contents")
+    tensor_data_pb = getattr(protobuf_tensor, contents_type)
+
+    size = tuple(tensor_data_pb.shape.dims)
+    data = getattr(tensor_data_pb, "contents_" + tensor_data_pb.dtype)
+
+    if tensor_data_pb.is_quantized:
+        # Drop the 'q' from the beginning of the quantized dtype to get the int type
+        dtype = TORCH_STR_DTYPE[tensor_data_pb.dtype[1:]]
+        int_tensor = th.tensor(data, dtype=dtype).reshape(size)
+        # Automatically converts int types to quantized types
+        tensor = th._make_per_tensor_quantized_tensor(
+            int_tensor, tensor_data_pb.scale, tensor_data_pb.zero_point
+        )
+    else:
+        dtype = TORCH_STR_DTYPE[tensor_data_pb.dtype]
+        tensor = th.tensor(data, dtype=dtype).reshape(size)
+
+    tensor.id = tensor_id
+    tensor.tags = set(tags)
+    tensor.description = description
+
+    return tensor

--- a/src/syft/federated/model_serialization/placeholder.py
+++ b/src/syft/federated/model_serialization/placeholder.py
@@ -1,0 +1,134 @@
+# third party
+from google.protobuf.reflection import GeneratedProtocolMessageType
+from syft_proto.execution.v1.placeholder_pb2 import Placeholder as PlaceholderPB
+
+# syft absolute
+from syft.core.common.object import Serializable
+
+# syft relative
+from .common import get_protobuf_id
+from .common import set_protobuf_id
+from .placeholder_id import PlaceholderId
+
+
+class PlaceHolder(Serializable):
+    def __init__(
+        self,
+        id=None,
+        tags: set = None,
+        description: str = None,
+        shape=None,
+        expected_dtype=None,
+    ):
+        """A PlaceHolder acts as a tensor but does nothing special. It can get
+        "instantiated" when a real tensor is appended as a child attribute. It
+        will send forward all the commands it receives to its child tensor.
+
+        When you send a PlaceHolder, you don't sent the instantiated tensors.
+
+        Args:
+            id: An optional string or integer id of the PlaceHolder.
+        """
+        super().__init__()
+
+        self.id = PlaceholderId(id)
+        self.tags = tags
+        self.description = description
+        self.expected_shape = tuple(shape) if shape is not None else None
+        self.expected_dtype = expected_dtype
+        self.child = None
+
+    @staticmethod
+    def get_protobuf_schema() -> GeneratedProtocolMessageType:
+        """Return the type of protobuf object which stores a class of this type
+
+        As a part of serialization and deserialization, we need the ability to
+        lookup the protobuf object type directly from the object type. This
+        static method allows us to do this.
+
+        Importantly, this method is also used to create the reverse lookup ability within
+        the metaclass of Serializable. In the metaclass, it calls this method and then
+        it takes whatever type is returned from this method and adds an attribute to it
+        with the type of this class attached to it. See the MetaSerializable class for details.
+
+        :return: the type of protobuf object which corresponds to this class.
+        :rtype: GeneratedProtocolMessageType
+
+        """
+        return PlaceholderPB
+
+    def _object2proto(self) -> PlaceholderPB:
+        """Returns a protobuf serialization of self.
+
+        As a requirement of all objects which inherit from Serializable,
+        this method transforms the current object into the corresponding
+        Protobuf object so that it can be further serialized.
+
+        :return: returns a protobuf object
+        :rtype: ObjectWithID_PB
+
+        .. note::
+            This method is purely an internal method. Please use object.serialize() or one of
+            the other public serialization methods if you wish to serialize an
+            object.
+        """
+
+        protobuf_placeholder = PlaceholderPB()
+        set_protobuf_id(protobuf_placeholder.id, self.id.value)
+        protobuf_placeholder.tags.extend(self.tags)
+
+        if self.description:
+            protobuf_placeholder.description = self.description
+
+        if self.expected_shape:
+            protobuf_placeholder.expected_shape.dims.extend(self.expected_shape)
+
+        return protobuf_placeholder
+
+    @staticmethod
+    def _proto2object(proto: PlaceholderPB) -> "PlaceHolder":
+        """Creates a ObjectWithID from a protobuf
+
+        As a requirement of all objects which inherit from Serializable,
+        this method transforms a protobuf object into an instance of this class.
+
+        :return: returns an instance of Plan
+        :rtype: Plan
+
+        .. note::
+            This method is purely an internal method. Please use syft.deserialize()
+            if you wish to deserialize an object.
+        """
+
+        tensor_id = get_protobuf_id(proto.id)
+        tags = set(proto.tags) if proto.tags else None
+
+        description = None
+        if bool(proto.description):
+            description = proto.description
+
+        expected_shape = tuple(proto.expected_shape.dims) or None
+
+        return PlaceHolder(
+            id=tensor_id, tags=tags, description=description, shape=expected_shape
+        )
+
+    def instantiate(self, tensor):
+        """
+        Add a tensor as a child attribute. All operations on the placeholder will be also
+        executed on this child tensor.
+
+        We remove Placeholders if is there are any.
+        """
+        if isinstance(tensor, PlaceHolder):
+            self.child = tensor.child
+        else:
+            self.child = tensor
+
+        if hasattr(self.child, "shape"):
+            self.expected_shape = tuple(self.child.shape)
+
+        if hasattr(self.child, "dtype"):
+            self.expected_dtype = self.child.dtype
+
+        return self

--- a/src/syft/federated/model_serialization/placeholder_id.py
+++ b/src/syft/federated/model_serialization/placeholder_id.py
@@ -1,0 +1,75 @@
+# third party
+from google.protobuf.reflection import GeneratedProtocolMessageType
+from syft_proto.execution.v1.placeholder_id_pb2 import PlaceholderId as PlaceholderIdPB
+
+# syft absolute
+from syft.core.common.object import Serializable
+
+# syft relative
+from .common import get_protobuf_id
+from .common import set_protobuf_id
+
+
+class PlaceholderId(Serializable):
+    """
+    Represents Syft Plan translated to TorchScript
+    """
+
+    def __init__(self, value):
+        super().__init__()
+        self.value = value
+
+    @staticmethod
+    def get_protobuf_schema() -> GeneratedProtocolMessageType:
+        """Return the type of protobuf object which stores a class of this type
+
+        As a part of serialization and deserialization, we need the ability to
+        lookup the protobuf object type directly from the object type. This
+        static method allows us to do this.
+
+        Importantly, this method is also used to create the reverse lookup ability within
+        the metaclass of Serializable. In the metaclass, it calls this method and then
+        it takes whatever type is returned from this method and adds an attribute to it
+        with the type of this class attached to it. See the MetaSerializable class for details.
+
+        :return: the type of protobuf object which corresponds to this class.
+        :rtype: GeneratedProtocolMessageType
+
+        """
+        return PlaceholderIdPB
+
+    def _object2proto(self) -> PlaceholderIdPB:
+        """Returns a protobuf serialization of self.
+
+        As a requirement of all objects which inherit from Serializable,
+        this method transforms the current object into the corresponding
+        Protobuf object so that it can be further serialized.
+
+        :return: returns a protobuf object
+        :rtype: ObjectWithID_PB
+
+        .. note::
+            This method is purely an internal method. Please use object.serialize() or one of
+            the other public serialization methods if you wish to serialize an
+            object.
+        """
+        protobuf_id = PlaceholderIdPB()
+        set_protobuf_id(protobuf_id.id, self.value)
+        return protobuf_id
+
+    @staticmethod
+    def _proto2object(proto: PlaceholderIdPB) -> "PlaceholderId":
+        """Creates a ObjectWithID from a protobuf
+
+        As a requirement of all objects which inherit from Serializable,
+        this method transforms a protobuf object into an instance of this class.
+
+        :return: returns an instance of Plan
+        :rtype: Plan
+
+        .. note::
+            This method is purely an internal method. Please use syft.deserialize()
+            if you wish to deserialize an object.
+        """
+        value = get_protobuf_id(proto.id)
+        return PlaceholderId(value)

--- a/src/syft/federated/model_serialization/state.py
+++ b/src/syft/federated/model_serialization/state.py
@@ -1,0 +1,115 @@
+# stdlib
+from typing import List
+
+# third party
+from google.protobuf.reflection import GeneratedProtocolMessageType
+from syft_proto.execution.v1.state_pb2 import State as StatePB
+from syft_proto.execution.v1.state_tensor_pb2 import StateTensor as StateTensorPB
+
+# syft absolute
+from syft.core.common.object import Serializable
+
+# syft relative
+from ...core.common.serde.serialize import _serialize as serialize
+from .common import deserialize_tensor
+from .common import serialize_tensor
+from .placeholder import PlaceHolder
+
+
+class State(Serializable):
+    """The State is a Plan attribute and is used to send tensors along functions.
+
+    It references Plan tensor or parameters attributes using their name, and make
+    sure they are provided to remote workers who are sent the Plan.
+    """
+
+    def __init__(self, state_placeholders=None):
+        self.state_placeholders = state_placeholders or []
+
+    def tensors(self) -> List:
+        """
+        Fetch and return all the state elements.
+        """
+        return [placeholder.child for placeholder in self.state_placeholders]
+
+    @staticmethod
+    def get_protobuf_schema() -> GeneratedProtocolMessageType:
+        """Return the type of protobuf object which stores a class of this type
+
+        As a part of serialization and deserialization, we need the ability to
+        lookup the protobuf object type directly from the object type. This
+        static method allows us to do this.
+
+        Importantly, this method is also used to create the reverse lookup ability within
+        the metaclass of Serializable. In the metaclass, it calls this method and then
+        it takes whatever type is returned from this method and adds an attribute to it
+        with the type of this class attached to it. See the MetaSerializable class for details.
+
+        :return: the type of protobuf object which corresponds to this class.
+        :rtype: GeneratedProtocolMessageType
+
+        """
+        return StatePB
+
+    def _object2proto(self) -> StatePB:
+        """Returns a protobuf serialization of self.
+
+        As a requirement of all objects which inherit from Serializable,
+        this method transforms the current object into the corresponding
+        Protobuf object so that it can be further serialized.
+
+        :return: returns a protobuf object
+        :rtype: ObjectWithID_PB
+
+        .. note::
+            This method is purely an internal method. Please use object.serialize() or one of
+            the other public serialization methods if you wish to serialize an
+            object.
+        """
+        proto = StatePB()
+        protobuf_placeholders = [
+            serialize(placeholder) for placeholder in self.state_placeholders
+        ]
+        proto.placeholders.extend(protobuf_placeholders)
+
+        state_tensors = []
+        for tensor in self.tensors():
+            state_tensor = StateTensorPB()
+            state_tensor.torch_tensor.CopyFrom(serialize_tensor(tensor))
+            state_tensors.append(state_tensor)
+
+        proto.tensors.extend(state_tensors)
+        return proto
+
+    @staticmethod
+    def _proto2object(proto: StatePB) -> "State":
+        """Creates a ObjectWithID from a protobuf
+
+        As a requirement of all objects which inherit from Serializable,
+        this method transforms a protobuf object into an instance of this class.
+
+        :return: returns an instance of Plan
+        :rtype: Plan
+
+        .. note::
+            This method is purely an internal method. Please use syft.deserialize()
+            if you wish to deserialize an object.
+        """
+
+        state_placeholders = proto.placeholders
+        state_elements = proto.tensors
+
+        state_placeholders = [
+            PlaceHolder._proto2object(placeholder) for placeholder in proto.placeholders
+        ]
+
+        state_elements = []
+        for protobuf_tensor in proto.tensors:
+            tensor = getattr(protobuf_tensor, protobuf_tensor.WhichOneof("tensor"))
+            state_elements.append(deserialize_tensor(tensor))
+
+        for state_placeholder, state_element in zip(state_placeholders, state_elements):
+            state_placeholder.instantiate(state_element)
+
+        state = State(state_placeholders)
+        return state

--- a/tests/syft/core/fl/model-centric/mcfl_create_execute_plan_test.py
+++ b/tests/syft/core/fl/model-centric/mcfl_create_execute_plan_test.py
@@ -1,5 +1,6 @@
 # stdlib
 import base64
+from collections import OrderedDict
 import json
 import os
 import time
@@ -14,6 +15,7 @@ import jwt
 import numpy as np
 import pytest
 import requests
+from syft_proto.execution.v1.plan_pb2 import Plan as PlanTorchscriptPB
 import torch as th
 from torchvision import datasets
 from torchvision import transforms
@@ -24,17 +26,23 @@ from xprocess import ProcessStarter
 import syft as sy
 from syft import deserialize
 from syft import serialize
+from syft.core.plan.plan_builder import PLAN_BUILDER_VM
 from syft.core.plan.plan_builder import ROOT_CLIENT
 from syft.core.plan.plan_builder import make_plan
+from syft.core.plan.translation.torchscript.plan import PlanTorchscript
+from syft.core.plan.translation.torchscript.plan_translate import (
+    translate as translate_to_ts,
+)
 from syft.federated import JSONDict
 from syft.federated.fl_client import FLClient
 from syft.federated.fl_job import FLJob
 from syft.federated.model_centric_fl_client import ModelCentricFLClient
+from syft.federated.model_serialization import deserialize_model_params
+from syft.federated.model_serialization import wrap_model_params
 from syft.lib.python.int import Int
 from syft.lib.python.list import List
 from syft.lib.torch.module import Module as SyModule
 from syft.proto.core.plan.plan_pb2 import Plan as PlanPB
-from syft.proto.lib.python.list_pb2 import List as ListPB
 from syft.util import get_root_data_path
 
 th.random.manual_seed(42)
@@ -50,7 +58,9 @@ def pygrid_domain(xprocess: Any) -> Generator:
         pattern = "Starting app"
 
         # command to start process
-        pygrid_path = f"{here}/../../../../../pygrid"
+        pygrid_path = os.environ.get(
+            "TEST_PYGRID_PATH", f"{here}/../../../../../pygrid"
+        )
         domain_path = os.path.abspath(f"{pygrid_path}/apps/domain")
         database_file = f"{domain_path}/src/nodedatabase.db"
         if os.path.exists(database_file):
@@ -72,23 +82,86 @@ def pygrid_domain(xprocess: Any) -> Generator:
 
 
 @pytest.mark.grid
-def test_create_and_execute_plan(pygrid_domain: Any) -> None:
-    model_param_type_size = create_plan()
+def test_create_and_execute_plan_autograd(pygrid_domain: Any) -> None:
+    fl_name = "mnist_autograd"
+    plan, model = create_plan_autograd()
+
+    plans = {"training_plan": plan}
+    host_to_grid(plans, model, fl_name)
+
+    plan_inputs = OrderedDict(
+        {"xs": th.rand([64 * 3, 28 * 28]), "ys": th.randint(0, 10, [64 * 3, 10])}
+    )
+    plan_params_output_idx = [0, 1, 2, 3]
+    model_param_type_size = sanity_check_hosted_plan(
+        fl_name, model, plan_inputs, plan_params_output_idx
+    )
     matches = [
-        (th.nn.Parameter, th.Size([100, 784])),
-        (th.nn.Parameter, th.Size([100])),
-        (th.nn.Parameter, th.Size([10, 100])),
-        (th.nn.Parameter, th.Size([10])),
+        (th.Tensor, th.Size([100, 784])),
+        (th.Tensor, th.Size([100])),
+        (th.Tensor, th.Size([10, 100])),
+        (th.Tensor, th.Size([10])),
     ]
 
     assert model_param_type_size == matches
 
-    accuracy = execute_plan()
+    train_with_hosted_training_plan(fl_name, {}, plan_params_output_idx)
+    accuracy = check_resulting_model(fl_name, model)
+
     print(f"Model Centric Federated Learning Complete. Accuracy {accuracy:.2F}")
     assert accuracy > 0.05
 
 
-class MLP(sy.Module):
+@pytest.mark.grid
+@pytest.mark.parametrize("plan_type", ["list", "torchscript"])
+def test_create_and_execute_plan_mobile(pygrid_domain: Any, plan_type) -> None:
+    fl_name = "mnist_mobile"
+    plan, plan_ts, model = create_plan_mobile()
+
+    plans = {
+        "training_plan": plan,
+        "training_plan:ts": plan_ts,
+    }
+    host_to_grid(plans, model, fl_name)
+
+    bs = 64
+    classes_num = 10
+    plan_inputs = OrderedDict(
+        {
+            "xs": th.randn(bs, 28 * 28),
+            "ys": th.nn.functional.one_hot(
+                th.randint(0, classes_num, [bs]), classes_num
+            ),
+            "lr": th.tensor([0.1]),
+            "batch_size": th.tensor([bs]),
+        }
+    )
+    plan_output_params_idx = [2, 3, 4, 5]
+
+    model_param_type_size = sanity_check_hosted_plan(
+        fl_name, model, plan_inputs, plan_output_params_idx, plan_type
+    )
+    matches = [
+        (th.Tensor, th.Size([100, 784])),
+        (th.Tensor, th.Size([100])),
+        (th.Tensor, th.Size([10, 100])),
+        (th.Tensor, th.Size([10])),
+    ]
+    assert model_param_type_size == matches
+
+    train_with_hosted_training_plan(
+        fl_name, plan_inputs, plan_output_params_idx, plan_type
+    )
+    accuracy = check_resulting_model(fl_name, model)
+
+    print(f"Model Centric Federated Learning Complete. Accuracy {accuracy:.2F}")
+    assert accuracy > 0.05
+
+
+# === Autograd Plan ===
+
+
+class MLPAutograd(sy.Module):
     def __init__(self, torch_ref: Any) -> None:
         super().__init__(torch_ref=torch_ref)
         self.l1 = self.torch_ref.nn.Linear(784, 100)
@@ -96,8 +169,7 @@ class MLP(sy.Module):
         self.l2 = self.torch_ref.nn.Linear(100, 10)
 
     def forward(self, x: Any) -> Any:
-        x_reshaped = x.view(-1, 28 * 28)
-        l1_out = self.a1(self.l1(x_reshaped))
+        l1_out = self.a1(self.l1(x))
         l2_out = self.l2(l1_out)
         return l2_out
 
@@ -122,6 +194,46 @@ def set_params(model: SyModule, params: List) -> None:
         p.data = p_new.data
 
 
+# === Non-Autograd Plan ===
+
+
+class MLPNoAutograd(sy.Module):
+    """
+    Simple model with method for loss and hand-written backprop.
+    """
+
+    def __init__(self, torch_ref=th):  # type: ignore
+        super(MLPNoAutograd, self).__init__(torch_ref=torch_ref)
+        self.fc1 = torch_ref.nn.Linear(784, 100)
+        self.relu = torch_ref.nn.ReLU()
+        self.fc2 = torch_ref.nn.Linear(100, 10)
+
+    def forward(self, x):  # type: ignore
+        self.z1 = self.fc1(x)
+        self.a1 = self.relu(self.z1)
+        return self.fc2(self.a1)
+
+    def backward(self, X, error):  # type: ignore
+        z1_grad = (error @ self.fc2.state_dict()["weight"]) * (self.a1 > 0).float()
+        fc1_weight_grad = z1_grad.t() @ X
+        fc1_bias_grad = z1_grad.sum(0)
+        fc2_weight_grad = error.t() @ self.a1
+        fc2_bias_grad = error.sum(0)
+        return fc1_weight_grad, fc1_bias_grad, fc2_weight_grad, fc2_bias_grad
+
+    def softmax_cross_entropy_with_logits(self, logits, target, batch_size):  # type: ignore
+        probs = self.torch_ref.softmax(logits, dim=1)
+        loss = -(target * self.torch_ref.log(probs)).mean()
+        loss_grad = (probs - target) / batch_size
+        return loss, loss_grad
+
+    def accuracy(self, logits, targets, batch_size):  # type: ignore
+        pred = self.torch_ref.argmax(logits, dim=1)
+        targets_idx = self.torch_ref.argmax(targets, dim=1)
+        acc = pred.eq(targets_idx).sum().float() / batch_size
+        return acc
+
+
 def read_file(fname: str) -> str:
     with open(fname, "r") as f:
         return f.read()
@@ -133,12 +245,12 @@ public_key = read_file(f"{here}/example_rsa.pub").strip()
 auth_token = jwt.encode({}, private_key, algorithm="RS256").decode("ascii")
 
 
-def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
-    local_model = MLP(th)
+def create_plan_autograd() -> TypeList[TypeTuple[type, th.Size]]:
+    local_model = MLPAutograd(th)
 
     @make_plan
     def train(  # type: ignore
-        xs=th.rand([64 * 3, 1, 28, 28]),
+        xs=th.rand([64 * 3, 28 * 28]),
         ys=th.randint(0, 10, [64 * 3, 10]),
         params=List(local_model.parameters()),
     ):
@@ -153,12 +265,77 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
             loss.backward()
             sgd_step(model)
 
-        return model.parameters()
+        return (*model.parameters(),)
+
+    return train, local_model
+
+
+def create_plan_mobile() -> Any:
+    def set_remote_model_params(module_ptrs, params_list_ptr):  # type: ignore
+        param_idx = 0
+        for module_name, module_ptr in module_ptrs.items():
+            for param_name, _ in PLAN_BUILDER_VM.store[
+                module_ptr.id_at_location
+            ].data.named_parameters():
+                module_ptr.register_parameter(param_name, params_list_ptr[param_idx])
+                param_idx += 1
+
+    local_model = MLPNoAutograd(th)
+
+    # Dummy inputs
+    bs = 3
+    classes_num = 10
+    model_params_zeros = sy.lib.python.List(
+        [th.nn.Parameter(th.zeros_like(param)) for param in local_model.parameters()]
+    )
 
     @make_plan
+    def training_plan(  # type: ignore
+        xs=th.randn(bs, 28 * 28),
+        ys=th.nn.functional.one_hot(th.randint(0, classes_num, [bs]), classes_num),
+        lr=th.tensor([0.1]),
+        batch_size=th.tensor([bs]),
+        params=model_params_zeros,
+    ):
+        # send the model to plan builder (but not its default params)
+        model = local_model.send(ROOT_CLIENT, send_parameters=False)
+
+        # set model params from input
+        set_remote_model_params(model.modules, params)
+
+        # forward
+        logits = model(xs)
+
+        # loss
+        loss, loss_grad = model.softmax_cross_entropy_with_logits(
+            logits, ys, batch_size
+        )
+
+        # backward
+        grads = model.backward(xs, loss_grad)
+
+        # SGD step
+        updated_params = tuple(
+            param - lr * grad for param, grad in zip(model.parameters(), grads)
+        )
+
+        # accuracy
+        acc = model.accuracy(logits, ys, batch_size)
+
+        # return things
+        return (loss, acc, *updated_params)
+
+    # Translate to torchscript
+    ts_plan = translate_to_ts(training_plan)
+
+    return training_plan, ts_plan, local_model
+
+
+def host_to_grid(plans, model, name):
+    @make_plan
     def avg_plan(  # type: ignore
-        avg=List(local_model.parameters()),
-        item=List(local_model.parameters()),
+        avg=List(model.parameters()),
+        item=List(model.parameters()),
         num=Int(0),
     ):
         new_avg = []
@@ -166,12 +343,11 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
             new_avg.append((avg[i] * num + item[i]) / (num + 1))
         return new_avg
 
-    name = "mnist"
-    version = "1.0"
+    name = name
 
     client_config = {
         "name": name,
-        "version": version,
+        "version": "1.0",
         "batch_size": 64,
         "lr": 0.1,
         "max_updates": 1,  # custom syft.js option that limits number of training loops per worker
@@ -183,7 +359,7 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
         "pool_selection": "random",
         "do_not_reuse_workers_until_cycle": 6,
         "cycle_length": 28800,  # max cycle length in seconds
-        "num_cycles": 2,  # max number of cycles
+        "num_cycles": 4,  # max number of cycles
         "max_diffs": 1,  # number of diffs to collect before avg
         "minimum_upload_speed": 0,
         "minimum_download_speed": 0,
@@ -197,23 +373,25 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
 
     # Auth
     grid_address = f"localhost:{DOMAIN_PORT}"
-
     grid = ModelCentricFLClient(address=grid_address, secure=False)
     grid.connect()
 
     # Host
-
     # If the process already exists, might you need to clear the db.
-    # To do that, set path below correctly and run:
     grid.host_federated_training(
-        model=local_model,
-        client_plans={"training_plan": train},
+        model=model,
+        client_plans=plans,
         client_protocols={},
         server_averaging_plan=avg_plan,
         client_config=client_config,
         server_config=server_config,
     )
 
+
+def sanity_check_hosted_plan(
+    name, model, plan_inputs, plan_output_params_idx, plan_type="list"
+):
+    grid_address = f"localhost:{DOMAIN_PORT}"
     # Authenticate for cycle
 
     # Helper function to make WS requests
@@ -227,7 +405,7 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
         "type": "model-centric/authenticate",
         "data": {
             "model_name": name,
-            "model_version": version,
+            "model_version": "1.0",
             "auth_token": auth_token,
         },
     }
@@ -235,13 +413,12 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
     auth_response = sendWsMessage(auth_request)
 
     # Do cycle request
-
     cycle_request = {
         "type": "model-centric/cycle-request",
         "data": {
             "worker_id": auth_response["data"]["worker_id"],
             "model": name,
-            "version": version,
+            "version": "1.0",
             "ping": 1,
             "download": 10000,
             "upload": 10000,
@@ -264,32 +441,46 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
                 f"request_key={request_key}&model_id={model_id}"
             )
         )
-        pb = ListPB()
-        pb.ParseFromString(req.content)
-        return deserialize(pb)
+        # TODO migrate to syft-core protobufs
+        return deserialize_model_params(req.content)
 
     # Model
     model_params_downloaded = get_model(grid_address, worker_id, request_key, model_id)
 
-    # Download & Execute Plan
-    req = requests.get(
-        (
-            f"http://{grid_address}/model-centric/get-plan?worker_id={worker_id}&"
-            f"request_key={request_key}&plan_id={training_plan_id}&receive_operations_as=list"
+    def get_plan(grid_address, worker_id, request_key, plan_id, plan_type):
+        req = requests.get(
+            (
+                f"http://{grid_address}/model-centric/get-plan?worker_id={worker_id}&"
+                f"request_key={request_key}&plan_id={plan_id}&receive_operations_as={plan_type}"
+            )
         )
-    )
-    pb = PlanPB()
-    pb.ParseFromString(req.content)
-    plan = deserialize(pb)
 
-    xs = th.rand([64 * 3, 1, 28, 28])
-    ys = th.randint(0, 10, [64 * 3, 10])
+        if plan_type == "torchscript":
+            pb = PlanTorchscriptPB()
+            pb.ParseFromString(req.content)
+            return PlanTorchscript._proto2object(pb)
+        else:
+            pb = PlanPB()
+            pb.ParseFromString(req.content)
+            return deserialize(pb)
 
-    (res,) = plan(xs=xs, ys=ys, params=model_params_downloaded)
+    # Download & Execute Plan
+    plan = get_plan(grid_address, worker_id, request_key, training_plan_id, plan_type)
+    plan_inputs["params"] = [
+        th.nn.Parameter(param) for param in model_params_downloaded
+    ]
+
+    if plan_type == "torchscript":
+        # kwargs are not supported in torchscript plan
+        res = plan(*plan_inputs.values())
+    else:
+        res = plan(**plan_inputs)
+
+    updated_params = [res[idx] for idx in plan_output_params_idx]
 
     # Report Model diff
-    diff = [orig - new for orig, new in zip(res, local_model.parameters())]
-    diff_serialized = serialize((List(diff))).SerializeToString()
+    diff = [orig - new for new, orig in zip(updated_params, model.parameters())]
+    diff_serialized = serialize(wrap_model_params(diff)).SerializeToString()
 
     params = {
         "type": "model-centric/report",
@@ -305,7 +496,7 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
     # Check new model
     req_params = {
         "name": name,
-        "version": version,
+        "version": "1.0",
         "checkpoint": "latest",
     }
 
@@ -313,23 +504,20 @@ def create_plan() -> TypeList[TypeTuple[type, th.Size]]:
         f"http://{grid_address}/model-centric/retrieve-model", req_params
     )
 
-    params_pb = ListPB()
-    params_pb.ParseFromString(res.content)
-    new_model_params = deserialize(params_pb)
-
-    new_model_params[0]
-
+    new_model_params = deserialize_model_params(res.content)
     param_type_size = [(type(v), v.shape) for v in new_model_params]
 
     return param_type_size
 
 
-def execute_plan() -> float:
+def train_with_hosted_training_plan(
+    name: str, plan_inputs, plan_output_params_idx, plan_type="list"
+) -> None:
     # PyGrid Node address
     gridAddress = f"ws://localhost:{DOMAIN_PORT}"
 
     # Hosted model name/version
-    model_name = "mnist"
+    model_name = name
     model_version = "1.0"
 
     # syft absolute
@@ -383,8 +571,17 @@ def execute_plan() -> float:
         )
 
         for batch_idx, (x, y) in enumerate(train_loader):
+            x = x.view(-1, 28 * 28)
             y = th.nn.functional.one_hot(y, 10)
-            (model_params,) = training_plan(xs=x, ys=y, params=model_params)
+            inputs = plan_inputs
+            inputs["xs"] = x
+            inputs["ys"] = y
+            inputs["params"] = [th.nn.Parameter(param) for param in model_params]
+            if plan_type == "torchscript":
+                res = training_plan(*inputs.values())
+            else:
+                res = training_plan(**inputs)
+            model_params = [res[idx] for idx in plan_output_params_idx]
 
             if batch_idx >= max_updates - 1:
                 break
@@ -414,6 +611,9 @@ def execute_plan() -> float:
         )["data"]["worker_id"]
         job = client.new_job(model_name, model_version)
 
+        # Override plan type to use
+        job.plan_type = plan_type
+
         # Set event handlers
         job.add_listener(job.EVENT_ACCEPTED, on_accepted)
         job.add_listener(job.EVENT_REJECTED, on_rejected)
@@ -426,25 +626,26 @@ def execute_plan() -> float:
         create_client_and_run_cycle()
         time.sleep(1)
 
+
+def check_resulting_model(name, model):
     # Download trained model
     grid_address = f"localhost:{DOMAIN_PORT}"
     grid = ModelCentricFLClient(address=grid_address, secure=False)
     grid.connect()
+    trained_params = grid.retrieve_model(name, "1.0")
 
-    trained_params = grid.retrieve_model(model_name, model_version)
     # Inference
-
     def test(test_loader: th.utils.data.DataLoader, model: SyModule) -> th.Tensor:
         correct = []
         model.eval()
         for data, target in test_loader:
-            output = model(data)
+            x = data.view(-1, 28 * 28)
+            output = model(x)
             _, pred = th.max(output, 1)
             correct.append(th.sum(np.squeeze(pred.eq(target.data.view_as(pred)))))
         acc = sum(correct) / len(test_loader.dataset)
         return acc
 
-    model = MLP(th)
     set_params(model, trained_params)
 
     tfs = transforms.Compose(


### PR DESCRIPTION
## Description
* Workers use old model serialization protobuf from syft-proto :(
* For now it's easier to serialize with old protobuf and store that in grid
* Added old MNIST plan to grid integration test (with both syft and torchscript variants of plan)
* Fixed grid integration test to actually execute training (bumped # of cycles)

NOTE: need to be tested with mobile workers prior to merge!
@vkkhare @mjjimenez you can populate grid's DB by running 
`TEST_GRID_PATH=/path/to/grid/ pytest tests/syft/core/fl/model-centric/mcfl_create_execute_plan_test.py`
Then spin up grid (`cd /path/to/grid/apps/domain; ./run.sh --start_local_db --port 5000`) and you should have `mnist_mobile`, `1.0` FL job there.

## Affected Dependencies
There's corresponding PR for Grid

## How has this been tested?
- Unit test

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
