### PR TITLE
bugfix, base tokenizer not in AST

### DIFF
--- a/packages/syft/src/syft/lib/transformers/allowlist.py
+++ b/packages/syft/src/syft/lib/transformers/allowlist.py
@@ -12,6 +12,13 @@ allowlist[
 allowlist[
     "transformers.tokenization_utils_base.BatchEncoding.__getitem__"
 ] = "torch.Tensor"
+allowlist[
+    "transformers.tokenization_utils_fast.PreTrainedTokenizerFast"
+] = "transformers.tokenization_utils_fast.PreTrainedTokenizerFast"
+allowlist[
+    "transformers.tokenization_utils_fast.PreTrainedTokenizerFast.__call__"
+] = "transformers.tokenization_utils_base.BatchEncoding"
+
 
 # Distilbert model
 allowlist[


### PR DESCRIPTION
## Description
previous PR changed tokenizer serde to upcast tokenizers to baseclass, I forgot to add the baseclass to allowlist.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Local

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
