### PR TITLE
Fixing broken torch tests due to changed handling of builtins and boxes

### DIFF
--- a/packages/syft/src/syft/core/common/serde/serialize.py
+++ b/packages/syft/src/syft/core/common/serde/serialize.py
@@ -5,7 +5,6 @@ from typing import Union
 from google.protobuf.message import Message
 
 # relative
-from ....logger import debug
 from ....logger import traceback_and_raise
 from ....proto.util.data_message_pb2 import DataMessage
 from ....util import get_fully_qualified_name

--- a/packages/syft/src/syft/core/node/common/action/exception_action.py
+++ b/packages/syft/src/syft/core/node/common/action/exception_action.py
@@ -9,10 +9,10 @@ from typing_extensions import final
 
 # relative
 from ..... import serialize
+from .....lib.util import full_name_with_qualname
 from .....proto.core.node.common.action.exception_action_pb2 import (
     ExceptionMessage as ExceptionMessage_PB,
 )
-from .....util import get_fully_qualified_name
 from .....util import validate_type
 from ....common.message import ImmediateSyftMessageWithoutReply
 from ....common.serde.deserialize import _deserialize
@@ -58,7 +58,7 @@ class ExceptionMessage(ImmediateSyftMessageWithoutReply):
         """
 
         # convert exception into fully qualified class path
-        fqn = get_fully_qualified_name(obj=self.exception_type)
+        fqn = full_name_with_qualname(klass=self.exception_type)
         module_parts = fqn.split(".")
         _ = module_parts.pop()  # remove incorrect .type ending
         module_parts.append(self.exception_type.__name__)

--- a/packages/syft/src/syft/core/store/storeable_object.py
+++ b/packages/syft/src/syft/core/store/storeable_object.py
@@ -18,6 +18,7 @@ from ...util import key_emoji
 from ..common.serde.deserialize import _deserialize
 from ..common.serde.serializable import Serializable
 from ..common.serde.serializable import bind_protobuf
+from ..common.serde.serialize import _serialize
 from ..common.storeable_object import AbstractStorableObject
 from ..common.uid import UID
 
@@ -130,7 +131,12 @@ class StorableObject(AbstractStorableObject):
         proto.data_type = get_fully_qualified_name(obj=self._data)
 
         # Step 3: Serialize data to protobuf and pack into proto
-        data = self._data._object2proto()
+        if hasattr(self._data, "_object2proto"):
+            data = self._data._object2proto()
+        else:
+            # @Tudor this needs fixing during the serde refactor
+            # we should probably just support the native type names as lookups for serde
+            data = _serialize(self._data, to_proto=True)
 
         proto.data.Pack(data)
 

--- a/packages/syft/src/syft/util.py
+++ b/packages/syft/src/syft/util.py
@@ -103,6 +103,11 @@ def index_syft_by_module_name(fully_qualified_name: str) -> object:
         a reference to the actual object at that string path
 
     """
+
+    # @Tudor this needs fixing during the serde refactor
+    # we should probably just support the native type names as lookups for serde
+    if fully_qualified_name == "builtins.NoneType":
+        fully_qualified_name = "syft.lib.python._SyNone"
     attr_list = fully_qualified_name.split(".")
 
     # we deal with VerifyAll differently, because we don't it be imported and used by users
@@ -139,7 +144,8 @@ def get_fully_qualified_name(obj: object) -> str:
         the full path and name of the object
 
     """
-    fqn = obj.__module__
+
+    fqn = obj.__class__.__module__
     try:
         fqn += "." + obj.__class__.__name__
     except Exception as e:


### PR DESCRIPTION
## Description
- fixing broken torch tests due to changed handling of builtins and boxes
- temporary_box now means that StorableObject can contain primitives
- StorableObject expects all storeables to have _object2proto
- fqn = obj.__module__ was technically invalid and worked via mro

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
