### PR TITLE
Modified deserialization to use share config.

### DIFF
--- a/packages/syft/src/syft/lib/sympc/rst_share.py
+++ b/packages/syft/src/syft/lib/sympc/rst_share.py
@@ -51,9 +51,7 @@ def proto2object(proto: ReplicatedSharedTensor_PB) -> ReplicatedSharedTensor:
         if session is None:
             raise ValueError(f"The session {proto.session_uuid} could not be found")
 
-        config = dataclasses.asdict(session.config)
-    else:
-        config = syft.deserialize(proto.config, from_proto=True)
+    config = syft.deserialize(proto.config, from_proto=True)
 
     output_shares = []
 

--- a/packages/syft/src/syft/lib/sympc/session_util.py
+++ b/packages/syft/src/syft/lib/sympc/session_util.py
@@ -24,7 +24,7 @@ def protobuf_session_serializer(session: Session) -> MPCSession_PB:
     length_rs = session.ring_size.bit_length()
     rs_bytes = session.ring_size.to_bytes((length_rs + 7) // 8, byteorder="big")
 
-    length_nr_parties = session.ring_size.bit_length()
+    length_nr_parties = session.nr_parties.bit_length()
     nr_parties_bytes = session.nr_parties.to_bytes(
         (length_nr_parties + 7) // 8, byteorder="big"
     )

--- a/packages/syft/src/syft/lib/sympc/share.py
+++ b/packages/syft/src/syft/lib/sympc/share.py
@@ -52,12 +52,11 @@ def proto2object(proto: ShareTensor_PB) -> ShareTensor:
         if session is None:
             raise ValueError(f"The session {proto.session_uuid} could not be found")
 
-        config = dataclasses.asdict(session.config)
-    else:
-        config = syft.deserialize(proto.config, from_proto=True)
+    config = syft.deserialize(proto.config, from_proto=True)
 
     tensor = syft.deserialize(proto.tensor, from_proto=True)
     ring_size = int.from_bytes(proto.ring_size, "big")
+
     share = ShareTensor(data=None, config=Config(**config), ring_size=ring_size)
 
     if proto.session_uuid:


### PR DESCRIPTION
## Description
During de serialization of tensors, we use the session config, since we are working with multiple share values, we require the config value during deserializaiton, so the deserialization is refactored.

## Affected Dependencies
None

## How has this been tested?
SyMPC Tests.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
