### PR TITLE
Removing time.sleep

### DIFF
--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -426,7 +426,7 @@ class Pointer(AbstractPointer):
         self.client.send_immediate_msg_without_reply(msg=msg)
 
         # wait long enough for it to arrive and trigger a handler
-        time.sleep(0.1)
+        # time.sleep(0.1)
 
         if not block:
             return None
@@ -475,7 +475,7 @@ class Pointer(AbstractPointer):
                         )
                         status = response.status
                         if response.status == RequestStatus.Pending:
-                            time.sleep(0.1)
+                            # time.sleep(0.1)
                             continue
                         else:
                             # accepted or rejected lets exit

--- a/src/syft/core/pointer/pointer.py
+++ b/src/syft/core/pointer/pointer.py
@@ -425,9 +425,6 @@ class Pointer(AbstractPointer):
 
         self.client.send_immediate_msg_without_reply(msg=msg)
 
-        # wait long enough for it to arrive and trigger a handler
-        # time.sleep(0.1)
-
         if not block:
             return None
         else:
@@ -475,7 +472,6 @@ class Pointer(AbstractPointer):
                         )
                         status = response.status
                         if response.status == RequestStatus.Pending:
-                            # time.sleep(0.1)
                             continue
                         else:
                             # accepted or rejected lets exit

--- a/src/syft/grid/duet/exchange_ids.py
+++ b/src/syft/grid/duet/exchange_ids.py
@@ -2,7 +2,6 @@
 import json
 from pathlib import Path
 import tempfile
-import time
 from typing import Any as TypeAny
 from typing import Optional as TypeOptional
 from typing import Tuple as TypeTuple
@@ -155,13 +154,11 @@ class OpenGridTokenFileExchanger(DuetCredentialExchanger):
                         client_id = str(loopback_config["client_id"])
                         break
                 debug("client not ready")
-                time.sleep(0.5)
             except KeyboardInterrupt:
                 debug("Cancelling server connection")
                 break
             except Exception as e:
                 info("server config load failed", self.file_path, e)
-                time.sleep(0.5)
 
         if client_id == "":
             raise Exception("failed to load client ID")
@@ -184,13 +181,11 @@ class OpenGridTokenFileExchanger(DuetCredentialExchanger):
                         server_id = str(loopback_config["server_id"])
                         break
                 debug("server not ready")
-                time.sleep(0.5)
             except KeyboardInterrupt:
                 debug("Cancelling client connection")
                 break
             except Exception as e:
                 info("client config load failed", self.file_path, e)
-                time.sleep(0.5)
 
         if server_id == "":
             raise Exception("failed to load client ID")


### PR DESCRIPTION
## Description
#5394
Removed `time.sleep()` from the  `Pointer class` from `pointer.py` and `OpenGridTokenFileExchanger` from  `exchange_ids.py`. As of now I haven't experienced any time lag after removing it. Creating this PR for testing any error/bug on github tests.

## Affected Dependencies
`src/syft/core/pointer/pointer.py`
`src/syft/grid/duet/exchange_ids.py`

## How has this been tested?
A seperate script was made where I made requesting access to the pointer with and without `time.sleep` and I could not find any sort of time lag.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
