### PR TITLE
Add support and tests for all transform operations for RowEntityPhiTensors

### DIFF
--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -267,7 +267,8 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
             )
         new_list = list()
         for tensor in self.child:
-            new_list.append(tensor.swapaxes(axis1, axis2))
+            # Axis=0 for REPT.child is Axis=1 for REPT, so subtract 1
+            new_list.append(tensor.swapaxes(axis1 - 1, axis2 - 1))
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
     def squeeze(
@@ -288,10 +289,6 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
     def reshape(self, *shape: List[int]) -> RowEntityPhiTensor:
-        print(shape, type(shape), self.shape, type(self.shape))
-        print(type(shape[0]))
-        print(type(self.shape[0]))
-
         # This is to fix the bug where shape = ([a, b, c], )
         if isinstance(shape[0], list) or isinstance(shape[0], tuple):
             shape = shape[0]

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -183,31 +183,31 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
             if isinstance(other, np.ndarray):
                 if is_broadcastable(self.shape, other.shape):
                     new_list.append(
-                        [self.child[i] * other[i] for i in range(len(self.child))]
+                        [self.child[i] * other[i] for i in range(len(self.child))]  # type: ignore
                     )
                 else:
                     raise Exception(
                         f"Tensor dims do not match for __sub__: {self.child.shape} != {other.shape}"  # type: ignore
                     )
             else:  # int, float, bool, etc
-                new_list = [child * other for child in self.child]
+                new_list = [child * other for child in self.child]  # type: ignore
         elif isinstance(other, RowEntityPhiTensor):
             if is_broadcastable(self.shape, other.shape):
                 new_list = [
-                    self.child[i] * other.child[i] for i in range(len(self.child))
+                    self.child[i] * other.child[i] for i in range(len(self.child))  # type: ignore
                 ]
             else:
                 raise Exception(
                     f"Tensor dims do not match for __sub__: {self.shape} != {other.shape}"  # type: ignore
                 )
         elif isinstance(other, SingleEntityPhiTensor):
-            for child in self.child:
+            for child in self.child:  # type: ignore
                 # If even a single SEPT in the REPT isn't broadcastable, the multiplication operation doesn't work
                 if not is_broadcastable(child.shape, other.shape):
                     raise Exception(
                         f"Tensor dims do not match for __sub__: {self.shape} != {other.shape}"  # type: ignore
                     )
-            new_list = [i * other for i in self.child]
+            new_list = [i * other for i in self.child]  # type: ignore
         else:
             raise NotImplementedError
         return RowEntityPhiTensor(rows=new_list)
@@ -236,16 +236,16 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         return RowEntityPhiTensor(rows=[+x for x in self.child], check_shape=False)  # type: ignore
 
     def __neg__(self) -> RowEntityPhiTensor:
-        return RowEntityPhiTensor(rows=[-x for x in self.child], check_shape=False)
+        return RowEntityPhiTensor(rows=[-x for x in self.child], check_shape=False)  # type: ignore
 
     def __or__(self, other: Any) -> RowEntityPhiTensor:
         return RowEntityPhiTensor(
-            rows=[x | other for x in self.child], check_shape=False
+            rows=[x | other for x in self.child], check_shape=False  # type: ignore
         )
 
     def __and__(self, other: Any) -> RowEntityPhiTensor:
         return RowEntityPhiTensor(
-            rows=[x & other for x in self.child], check_shape=False
+            rows=[x & other for x in self.child], check_shape=False  # type: ignore
         )
 
     def __truediv__(  # type: ignore

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -69,7 +69,7 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
     @property
     def scalar_manager(self) -> TypeScalarManager:
-        return self.child[0].scalar_manager
+        return self.child[0].scalar_manager  # type: ignore
 
     @property
     def min_vals(self) -> np.ndarray:
@@ -86,7 +86,7 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
     @property
     def entities(self) -> np.ndarray:
         return np.array(
-            [[x.entity] * np.array(x.shape).prod() for x in self.child]
+            [[x.entity] * np.array(x.shape).prod() for x in self.child]  # type: ignore
         ).reshape(self.shape)
 
     @property
@@ -116,9 +116,9 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         if is_acceptable_simple_type(other) or len(self.child) == len(other.child):  # type: ignore
             new_list = list()
-            for i in range(len(self.child)):
+            for i in range(len(self.child)):  # type: ignore
                 if is_acceptable_simple_type(other):
-                    new_list.append(self.child[i] == other)
+                    new_list.append(self.child[i] == other)  # type: ignore
                 else:
                     new_list.append(self.child[i] == other.child[i])  # type: ignore
             return RowEntityPhiTensor(rows=new_list, check_shape=False)
@@ -132,7 +132,7 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         # Normal inversion on (opposite_result.child) might not work on nested lists
         result = []
-        for row in opposite_result.child:
+        for row in opposite_result.child:  # type: ignore
             result.append(np.invert(row))
 
         return RowEntityPhiTensor(rows=result)
@@ -143,9 +143,9 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         # TODO: Catch unacceptable types (str, dict, etc) to avoid errors for other.child below
         if is_acceptable_simple_type(other) or len(self.child) == len(other.child):  # type: ignore
             new_list = list()
-            for i in range(len(self.child)):
+            for i in range(len(self.child)):  # type: ignore
                 if is_acceptable_simple_type(other):
-                    new_list.append(self.child[i] + other)
+                    new_list.append(self.child[i] + other)  # type: ignore
                 else:
                     # Private/Public and Private/Private are handled by the underlying SEPT self.child objects.
                     new_list.append(self.child[i] + other.child[i])  # type: ignore
@@ -162,9 +162,9 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         # TODO: Catch unacceptable types (str, dict, etc) to avoid errors for other.child below
         if is_acceptable_simple_type(other) or len(self.child) == len(other.child):  # type: ignore
             new_list = list()
-            for i in range(len(self.child)):
+            for i in range(len(self.child)):  # type: ignore
                 if is_acceptable_simple_type(other):
-                    new_list.append(self.child[i] - other)
+                    new_list.append(self.child[i] - other)  # type: ignore
                 else:
                     new_list.append(self.child[i] - other.child[i])  # type: ignore
             return RowEntityPhiTensor(rows=new_list, check_shape=False)
@@ -179,10 +179,10 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         if is_acceptable_simple_type(other) or len(self.child) == len(other.child):  # type: ignore
             new_list = list()
-            for i in range(len(self.child)):
+            for i in range(len(self.child)):  # type: ignore
                 if is_acceptable_simple_type(other):
                     if isinstance(other, (int, bool, float)):
-                        new_list.append(self.child[i] * other)
+                        new_list.append(self.child[i] * other)  # type: ignore
                     else:
                         new_list.append(self.child[i] * other[i])  # type: ignore
                 else:
@@ -194,7 +194,7 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
             )
 
     def __pos__(self) -> RowEntityPhiTensor:
-        return RowEntityPhiTensor(rows=[+x for x in self.child], check_shape=False)
+        return RowEntityPhiTensor(rows=[+x for x in self.child], check_shape=False)  # type: ignore
 
     def __truediv__(  # type: ignore
         self, other: Union[RowEntityPhiTensor, AcceptableSimpleType]
@@ -202,9 +202,9 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         if is_acceptable_simple_type(other) or len(self.child) == len(other.child):  # type: ignore
             new_list = list()
-            for i in range(len(self.child)):
+            for i in range(len(self.child)):  # type: ignore
                 if is_acceptable_simple_type(other):
-                    new_list.append(self.child[i] / other)
+                    new_list.append(self.child[i] / other)  # type: ignore
                 else:
                     new_list.append(self.child[i] / other.child[i])  # type: ignore
             return RowEntityPhiTensor(rows=new_list, check_shape=False)
@@ -225,20 +225,20 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         if axis == 0 or axis == -len(self.shape):
             new_list = list()
             for r in range(repeats):  # type: ignore
-                for row in self.child:
+                for row in self.child:  # type: ignore
                     new_list.append(row)
             return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
         elif axis > 0:
             new_list = list()
-            for row in self.child:
+            for row in self.child:  # type: ignore
                 new_list.append(row.repeat(repeats, axis=axis - 1))
             return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
         # axis is negative
         elif abs(axis) < len(self.shape):
             new_list = list()
-            for row in self.child:
+            for row in self.child:  # type: ignore
                 new_list.append(row.repeat(repeats, axis=axis))
             return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
@@ -249,13 +249,13 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
     def flatten(self, order: Optional[str] = "C") -> RowEntityPhiTensor:
         new_list = list()
-        for tensor in self.child:
+        for tensor in self.child:  # type: ignore
             new_list.append(tensor.flatten(order))
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
     def ravel(self, order: Optional[str] = "C") -> RowEntityPhiTensor:
         new_list = list()
-        for tensor in self.child:
+        for tensor in self.child:  # type: ignore
             new_list.append(tensor.ravel(order))
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
@@ -266,23 +266,23 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
                 "probably create a Gamma Tensor. Sorry about that!"
             )
         new_list = list()
-        for tensor in self.child:
+        for tensor in self.child:  # type: ignore
             # Axis=0 for REPT.child is Axis=1 for REPT, so subtract 1
             new_list.append(tensor.swapaxes(axis1 - 1, axis2 - 1))
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
     def squeeze(
-        self, axis: Optional[Union[int, TypeTuple[int, ...]]] = None
+        self, axis: Optional[Union[int, Tuple[int, ...]]] = None
     ) -> RowEntityPhiTensor:
         if axis == 0:
             # If the first axis can be squeezed then there is only one
             # tensor in the REPT, as such it might be a SEPT
             # TODO: Check if the output type is still a REPT
-            #if isinstance(self.child[0], SEPT): return self.child[0]
-            return RowEntityPhiTensor(rows=self.child[0])
+            # if isinstance(self.child[0], SEPT): return self.child[0]
+            return RowEntityPhiTensor(rows=self.child[0])  # type: ignore
         else:
             new_list = list()
-            for tensor in self.child:
+            for tensor in self.child:  # type: ignore
                 new_list.append(tensor.squeeze(axis))
             self.child = new_list
 
@@ -290,14 +290,16 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
     def reshape(self, *shape: List[int]) -> RowEntityPhiTensor:
         # This is to fix the bug where shape = ([a, b, c], )
-        if isinstance(shape[0], list) or isinstance(shape[0], tuple):
-            shape = shape[0]
+        if isinstance(shape[0], list) or isinstance(shape[0], tuple):  # type: ignore
+            shape = shape[0]  # type: ignore
 
         if shape[0] != self.shape[0]:
             raise Exception(
                 "For now, you can't reshape the first dimension because that would"
                 + "probably require creating a gamma tensor."
-                + str(shape) + " and " + str(self.shape)
+                + str(shape)
+                + " and "
+                + str(self.shape)
             )
 
         new_list = list()
@@ -308,11 +310,11 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
     def resize(
         self,
-        new_shape: Union[int, TypeTuple[int, ...]],
+        new_shape: Union[int, Tuple[int, ...]],
         refcheck: Optional[bool] = True,
     ) -> None:
-        """ This method is identical to reshape, but it modifies the Tensor in-place instead of returning a new one"""
-        if new_shape[0] != self.shape[0]:
+        """This method is identical to reshape, but it modifies the Tensor in-place instead of returning a new one"""
+        if new_shape[0] != self.shape[0]:  # type: ignore
             raise Exception(
                 "For now, you can't reshape the first dimension because that would"
                 + "probably require creating a gamma tensor."
@@ -320,13 +322,13 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         new_list = list()
         for row in self.child:
-            new_list.append(row.reshape(new_shape[1:]))
+            new_list.append(row.reshape(new_shape[1:]))  # type: ignore
 
         # Modify the tensor data in-place instead of returning a new one.
         self.child = new_list
 
     def compress(
-        self, condition: List[bool], axis: int = None, out: Optional[np.ndarray] = None
+        self, condition: List[bool], axis: int = None, out: Optional[np.ndarray] = None  # type: ignore
     ) -> RowEntityPhiTensor:
         # TODO: Could any conditions result in GammaTensors being formed?
         # TODO: Will min/max vals change upon filtering? I don't think so, since they're data independent
@@ -337,10 +339,10 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
     def partition(
         self,
-        kth: Union[int, TypeTuple[int, ...]],
+        kth: Union[int, Tuple[int, ...]],
         axis: Optional[int] = -1,
         kind: Optional[str] = "introselect",
-        order: Optional[Union[int, TypeTuple[int, ...]]] = None,
+        order: Optional[Union[int, Tuple[int, ...]]] = None,
     ) -> RowEntityPhiTensor:
         if axis == 0:  # Unclear how to sort the SEPTs in a REPT
             raise NotImplementedError

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -242,6 +242,46 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
                 "'axis' arg is negative and strangely large... not sure what to do."
             )
 
+    def flatten(self, order: Optional[str] = "C") -> RowEntityPhiTensor:
+        new_list = list()
+        for tensor in self.child:
+            new_list.append(tensor.flatten(order))
+        return RowEntityPhiTensor(rows=new_list, check_shape=False)
+
+    def ravel(self, order: Optional[str] = "C") -> RowEntityPhiTensor:
+        new_list = list()
+        for tensor in self.child:
+            new_list.append(tensor.ravel(order))
+        return RowEntityPhiTensor(rows=new_list, check_shape=False)
+
+    def swapaxes(self, axis1: int, axis2: int) -> RowEntityPhiTensor:
+        if axis1 == 0 or axis2 == 0:
+            raise Exception(
+                "For now, you can't swap the first axis b/c that would "
+                "probably create a Gamma Tensor. Sorry about that!"
+            )
+        new_list = list()
+        for tensor in self.child:
+            new_list.append(tensor.swapaxes(axis1, axis2))
+        return RowEntityPhiTensor(rows=new_list, check_shape=False)
+
+    def squeeze(
+        self, axis: Optional[Union[int, TypeTuple[int, ...]]] = None
+    ) -> RowEntityPhiTensor:
+        if axis == 0:
+            # If the first axis can be squeezed then there is only one
+            # tensor in the REPT, as such it might be a SEPT
+            # TODO: Check if the output type is still a REPT
+            #if isinstance(self.child[0], SEPT): return self.child[0]
+            return RowEntityPhiTensor(rows=self.child[0])
+        else:
+            new_list = list()
+            for tensor in self.child:
+                new_list.append(tensor.squeeze(axis))
+            self.child = new_list
+
+        return RowEntityPhiTensor(rows=new_list, check_shape=False)
+
     def reshape(self, *shape: List[int]) -> RowEntityPhiTensor:
 
         if shape[0] != self.shape[0]:

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -256,6 +256,25 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
+    def resize(
+        self,
+        new_shape: Union[int, TypeTuple[int, ...]],
+        refcheck: Optional[bool] = True,
+    ) -> None:
+        """ This method is identical to reshape, but it modifies the Tensor in-place instead of returning a new one"""
+        if new_shape[0] != self.shape[0]:
+            raise Exception(
+                "For now, you can't reshape the first dimension because that would"
+                + "probably require creating a gamma tensor."
+            )
+
+        new_list = list()
+        for row in self.child:
+            new_list.append(row.reshape(new_shape[1:]))
+
+        # Modify the tensor data in-place instead of returning a new one.
+        self.child = new_list
+
     # Since this is being used differently compared to supertype, ignoring type annotation errors
     def sum(  # type: ignore
         self, *args: Any, axis: Optional[int] = None, **kwargs: Any

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -315,6 +315,25 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         # Modify the tensor data in-place instead of returning a new one.
         self.child = new_list
 
+    def compress(
+        self, condition: List[bool], axis: int = None, out: Optional[np.ndarray] = None
+    ) -> RowEntityPhiTensor:
+        # TODO: Could any conditions result in GammaTensors being formed?
+        # TODO: Will min/max vals change upon filtering? I don't think so, since they're data independent
+        new_list = list()
+        for tensor in self.child:
+            new_list.append(tensor.compress(condition, axis, out))
+        return RowEntityPhiTensor(rows=new_list, check_shape=False)
+
+    def partition(
+        self,
+        kth: Union[int, TypeTuple[int, ...]],
+        axis: Optional[int] = -1,
+        kind: Optional[str] = "introselect",
+        order: Optional[Union[int, TypeTuple[int, ...]]] = None,
+    ) -> RowEntityPhiTensor:
+        pass
+
     # Since this is being used differently compared to supertype, ignoring type annotation errors
     def sum(  # type: ignore
         self, *args: Any, axis: Optional[int] = None, **kwargs: Any

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -797,7 +797,7 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
         axis: Optional[int] = -1,
         kind: Optional[str] = "introselect",
         order: Optional[Union[str, List[str]]] = None,
-    ) -> SingleEntityPhiTensor:
+    ) -> None:
         """Interchange two axes of the Tensor"""
         if (
             isinstance(self.child, int)
@@ -818,7 +818,9 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             or isinstance(self.min_vals, bool)
         ):
             # For these singleton data types, the partition operation is meaningless, so don't change them.
-            print(f'Warning: Min_vals metadata was of type {type(self.min_vals)}, partition operation had no effect.')
+            print(
+                f"Warning: Min_vals metadata was of type {type(self.min_vals)}, partition operation had no effect."
+            )
         else:
             self.min_vals.partition(kth, axis, kind, order)
 
@@ -828,7 +830,9 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             or isinstance(self.max_vals, bool)
         ):
             # For these singleton data types, the partition operation is meaningless, so don't change them.
-            print(f'Warning: Max_vals metadata was of type {type(self.max_vals)}, partition operation had no effect.')
+            print(
+                f"Warning: Max_vals metadata was of type {type(self.max_vals)}, partition operation had no effect."
+            )
         else:
             self.max_vals.partition(kth, axis, kind, order)
 

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -805,12 +805,11 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             or isinstance(self.child, bool)
         ):
             # For these singleton data types, the partition operation is meaningless, so don't change them.
-            data = self.child
             print(
-                f"Warning: Tensor data was of type {type(data)}, partition operation had no effect."
+                f"Warning: Tensor data was of type {type(self.child)}, partition operation had no effect."
             )
         else:
-            data = self.child.partition(kth, axis, kind, order)
+            self.child.partition(kth, axis, kind, order)
 
             # TODO: Should we give warnings for min_val and max_val being single floats/integers/booleans too?
         if (
@@ -819,10 +818,9 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             or isinstance(self.min_vals, bool)
         ):
             # For these singleton data types, the partition operation is meaningless, so don't change them.
-            min_vals = self.min_vals
-            # print(f'Warning: Tensor data was of type {type(data)}, partition operation had no effect.')
+            print(f'Warning: Min_vals metadata was of type {type(self.min_vals)}, partition operation had no effect.')
         else:
-            min_vals = self.min_vals.partition(kth, axis, kind, order)
+            self.min_vals.partition(kth, axis, kind, order)
 
         if (
             isinstance(self.max_vals, int)
@@ -830,20 +828,9 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             or isinstance(self.max_vals, bool)
         ):
             # For these singleton data types, the partition operation is meaningless, so don't change them.
-            max_vals = self.max_vals
-            # print(f'Warning: Tensor data was of type {type(data)}, partition operation had no effect.')
+            print(f'Warning: Max_vals metadata was of type {type(self.max_vals)}, partition operation had no effect.')
         else:
-            max_vals = self.max_vals.partition(kth, axis, kind, order)
-
-        entity = self.entity
-
-        return SingleEntityPhiTensor(
-            child=data,
-            entity=entity,
-            min_vals=min_vals,
-            max_vals=max_vals,
-            scalar_manager=self.scalar_manager,
-        )
+            self.max_vals.partition(kth, axis, kind, order)
 
     # ndarray.ravel(order='C')
     def ravel(self, order: str = "C") -> SingleEntityPhiTensor:

--- a/packages/syft/src/syft/core/tensor/passthrough.py
+++ b/packages/syft/src/syft/core/tensor/passthrough.py
@@ -32,7 +32,7 @@ def is_acceptable_simple_type(obj):
 class PassthroughTensor(np.lib.mixins.NDArrayOperatorsMixin):
     """A simple tensor class which passes method/function calls to self.child"""
 
-    def __init__(self, child) -> None:
+    def __init__(self, child: Any) -> None:
         self.child = child
 
     # TODO: Remove

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -379,7 +379,7 @@ def test_sub_result_gamma(row_data_ishan: List, row_data_trask: List) -> None:
 
 
 def test_flatten(row_data_ishan: List) -> None:
-    """ Test to see if Flatten works for the ideal case """
+    """Test to see if Flatten works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
     output = reference_tensor.flatten()
     for sept in output:
@@ -392,7 +392,7 @@ def test_flatten(row_data_ishan: List) -> None:
 
 
 def test_ravel(row_data_ishan: List) -> None:
-    """ Test to see if Ravel works for the ideal case """
+    """Test to see if Ravel works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
     output = reference_tensor.ravel()
     for sept in output:
@@ -405,11 +405,13 @@ def test_ravel(row_data_ishan: List) -> None:
 
 
 def test_transpose(row_data_ishan: List) -> None:
-    """ Test to see if Transpose works for the ideal case """
+    """Test to see if Transpose works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
     output = reference_tensor.transpose()
     for index, sept in enumerate(output):
-        assert tuple(sept.shape) == reference_tensor.child[index].shape, "Transpose shape incorrect"
+        assert (
+            tuple(sept.shape) == reference_tensor.child[index].shape
+        ), "Transpose shape incorrect"
 
     correct_output = []
     for row in row_data_ishan:
@@ -418,9 +420,14 @@ def test_transpose(row_data_ishan: List) -> None:
 
 
 def test_partition() -> None:
-    """ Test to see if Partition works for the ideal case """
+    """Test to see if Partition works for the ideal case"""
     data = np.random.randint(low=-100, high=100, size=(10, 10), dtype=np.int32)
-    sept = SEPT(child=data, entity=ishan, min_vals=np.ones_like(data) * -100, max_vals=np.ones_like(data) * 100)
+    sept = SEPT(
+        child=data,
+        entity=ishan,
+        min_vals=np.ones_like(data) * -100,
+        max_vals=np.ones_like(data) * 100,
+    )
     reference_tensor = REPT(rows=sept)
 
     reference_tensor.partition(kth=1)
@@ -428,9 +435,11 @@ def test_partition() -> None:
     assert reference_tensor.child == sept, "Partition did not work as expected"
 
 
-@pytest.mark.skipif(dims == 1, reason="Not enough dimensions to do the compress operation")
+@pytest.mark.skipif(
+    dims == 1, reason="Not enough dimensions to do the compress operation"
+)
 def test_compress(row_data_ishan: List) -> None:
-    """ Test to see if Compress works for the ideal case """
+    """Test to see if Compress works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
 
     output = reference_tensor.compress([0, 1])
@@ -444,7 +453,7 @@ def test_compress(row_data_ishan: List) -> None:
 
 
 def test_resize(row_data_ishan: List) -> None:
-    """ Test to see if Resize works for the ideal case """
+    """Test to see if Resize works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
     original_tensor = reference_tensor.copy()
 
@@ -456,10 +465,12 @@ def test_resize(row_data_ishan: List) -> None:
 
 @pytest.mark.skipif(dims == 1, reason="Dims too low for this operation")
 def test_reshape(row_data_ishan: List) -> None:
-    """ Test to see if Reshape works for the ideal case """
+    """Test to see if Reshape works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
     original_shape = reference_tensor.shape
-    new_shape = [len(reference_tensor.child)] + [np.prod(reference_tensor.child[0].shape)] + [1]
+    new_shape = (
+        [len(reference_tensor.child)] + [np.prod(reference_tensor.child[0].shape)] + [1]
+    )
     assert new_shape[0] == reference_tensor.shape[0], "Shape isn't usable for reshape"
     output = reference_tensor.reshape(new_shape)
     assert output.shape != original_shape, "Reshape didn't change shape at all"
@@ -469,9 +480,14 @@ def test_reshape(row_data_ishan: List) -> None:
 
 
 def test_squeeze(row_data_ishan: List) -> None:
-    """ Test to see if Squeeze works for the ideal case """
+    """Test to see if Squeeze works for the ideal case"""
     data = np.random.randint(low=-100, high=100, size=(10, 1, 10), dtype=np.int32)
-    sept = SEPT(child=data, entity=ishan, min_vals=np.ones_like(data) * -100, max_vals=np.ones_like(data) * 100)
+    sept = SEPT(
+        child=data,
+        entity=ishan,
+        min_vals=np.ones_like(data) * -100,
+        max_vals=np.ones_like(data) * 100,
+    )
     reference_tensor = REPT(rows=sept)
 
     output = reference_tensor.squeeze()
@@ -480,9 +496,14 @@ def test_squeeze(row_data_ishan: List) -> None:
 
 
 def test_swapaxes(row_data_ishan: List) -> None:
-    """ Test to see if Swapaxes works for the ideal case """
+    """Test to see if Swapaxes works for the ideal case"""
     data = np.random.randint(low=-100, high=100, size=(10, 10), dtype=np.int32)
-    sept = SEPT(child=data, entity=ishan, min_vals=np.ones_like(data) * -100, max_vals=np.ones_like(data) * 100)
+    sept = SEPT(
+        child=data,
+        entity=ishan,
+        min_vals=np.ones_like(data) * -100,
+        max_vals=np.ones_like(data) * 100,
+    )
     reference_tensor = REPT(rows=[sept])
 
     output = reference_tensor.swapaxes(1, 2)

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -21,8 +21,8 @@ from syft.core.tensor.tensor import Tensor
 # Global constants
 ishan = Entity(name="Ishan")
 traskmaster = Entity(name="Trask")
-dims = np.random.randint(10) + 3  # Avoid size 0, 1
-row_count = np.random.randint(7) + 1
+dims = max(3, np.random.randint(10) + 3)  # Avoid size 0, 1
+row_count = max(3, np.random.randint(7) + 1)  # Avoids size 0, 1
 scalar_manager = ScalarManager()
 
 
@@ -376,6 +376,97 @@ def test_sub_result_gamma(row_data_ishan: List, row_data_trask: List) -> None:
         assert isinstance(
             tensor, IGT
         ), "SEPT(entity1) + SEPT(entity2) != IGT(entity1, entity2)"
+
+
+def test_flatten(row_data_ishan: List) -> None:
+    """ Test to see if Flatten works for the ideal case """
+    reference_tensor = REPT(rows=row_data_ishan)
+    output = reference_tensor.flatten()
+    for sept in output:
+        assert len(sept.child.shape) == 1, "Flatten shape incorrect"
+
+    correct_output = []
+    for row in row_data_ishan:
+        correct_output.append(row.flatten())
+    assert correct_output == output.child, "Flatten did not work as expected"
+
+
+def test_ravel(row_data_ishan: List) -> None:
+    """ Test to see if Ravel works for the ideal case """
+    reference_tensor = REPT(rows=row_data_ishan)
+    output = reference_tensor.ravel()
+    for sept in output:
+        assert len(sept.child.shape) == 1, "Ravel shape incorrect"
+
+    correct_output = []
+    for row in row_data_ishan:
+        correct_output.append(row.ravel())
+    assert correct_output == output.child, "Ravel did not work as expected"
+
+
+def test_transpose(row_data_ishan: List) -> None:
+    """ Test to see if Transpose works for the ideal case """
+    reference_tensor = REPT(rows=row_data_ishan)
+    output = reference_tensor.transpose()
+    for index, sept in enumerate(output):
+        assert tuple(sept.shape) == reference_tensor.child[index].shape, "Transpose shape incorrect"
+
+    correct_output = []
+    for row in row_data_ishan:
+        correct_output.append(row.transpose())
+    assert correct_output == output.child, "Transpose did not work as expected"
+
+
+def test_partition() -> None:
+    """ Test to see if Partition works for the ideal case """
+    data = np.random.randint(low=-100, high=100, size=(10, 10), dtype=np.int32)
+    sept = SEPT(child=data, entity=ishan, min_vals=np.ones_like(data) * -100, max_vals=np.ones_like(data) * 100)
+    reference_tensor = REPT(rows=[sept])
+
+    reference_tensor.partition(kth=1)
+    sept.partition(kth=1)
+    assert reference_tensor == sept, "Partition did not work as expected"
+
+
+def test_compress(row_data_ishan: List) -> None:
+    """ Test to see if Compress works for the ideal case """
+    pass
+
+
+def test_resize(row_data_ishan: List) -> None:
+    """ Test to see if Resize works for the ideal case """
+    reference_tensor = REPT(rows=row_data_ishan)
+    original_tensor = reference_tensor.copy()
+
+    new_shape = original_tensor.flatten().shape
+    reference_tensor.resize(new_shape)
+    assert reference_tensor.shape != original_tensor.shape, "Resize didn't work"
+    assert reference_tensor.shape == new_shape, "Resize shape doesn't check out"
+
+
+def test_reshape(row_data_ishan: List) -> None:
+    """ Test to see if Reshape works for the ideal case """
+    reference_tensor = REPT(rows=row_data_ishan)
+    original_shape = reference_tensor.shape
+    new_shape = [len(reference_tensor.child)] + [np.prod(reference_tensor.child[0].shape)] + [1]
+    assert new_shape[0] == reference_tensor.shape[0], "Shape isn't usable for reshape"
+    output = reference_tensor.reshape(new_shape)
+    assert output.shape != original_shape, "Reshape didn't change shape at all"
+    assert output.shape == new_shape, "Reshape didn't change shape properly"
+    assert output.shape != reference_tensor.shape, "Reshape didn't modify in-place"
+    assert original_shape == reference_tensor.shape, "Reshape didn't modify in-place"
+
+
+def test_squeeze(row_data_ishan: List) -> None:
+    """ Test to see if Squeeze works for the ideal case """
+    pass
+
+
+def test_swapaxes(row_data_ishan: List) -> None:
+    """ Test to see if Swapaxes works for the ideal case """
+    pass
+
+
 
 
 ent = Entity(name="test")

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -481,7 +481,7 @@ def test_reshape(row_data_ishan: List) -> None:
     """Test to see if Reshape works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
     original_shape = reference_tensor.shape
-    new_shape = (
+    new_shape = tuple(
         [len(reference_tensor.child)] + [np.prod(reference_tensor.child[0].shape)] + [1]
     )
     assert new_shape[0] == reference_tensor.shape[0], "Shape isn't usable for reshape"

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -386,7 +386,6 @@ def test_sub_result_gamma(row_data_ishan: List, row_data_trask: List) -> None:
         ), "SEPT(entity1) + SEPT(entity2) != IGT(entity1, entity2)"
 
 
-
 def test_flatten(row_data_ishan: List) -> None:
     """Test to see if Flatten works for the ideal case"""
     reference_tensor = REPT(rows=row_data_ishan)
@@ -455,10 +454,15 @@ def test_compress(row_data_ishan: List) -> None:
 
     target_output = list()
     for row in row_data_ishan:
-        target_output.append(row.compress([0, 1]))
+        assert row.entity == ishan
+        new_row = row.compress([0, 1])
+        assert new_row.entity == ishan
+        target_output.append(new_row)
 
     for result, target in zip(output, target_output):
-        assert result == target, "Compress operation failed"
+        assert isinstance(result.child, SEPT)
+        assert isinstance(target, SEPT)
+        assert result.child == target, "Compress operation failed"
 
 
 def test_resize(row_data_ishan: List) -> None:
@@ -518,6 +522,7 @@ def test_swapaxes(row_data_ishan: List) -> None:
     output = reference_tensor.swapaxes(1, 2)
     target = sept.swapaxes(0, 1)
     assert output.child[0] == target, "Swapaxes did not work as expected"
+
 
 def test_mul_simple(row_data_ishan: List) -> None:
     """Ensure multiplication works with REPTs & Simple types (int/float/bool/np.ndarray)"""
@@ -617,7 +622,6 @@ def test_or() -> None:
     output = reference_tensor | False
     for index, tensor in enumerate(reference_tensor.child):
         assert (tensor | False) == output[index]
-
 
 
 ent = Entity(name="test")


### PR DESCRIPTION
## Description
Added support and tests for all transform operations for RowEntityPhiTensors:

- [x] Transpose
- [x] Reshape
- [x] Resize
- [x] Partition
- [x] Compress
- [x] Squeeze
- [x] Swapaxes
- [x] Ravel 

## Affected Dependencies
No affected dependencies.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

Added pytest tests to the `row_entity_phi_test.py` file, and used a `pre-commit run --all-files` to verify linting and other errors.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
