### PR TITLE
Removed references to Python 3.6, testing and support

### DIFF
--- a/.github/workflows/syft-version_tests.yml
+++ b/.github/workflows/syft-version_tests.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         branches: ["dev"]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         torch-version: [1.6.0, 1.7.1, 1.8.1]
         exclude:
           - python-version: 3.9
@@ -99,7 +99,7 @@ jobs:
       max-parallel: 4
       matrix:
         branches: ["dev"]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         torch-version: [1.8.1]
 
     steps:
@@ -160,7 +160,7 @@ jobs:
       matrix:
         branches: ["dev"]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         torch-version: [1.6.0, 1.7.1, 1.8.1]
         exclude:
           - python-version: 3.9

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ $ conda install jupyter notebook
 ## Version Support
 
 We support **Linux**, **MacOS** and **Windows** and the following Python and Torch versions.
+Older versions may work, however we have stopped testing and supporting them.
 
-| Py / Torch | 1.4 | 1.5 | 1.6 | 1.7 | 1.8 |
-| ---------- | --- | --- | --- | --- | --- |
-| 3.6        | ✅  | ✅  | ✅  | ✅  | ✅  |
-| 3.7        | ✅  | ✅  | ✅  | ✅  | ✅  |
-| 3.8        | ✅  | ✅  | ✅  | ✅  | ✅  |
-| 3.9        | ➖  | ➖  | ➖  | ✅  | ✅  |
+| Py / Torch | 1.6 | 1.7 | 1.8 |
+| ---------- | --- | --- | --- |
+| 3.7        | ✅  | ✅  | ✅  |
+| 3.8        | ✅  | ✅  | ✅  |
+| 3.9        | ➖  | ✅  | ✅  |
 
 ## Installation
 

--- a/packages/syft/CONTRIBUTING.md
+++ b/packages/syft/CONTRIBUTING.md
@@ -81,7 +81,7 @@ If you are new to the project and want to get into the code, we recommend pickin
 Before you get started you will need a few things installed depending on your operating system.
 
 - OS Package Manager
-- Python 3.6+
+- Python 3.7+
 - git
 - protobuf (protoc)
 
@@ -150,7 +150,7 @@ $ sudo apt install protobuf-compiler
 
 ## Python Versions
 
-This project supports Python 3.6+, however, if you are contributing it can help to be able to switch between python versions to fix issues or bugs that relate to a specific python version. Depending on your operating system there are a number of ways to install different versions of python however one of the easiest is with the `pyenv` tool. Additionally, as we will be frequently be installing and changing python packages for this project we should isolate it from your system python and other projects you have using a virtualenv.
+This project supports Python 3.7+, however, if you are contributing it can help to be able to switch between python versions to fix issues or bugs that relate to a specific python version. Depending on your operating system there are a number of ways to install different versions of python however one of the easiest is with the `pyenv` tool. Additionally, as we will be frequently be installing and changing python packages for this project we should isolate it from your system python and other projects you have using a virtualenv.
 
 ### MacOS
 
@@ -172,34 +172,33 @@ Running the command will give you help:
 $ pyenv
 ```
 
-Lets say you wanted to install python 3.6.9 because its the version that Google Colab uses and you want to debug a Colab issue.
+Lets say you wanted to install python 3.7.10 because its the version that Google Colab uses and you want to debug a Colab issue.
 
 First, search for available python versions:
 
 ```
-$  pyenv install --list | grep 3.6
+$  pyenv install --list | grep 3.7
 ...
-3.6.7
-3.6.8
-3.6.9
-3.6.10
-3.6.11
-3.6.12
+3.7.5
+3.7.6
+3.7.7
+3.7.8
+3.7.9
+3.7.10
 ```
 
-Wow, there are lots of options, lets install 3.6.
+Wow, there are lots of options, lets install 3.7.10.
 
 ```
-$ pyenv install 3.6.9
+$ pyenv install 3.7.10
 ```
 
 Now, lets see what versions are installed:
 
 ```
 $ pyenv versions
-3.5.9
-3.6.9
-3.7.8
+3.7.10
+3.8.9
 3.9.0
 ```
 
@@ -332,10 +331,10 @@ Lets create a virtualenv and install the required packages so that we can start 
 Using pipenv you would do the following:
 
 ```
-$ pipenv --python=3.6
+$ pipenv --python=3.7
 ```
 
-We installed python 3.6 earlier so here we can just specify the version and we will get a virtualenv with that version. If you want to use a different version make sure to install it to your system with your system package manager or `pyenv` first.
+We installed python 3.7 earlier so here we can just specify the version and we will get a virtualenv with that version. If you want to use a different version make sure to install it to your system with your system package manager or `pyenv` first.
 
 We have created the virtualenv but it is not active yet.
 If you type the following:
@@ -552,9 +551,6 @@ $ pytest -m slow -n auto
   This script will re-generate all of the protobuf files using the `protoc` protobuf compiler.
 - nb_test.sh
   This converts notebooks that have asserts into tests so they can be run with pytest.
-- colab.sh
-  This fixes some issues in Colab with python 3.6.9 and our code and helps to clone the
-  repo if you want to test code which is not on PyPI yet.
 
 ### Creating a Pull Request
 

--- a/packages/syft/docs/installing.rst
+++ b/packages/syft/docs/installing.rst
@@ -51,8 +51,8 @@ at https://github.com/OpenMined/PySyft. Something like the following:
 Step 2 - Check Python Version
 -----------------------------
 
-PySyft can only run on python versions 3.6 and up. At the time of writing, this is only
-python versions 3.6, 3.7, and 3.8. So, before you proceed, you need to ensure that you
+PySyft can only run on python versions 3.7 and up. At the time of writing, this is only
+python versions 3.7, 3.8 and 3.9. So, before you proceed, you need to ensure that you
 are running one of these versions. Run the following:
 
 .. code:: console
@@ -60,7 +60,7 @@ are running one of these versions. Run the following:
     > python --version
     Python 3.8.1
 
-If the version printed underneath your command is less than 3.6, then you MUST use anaconda
+If the version printed underneath your command is less than 3.7, then you MUST use anaconda
 in the next step (which is recommended). Technically, you could try to upgrade your
 version of python but fair warning (e're be dragons)...
 
@@ -240,8 +240,7 @@ at https://github.com/OpenMined/PySyft. Something like the following:
 Step 2 - Check Python Version
 -----------------------------
 
-PySyft can only run on python versions 3.6 and up. At the time of writing, this is only
-python versions 3.6, 3.7, and 3.8. So, before you proceed, you need to ensure that you
+PySyft can only run on python versions 3.7 and up. So, before you proceed, you need to ensure that you
 are running one of these versions. Run the following:
 
 .. code:: console
@@ -249,7 +248,7 @@ are running one of these versions. Run the following:
     > python --version
     Python 3.8.1
 
-If the version printed underneath your command is less than 3.6, then you MUST use anaconda
+If the version printed underneath your command is less than 3.7, then you MUST use anaconda
 in the next step (which is recommended). Technically, you could try to upgrade your
 version of python but fair warning (e're be dragons)...
 
@@ -439,8 +438,7 @@ at https://github.com/OpenMined/PySyft. Something like the following:
 Step 4 - Check Python Version
 -----------------------------
 
-PySyft can only run on python versions 3.6 and up. At the time of writing, this is only
-python versions 3.6, 3.7, and 3.8. So, before you proceed, you need to ensure that you
+PySyft can only run on python versions 3.7 and up. So, before you proceed, you need to ensure that you
 are running one of these versions. Run the following:
 
 .. code:: console
@@ -448,7 +446,7 @@ are running one of these versions. Run the following:
     > python --version
     Python 3.8.1
 
-If the version printed underneath your command is less than 3.6, then you MUST use anaconda
+If the version printed underneath your command is less than 3.7, then you MUST use anaconda
 in the next step (which is recommended). Technically, you could try to upgrade your
 version of python but fair warning (e're be dragons)...
 

--- a/packages/syft/examples/duet/README.md
+++ b/packages/syft/examples/duet/README.md
@@ -22,15 +22,14 @@ Duet is the latest part of the Syft family and is designed to provide you with a
 
 ## Version Support
 
-We support **Linux**, **MacOS** and **Windows** and the following Python and PyTorch versions.
-Other Deep Learning and Data Science libraries are coming very soon.
+We support **Linux**, **MacOS** and **Windows** and the following Python and Torch versions.
+Older versions may work, however we have stopped testing and supporting them.
 
-| Py / Torch | 1.4 | 1.5 | 1.6 | 1.7 | 1.8 |
-| ---------- | --- | --- | --- | --- | --- |
-| 3.6        | ✅  | ✅  | ✅  | ✅  | ✅  |
-| 3.7        | ✅  | ✅  | ✅  | ✅  | ✅  |
-| 3.8        | ✅  | ✅  | ✅  | ✅  | ✅  |
-| 3.9        | ➖  | ➖  | ➖  | ✅  | ✅  |
+| Py / Torch | 1.6 | 1.7 | 1.8 |
+| ---------- | --- | --- | --- |
+| 3.7        | ✅  | ✅  | ✅  |
+| 3.8        | ✅  | ✅  | ✅  |
+| 3.9        | ➖  | ✅  | ✅  |
 
 ## Setup 🐍
 

--- a/packages/syft/examples/private-ai-series/duet_basics/Duet_Basics_Data_Owner.ipynb
+++ b/packages/syft/examples/private-ai-series/duet_basics/Duet_Basics_Data_Owner.ipynb
@@ -239,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/examples/private-ai-series/duet_basics/Duet_Basics_Data_Scientist.ipynb
+++ b/packages/syft/examples/private-ai-series/duet_basics/Duet_Basics_Data_Scientist.ipynb
@@ -317,7 +317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/examples/private-ai-series/duet_basics/exercise/Exercise_Duet_Basics_Data_Owner.ipynb
+++ b/packages/syft/examples/private-ai-series/duet_basics/exercise/Exercise_Duet_Basics_Data_Owner.ipynb
@@ -151,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/examples/private-ai-series/duet_fl/Duet_FL_1_Data_Owner.ipynb
+++ b/packages/syft/examples/private-ai-series/duet_fl/Duet_FL_1_Data_Owner.ipynb
@@ -112,7 +112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/examples/private-ai-series/duet_fl/Duet_FL_2_Data_Owner.ipynb
+++ b/packages/syft/examples/private-ai-series/duet_fl/Duet_FL_2_Data_Owner.ipynb
@@ -112,7 +112,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/examples/private-ai-series/duet_fl/Duet_FL_Data_Scientist.ipynb
+++ b/packages/syft/examples/private-ai-series/duet_fl/Duet_FL_Data_Scientist.ipynb
@@ -687,7 +687,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/examples/vertical-learning/advanced/MNIST/DO.ipynb
+++ b/packages/syft/examples/vertical-learning/advanced/MNIST/DO.ipynb
@@ -69,7 +69,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/examples/vertical-learning/advanced/MNIST/DS.ipynb
+++ b/packages/syft/examples/vertical-learning/advanced/MNIST/DS.ipynb
@@ -300,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -33,7 +33,6 @@ syft =
     %(torch_ecosystem)s #should remove this and make it a lib
     aiortc
     cryptography>=3.4.7
-    dataclasses # backport to python 3.6
     dpcontracts
     flask>=1.1.2,<2.0.0
     forbiddenfruit>=0.1.3
@@ -62,7 +61,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 where = src
@@ -104,7 +103,6 @@ libs =
 
 dev =
     %(test_plugins)s
-    dataclasses
     flask
     pandas
     pre-commit

--- a/packages/syft/src/syft/lib/python/dict.py
+++ b/packages/syft/src/syft/lib/python/dict.py
@@ -33,7 +33,7 @@ from .util import upcast
 class Dict(UserDict, PyPrimitive):
     # the incoming types to UserDict __init__ are overloaded and weird
     # see https://github.com/python/cpython/blob/master/Lib/collections/__init__.py
-    # this is the version from python 3.7 because we need to support 3.6 and 3.7
+    # this is the version from python 3.7 because we need to support 3.7
     # python 3.8 signature includes a new PEP 570 (args, /, kwargs) syntax:
     # https://www.python.org/dev/peps/pep-0570/
 


### PR DESCRIPTION
## Description
- Removed references to Python 3.6, testing and support
- Removed older Torch versions from the support matrix

## Affected Dependencies
Python 3.6 is gone.

## How has this been tested?
Locally and CI

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
