### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can find all [Duet examples](https://github.com/OpenMined/PySyft/tree/main/p
 
 ## Contributing
 
-The guide for contributors can be found [here](https://github.com/OpenMined/PySyft/blob/main/CONTRIBUTING.md).
+The guide for contributors can be found [here](https://github.com/OpenMined/PySyft/blob/main/packages/syft/CONTRIBUTING.md).
 It covers all that you need to know to start contributing code to PySyft today.
 
 Also, join the rapidly growing community of 12,000+ on [Slack](http://slack.openmined.org).


### PR DESCRIPTION
## Description
Fixes a broken link in the README pointing to the contributing guide.

## Affected Dependencies
NA

## How has this been tested?
NA

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] (NA) I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] (NA) My changes are covered by tests
