### PR TITLE
hagrid create and destroy local vm

### DIFF
--- a/packages/hagrid/hagrid/art.py
+++ b/packages/hagrid/hagrid/art.py
@@ -3,6 +3,7 @@ import os
 import random
 
 
+
 def motorcycle():
     print(
         """


### PR DESCRIPTION
We need the ability for [hagrid](https://github.com/OpenMined/PySyft/tree/demo_strike_team_branch_4/packages/hagrid) to perform basic deployment and teardown of single VM nodes locally, which can subsequently be provisioned with Domain/Network functionality (perhaps using a tool like ansible).

**Acceptance Criteria:**

- this feature shouldn't require any additional local file configuration
- this feature should be usable out of the box immedaitely after running "pip install hagrid" (see [ch65])
- this feature should ask for any additional information it needs in the command prompt (login information, what machine to use, etc.). 
- this feature should provide good defaults and there should be an optional place to put local file configuration for inputs
- should use the same grammar as cloud deployments (but just replace the eword "azure" or "aws" with "local"). 
- it should be possible to run this command multiple times and specify different ports for multiple VMs to run on
- if a port is not available - it should automatically iterate up one until it finds an available port.
------

If you would like to claim this issue, you must first open a pull request with the following attributes:
- **Title:** [WIP] hagrid create and destroy local vm
- **Branch merging into:** [ iamtrask/ch67/hagrid-create-and-destroy-local-vm](https://github.com/OpenMined/PySyft/tree/iamtrask/ch67/hagrid-create-and-destroy-local-vm)
- **Description:** must include the text "[ch67]" and "#5789"

If you do not claim this issue by creating a pull request, others will assume you are not working on it and will pick up the task themselves (regardless of whether you comment on this issue).
