### PR TITLE
Add 'publish' method to share tensor

### DIFF
--- a/packages/syft/src/syft/core/tensor/__init__.py
+++ b/packages/syft/src/syft/core/tensor/__init__.py
@@ -148,6 +148,16 @@ def create_tensor_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ),
         # ("syft.core.tensor.tensor.Tensor.share", "syft.core.tensor.tensor.Tensor"),
         # Share Tensor Operations
+        # TODO: This should be done better - for the moment this is put here to allow
+        # forwarding publish method on a ShareTensorPointer - even though we will not
+        # reach to call the publish from ShareTensor, but from the ADP Tensor Entity
+        # MPC -> ADP -> ShareTensor
+        # But MPC considers MPC -> ShareTensor (it might be a good idea to keep the obfuscation here)
+        # Another way to do it, is that MPCTensor has as child a Union between ADPTensor and ShareTensor
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.publish",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
         (
             "syft.core.tensor.smpc.share_tensor.ShareTensor.__add__",
             "syft.core.tensor.smpc.share_tensor.ShareTensor",

--- a/packages/syft/src/syft/core/tensor/autograd/tensor.py
+++ b/packages/syft/src/syft/core/tensor/autograd/tensor.py
@@ -18,8 +18,8 @@ import numpy as np
 
 # relative
 from .. import autograd
-from ....core.adp.collections import DefaultDict
-from ....core.adp.collections import SerializableCounter
+from ....lib.python.collections.collections import DefaultDict
+from ....lib.python.collections.collections import SerializableCounter
 from ....core.common.serde.recursive import RecursiveSerde
 from ...common.serde.serializable import bind_protobuf
 from ..ancestors import AutogradTensorAncestor

--- a/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
+++ b/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
@@ -36,6 +36,8 @@ METHODS_FORWARD_ALL_SHARES = {
     "narrow",
     "dim",
     "transpose",
+    # DP
+    "publish",
 }
 
 

--- a/packages/syft/src/syft/core/tensor/smpc/share_tensor.py
+++ b/packages/syft/src/syft/core/tensor/smpc/share_tensor.py
@@ -2,6 +2,8 @@
 from functools import lru_cache
 import operator
 from typing import Any
+from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -288,6 +290,12 @@ class ShareTensor(PassthroughTensor, Serializable):
         # res = self.apply_function(y, "floordiv")
         res.tensor = self.tensor // y
         return res
+
+    def publish(self, *args: List[Any], **kwargs: Dict[Any, Any]) -> None:
+        raise NotImplementedError(
+            """It should not reach here. """
+            """somewhere on the chain it should have been an ADP Tensor"""
+        )
 
     def _object2proto(self) -> ShareTensor_PB:
         if isinstance(self.child, np.ndarray):

--- a/packages/syft/src/syft/lib/python/collections/collections.py
+++ b/packages/syft/src/syft/lib/python/collections/collections.py
@@ -5,8 +5,8 @@ from typing import Any
 from typing import Optional
 
 # relative
-from ..core.common.serde.recursive import RecursiveSerde
-from ..core.common.serde.serializable import bind_protobuf
+from ....core.common.serde.recursive import RecursiveSerde
+from ....core.common.serde.serializable import bind_protobuf
 
 
 @bind_protobuf

--- a/packages/syft/tests/syft/core/tensor/smpc/share_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/smpc/share_tensor_test.py
@@ -1,0 +1,15 @@
+# third party
+import pytest
+
+# syft absolute
+from syft.core.tensor.smpc.share_tensor import ShareTensor
+
+
+# TODO: This needs more tests (Added issue)
+
+
+def test_publish_raise_not_implemented() -> None:
+    share = ShareTensor(rank=0, nr_parties=1)
+
+    with pytest.raises(NotImplementedError) as exp:
+        share.publish()


### PR DESCRIPTION
## Description
 - Add `publish` method to share to be executed on all shares when `MPCTensor` calls it.

## How has this been tested?
- Added test for ShareTensor, although that method should not be reached because `publish` should be treated by the `ADPTensor` which is before the `ShareTensor` (in the chain of tensors)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
