### PR TITLE
MPCTensor : Numpy Hook Methods

### DIFF
--- a/packages/syft/src/syft/core/tensor/__init__.py
+++ b/packages/syft/src/syft/core/tensor/__init__.py
@@ -126,7 +126,6 @@ def create_tensor_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ("syft.core.tensor.tensor.Tensor.diagonal", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.dot", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.flatten", "syft.core.tensor.tensor.Tensor"),
-        ("syft.core.tensor.tensor.Tensor.partition", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.ravel", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.compress", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.swapaxes", "syft.core.tensor.tensor.Tensor"),
@@ -199,10 +198,6 @@ def create_tensor_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ),
         (
             "syft.core.tensor.smpc.share_tensor.ShareTensor.transpose",
-            "syft.core.tensor.smpc.share_tensor.ShareTensor",
-        ),
-        (
-            "syft.core.tensor.smpc.share_tensor.ShareTensor.partition",
             "syft.core.tensor.smpc.share_tensor.ShareTensor",
         ),
         (

--- a/packages/syft/src/syft/core/tensor/__init__.py
+++ b/packages/syft/src/syft/core/tensor/__init__.py
@@ -177,6 +177,54 @@ def create_tensor_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
             "syft.core.tensor.smpc.share_tensor.ShareTensor.sum",
             "syft.core.tensor.smpc.share_tensor.ShareTensor",
         ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.repeat",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.copy",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.diagonal",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.flatten",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.transpose",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        # (
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.partition",
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        # ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.resize",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        # (
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.ravel",
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        # ),
+        # (
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.compress",
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        # ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.reshape",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.squeeze",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        # (
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.swapaxes",
+        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        # ),
     ]
 
     add_modules(ast, modules)

--- a/packages/syft/src/syft/core/tensor/__init__.py
+++ b/packages/syft/src/syft/core/tensor/__init__.py
@@ -126,6 +126,10 @@ def create_tensor_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
         ("syft.core.tensor.tensor.Tensor.diagonal", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.dot", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.flatten", "syft.core.tensor.tensor.Tensor"),
+        ("syft.core.tensor.tensor.Tensor.partition", "syft.core.tensor.tensor.Tensor"),
+        ("syft.core.tensor.tensor.Tensor.ravel", "syft.core.tensor.tensor.Tensor"),
+        ("syft.core.tensor.tensor.Tensor.compress", "syft.core.tensor.tensor.Tensor"),
+        ("syft.core.tensor.tensor.Tensor.swapaxes", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.gamma", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.grad", "syft.core.tensor.tensor.Tensor"),
         ("syft.core.tensor.tensor.Tensor.max", "syft.core.tensor.tensor.Tensor"),
@@ -197,22 +201,22 @@ def create_tensor_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
             "syft.core.tensor.smpc.share_tensor.ShareTensor.transpose",
             "syft.core.tensor.smpc.share_tensor.ShareTensor",
         ),
-        # (
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.partition",
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
-        # ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.partition",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
         (
             "syft.core.tensor.smpc.share_tensor.ShareTensor.resize",
             "syft.core.tensor.smpc.share_tensor.ShareTensor",
         ),
-        # (
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.ravel",
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
-        # ),
-        # (
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.compress",
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
-        # ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.ravel",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.compress",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
         (
             "syft.core.tensor.smpc.share_tensor.ShareTensor.reshape",
             "syft.core.tensor.smpc.share_tensor.ShareTensor",
@@ -221,10 +225,10 @@ def create_tensor_ast(client: Optional[AbstractNodeClient] = None) -> Globals:
             "syft.core.tensor.smpc.share_tensor.ShareTensor.squeeze",
             "syft.core.tensor.smpc.share_tensor.ShareTensor",
         ),
-        # (
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor.swapaxes",
-        #    "syft.core.tensor.smpc.share_tensor.ShareTensor",
-        # ),
+        (
+            "syft.core.tensor.smpc.share_tensor.ShareTensor.swapaxes",
+            "syft.core.tensor.smpc.share_tensor.ShareTensor",
+        ),
     ]
 
     add_modules(ast, modules)

--- a/packages/syft/src/syft/core/tensor/passthrough.py
+++ b/packages/syft/src/syft/core/tensor/passthrough.py
@@ -340,8 +340,11 @@ class PassthroughTensor(np.lib.mixins.NDArrayOperatorsMixin):
         new_shape: Union[int, TypeTuple[int, ...]],
         refcheck: Optional[bool] = True,
     ) -> PassthroughTensor:
-        self.child.resize(new_shape, refcheck=refcheck)  # inplace op
-        return self.__class__(self.child)
+        # Should be modified to  remove copy
+        # https://stackoverflow.com/questions/23253144/numpy-the-array-doesnt-have-its-own-data
+        res = self.child.copy()
+        res.resize(new_shape, refcheck=refcheck)
+        return self.__class__(res)
 
     @property
     def T(self) -> PassthroughTensor:

--- a/packages/syft/src/syft/core/tensor/passthrough.py
+++ b/packages/syft/src/syft/core/tensor/passthrough.py
@@ -335,8 +335,13 @@ class PassthroughTensor(np.lib.mixins.NDArrayOperatorsMixin):
     ) -> PassthroughTensor:
         return self.__class__(self.child.repeat(repeats, axis))
 
-    def resize(self, new_shape: Union[int, TypeTuple[int, ...]]) -> PassthroughTensor:
-        return self.__class__(self.child.resize(new_shape))
+    def resize(
+        self,
+        new_shape: Union[int, TypeTuple[int, ...]],
+        refcheck: Optional[bool] = True,
+    ) -> PassthroughTensor:
+        self.child.resize(new_shape, refcheck=refcheck)  # inplace op
+        return self.__class__(self.child)
 
     @property
     def T(self) -> PassthroughTensor:
@@ -394,8 +399,35 @@ class PassthroughTensor(np.lib.mixins.NDArrayOperatorsMixin):
         return self.__class__(self.child.tolist())
 
     # ndarray.flatten(order='C')
-    def flatten(self, order: str = "C") -> PassthroughTensor:
+    def flatten(self, order: Optional[str] = "C") -> PassthroughTensor:
         return self.__class__(self.child.flatten(order))
+
+    # ndarray.partition(kth, axis=- 1, kind='introselect', order=None)
+    def partition(
+        self,
+        kth: Union[int, TypeTuple[int, ...]],
+        axis: Optional[int] = -1,
+        kind: Optional[str] = "introselect",
+        order: Optional[Union[int, TypeTuple[int, ...]]] = None,
+    ) -> PassthroughTensor:
+        self.child.partition(kth=kth, axis=axis, kind=kind, order=order)  # inplace op
+        return self.__class__(self.child)
+
+    # ndarray.ravel([order])
+    def ravel(self, order: Optional[str] = "C") -> PassthroughTensor:
+        return self.__class__(self.child.ravel(order=order))
+
+    # ndarray.compress(condition, axis=None, out=None)
+    def compress(
+        self, condition: List[bool], axis: int = None, out: Optional[np.ndarray] = None
+    ) -> PassthroughTensor:
+        return self.__class__(
+            self.child.compress(condition=condition, axis=axis, out=out)
+        )
+
+    # ndarray.swapaxes(axis1, axis2)
+    def swapaxes(self, axis1: int, axis2: int) -> PassthroughTensor:
+        return self.__class__(self.child.swapaxes(axis1=axis1, axis2=axis2))
 
     # numpy.mean(a, axis=None, dtype=None, out=None, keepdims=<no value>, *, where=<no value>)
     def mean(

--- a/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
+++ b/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
@@ -42,6 +42,7 @@ METHODS_FORWARD_ALL_SHARES = {
     "reshape",
     "squeeze",
     "swapaxes",
+    "sum",
 }
 
 

--- a/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
+++ b/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
@@ -44,6 +44,10 @@ METHODS_FORWARD_ALL_SHARES = {
     "swapaxes",
     "sum",
 }
+INPLACE_OPS = {
+    "resize",
+    "partition",
+}
 
 
 class MPCTensor(PassthroughTensor):
@@ -329,9 +333,14 @@ class MPCTensor(PassthroughTensor):
                 new_share = method(*args, **kwargs)
                 shares.append(new_share)
 
-                dummy_res = getattr(np.empty(_self.mpc_shape), method_name)(
-                    *args, **kwargs
-                )
+                dummy_res = np.empty(_self.mpc_shape)
+                if method_name not in INPLACE_OPS:
+                    dummy_res = getattr(np.empty(_self.mpc_shape), method_name)(
+                        *args, **kwargs
+                    )
+                else:
+                    getattr(np.empty(_self.mpc_shape), method_name)(*args, **kwargs)
+
                 new_shape = dummy_res.shape
             res = MPCTensor(shares=shares, shape=new_shape)
             return res

--- a/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
+++ b/packages/syft/src/syft/core/tensor/smpc/mpc_tensor.py
@@ -46,7 +46,6 @@ METHODS_FORWARD_ALL_SHARES = {
 }
 INPLACE_OPS = {
     "resize",
-    "partition",
 }
 
 

--- a/packages/syft/src/syft/core/tensor/smpc/share_tensor.py
+++ b/packages/syft/src/syft/core/tensor/smpc/share_tensor.py
@@ -42,7 +42,6 @@ METHODS_FORWARD_ALL_SHARES = {
 }
 INPLACE_OPS = {
     "resize",
-    "partition",
 }
 
 
@@ -373,7 +372,13 @@ class ShareTensor(PassthroughTensor, Serializable):
         ) -> Any:
 
             share = _self.child
-            method = getattr(share, method_name)
+            if method_name != "resize":
+                method = getattr(share, method_name)
+            else:
+                # Should be modified to remove copy
+                # https://stackoverflow.com/questions/23253144/numpy-the-array-doesnt-have-its-own-data
+                share = share.copy()
+                method = getattr(share, method_name)
 
             if method_name not in INPLACE_OPS:
                 new_share = method(*args, **kwargs)

--- a/packages/syft/tests/syft/core/tensor/smpc/smpc_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/smpc/smpc_tensor_test.py
@@ -132,3 +132,186 @@ def test_mpc_forward_methods(method_str: str, kwargs: TypeDict[str, Any]) -> Non
     expected = op(**kwargs)
 
     assert (res == expected).all()
+
+
+def test_repeat() -> None:
+    value = np.array([[1, 2], [3, 4]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(2, 2), seed_shares=42
+    )
+
+    res = mpc_tensor.repeat(3).reconstruct()
+    exp_res = value.repeat(3)
+
+    assert (res == exp_res).all()
+
+
+def test_copy() -> None:
+    value = np.array([[1, 2], [3, 4]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(2, 2), seed_shares=42
+    )
+
+    res = mpc_tensor.copy().reconstruct()
+    exp_res = mpc_tensor.reconstruct()
+    # we cannot check id for copy as the values are in different locations
+
+    assert (res == exp_res).all()
+
+
+def test_diagonal() -> None:
+    value = np.array([[0, 1], [2, 3]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(2, 2), seed_shares=42
+    )
+
+    res = mpc_tensor.diagonal().reconstruct()
+    exp_res = value.diagonal()
+
+    assert (res == exp_res).all()
+
+
+def test_flatten() -> None:
+    value = np.array([[89, 12, 54], [412, 89, 42], [87, 32, 58]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(3, 3), seed_shares=42
+    )
+
+    res = mpc_tensor.flatten().reconstruct()
+    exp_res = value.flatten()
+
+    assert (res == exp_res).all()
+
+
+def test_transpose() -> None:
+    value = np.array([[89, 12, 54], [412, 89, 42], [87, 32, 58]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(3, 3), seed_shares=42
+    )
+
+    res = mpc_tensor.transpose().reconstruct()
+    exp_res = value.transpose()
+
+    assert (res == exp_res).all()
+
+
+@pytest.mark.xfail
+def test_partition() -> None:
+    value = np.array([12, 1, 12, 41, 8, 4, 7, 39, 27])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(9,), seed_shares=42
+    )
+
+    res = mpc_tensor.partition(5).reconstruct()
+    exp_res = value.partition(5)
+
+    assert (res == exp_res).all()
+
+
+@pytest.mark.xfail
+def test_resize() -> None:
+    value = np.array([[89, 12, 54], [412, 89, 42], [87, 32, 58]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(3, 3), seed_shares=42
+    )
+
+    res = mpc_tensor.resize(2, 3).reconstruct()
+    exp_res = value.resize(2, 3)
+
+    assert (res == exp_res).all()
+
+
+def test_ravel() -> None:
+    value = np.array([[8, 1, 5], [4, 8, 4], [7, 2, 27]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(3, 3), seed_shares=42
+    )
+
+    res = mpc_tensor.ravel().reconstruct()
+    exp_res = value.ravel()
+
+    assert (res == exp_res).all()
+
+
+def test_compress() -> None:
+    value = np.array([[1, 2], [3, 4], [5, 6]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(3, 2), seed_shares=42
+    )
+
+    res = mpc_tensor.compress([0, 1], axis=0).reconstruct()
+    exp_res = value.compress([0, 1], axis=0)
+
+    assert (res == exp_res).all()
+
+
+def test_reshape() -> None:
+    value = np.array([[1, 2], [3, 4], [5, 6]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(3, 2), seed_shares=42
+    )
+
+    res = mpc_tensor.reshape((2, 3)).reconstruct()
+    exp_res = value.reshape((2, 3))
+
+    assert (res == exp_res).all()
+
+
+def test_squeeze() -> None:
+    value = np.array([[7], [6], [72]])
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(3, 1), seed_shares=42
+    )
+
+    res = mpc_tensor.squeeze().reconstruct()
+    exp_res = value.squeeze()
+
+    assert (res == exp_res).all()
+
+
+def test_swapaxes() -> None:
+    value = np.array(np.array([[613, 645, 738], [531, 412, 658]]))
+
+    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
+
+    mpc_tensor = MPCTensor(
+        parties=clients, secret=remote_value, shape=(2, 3), seed_shares=42
+    )
+
+    res = mpc_tensor.swapaxes(0, 1).reconstruct()
+    exp_res = value.swapaxes(0, 1)
+
+    assert (res == exp_res).all()

--- a/packages/syft/tests/syft/core/tensor/smpc/smpc_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/smpc/smpc_tensor_test.py
@@ -210,34 +210,18 @@ def test_transpose() -> None:
     assert (res == exp_res).all()
 
 
-@pytest.mark.xfail
-def test_partition() -> None:
-    value = np.array([12, 1, 12, 41, 8, 4, 7, 39, 27])
-
-    remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
-
-    mpc_tensor = MPCTensor(
-        parties=clients, secret=remote_value, shape=(9,), seed_shares=42
-    )
-
-    res = mpc_tensor.partition(5).reconstruct()
-    exp_res = value.partition(5)
-
-    assert (res == exp_res).all()
-
-
-@pytest.mark.xfail
 def test_resize() -> None:
-    value = np.array([[89, 12, 54], [412, 89, 42], [87, 32, 58]])
+    value = np.array([[89, 12], [412, 89], [87, 32]])
 
     remote_value = clients[0].syft.core.tensor.tensor.Tensor(value)
 
     mpc_tensor = MPCTensor(
-        parties=clients, secret=remote_value, shape=(3, 3), seed_shares=42
+        parties=clients, secret=remote_value, shape=(3, 2), seed_shares=42
     )
 
     res = mpc_tensor.resize(2, 3).reconstruct()
-    exp_res = value.resize(2, 3)
+    value.resize(2, 3)
+    exp_res = value  # inplace op
 
     assert (res == exp_res).all()
 


### PR DESCRIPTION
## Description
Implementation of Numpy Methods on MPCTensor which performs it on the underlying tensor

Implemented Ops:
- [x] np.repeat
- [x] np.copy
- [x] np.diagonal
- [x] np.flatten
- [x] np.transpose
- [x] np.resize
- [x] np.ravel
- [x] np.compress
- [x] np.reshape
- [x] np.squeeze
- [x] np.swapaxes



## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
