### PR TITLE
Added test for ordered pd.categorical

### DIFF
--- a/packages/syft/tests/syft/lib/pandas/categorical_test.py
+++ b/packages/syft/tests/syft/lib/pandas/categorical_test.py
@@ -20,8 +20,8 @@ inputs = [
 ]
 
 objects = [
-    # pd.Categorical(["a", "b", "c", "a"], ordered=False), # Results in Error in comparision func
-    pd.Categorical(["a", "b", "c", "a"], ordered=True),
+    pd.Categorical(["a", "b", "c", "a"]),
+    pd.Categorical([1, 2, 3, 1], ordered=True),
 ]
 
 

--- a/packages/syft/tests/syft/lib/pandas/categorical_test.py
+++ b/packages/syft/tests/syft/lib/pandas/categorical_test.py
@@ -17,6 +17,7 @@ inputs = [
         {"func": "to_numpy", "args": [], "kwargs": {}},
         marks=pytest.mark.xfail(reason="np.ndarray object dtype not Implemented"),
     ),
+    {"func": "sort_values", "args": [], "kwargs": {}},
 ]
 
 objects = [

--- a/packages/syft/tests/syft/lib/pandas/pandas_test.py
+++ b/packages/syft/tests/syft/lib/pandas/pandas_test.py
@@ -1,6 +1,8 @@
 # stdlib
 from collections import OrderedDict
+from typing import Any
 from typing import Dict
+from typing import List
 
 # third party
 import pytest
@@ -27,14 +29,18 @@ def test_pandas(root_client: sy.VirtualMachineClient) -> None:
     assert df2.to_dict() == data
 
 
+@pytest.mark.parametrize("ordered", [True, False])
+@pytest.mark.parametrize("categories", [["b", "a"], [1, 2, 3]])
 @pytest.mark.vendor(lib="pandas")
-def test_pd_categoriesdtype(root_client: sy.VirtualMachineClient) -> None:
+def test_pd_categoriesdtype(
+    root_client: sy.VirtualMachineClient,
+    categories: List[Any],
+    ordered: bool,
+) -> None:
     sy.load("pandas")
     # third party
     import pandas as pd
 
-    categories = ["b", "a"]
-    ordered = False
     t = pd.CategoricalDtype(categories=categories, ordered=ordered)
 
     t_ptr = t.send(root_client)
@@ -45,23 +51,23 @@ def test_pd_categoriesdtype(root_client: sy.VirtualMachineClient) -> None:
     assert t2.ordered == ordered
 
 
+@pytest.mark.parametrize("ordered", [True, False])
+@pytest.mark.parametrize("data", [["a", "a", "b", "f"], [1, 2, 3]])
 @pytest.mark.vendor(lib="pandas")
-def test_pd_categories(root_client: sy.VirtualMachineClient) -> None:
+def test_pd_categories(
+    root_client: sy.VirtualMachineClient, data: List[Any], ordered: bool
+) -> None:
     sy.load("pandas")
     # third party
     import pandas as pd
 
-    categories = ["b", "a"]
-    ordered = False
-    t = pd.Categorical(
-        ["b", "a", "c", "a", "b"], categories=categories, ordered=ordered
-    )
+    t = pd.Categorical(data, ordered=ordered)
 
     t_ptr = t.send(root_client)
 
     t2 = t_ptr.get()
     print(t2)
-    assert t2.categories.to_list() == categories
+    assert (t2.categories.to_list() == t.categories).all()
     assert t2.ordered == ordered
     assert t2.codes.tolist() == t.codes.tolist()
 


### PR DESCRIPTION
## Description
Updated tests to check the behavior of ordered `pd.Categorical` object in ser/de and added test for  `sort_values`.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
