### PR TITLE
Redback | Support Short Long Path

### DIFF
--- a/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/script.py
+++ b/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/script.py
@@ -303,8 +303,10 @@ def generate_package_support(
         allowlist += allowlist_i  # append to list
 
         debug_list.extend(debug_list_i)
+        tmp_class = class_import(class_)
+        original_path = tmp_class.__module__+"."+tmp_class.__name__
 
-        if len(list_nb_i) > 0:
+        if len(list_nb_i) > 0  and original_path == class_:
             nb = nbf.v4.new_notebook()
             class_name = class_.replace(".", "_")
             nb_name = f"{class_name}.ipynb"

--- a/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/script.py
+++ b/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/script.py
@@ -254,7 +254,7 @@ def dict_allowlist(
                     ).replace("\t", " " * 4)
 
                     list_nb.append(nbf.v4.new_code_cell(code))
-                allowlist[i + "." + t.__name__] = string
+                allowlist.append((i + "." + t.__name__, string))
 
         elif isinstance(t, property):
             missing_return += 1
@@ -352,9 +352,9 @@ def generate_package_support(
 
         debug_list.extend(debug_list_i)
         tmp_class = class_import(class_)
-        original_path = tmp_class.__module__+"."+tmp_class.__name__
+        original_path = tmp_class.__module__ + "." + tmp_class.__name__
 
-        if len(list_nb_i) > 0  and original_path == class_:
+        if len(list_nb_i) > 0 and original_path == class_:
             nb = nbf.v4.new_notebook()
             class_name = class_.replace(".", "_")
             nb_name = f"{class_name}.ipynb"

--- a/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/templates/update_py.template
+++ b/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/templates/update_py.template
@@ -3,6 +3,16 @@ from importlib.machinery import SourceFileLoader
 import json
 import os
 from pathlib import Path
+import importlib
+from typing import Any as TypeAny
+
+def class_import(name: TypeAny) -> TypeAny:
+    components = name.split(".")
+    mod = importlib.import_module(components[0])
+    for comp in components[1:]:
+        mod = getattr(mod, comp, None)
+    return mod
+
 
 def update_json() -> None:
     root_dir = os.path.abspath(Path(os.path.dirname(__file__)) / "..")
@@ -18,17 +28,17 @@ def update_json() -> None:
     for x,(method,return_type) in enumerate(allowlist):
         if return_type in ["_syft_missing", "_syft_return_absent"]:
 
-            arr = method.split(".")[:-1]
+            tmp_class = class_import(".".join(method.split(".")[:-1]))
+            original_class = tmp_class.__module__+"."+tmp_class.__name__
+            class_ = original_class.replace(".", "_")
 
-            class_ = str()
+            method_name = method.split(".")[-1]
+            method_path = original_class+"."+method_name
+            method_ = method_path.replace(".", "_")
 
-            for a in arr:
-                class_ += a + "_"
-
-            method_ = method.replace(".", "_")
             # executing this string should work :)
             try:
-                return_type = eval(f"_missing_return.{class_[:-1]}.type_{method_}")
+                return_type = eval(f"_missing_return.{class_}.type_{method_}")
                 if return_type not in ["_syft_missing", "_syft_return_absent"]:
                     print(f"Updating {return_type}")
                     allowlist[x] = (method,return_type)

--- a/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/templates/update_sh.template
+++ b/packages/syft-libs/pyscaffoldext-syft-support/src/pyscaffoldext/syft_support/templates/update_sh.template
@@ -1,4 +1,4 @@
 #!/bin/bash
 jupyter-nbconvert --to python --execute _missing_return/*.ipynb 
 python scripts/update.py
-find . -name "*.py" -and ! -name "__init__.py" -delete
+find _missing_return -name "*.py" -and ! -name "__init__.py" -delete


### PR DESCRIPTION
## Description
If a class is imported several times, to support long/short import paths we add all these paths to the allowlist, however, it becomes more tedious if we were to add return_type for all these paths (which would be the same). To resolve this we check the base module of the class and reflect the changes to all other class references.

For instance,
```json
"classes": ["mypkg.A", "mypkg.b.A", "mypkg.b.B", "mypkg.subpkg.a.A"]
 ```
 here, `"mypkg.A", "mypkg.b.A"` refer to the base class ` "mypkg.subpkg.a.A"` and return_type fixes for `mypkg.subpkg.a.A` can be reflected in others.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- locally on sample lib

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
