### PR TITLE
[WIP][Redback] Register and bind external lib

### DIFF
--- a/packages/syft/examples/experimental/aditi/redback/example.py
+++ b/packages/syft/examples/experimental/aditi/redback/example.py
@@ -1,0 +1,9 @@
+import sys
+import syft
+import numpy as np
+
+np = sys.modules["syft.lib.numpy"]
+np
+np.ndarray.dtype
+a = np.array([1, 2, 4])
+a.dtype

--- a/packages/syft/src/syft/lib/modules.py
+++ b/packages/syft/src/syft/lib/modules.py
@@ -1,7 +1,10 @@
 import sys
-import syft
+
+# import syft
 import importlib
-import sklearn
+
+# import sklearn
+import wrapt
 
 # import sklearn
 import functools
@@ -19,10 +22,22 @@ from ..ast import add_methods
 from ..ast import add_modules
 from ..ast.globals import Globals
 from .util import generic_update_ast
+from lib import create_lib_ast, load
+
+lib_ast = create_lib_ast(None)
+bind_lib = ""
 
 
 def register_library(lib: str, update_ast: Callable, objects):
-
+    load(lib, ignore_warning=True)
     if "_SYFT_PACKAGE_SUPPORT" not in sys.modules:
         sys.modules["_SYFT_PACKAGE_SUPPORT"] = []
-    sys.modules["_SYFT_PACKAGE_SUPPORT"].append()
+    sys.modules["_SYFT_PACKAGE_SUPPORT"].append(lib)
+    bind_library(lib)
+
+
+def bind_library(lib: str):
+    global bind_lib
+    package = "syft.lib"
+    module_path = f"{package}.{lib}"
+    bind_lib = sys.modules[module_path]

--- a/packages/syft/src/syft/lib/modules.py
+++ b/packages/syft/src/syft/lib/modules.py
@@ -1,0 +1,28 @@
+import sys
+import syft
+import importlib
+import sklearn
+
+# import sklearn
+import functools
+from typing import Any as TypeAny
+from typing import List as TypeList
+from typing import Tuple as TypeTuple
+from typing import Dict as TypeDict
+from typing import Union as TypeUnion
+from typing import Callable
+from typing import Iterable
+from typing import Optional
+
+from ..ast import add_classes
+from ..ast import add_methods
+from ..ast import add_modules
+from ..ast.globals import Globals
+from .util import generic_update_ast
+
+
+def register_library(lib: str, update_ast: Callable, objects):
+
+    if "_SYFT_PACKAGE_SUPPORT" not in sys.modules:
+        sys.modules["_SYFT_PACKAGE_SUPPORT"] = []
+    sys.modules["_SYFT_PACKAGE_SUPPORT"].append()


### PR DESCRIPTION
## Description
This PR adds mechanism to register an external (3rd party) library and binding it to a global name. Part of the Redback project.
### TODO:
- [ ] Binding to specific names.
- [ ] Modify to work with the lib refactor.
- [ ] Modify Syft to have a support_packages() func.

## Affected Dependencies
None.

## How has this been tested?
- [x] Manually
- [ ] Example notebook.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
