### PR TITLE
Add build-essential to dependencies in order to fix building error

### DIFF
--- a/docker/syft.Dockerfile
+++ b/docker/syft.Dockerfile
@@ -22,7 +22,7 @@ RUN echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.lis
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
     apt-get install -yqq \
-    gcc gcc-9 g++-9 libc6 git python3-dev libssl-dev libffi-dev && \
+    gcc gcc-9 g++-9 libc6 git python3-dev libssl-dev libffi-dev build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # update pip


### PR DESCRIPTION
## Description
The library bplib fails on building when docker image is trying to be created. This cause pip tries to install other versions of bplib and then tries to get all other versions of the other dependencies, taking hours to try to build the image.

Adding build-essential allows to build bplib and then the image is created in a few minutes.

## Affected Dependencies
build-essential 

## How has this been tested?
Executing 
docker build -f docker/syft.Dockerfile --build-arg GPU=false -t openmined/syft:latest -t openmined/syft:`python VERSION` .
as explained in docker/syft.Dockerfile and getting the image created.


## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [] My changes are covered by tests
