### PR TITLE
Swap batch_size and lr args in MCFL MNIST demo training plan

### DIFF
--- a/tests/syft/core/fl/model-centric/mcfl_create_execute_plan_test.py
+++ b/tests/syft/core/fl/model-centric/mcfl_create_execute_plan_test.py
@@ -135,8 +135,8 @@ def test_create_and_execute_plan_mobile(pygrid_domain: Any, plan_type: str) -> N
             "ys": th.nn.functional.one_hot(
                 th.randint(0, classes_num, [bs]), classes_num
             ),
-            "lr": th.tensor([0.1]),
             "batch_size": th.tensor([bs]),
+            "lr": th.tensor([0.1]),
         }
     )
     plan_output_params_idx = [2, 3, 4, 5]
@@ -298,8 +298,8 @@ def create_plan_mobile() -> Any:
     def training_plan(  # type: ignore
         xs=th.randn(bs, 28 * 28),
         ys=th.nn.functional.one_hot(th.randint(0, classes_num, [bs]), classes_num),
-        lr=th.tensor([0.1]),
         batch_size=th.tensor([bs]),
+        lr=th.tensor([0.1]),
         params=model_params_zeros,
     ):
         # send the model to plan builder (but not its default params)


### PR DESCRIPTION
## Description
Trivial change in order of arguments in MCFL MNIST demo training plan. 
This is to make less changes in existing worker demo apps.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
