### PR TITLE
Make redeploy.sh only run once at a time

### DIFF
--- a/packages/grid/scripts/redeploy.sh
+++ b/packages/grid/scripts/redeploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# only run one redeploy.sh at a time
+pidof -o %PPID -x $0 >/dev/null && echo "ERROR: Script $0 already running" && exit 1
+
 # cronjob logs: $ tail -f /var/log/syslog | grep -i cron
 
 # $1 is the PySyft dir


### PR DESCRIPTION
## Description
Make redeploy.sh only run once at a time

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
