### PR TITLE
Revert CI Action for Snyk to 3.8 since 3.9 not supported yet

### DIFF
--- a/.github/workflows/syft-security.yml
+++ b/.github/workflows/syft-security.yml
@@ -70,6 +70,6 @@ jobs:
           mv .snyk ${{ github.workspace }}
 
       - name: Snyk security check
-        uses: snyk/actions/python-3.9@master
+        uses: snyk/actions/python-3.8@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Description
- Revert CI Action for Snyk to 3.8 since 3.9 not supported yet

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
