### PR TITLE
Split cron into redeploy

### DIFF
--- a/packages/grid/scripts/cron.sh
+++ b/packages/grid/scripts/cron.sh
@@ -51,14 +51,17 @@ git pull origin $3 --rebase
 chown -R $4:$5 .
 
 END_HASH=$(git rev-parse HEAD)
+CONTAINER_HASH=$(docker exec $(docker ps --format "{{.Names}}" | grep frontend) env | grep VERSION_HASH | sed 's/VERSION_HASH=//')
+
+SCRIPT_PATH="$(dirname \"$0\")"
 
 if [ "$START_HASH" != "$END_HASH" ]
 then
-    echo "Code has changed so redeploying with HAGrid"
-    rm -rf ${8}
-    cp -r ${1} ${8}
-    chown -R ${4}:${5} ${8}
-    /usr/sbin/runuser -l ${4} -c "pip install -e ${8}/packages/hagrid"
-    /usr/sbin/runuser -l ${4} -c "hagrid launch ${7} ${6} to localhost --repo=${2} --branch=${3} --ansible_extras='docker_volume_destroy=true'"
+    echo "Git hashes dont match, redeploying"
+    bash $SCRIPT_PATH/redeploy.sh $1 $2 $3 $4 $5 $6 $7 $8
+elif [[ ! "$END_HASH" == *"$CONTAINER_HASH"* ]]
+then
+    echo "Container hash doesnt match code, redeploying"
+    bash $SCRIPT_PATH/redeploy.sh $1 $2 $3 $4 $5 $6 $7 $8
 fi
 echo "Finished autoupdate CRON"

--- a/packages/grid/scripts/redeploy.sh
+++ b/packages/grid/scripts/redeploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# cronjob logs: $ tail -f /var/log/syslog | grep -i cron
+
+# $1 is the PySyft dir
+# $2 is the git repo like: https://github.com/OpenMined/PySyft
+# $3 is the branch like: dev
+# $4 is the permission user like: om
+# $5 is the permission group like: om
+# $6 is the node type like: domain
+# $7 is the node name like: node
+# $8 is the build directory where we copy the source so we dont trigger hot reloading
+
+echo "Code has changed so redeploying with HAGrid"
+rm -rf ${8}
+cp -r ${1} ${8}
+chown -R ${4}:${5} ${8}
+/usr/sbin/runuser -l ${4} -c "pip install -e ${8}/packages/hagrid"
+/usr/sbin/runuser -l ${4} -c "hagrid launch ${7} ${6} to localhost --repo=${2} --branch=${3} --ansible_extras='docker_volume_destroy=true'"


### PR DESCRIPTION
## Description
- Split cron into redeploy
- Added code to check container hash as a second redeploy check

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
