### PR TITLE
[Redback] Denylist for Syft

### DIFF
--- a/packages/syft/src/syft/ast/__init__.py
+++ b/packages/syft/src/syft/ast/__init__.py
@@ -75,6 +75,8 @@ from . import klass  # noqa: F401
 from . import module  # noqa: F401
 from . import property  # noqa: F401
 from . import static_attr  # noqa: F401
+from ..logger import warning
+from .denylist import deny
 
 
 def get_parent(
@@ -147,6 +149,9 @@ def add_classes(
         paths: A list of classes, each of which is a tuple of the path, the return type, and its reference.
     """
     for path, return_type, ref in paths:
+        if deny(path):
+            warning(f"{path} denied. Cannot be added to AST.", print=True)
+            continue
         parent = get_parent(path, ast)
         attr_name = path.rsplit(".", 1)[-1]
         parent.add_attr(
@@ -172,6 +177,9 @@ def add_methods(
         paths: A list of methods, each of which is a tuple of the method's path and its return type.
     """
     for path, return_type in paths:
+        if deny(path):
+            warning(f"{path} denied. Cannot be added to AST.", print=True)
+            continue
         parent = get_parent(path, ast)
         path_list = path.split(".")
         parent.add_path(

--- a/packages/syft/src/syft/ast/denylist.py
+++ b/packages/syft/src/syft/ast/denylist.py
@@ -1,0 +1,25 @@
+"""This module contains denylist.
+
+`denylist` contains list of paths that are explicitly denied and shouldn't be added to ast for security issues."""
+
+# stdlib
+import re
+from typing import Set
+
+_denylist: Set[str] = {
+    "pandas.read_",
+}
+
+_denylist_re = list(map(re.compile, _denylist))  # type: ignore
+
+
+def deny(path: str) -> bool:
+    """Check if path is in denylist.
+
+    Args:
+        path: the path of the `Attribute` to be added to AST.
+
+    Returns:
+        bool: True if the path is denied. (Don't add this path)
+    """
+    return any(bool(regex.match(path)) for regex in _denylist_re)  # type: ignore

--- a/packages/syft/src/syft/lib/pandas/__init__.py
+++ b/packages/syft/src/syft/lib/pandas/__init__.py
@@ -39,6 +39,8 @@ def create_ast(client: TypeAny = None) -> Globals:
     ]
 
     methods: TypeList[TypeTuple[str, str]] = [
+        ("pandas.read_csv","pandas.DataFrame"),
+        ("pandas.read_json","pandas.DataFrame"),
         ("pandas.json_normalize", "pandas.DataFrame"),
         ("pandas.DataFrame.__getitem__", "pandas.Series"),
         ("pandas.DataFrame.__setitem__", "pandas.Series"),


### PR DESCRIPTION
## Description
Adding denylist for syft to explicitly deny methods and classes.
This will help us tackle security issues that may arise on moving syft libs support out of syft.

## Affected Dependencies


## How has this been tested?
- Manually

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
