### PR TITLE
Modified RSTensor proto to use TensorProto

### DIFF
--- a/packages/syft/proto/lib/sympc/replicatedshared_tensor.proto
+++ b/packages/syft/proto/lib/sympc/replicatedshared_tensor.proto
@@ -6,7 +6,7 @@ import "proto/lib/torch/tensor.proto";
 import "proto/lib/python/dict.proto";
 
 message ReplicatedSharedTensor {
-  repeated syft.lib.torch.TensorData tensor = 1;
+  repeated syft.lib.torch.TensorProto tensor = 1;
   syft.lib.python.Dict config = 2;
   string session_uuid = 3;
 }

--- a/packages/syft/src/syft/lib/sympc/rst_share.py
+++ b/packages/syft/src/syft/lib/sympc/rst_share.py
@@ -12,8 +12,6 @@ import syft
 
 # syft relative
 from ...generate_wrapper import GenerateWrapper
-from ...lib.torch.tensor_util import tensor_deserializer
-from ...lib.torch.tensor_util import tensor_serializer
 from ...proto.lib.sympc.replicatedshared_tensor_pb2 import (
     ReplicatedSharedTensor as ReplicatedSharedTensor_PB,
 )
@@ -37,7 +35,7 @@ def object2proto(obj: object) -> ReplicatedSharedTensor_PB:
     proto = ReplicatedSharedTensor_PB(session_uuid=session_uuid_syft, config=conf_syft)
 
     for tensor in share.shares:
-        proto.tensor.append(tensor_serializer(tensor))
+        proto.tensor.append(syft.serialize(tensor, to_proto=True))
 
     return proto
 
@@ -55,7 +53,7 @@ def proto2object(proto: ReplicatedSharedTensor_PB) -> ReplicatedSharedTensor:
     output_shares = []
 
     for tensor in proto.tensor:
-        output_shares.append(tensor_deserializer(tensor))
+        output_shares.append(syft.deserialize(tensor, from_proto=True))
 
     share = ReplicatedSharedTensor(shares=None, config=Config(**config))
 

--- a/packages/syft/src/syft/proto/lib/sympc/replicatedshared_tensor_pb2.py
+++ b/packages/syft/src/syft/proto/lib/sympc/replicatedshared_tensor_pb2.py
@@ -23,7 +23,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n-proto/lib/sympc/replicatedshared_tensor.proto\x12\x0esyft.lib.sympc\x1a\x1cproto/lib/torch/tensor.proto\x1a\x1bproto/lib/python/dict.proto"\x81\x01\n\x16ReplicatedSharedTensor\x12*\n\x06tensor\x18\x01 \x03(\x0b\x32\x1a.syft.lib.torch.TensorData\x12%\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x15.syft.lib.python.Dict\x12\x14\n\x0csession_uuid\x18\x03 \x01(\tb\x06proto3',
+    serialized_pb=b'\n-proto/lib/sympc/replicatedshared_tensor.proto\x12\x0esyft.lib.sympc\x1a\x1cproto/lib/torch/tensor.proto\x1a\x1bproto/lib/python/dict.proto"\x82\x01\n\x16ReplicatedSharedTensor\x12+\n\x06tensor\x18\x01 \x03(\x0b\x32\x1b.syft.lib.torch.TensorProto\x12%\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x15.syft.lib.python.Dict\x12\x14\n\x0csession_uuid\x18\x03 \x01(\tb\x06proto3',
     dependencies=[
         proto_dot_lib_dot_torch_dot_tensor__pb2.DESCRIPTOR,
         proto_dot_lib_dot_python_dot_dict__pb2.DESCRIPTOR,
@@ -106,12 +106,12 @@ _REPLICATEDSHAREDTENSOR = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=125,
-    serialized_end=254,
+    serialized_end=255,
 )
 
 _REPLICATEDSHAREDTENSOR.fields_by_name[
     "tensor"
-].message_type = proto_dot_lib_dot_torch_dot_tensor__pb2._TENSORDATA
+].message_type = proto_dot_lib_dot_torch_dot_tensor__pb2._TENSORPROTO
 _REPLICATEDSHAREDTENSOR.fields_by_name[
     "config"
 ].message_type = proto_dot_lib_dot_python_dot_dict__pb2._DICT


### PR DESCRIPTION
## Description
Modified RSTensor proto file to use  TensorProto  instead of TensorData for serialization/deserialization

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
SyMPC Test

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
