### PR TITLE
Implement Min() and Max() for SingleEntityPhiTensor

### DIFF
--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -10,6 +10,7 @@ from typing import Tuple as TypeTuple
 from typing import Union
 
 # third party
+import torch
 from google.protobuf.reflection import GeneratedProtocolMessageType
 from nacl.signing import VerifyKey
 import numpy as np
@@ -1386,6 +1387,76 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             min_vals=min_vals,
             max_vals=max_vals,
             scalar_manager=self.scalar_manager,
+        )
+
+    def max(self,
+            axis=None,
+            out: Optional[np.ndarray]=None,
+            keepdims: Optional[bool]=False,
+            initial: Optional[int]=None,
+            where: bool = True):
+        # Note: Who knew this method had SO MANY ARGUMENTS?!?!?
+        if is_acceptable_simple_type(self.child):
+            if isinstance(self.child, np.ndarray):
+                data = self.child.max(axis, out, keepdims, initial, where)
+            else:
+                # This implies self.child is a singleton (int, float, bool, etc)
+                data = self.child
+        elif isinstance(self.child, torch.Tensor):
+            data = self.child.numpy().max(axis, out, keepdims, initial, where)
+        else:
+            raise NotImplementedError
+
+        if isinstance(self.min_vals, np.ndarray):
+            min_vals = self.min_vals.max(axis, out, keepdims, initial, where)
+        else:
+            min_vals = self.min_vals
+
+        if isinstance(self.max_vals, np.ndarray):
+            max_vals = self.max_vals.max(axis, out, keepdims, initial, where)
+        else:
+            max_vals = self.max_vals
+
+        return SingleEntityPhiTensor(
+                child=data,
+                max_vals=max_vals,
+                min_vals=min_vals,
+                entity=self.entity,
+            )
+
+    def min(self,
+            axis=None,
+            out: Optional[np.ndarray] = None,
+            keepdims: Optional[bool] = False,
+            initial: Optional[int] = None,
+            where: bool = True):
+        # Note: Who knew this method had SO MANY ARGUMENTS?!?!?
+        if is_acceptable_simple_type(self.child):
+            if isinstance(self.child, np.ndarray):
+                data = self.child.min(axis, out, keepdims, initial, where)
+            else:
+                # This implies self.child is a singleton (int, float, bool, etc)
+                data = self.child
+        elif isinstance(self.child, torch.Tensor):
+            data = self.child.numpy().min(axis, out, keepdims, initial, where)
+        else:
+            raise NotImplementedError
+
+        if isinstance(self.min_vals, np.ndarray):
+            min_vals = self.min_vals.min(axis, out, keepdims, initial, where)
+        else:
+            min_vals = self.min_vals
+
+        if isinstance(self.max_vals, np.ndarray):
+            max_vals = self.max_vals.min(axis, out, keepdims, initial, where)
+        else:
+            max_vals = self.max_vals
+
+        return SingleEntityPhiTensor(
+            child=data,
+            max_vals=max_vals,
+            min_vals=min_vals,
+            entity=self.entity,
         )
 
 

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -10,11 +10,11 @@ from typing import Tuple as TypeTuple
 from typing import Union
 
 # third party
-import torch
 from google.protobuf.reflection import GeneratedProtocolMessageType
 from nacl.signing import VerifyKey
 import numpy as np
 import numpy.typing as npt
+import torch
 
 # relative
 from ....proto.core.tensor.single_entity_phi_tensor_pb2 import (
@@ -1389,12 +1389,14 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             scalar_manager=self.scalar_manager,
         )
 
-    def max(self,
-            axis=None,
-            out: Optional[np.ndarray]=None,
-            keepdims: Optional[bool]=False,
-            initial: Optional[int]=None,
-            where: bool = True):
+    def max(
+        self,
+        axis: Optional[int] = None,
+        out: Optional[np.ndarray] = None,
+        keepdims: Optional[bool] = False,
+        initial: Optional[int] = None,
+        where: bool = True,
+    ) -> SingleEntityPhiTensor:
         # Note: Who knew this method had SO MANY ARGUMENTS?!?!?
         if is_acceptable_simple_type(self.child):
             if isinstance(self.child, np.ndarray):
@@ -1418,18 +1420,20 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             max_vals = self.max_vals
 
         return SingleEntityPhiTensor(
-                child=data,
-                max_vals=max_vals,
-                min_vals=min_vals,
-                entity=self.entity,
-            )
+            child=data,
+            max_vals=max_vals,
+            min_vals=min_vals,
+            entity=self.entity,
+        )
 
-    def min(self,
-            axis=None,
-            out: Optional[np.ndarray] = None,
-            keepdims: Optional[bool] = False,
-            initial: Optional[int] = None,
-            where: bool = True):
+    def min(
+        self,
+        axis: Optional[int] = None,
+        out: Optional[np.ndarray] = None,
+        keepdims: Optional[bool] = False,
+        initial: Optional[int] = None,
+        where: bool = True,
+    ) -> SingleEntityPhiTensor:
         # Note: Who knew this method had SO MANY ARGUMENTS?!?!?
         if is_acceptable_simple_type(self.child):
             if isinstance(self.child, np.ndarray):

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1084,6 +1084,94 @@ def test_or(reference_binary_data: np.ndarray) -> None:
     assert (output.child == target).all()
 
 
+def test_min(
+    reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray
+) -> None:
+    """Test min(), without any arguments"""
+    tensor = SEPT(
+        child=reference_data, max_vals=upper_bound, min_vals=lower_bound, entity=ishan
+    )
+    output = tensor.min()
+    target = reference_data.min()
+    assert output.child == target
+    assert output.min_vals == lower_bound.min()
+    assert output.max_vals == upper_bound.min()
+
+
+def test_min_args(
+    reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray
+) -> None:
+    """Test the hundred different args that exist for min()"""
+    tensor = SEPT(
+        child=reference_data, max_vals=upper_bound, min_vals=lower_bound, entity=ishan
+    )
+
+    # Test axis
+    output = tensor.min(axis=1)
+    target = reference_data.min(axis=1)
+    assert (output.child == target).all()
+    assert (output.min_vals == lower_bound.min(axis=1)).all()
+    assert (output.max_vals == upper_bound.min(axis=1)).all()
+
+    # Test keepdims
+    output = tensor.min(keepdims=True)
+    target = reference_data.min(keepdims=True)
+    assert (output.child == target).all()
+    assert (output.min_vals == lower_bound.min(keepdims=True)).all()
+    assert (output.max_vals == upper_bound.min(keepdims=True)).all()
+
+    # Test initial
+    output = tensor.min(initial=-high)
+    target = reference_data.min(initial=-high)
+    assert (output.child == target).all()
+    assert (output.min_vals == lower_bound.min(initial=-high)).all()
+    assert (output.max_vals == upper_bound.min(initial=-high)).all()
+
+
+def test_max(
+    reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray
+) -> None:
+    """Test min"""
+    tensor = SEPT(
+        child=reference_data, max_vals=upper_bound, min_vals=lower_bound, entity=ishan
+    )
+    output = tensor.max()
+    target = reference_data.max()
+    assert output.child == target
+    assert output.min_vals == lower_bound.max()
+    assert output.max_vals == upper_bound.max()
+
+
+def test_max_args(
+    reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray
+) -> None:
+    """Test the hundred different args that exist for min()"""
+    tensor = SEPT(
+        child=reference_data, max_vals=upper_bound, min_vals=lower_bound, entity=ishan
+    )
+
+    # Test axis
+    output = tensor.max(axis=1)
+    target = reference_data.max(axis=1)
+    assert (output.child == target).all()
+    assert (output.min_vals == lower_bound.max(axis=1)).all()
+    assert (output.max_vals == upper_bound.max(axis=1)).all()
+
+    # Test keepdims
+    output = tensor.max(keepdims=True)
+    target = reference_data.max(keepdims=True)
+    assert (output.child == target).all()
+    assert (output.min_vals == lower_bound.max(keepdims=True)).all()
+    assert (output.max_vals == upper_bound.max(keepdims=True)).all()
+
+    # Test initial
+    output = tensor.max(initial=-high)
+    target = reference_data.max(initial=-high)
+    assert (output.child == target).all()
+    assert (output.min_vals == lower_bound.max(initial=-high)).all()
+    assert (output.max_vals == upper_bound.max(initial=-high)).all()
+
+
 # End of Ishan's tests
 
 


### PR DESCRIPTION
## Description
Implemented the max and min operations for SingleEntityPhiTensor. These are the first two operators for Week 3 of the Syft Tensor Roadmap

## Affected Dependencies
No changes.

## How has this been tested?
```
Pre-commit run --all-files
pytest -v single_entity_phi_test.py
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
