### PR TITLE
Add session to globals during deserialize

### DIFF
--- a/src/syft/lib/sympc/session_util.py
+++ b/src/syft/lib/sympc/session_util.py
@@ -8,6 +8,7 @@ from sympc.session import Session
 from sympc.store import CryptoStore
 
 # syft relative
+from ....syft import logger
 from ...proto.lib.sympc.session_pb2 import MPCSession as MPCSession_PB
 from ..python import Dict
 from ..python.primitive_factory import PrimitiveFactory
@@ -58,6 +59,8 @@ def protobuf_session_deserializer(proto: MPCSession_PB) -> Session:
     session.crypto_store = CryptoStore()
     session.nr_parties = nr_parties
 
-    globals()["session"] = session
+    if "session" in globals():
+        logger.info("Overwritting session for MPC")
+        globals()["session"] = session
 
     return session

--- a/src/syft/lib/sympc/session_util.py
+++ b/src/syft/lib/sympc/session_util.py
@@ -8,7 +8,7 @@ from sympc.session import Session
 from sympc.store import CryptoStore
 
 # syft relative
-from ....syft import logger
+from ...logger import warning
 from ...proto.lib.sympc.session_pb2 import MPCSession as MPCSession_PB
 from ..python import Dict
 from ..python.primitive_factory import PrimitiveFactory
@@ -60,7 +60,7 @@ def protobuf_session_deserializer(proto: MPCSession_PB) -> Session:
     session.nr_parties = nr_parties
 
     if "session" in globals():
-        logger.info("Overwritting session for MPC")
+        warning("Overwritting session for MPC")
         globals()["session"] = session
 
     return session

--- a/src/syft/lib/sympc/session_util.py
+++ b/src/syft/lib/sympc/session_util.py
@@ -58,4 +58,6 @@ def protobuf_session_deserializer(proto: MPCSession_PB) -> Session:
     session.crypto_store = CryptoStore()
     session.nr_parties = nr_parties
 
+    globals()["session"] = session
+
     return session


### PR DESCRIPTION
## Description
Part of https://github.com/OpenMined/SyMPC/pull/129 for https://github.com/OpenMined/SyMPC/issues/66

## Affected Dependencies
SyMPC

## How has this been tested?
Ran the tests for PySyft using this code on my environment (Python 3.8.5)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
