### PR TITLE
Add publish as forward method

### DIFF
--- a/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
+++ b/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
@@ -36,6 +36,8 @@ METHODS_FORWARD_ALL_SHARES = {
     "narrow",
     "dim",
     "transpose",
+    # For ADP
+    "publish",
 }
 
 
@@ -94,20 +96,6 @@ class MPCTensor(PassthroughTensor):
         res.sort(key=lambda share: share.client.name + share.client.id.no_dash)
 
         super().__init__(res)
-
-    def publish(self, sigma: float):
-
-        new_shares = list()
-        for share in self.child:
-            new_share = share.publish(client=share.client, sigma=sigma)
-            new_shares.append(new_share)
-
-        return MPCTensor(
-            parties=self.parties,
-            shares=new_shares,
-            shape=self.mpc_shape,
-            seed_shares=self.seed_shares,
-        )
 
     @property
     def shape(self):


### PR DESCRIPTION
## Description
Simplify logic for `publish`.
For the moment, there is a list of methods that should be sent to all the shares - at the level of `MPCTensor`.
`publish` is one of those methods.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
