### PR TITLE
[WIP] hagrid create and terminate vms on azure/aws/gcp

### DIFF
--- a/packages/hagrid/hagrid/art.py
+++ b/packages/hagrid/hagrid/art.py
@@ -3,6 +3,7 @@ import os
 import random
 
 
+
 def motorcycle():
     print(
         """


### PR DESCRIPTION
We need the ability for hagrid to perform basic deployment and teardown of single nodes on AWS/Azure/GCP, which can subsequently be provisioned with Domain/Network functionality (perhaps using a tool like ansible).

**Acceptance Criteria:**

- this feature shouldn't require any additional local file configuration
- this feature should be usable out of the box immediately after running "pip install hagrid" (see [ch65])
- this feature should ask for any additional information it needs in the command prompt (login information, what machine to use, etc.). 
- this feature should provide good defaults and there should be an optional place to put local file configuration for inputs like username/password relating to a cloud provider (but this should be optional as mentioned)
- all three cloud providers should be configurable using the same CLI grammar