### PR TITLE
fix to allow execute cd command in tox.ini  Ubuntu

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     protoc-wheel-0
     pre-commit
 commands =
-    cd {toxinidir}/packages/syft && scripts/build_proto.sh
+    bash -c "cd {toxinidir}/packages/syft; ./scripts/build_proto.sh"
     black .
     isort .
     pre-commit run --all-files


### PR DESCRIPTION
## Description
Fix to allow execute cd command in tox.ini in Ubuntu

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
