### PR TITLE
[WIP] Tox Lint Errors (0.6 Alpha)

### DIFF
--- a/packages/grid/ansible/mitogen/ansible_mitogen/transport_config.py
+++ b/packages/grid/ansible/mitogen/ansible_mitogen/transport_config.py
@@ -26,10 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# future
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 """
 Mitogen extends Ansible's target configuration mechanism in several ways that
 require some care:
@@ -60,6 +56,10 @@ That is what this file is for. It exports two spec classes, one that takes all
 information from PlayContext, and another that takes (almost) all information
 from HostVars.
 """
+
+# future
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 # stdlib
 import abc


### PR DESCRIPTION
- [x] Solved check-docstring-first test case for transport_config.py by moving docstring above import code.

## Description
Solving the linting errors from the `tox -e lint` command.

## Affected Dependencies
None.

## How has this been tested?
`tox -e lint`

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
