### PR TITLE
Removed pandas read_csv from AST and DataLoader

### DIFF
--- a/src/syft/core/remote_dataloader/remote_dataloader.py
+++ b/src/syft/core/remote_dataloader/remote_dataloader.py
@@ -5,7 +5,6 @@ from typing import Union
 
 # third party
 from google.protobuf.reflection import GeneratedProtocolMessageType
-import pandas as pd
 import torch as th
 from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
@@ -24,7 +23,6 @@ from ..common.serde.serializable import Serializable
 from ..common.serde.serializable import bind_protobuf
 
 DATA_TYPE_TORCH_TENSOR = "torch_tensor"
-DATA_TYPE_PANDAS_CSV = "pandas_csv"
 
 
 @bind_protobuf
@@ -34,8 +32,7 @@ class RemoteDataset(Dataset, Serializable):
         Arguments:
             path: information about where to get the raw data, for example, a file path,
             or a directory path data_type: the type of data for example torch_tensor
-            or pandas_csv
-        For now, it's should simply be a .pt / .csv file, which stores a Dataset object.
+        For now, it's should simply be a .pt file, which stores a Dataset object.
         """
         self.path = path
         self.data_type = data_type
@@ -47,15 +44,11 @@ class RemoteDataset(Dataset, Serializable):
         """
         if self.data_type == DATA_TYPE_TORCH_TENSOR:
             self.dataset = th.load(self.path)
-        elif self.data_type == DATA_TYPE_PANDAS_CSV:
-            self.dataset = pd.read_csv(self.path)
 
     def __len__(self) -> int:
         return len(self.dataset)
 
-    def __getitem__(
-        self, key: Union[str, int, slice, pd.DataFrame, pd.Series]
-    ) -> Union[th.Tensor, pd.DataFrame, pd.Series]:
+    def __getitem__(self, key: Union[str, int, slice]) -> Union[th.Tensor]:
         return self.dataset[key]
 
     def __repr__(self) -> str:

--- a/src/syft/lib/pandas/__init__.py
+++ b/src/syft/lib/pandas/__init__.py
@@ -35,7 +35,6 @@ def create_ast(client: TypeAny = None) -> Globals:
     ]
 
     methods: TypeList[TypeTuple[str, str]] = [
-        ("pandas.read_csv", "pandas.DataFrame"),
         ("pandas.DataFrame.__getitem__", "pandas.Series"),
         ("pandas.DataFrame.__setitem__", "pandas.Series"),
         ("pandas.DataFrame.__len__", "syft.lib.python.Int"),


### PR DESCRIPTION
## Description
- Removed pandas read_csv from AST and DataLoader 

## Affected Dependencies
None

## How has this been tested?
Locally and CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
