### PR TITLE
Add round() to SEPT, REPT

### DIFF
--- a/packages/syft/src/syft/core/node/common/node_service/user_manager/user_manager_service.py
+++ b/packages/syft/src/syft/core/node/common/node_service/user_manager/user_manager_service.py
@@ -237,7 +237,7 @@ def get_all_users_msg(
                 user_key=VerifyKey(user.verify_key.encode("utf-8"), encoder=HexEncoder),
                 returned_epsilon_is_private=True,
             )
-            
+
             _msg.append(_user_json)
 
     return GetUsersResponse(

--- a/packages/syft/src/syft/core/node/network/client.py
+++ b/packages/syft/src/syft/core/node/network/client.py
@@ -16,7 +16,6 @@ from ...io.route import Route
 from ..common.client import Client
 from ..common.client_manager.association_api import AssociationRequestAPI
 from ..common.client_manager.dataset_api import DatasetRequestAPI
-
 from ..common.client_manager.role_api import RoleRequestAPI
 from ..common.client_manager.user_api import UserRequestAPI
 

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -573,6 +573,12 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
+    def round(self, decimals: int = 0) -> RowEntityPhiTensor:
+        new_list = list()
+        for tensor in self.child:
+            new_list.append(tensor.round(decimals))
+        return RowEntityPhiTensor(rows=new_list, check_shape=False)
+
 
 @implements(RowEntityPhiTensor, np.expand_dims)
 def expand_dims(a: np.typing.ArrayLike, axis: int) -> RowEntityPhiTensor:

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -1379,16 +1379,18 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             scalar_manager=self.scalar_manager,
         )
 
-    def round(self, decimals: int = 0):
+    def round(self, decimals: int = 0) -> SingleEntityPhiTensor:
         if decimals != 0:
-            raise Exception("We currently only support np.int32. Sorry about the inconvenience-"
-                            "we plan to support more types soon!")
+            raise Exception(
+                "We currently only support np.int32. Sorry about the inconvenience-"
+                "we plan to support more types soon!"
+            )
         return SingleEntityPhiTensor(
             child=self.child.astype(dtype=np.int32),
             min_vals=self.min_vals.astype(dtype=np.int32),
             max_vals=self.max_vals.astype(dtype=np.int32),
             scalar_manager=self.scalar_manager,
-            entity=self.entity
+            entity=self.entity,
         )
 
 

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -1379,6 +1379,18 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             scalar_manager=self.scalar_manager,
         )
 
+    def round(self, decimals: int = 0):
+        if decimals != 0:
+            raise Exception("We currently only support np.int32. Sorry about the inconvenience-"
+                            "we plan to support more types soon!")
+        return SingleEntityPhiTensor(
+            child=self.child.astype(dtype=np.int32),
+            min_vals=self.min_vals.astype(dtype=np.int32),
+            max_vals=self.max_vals.astype(dtype=np.int32),
+            scalar_manager=self.scalar_manager,
+            entity=self.entity
+        )
+
 
 @implements(SingleEntityPhiTensor, np.expand_dims)
 def expand_dims(a: npt.ArrayLike, axis: Optional[int] = None) -> SingleEntityPhiTensor:

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -667,6 +667,12 @@ def test_or(row_count: int, ishan: Entity) -> None:
         assert (tensor | False) == output[index]
 
 
+def test_round(row_data_ishan: list) -> None:
+    reference_tensor = REPT(rows=row_data_ishan)
+    for target, output in zip(row_data_ishan, reference_tensor.round(decimals=0).child):
+        assert (target.child.astype(np.int32) == output.child).all()
+
+
 @pytest.fixture
 def tensor1(traskmaster: Entity, row_count: int, dims: int) -> REPT:
     """Reference tensor"""

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1210,12 +1210,14 @@ def test_or(reference_binary_data: np.ndarray, ishan: Entity) -> None:
     assert (output.child == target).all()
 
 
-def test_round(reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity) -> None:
+def test_round(
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+) -> None:
     reference_tensor = SEPT(
-        child=reference_data,
-        max_vals=upper_bound,
-        min_vals=lower_bound,
-        entity=ishan
+        child=reference_data, max_vals=upper_bound, min_vals=lower_bound, entity=ishan
     )
     output = reference_tensor.round(decimals=0)
     target = reference_data.astype(dtype=np.int32)

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1210,6 +1210,20 @@ def test_or(reference_binary_data: np.ndarray, ishan: Entity) -> None:
     assert (output.child == target).all()
 
 
+def test_round(reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity) -> None:
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan
+    )
+    output = reference_tensor.round(decimals=0)
+    target = reference_data.astype(dtype=np.int32)
+    assert (output.child == target).all()
+    assert (output.min_vals == lower_bound.astype(dtype=np.int32)).all()
+    assert (output.max_vals == upper_bound.astype(dtype=np.int32)).all()
+
+
 # End of Ishan's tests
 
 


### PR DESCRIPTION
## Description
Implemented the `round()` operation for SingleEntityPhiTensor and RowEntityPhiTensor.

## Affected Dependencies
None.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

```
Pre-commit run --all-files
pytest -v single_entity_phi_test.py
```


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
