### PR TITLE
[W.I.P.] Fixing linting errors in Autograd

### DIFF
--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/abs.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/abs.py
@@ -1,16 +1,22 @@
 # syft relative
+# stdlib
+from uuid import UUID
+
+# third party
+from numpy import ndarray
+
 # relative
 from ..tensor import AutogradTensor
 from .op import Op
 
 
 class AbsOp(Op):
-    def forward(self, x: AutogradTensor):
+    def forward(self, x: AutogradTensor) -> AutogradTensor:
         self.x = x
 
         return AutogradTensor(x.child.__abs__(), requires_grad=x.requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: ndarray, backprop_id: UUID) -> None:
 
         if self.x.requires_grad:
             _grad = self.x > 0  # returns 0s and 1s

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/add.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/add.py
@@ -1,3 +1,6 @@
+# stdlib
+from uuid import UUID
+
 # third party
 import numpy as np
 
@@ -11,7 +14,7 @@ from .op import Op
 class AddOp(Op):
     """Sumation operation with 2 tensors"""
 
-    def forward(self, x: AutogradTensor, y: AutogradTensor):
+    def forward(self, x: AutogradTensor, y: AutogradTensor) -> AutogradTensor:
         self.x = x
         self.y = y
 
@@ -23,7 +26,7 @@ class AddOp(Op):
         requires_grad = requires_grad or y.requires_grad
         return AutogradTensor(x.child + y.child, requires_grad=requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: np.ndarray, backprop_id: UUID) -> None:
         if self.x.requires_grad:
             # as we have matrix operation one of the parameters can
             # have partial shape in such scenarion we need to sum

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/argmax.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/argmax.py
@@ -1,4 +1,5 @@
 # stdlib
+from typing import Optional
 import uuid
 
 # relative
@@ -8,9 +9,12 @@ from .op import Op
 
 
 class ArgMaxOp(Op):
-    def forward(self, x: AutogradTensor, axis=None) -> AutogradTensor:
+    def forward(self, x: AutogradTensor, axis: Optional[int] = None) -> AutogradTensor:
         self.x = x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return x.max() if not axis else x.max(axis)
+
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/argmin.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/argmin.py
@@ -11,8 +11,10 @@ class ArgMinOp(Op):
     def forward(self, x: AutogradTensor, y: AutogradTensor) -> AutogradTensor:
         self.x = x
         self.y = y
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/argsort.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/argsort.py
@@ -11,8 +11,10 @@ class ArgSortOp(Op):
     def forward(self, x: AutogradTensor, y: AutogradTensor) -> AutogradTensor:
         self.x = x
         self.y = y
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/clip.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/clip.py
@@ -14,8 +14,10 @@ class ClipOp(Op):
         self.x = x
         self.y = y
         self.z = z
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/copy.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/copy.py
@@ -1,4 +1,10 @@
 # syft relative
+# stdlib
+from uuid import UUID
+
+# third party
+from numpy import ndarray
+
 # relative
 from ..tensor import AutogradTensor
 from .op import Op
@@ -7,12 +13,12 @@ from .op import Op
 class CopyOp(Op):
     """Copy a tensor"""
 
-    def forward(self, x: AutogradTensor):
+    def forward(self, x: AutogradTensor) -> AutogradTensor:
         self.x = x
 
         return AutogradTensor(x.child.copy(), requires_grad=x.requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: ndarray, backprop_id: UUID) -> None:
 
         if self.x.requires_grad:
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/dot.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/dot.py
@@ -12,7 +12,10 @@ class DotOp(Op):
         self.x = x
         self.y = y
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+        # This is just a placeholder to remove return type linting errors until the method is built
+        return AutogradTensor(x.child)
+
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/getitem.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/getitem.py
@@ -11,8 +11,10 @@ class GetItemOp(Op):
     def forward(self, x: AutogradTensor, y: AutogradTensor) -> AutogradTensor:
         self.x = x
         self.y = y
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/invert.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/invert.py
@@ -11,6 +11,9 @@ class InvertOp(Op):
     def forward(self, x: AutogradTensor) -> AutogradTensor:
         self.x = x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return x
+
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/mul.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/mul.py
@@ -1,4 +1,10 @@
 # syft relative
+# stdlib
+from uuid import UUID
+
+# third party
+from numpy import ndarray
+
 # relative
 from ...passthrough import is_acceptable_simple_type
 from ..tensor import AutogradTensor
@@ -8,7 +14,7 @@ from .op import Op
 class MulOp(Op):
     """Multiplication operation with 2 tensors"""
 
-    def forward(self, x: AutogradTensor, y: AutogradTensor):
+    def forward(self, x: AutogradTensor, y: AutogradTensor) -> AutogradTensor:
         self.x = x
         self.y = y
 
@@ -31,7 +37,7 @@ class MulOp(Op):
 
         return AutogradTensor(y.child * x.child, requires_grad=requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: ndarray, backprop_id: UUID) -> None:
 
         y_is_simple = is_acceptable_simple_type(self.y)
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/op.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/op.py
@@ -2,6 +2,7 @@
 # stdlib
 from abc import abstractmethod
 from typing import Any
+from typing import Optional
 from uuid import UUID
 
 # third party
@@ -13,16 +14,16 @@ from ..tensor import AutogradTensor
 
 class Op:
     def __init__(self) -> None:
-        self.backprop_id = None
+        self.backprop_id: Optional[UUID] = None
 
     @abstractmethod
-    def forward(self, *args: Any, **kwargs: Any):
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
-    def _backward(self, grad: ndarray, backprop_id: UUID):
+    def _backward(self, grad: ndarray, backprop_id: UUID) -> Any:
         raise NotImplementedError
 
-    def backward(self, grad: ndarray, backprop_id: UUID):
+    def backward(self, grad: ndarray, backprop_id: UUID) -> Any:
 
         self.backprop_id = backprop_id
 
@@ -31,7 +32,7 @@ class Op:
 
         return self._backward(grad=grad, backprop_id=backprop_id)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
 
         self.parent_tensors = list()
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/op.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/op.py
@@ -1,24 +1,28 @@
 # syft relative
 # stdlib
+from abc import abstractmethod
 from typing import Any
-from typing import abstractmethod
+from uuid import UUID
+
+# third party
+from numpy import ndarray
 
 # relative
 from ..tensor import AutogradTensor
 
 
 class Op:
-    def __init__(self):
+    def __init__(self) -> None:
         self.backprop_id = None
 
     @abstractmethod
-    def forward(self, *args: Any, **kwargs: Any) -> None:
+    def forward(self, *args: Any, **kwargs: Any):
         raise NotImplementedError
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: ndarray, backprop_id: UUID):
         raise NotImplementedError
 
-    def backward(self, grad, backprop_id):
+    def backward(self, grad: ndarray, backprop_id: UUID):
 
         self.backprop_id = backprop_id
 
@@ -39,7 +43,7 @@ class Op:
         for key, arg in kwargs.items():
             if isinstance(arg, AutogradTensor):
                 arg.ops.append(self)
-                self.parent_tensor.append(arg)
+                self.parent_tensors.append(arg)
 
         self.out = self.forward(*args, **kwargs)
         self.out._grad_fn = self

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/pow.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/pow.py
@@ -31,7 +31,8 @@ class PowOp(Op):
         if self.x.requires_grad:
             y_form = self.y
 
-            self.x.add_grad(grad * y_form * (self.x ** (y_form - 1)))
+            # ignoring type b/c method hasn't been implemented yet
+            self.x.add_grad(grad * y_form * (self.x ** (y_form - 1)))  # type: ignore
 
             if self.x.grad_fn:
                 self.x.backward(backprop_id=backprop_id)

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/pow.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/pow.py
@@ -24,7 +24,7 @@ class PowOp(Op):
         requires_grad = requires_grad or y.requires_grad
         return AutogradTensor(x.child ** y.child, requires_grad=requires_grad)
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
 
         y_is_simple = is_acceptable_simple_type(self.y)
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/repeat.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/repeat.py
@@ -1,4 +1,11 @@
 # syft relative
+# stdlib
+from typing import Optional
+from uuid import UUID
+
+# third party
+from numpy import ndarray
+
 # relative
 from ..tensor import AutogradTensor
 from .op import Op
@@ -7,7 +14,9 @@ from .op import Op
 class RepeatOp(Op):
     """Repeat operation across a dimension"""
 
-    def forward(self, x: AutogradTensor, repeats, axis=None):
+    def forward(
+        self, x: AutogradTensor, repeats: int, axis: Optional[int] = None
+    ) -> AutogradTensor:
         self.x = x
         self.repeats = repeats
         self.axis = axis
@@ -20,7 +29,7 @@ class RepeatOp(Op):
 
         return AutogradTensor(output, requires_grad=x.requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: ndarray, backprop_id: UUID) -> None:
 
         if self.x.requires_grad:
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/reshape.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/reshape.py
@@ -1,4 +1,10 @@
 # syft relative
+# stdlib
+from uuid import UUID
+
+# third party
+from numpy import ndarray
+
 # relative
 from ..tensor import AutogradTensor
 from .op import Op
@@ -7,14 +13,14 @@ from .op import Op
 class ReshapeOp(Op):
     """Multiplication operation with 2 tensors"""
 
-    def forward(self, x: AutogradTensor, *shape):
+    def forward(self, x: AutogradTensor, *shape: tuple) -> AutogradTensor:
         self.x = x
         self.shape = shape
         self.backward_shape = self.x.shape
 
         return AutogradTensor(x.child.reshape(*shape), requires_grad=x.requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: ndarray, backprop_id: UUID) -> None:
 
         if self.x.requires_grad:
             self.x.add_grad(grad.reshape(*self.backward_shape))

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/resize.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/resize.py
@@ -11,6 +11,9 @@ class ResizeOp(Op):
     def forward(self, x: AutogradTensor) -> AutogradTensor:
         self.x = x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return AutogradTensor(x)
+
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/rpow.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/rpow.py
@@ -24,7 +24,7 @@ class RPowOp(Op):
         requires_grad = requires_grad or y.requires_grad
         return AutogradTensor(y.child ** x.child, requires_grad=requires_grad)
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
 
         y_is_simple = is_acceptable_simple_type(self.y)
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/rpow.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/rpow.py
@@ -38,6 +38,7 @@ class RPowOp(Op):
                 self.x.backward(backprop_id=backprop_id)
 
         if not y_is_simple and self.y.requires_grad:
-            self.y.add_grad(grad * self.x * self.y ** (self.x - 1))
+            # ignore type error b/c method hasn't been implemented yet
+            self.y.add_grad(grad * self.x * self.y ** (self.x - 1))  # type: ignore
             if self.y.grad_fn:
                 self.y.backward(backprop_id=backprop_id)

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/rshift.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/rshift.py
@@ -11,8 +11,10 @@ class RShiftOp(Op):
     def forward(self, x: AutogradTensor, y: AutogradTensor) -> AutogradTensor:
         self.x = x
         self.y = y
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return x
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/sort.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/sort.py
@@ -12,7 +12,10 @@ class SortOp(Op):
         self.x = x
         self.y = y
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+        # This is just a placeholder to suppress linting errors until the method is built out
+        return AutogradTensor(x.child)
+
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/sub.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/sub.py
@@ -1,3 +1,6 @@
+# stdlib
+from uuid import UUID
+
 # third party
 import numpy as np
 
@@ -11,7 +14,7 @@ from .op import Op
 class SubOp(Op):
     """Substraction operation with 2 tensors"""
 
-    def forward(self, x: AutogradTensor, y: AutogradTensor):
+    def forward(self, x: AutogradTensor, y: AutogradTensor) -> AutogradTensor:
         self.x = x
         self.y = y
 
@@ -27,7 +30,7 @@ class SubOp(Op):
 
         return AutogradTensor(x.child - y.child, requires_grad=requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: np.ndarray, backprop_id: UUID) -> None:
 
         if self.x.requires_grad:
             # as we have matrix operation one of the parameters can

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/sum.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/sum.py
@@ -20,7 +20,7 @@ class SumOp(Op):
             # obj.sum() can be called without dims
             self.dim_at_axis = self.x.shape[self.axis]
         else:
-            self.dim_at_axis = None
+            self.dim_at_axis = None  # type: ignore
         self.backward_shape = self.x.shape
 
         result = x.child.sum(axis=axis)
@@ -40,7 +40,7 @@ class SumOp(Op):
                 grad = grad.repeat(self.dim_at_axis, axis=self.axis)
 
             else:
-                n_times = np.prod(self.backward_shape)
+                n_times = np.prod(self.backward_shape)  # type: ignore
                 grad = grad.repeat(n_times, axis=0).reshape(self.backward_shape)
 
             self.x.add_grad(grad)

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/sum.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/sum.py
@@ -1,3 +1,6 @@
+# stdlib
+from uuid import UUID
+
 # third party
 import numpy as np
 
@@ -10,7 +13,7 @@ from .op import Op
 class SumOp(Op):
     """Sum operation across a dimension"""
 
-    def forward(self, x: AutogradTensor, axis):
+    def forward(self, x: AutogradTensor, axis: int) -> AutogradTensor:
         self.x = x
         self.axis = axis
         if axis is not None:
@@ -27,7 +30,7 @@ class SumOp(Op):
 
         return AutogradTensor(result, requires_grad=x.requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: np.ndarray, backprop_id: UUID) -> None:
 
         if self.x.requires_grad:
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/transpose.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/transpose.py
@@ -1,4 +1,10 @@
 # syft relative
+# stdlib
+from uuid import UUID
+
+# third party
+from numpy import ndarray
+
 # relative
 from ..tensor import AutogradTensor
 from .op import Op
@@ -7,7 +13,7 @@ from .op import Op
 class TransposeOp(Op):
     """Repeat operation across a dimension"""
 
-    def forward(self, x: AutogradTensor, *dims):
+    def forward(self, x: AutogradTensor, *dims: tuple) -> AutogradTensor:
         self.x = x
         self.dims = dims
 
@@ -22,7 +28,7 @@ class TransposeOp(Op):
 
         return AutogradTensor(x.child.transpose(*dims), requires_grad=x.requires_grad)
 
-    def _backward(self, grad, backprop_id):
+    def _backward(self, grad: ndarray, backprop_id: UUID) -> None:
 
         if self.x.requires_grad:
 

--- a/packages/syft/src/syft/core/tensor/autograd/backward_ops/truediv.py
+++ b/packages/syft/src/syft/core/tensor/autograd/backward_ops/truediv.py
@@ -12,7 +12,10 @@ class TrueDivOp(Op):
         self.x = x
         self.y = y
 
-    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID):
+        # This is just a placeholder to remove return type linting errors until this method is built out fully
+        return AutogradTensor(x.child / y)
+
+    def _backward(self, grad: AutogradTensor, backprop_id: uuid.UUID) -> None:
         if self.x.requires_grad:
             pass
 

--- a/packages/syft/src/syft/core/tensor/autograd/tensor.py
+++ b/packages/syft/src/syft/core/tensor/autograd/tensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 # stdlib
 from collections import Counter
 from collections import defaultdict
+from typing import Any
 from typing import DefaultDict
 from typing import List
 from typing import Optional
@@ -105,11 +106,15 @@ class AutogradTensor(PassthroughTensor, PhiTensorAncestor, Serializable):
             return self * (1 / other)
         return NotImplemented
 
-    def __pow__(self, other: AutogradTensor) -> AutogradTensorAncestor:
+    def __pow__(
+        self, other: Union[AutogradTensor, Union[int, bool, float, Any]]
+    ) -> AutogradTensorAncestor:
         op = autograd.backward_ops.PowOp()
         return op(self, other)
 
-    def __rpow__(self, other: AutogradTensor) -> AutogradTensorAncestor:
+    def __rpow__(
+        self, other: Union[AutogradTensor, Union[int, bool, float, Any]]
+    ) -> AutogradTensorAncestor:
         op = autograd.backward_ops.RPowOp()
         return op(self, other)
 
@@ -248,14 +253,13 @@ class AutogradTensor(PassthroughTensor, PhiTensorAncestor, Serializable):
     @staticmethod
     def _proto2object(proto: Tensor_PB) -> AutogradTensor:
         use_tensors = proto.use_tensors
-        child = []
+        child: List[AutogradTensor] = []
         if use_tensors:
             child = [deserialize(tensor) for tensor in proto.tensors]
         else:
             child = [deserialize(array) for array in proto.arrays]
 
-        child = child[0]
-        return AutogradTensor(child, requires_grad=proto.requires_grad)
+        return AutogradTensor(child[0], requires_grad=proto.requires_grad)
 
     @staticmethod
     def get_protobuf_schema() -> GeneratedProtocolMessageType:


### PR DESCRIPTION
## Description
Fixed 75 out of 128 initial linting errors that were found for core/tensor/autograd.
43 of the remaining 53 pertain to types that are incompatible between a class method and its corresponding method in the superclass. This is happening with 2 super classes in particular:

**1. AutogradTensor & PassthroughTensor**
`packages/syft/src/syft/core/tensor/autograd/tensor.py:83: error: Return type "AutogradTensorAncestor" of "__abs__" incompatible with return type "PassthroughTensor" in supertype "PassthroughTensor"`

**2. Many of the backward_ops and the Op superclass**
`packages/syft/src/syft/core/tensor/autograd/backward_ops/invert.py:11: error: Signature of "forward" incompatible with supertype "Op"`



## Affected Dependencies
No new dependencies were needed, nor old ones removed

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
