### PR TITLE
Added remaining Week 3 operators plus a bonus Week 4 operator

### DIFF
--- a/packages/syft/src/syft/core/node/common/node_service/user_manager/user_manager_service.py
+++ b/packages/syft/src/syft/core/node/common/node_service/user_manager/user_manager_service.py
@@ -237,7 +237,7 @@ def get_all_users_msg(
                 user_key=VerifyKey(user.verify_key.encode("utf-8"), encoder=HexEncoder),
                 returned_epsilon_is_private=True,
             )
-            
+
             _msg.append(_user_json)
 
     return GetUsersResponse(

--- a/packages/syft/src/syft/core/node/network/client.py
+++ b/packages/syft/src/syft/core/node/network/client.py
@@ -16,7 +16,6 @@ from ...io.route import Route
 from ..common.client import Client
 from ..common.client_manager.association_api import AssociationRequestAPI
 from ..common.client_manager.dataset_api import DatasetRequestAPI
-
 from ..common.client_manager.role_api import RoleRequestAPI
 from ..common.client_manager.user_api import UserRequestAPI
 

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -603,8 +603,8 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
     def __mod__(
-            self,
-            other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor],
+        self,
+        other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor],
     ) -> RowEntityPhiTensor:
 
         # We will let the underlying SingleEntityPhiTensor logic handle most of the errors/exceptions
@@ -632,7 +632,8 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
     def __divmod__(
-            self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor]
+        self,
+        other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor],
     ) -> Tuple:
         # Let logic written out in mod, floordiv and SEPT handle all exceptions
         return self // other, self % other

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -602,6 +602,41 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
             raise NotImplementedError
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
+    def __mod__(
+            self,
+            other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor],
+    ) -> RowEntityPhiTensor:
+
+        # We will let the underlying SingleEntityPhiTensor logic handle most of the errors/exceptions
+        new_list = list()
+        if is_acceptable_simple_type(other):
+            for tensor in self.child:
+                new_list.append(tensor % other)
+        elif isinstance(other, SingleEntityPhiTensor):
+            for tensor in self.child:
+                new_list.append(tensor % other)
+        elif isinstance(other, RowEntityPhiTensor):
+            if not is_broadcastable(self.shape, other.shape):
+                raise Exception(
+                    f"Shapes not broadcastable: {self.shape}, {other.shape}"
+                )
+            else:
+                if other.shape[0] == 1:
+                    for tensor in self.child:
+                        new_list.append(tensor % other.child[0])
+                else:
+                    for self_tensors, other_tensors in zip(self.child, other.child):
+                        new_list.append(self_tensors % other_tensors)
+        else:
+            raise NotImplementedError
+        return RowEntityPhiTensor(rows=new_list, check_shape=False)
+
+    def __divmod__(
+            self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor]
+    ) -> Tuple:
+        # Let logic written out in mod, floordiv and SEPT handle all exceptions
+        return self // other, self % other
+
 
 @implements(RowEntityPhiTensor, np.expand_dims)
 def expand_dims(a: np.typing.ArrayLike, axis: int) -> RowEntityPhiTensor:

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -639,7 +639,8 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         return self // other, self % other
 
     def __matmul__(
-            self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor]
+        self,
+        other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor],
     ) -> RowEntityPhiTensor:
         new_list = list()
         if is_acceptable_simple_type(other):

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -643,7 +643,7 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
         other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor],
     ) -> RowEntityPhiTensor:
         new_list = list()
-        if is_acceptable_simple_type(other):
+        if isinstance(other, np.ndarray):
             for tensor in self.child:
                 new_list.append(tensor.__matmul__(other))
         elif isinstance(other, SingleEntityPhiTensor):

--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -573,7 +573,10 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
 
         return RowEntityPhiTensor(rows=new_list, check_shape=False)
 
-    def __floordiv__(self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor]) -> RowEntityPhiTensor:
+    def __floordiv__(
+        self,
+        other: Union[AcceptableSimpleType, SingleEntityPhiTensor, RowEntityPhiTensor],
+    ) -> RowEntityPhiTensor:
 
         # We will let the underlying SingleEntityPhiTensor logic handle most of the errors/exceptions
         new_list = list()
@@ -585,7 +588,9 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
                 new_list.append(tensor // other)
         elif isinstance(other, RowEntityPhiTensor):
             if not is_broadcastable(self.shape, other.shape):
-                raise Exception(f'Shapes not broadcastable: {self.shape}, {other.shape}')
+                raise Exception(
+                    f"Shapes not broadcastable: {self.shape}, {other.shape}"
+                )
             else:
                 if other.shape[0] == 1:
                     for tensor in self.child:

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -1380,12 +1380,14 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
         )
 
     def __floordiv__(
-            self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor]
+        self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor]
     ) -> Union[SingleEntityPhiTensor, IntermediateGammaTensor]:
         if is_acceptable_simple_type(other):
             if isinstance(other, np.ndarray):
                 if not is_broadcastable(self.shape, other.shape):
-                    raise Exception(f'Shapes not broadcastable: {self.shape} and {other.shape}')
+                    raise Exception(
+                        f"Shapes not broadcastable: {self.shape} and {other.shape}"
+                    )
                 else:
                     data = self.child // other
                     mins = self.min_vals // other
@@ -1404,7 +1406,9 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
                     # return convert_to_gamma_tensor(self) // convert_to_gamma_tensor(other)
                     raise NotImplementedError
             else:
-                raise Exception(f'Shapes not broadcastable: {self.shape} and {other.shape}')
+                raise Exception(
+                    f"Shapes not broadcastable: {self.shape} and {other.shape}"
+                )
         else:
             raise NotImplementedError
         return SingleEntityPhiTensor(
@@ -1412,7 +1416,7 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             max_vals=maxes,
             min_vals=mins,
             entity=self.entity,
-            scalar_manager=self.scalar_manager
+            scalar_manager=self.scalar_manager,
         )
 
 

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -1379,6 +1379,42 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             scalar_manager=self.scalar_manager,
         )
 
+    def __floordiv__(
+            self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor]
+    ) -> Union[SingleEntityPhiTensor, IntermediateGammaTensor]:
+        if is_acceptable_simple_type(other):
+            if isinstance(other, np.ndarray):
+                if not is_broadcastable(self.shape, other.shape):
+                    raise Exception(f'Shapes not broadcastable: {self.shape} and {other.shape}')
+                else:
+                    data = self.child // other
+                    mins = self.min_vals // other
+                    maxes = self.max_vals // other
+            else:
+                data = self.child // other
+                mins = self.min_vals // other
+                maxes = self.max_vals // other
+        elif isinstance(other, SingleEntityPhiTensor):
+            if is_broadcastable(self.shape, other.shape):
+                if self.entity == other.entity:
+                    data = self.child // other.child
+                    mins = self.min_vals // other.min_vals
+                    maxes = self.max_vals // other.max_vals
+                else:
+                    # return convert_to_gamma_tensor(self) // convert_to_gamma_tensor(other)
+                    raise NotImplementedError
+            else:
+                raise Exception(f'Shapes not broadcastable: {self.shape} and {other.shape}')
+        else:
+            raise NotImplementedError
+        return SingleEntityPhiTensor(
+            child=data,
+            max_vals=maxes,
+            min_vals=mins,
+            entity=self.entity,
+            scalar_manager=self.scalar_manager
+        )
+
 
 @implements(SingleEntityPhiTensor, np.expand_dims)
 def expand_dims(a: npt.ArrayLike, axis: Optional[int] = None) -> SingleEntityPhiTensor:

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -1466,10 +1466,12 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
         return self // other, self % other
 
     def __matmul__(
-            self, other: Union[np.ndarray, SingleEntityPhiTensor]
+        self, other: Union[np.ndarray, SingleEntityPhiTensor]
     ) -> Union[SingleEntityPhiTensor, IntermediateGammaTensor]:
         if not isinstance(np.ndarray, SingleEntityPhiTensor):
-            raise Exception(f"Matrix multiplication not yet implemented for type {type(other)}")
+            raise Exception(
+                f"Matrix multiplication not yet implemented for type {type(other)}"
+            )
         else:
             if not is_broadcastable(self.shape, other.shape):
                 raise Exception(
@@ -1495,7 +1497,7 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
                     max_vals=maxes,
                     min_vals=mins,
                     entity=self.entity,
-                    scalar_manager=self.scalar_manager
+                    scalar_manager=self.scalar_manager,
                 )
 
 

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -1468,7 +1468,7 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
     def __matmul__(
         self, other: Union[np.ndarray, SingleEntityPhiTensor]
     ) -> Union[SingleEntityPhiTensor, IntermediateGammaTensor]:
-        if not isinstance(np.ndarray, SingleEntityPhiTensor):
+        if not isinstance(other, (np.ndarray, SingleEntityPhiTensor)):
             raise Exception(
                 f"Matrix multiplication not yet implemented for type {type(other)}"
             )
@@ -1483,7 +1483,7 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
                     mins = self.min_vals.__matmul__(other)
                     maxes = self.max_vals.__matmul__(other)
                 elif isinstance(other, SingleEntityPhiTensor):
-                    if self.entity == other.entity:
+                    if self.entity != other.entity:
                         # return convert_to_gamma_tensor(self).__matmul__(convert_to_gamma_tensor(other))
                         raise NotImplementedError
                     else:

--- a/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/single_entity_phi.py
@@ -1419,10 +1419,9 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
             scalar_manager=self.scalar_manager,
         )
 
-
     # TODO: Check to see if non-integers are ever introduced
     def __mod__(
-            self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor]
+        self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor]
     ) -> Union[SingleEntityPhiTensor, IntermediateGammaTensor]:
         if is_acceptable_simple_type(other):
             if isinstance(other, np.ndarray):
@@ -1462,7 +1461,7 @@ class SingleEntityPhiTensor(PassthroughTensor, AutogradTensorAncestor, ADPTensor
         )
 
     def __divmod__(
-            self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor]
+        self, other: Union[AcceptableSimpleType, SingleEntityPhiTensor]
     ) -> TypeTuple:
         return self // other, self % other
 

--- a/packages/syft/src/syft/core/tensor/broadcastable.py
+++ b/packages/syft/src/syft/core/tensor/broadcastable.py
@@ -16,3 +16,14 @@ def is_broadcastable(shape1: Sequence, shape2: Sequence) -> bool:
         else:
             return False
     return True
+
+
+# def is_mat_multiplicable(shape1: Sequence, shape2: Sequence) -> bool:
+#     if len(shape1) >= 2:
+#         if shape1[-1] == shape2[-2]:
+#             return True
+#         return False
+#     else:
+#         if shape1[0] == shape2[-2]:
+#             return True
+#         return False

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -678,6 +678,76 @@ def test_floordiv_rept(row_data_ishan: list) -> None:
         assert tensor == row_data_ishan[index] // other_data[index]
 
 
+def test_mod_array(row_data_ishan: list) -> None:
+    """Test mod with np.ndarrays"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = np.ones_like(row_data_ishan[0].child)
+    output = reference_tensor % other
+    for index, tensor in enumerate(output.child):
+        assert tensor == row_data_ishan[index] % other
+
+
+@pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
+def test_mod_sept(row_data_ishan: list) -> None:
+    """Test mod with SEPT"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = row_data_ishan[0]
+    output = reference_tensor % other
+
+    for index, tensor in enumerate(output.child):
+        assert tensor == row_data_ishan[index] % other.child
+
+
+@pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
+def test_mod_rept(row_data_ishan: list) -> None:
+    """Test mod with REPT"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other_data = [i // 2 + 1 for i in row_data_ishan]
+    other = REPT(rows=other_data)
+    output = reference_tensor % other
+
+    for index, tensor in enumerate(output.child):
+        assert tensor == row_data_ishan[index] // other_data[index]
+
+
+def test_divmod_array(row_data_ishan: list) -> None:
+    """Test divmod with np.ndarrays"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = np.ones_like(row_data_ishan[0].child)
+    quotient, remainder = reference_tensor.__divmod__(other)
+    for index, tensors in enumerate(zip(quotient.child, remainder.child)):
+        assert tensors[0] == row_data_ishan[index] % other
+        assert tensors[1] == row_data_ishan[index] % other
+
+
+@pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
+def test_divmod_sept(row_data_ishan: list) -> None:
+    """Test divmod with SEPT"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = row_data_ishan[0]
+    quotient, remainder = reference_tensor.__divmod__(other)
+
+    for index, tensors in enumerate(zip(quotient.child, remainder.child)):
+        assert tensors[0] == row_data_ishan[index] // other.child
+        assert tensors[1] == row_data_ishan[index] % other.child
+
+
+@pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
+def test_divmod_rept(row_data_ishan: list) -> None:
+    """Test divmod with REPT"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other_data = [i // 2 + 1 for i in row_data_ishan]
+    other = REPT(rows=other_data)
+    quotient, remainder = reference_tensor.__divmod__(other)
+
+    for index, tensors in enumerate(zip(quotient.child, remainder.child)):
+        assert tensors[0] == row_data_ishan[index] // other_data[index]
+        assert tensors[1] == row_data_ishan[index] % other_data[index]
+
+
+
+
+
 @pytest.mark.skip(
     reason="Test passes, but raises a Deprecation Warning for elementwise comparisons"
 )

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -647,7 +647,7 @@ def test_and(row_count: int, ishan: Entity) -> None:
 
 
 def test_floordiv_array(row_data_ishan: list) -> None:
-    """ Test floordiv with np.ndarrays"""
+    """Test floordiv with np.ndarrays"""
     reference_tensor = REPT(rows=row_data_ishan)
     other = np.ones_like(row_data_ishan[0].child)
     output = reference_tensor // other
@@ -657,7 +657,7 @@ def test_floordiv_array(row_data_ishan: list) -> None:
 
 @pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
 def test_floordiv_sept(row_data_ishan: list) -> None:
-    """ Test floordiv with SEPT"""
+    """Test floordiv with SEPT"""
     reference_tensor = REPT(rows=row_data_ishan)
     other = row_data_ishan[0]
     output = reference_tensor // other
@@ -668,7 +668,7 @@ def test_floordiv_sept(row_data_ishan: list) -> None:
 
 @pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
 def test_floordiv_rept(row_data_ishan: list) -> None:
-    """ Test floordiv with REPT"""
+    """Test floordiv with REPT"""
     reference_tensor = REPT(rows=row_data_ishan)
     other_data = [i // 2 + 1 for i in row_data_ishan]
     other = REPT(rows=other_data)

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -766,6 +766,42 @@ def test_or(row_count: int, ishan: Entity) -> None:
         assert (tensor | False) == output[index]
 
 
+def test_matmul_array(row_data_ishan: list) -> None:
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = np.ones_like(row_data_ishan[0].child.T) * 5
+    output = reference_tensor.__matmul__(other)
+
+    for input_tensor, output_tensor in zip(reference_tensor.child, output.child):
+        assert output_tensor.shape[1] == reference_tensor.shape[1]
+        assert output_tensor.shape[-1] == other.shape[-1]
+        assert output_tensor == input_tensor.__matmul__(other)
+
+
+def test_matmul_sept(
+        row_data_ishan: list, reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity
+) -> None:
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = row_data_ishan[0].transpose() * 2
+    output = reference_tensor.__matmul__(other)
+
+    for input_tensor, output_tensor in zip(reference_tensor.child, output.child):
+        assert output_tensor.shape[1] == reference_tensor.shape[1]
+        assert output_tensor.shape[-1] == other.shape[-1]
+        assert output_tensor == input_tensor.__matmul__(other.child)
+
+
+def test_matmul_rept(row_data_ishan: list) -> None:
+    reference_tensor = REPT(rows=row_data_ishan)
+    data = [i.transpose() * 2 for i in row_data_ishan]
+    other = REPT(rows=data)
+    output = reference_tensor.__matmul__(other)
+
+    for input_tensor, other_tensor, output_tensor in zip(reference_tensor.child, other.child, output.child):
+        assert output_tensor.shape[1] == reference_tensor.shape[1]
+        assert output_tensor.shape[-1] == other.shape[-1]
+        assert output_tensor == input_tensor.child.__matmul__(other_tensor.child)
+
+
 @pytest.fixture
 def tensor1(traskmaster: Entity, row_count: int, dims: int) -> REPT:
     """Reference tensor"""

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -745,9 +745,6 @@ def test_divmod_rept(row_data_ishan: list) -> None:
         assert tensors[1] == row_data_ishan[index] % other_data[index]
 
 
-
-
-
 @pytest.mark.skip(
     reason="Test passes, but raises a Deprecation Warning for elementwise comparisons"
 )

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -778,7 +778,11 @@ def test_matmul_array(row_data_ishan: list) -> None:
 
 
 def test_matmul_sept(
-        row_data_ishan: list, reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity
+    row_data_ishan: list,
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
 ) -> None:
     reference_tensor = REPT(rows=row_data_ishan)
     other = row_data_ishan[0].transpose() * 2
@@ -796,7 +800,9 @@ def test_matmul_rept(row_data_ishan: list) -> None:
     other = REPT(rows=data)
     output = reference_tensor.__matmul__(other)
 
-    for input_tensor, other_tensor, output_tensor in zip(reference_tensor.child, other.child, output.child):
+    for input_tensor, other_tensor, output_tensor in zip(
+        reference_tensor.child, other.child, output.child
+    ):
         assert output_tensor.shape[1] == reference_tensor.shape[1]
         assert output_tensor.shape[-1] == other.shape[-1]
         assert output_tensor == input_tensor.child.__matmul__(other_tensor.child)

--- a/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/row_entity_phi_test.py
@@ -646,6 +646,38 @@ def test_and(row_count: int, ishan: Entity) -> None:
         assert (tensor & False) == output[index]
 
 
+def test_floordiv_array(row_data_ishan: list) -> None:
+    """ Test floordiv with np.ndarrays"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = np.ones_like(row_data_ishan[0].child)
+    output = reference_tensor // other
+    for index, tensor in enumerate(output.child):
+        assert tensor == row_data_ishan[index] // other
+
+
+@pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
+def test_floordiv_sept(row_data_ishan: list) -> None:
+    """ Test floordiv with SEPT"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other = row_data_ishan[0]
+    output = reference_tensor // other
+
+    for index, tensor in enumerate(output.child):
+        assert tensor == row_data_ishan[index] // other.child
+
+
+@pytest.mark.skip(reason="Test works but occasionally gives a division by zero error")
+def test_floordiv_rept(row_data_ishan: list) -> None:
+    """ Test floordiv with REPT"""
+    reference_tensor = REPT(rows=row_data_ishan)
+    other_data = [i // 2 + 1 for i in row_data_ishan]
+    other = REPT(rows=other_data)
+    output = reference_tensor // other
+
+    for index, tensor in enumerate(output.child):
+        assert tensor == row_data_ishan[index] // other_data[index]
+
+
 @pytest.mark.skip(
     reason="Test passes, but raises a Deprecation Warning for elementwise comparisons"
 )

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1443,19 +1443,19 @@ def test_divmod_sept(
 
 
 def test_matmul_array(
-        reference_data: np.ndarray,
-        upper_bound: np.ndarray,
-        lower_bound: np.ndarray,
-        ishan: Entity,
-        traskmaster: Entity,
-        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
 ) -> None:
     reference_tensor = SEPT(
         child=reference_data,
         max_vals=upper_bound,
         min_vals=lower_bound,
         entity=ishan,
-        scalar_manager=reference_scalar_manager
+        scalar_manager=reference_scalar_manager,
     )
     other = np.ones_like(reference_data.T) * 5
     output = reference_tensor.__matmul__(other)
@@ -1465,19 +1465,19 @@ def test_matmul_array(
 
 
 def test_matmul_sept(
-        reference_data: np.ndarray,
-        upper_bound: np.ndarray,
-        lower_bound: np.ndarray,
-        ishan: Entity,
-        traskmaster: Entity,
-        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
 ) -> None:
     reference_tensor = SEPT(
         child=reference_data,
         max_vals=upper_bound,
         min_vals=lower_bound,
         entity=ishan,
-        scalar_manager=reference_scalar_manager
+        scalar_manager=reference_scalar_manager,
     )
     data = np.ones_like(reference_data.T) * 5
     other = SEPT(
@@ -1485,7 +1485,7 @@ def test_matmul_sept(
         max_vals=np.ones_like(data) * 10,
         min_vals=np.ones_like(data),
         entity=ishan,
-        scalar_manager=reference_scalar_manager
+        scalar_manager=reference_scalar_manager,
     )
     output = reference_tensor.__matmul__(other)
     assert output.shape[0] == reference_data.shape[0]

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1442,6 +1442,57 @@ def test_divmod_sept(
     ).all()  # Beware of division by 0 error
 
 
+def test_matmul_array(
+        reference_data: np.ndarray,
+        upper_bound: np.ndarray,
+        lower_bound: np.ndarray,
+        ishan: Entity,
+        traskmaster: Entity,
+        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+) -> None:
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager
+    )
+    other = np.ones_like(reference_data.T) * 5
+    output = reference_tensor.__matmul__(other)
+    assert output.shape[0] == reference_data.shape[0]
+    assert output.shape[1] == other.shape[1]
+    assert (output.child == reference_data.__matmul__(other)).all()
+
+
+def test_matmul_sept(
+        reference_data: np.ndarray,
+        upper_bound: np.ndarray,
+        lower_bound: np.ndarray,
+        ishan: Entity,
+        traskmaster: Entity,
+        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+) -> None:
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager
+    )
+    data = np.ones_like(reference_data.T) * 5
+    other = SEPT(
+        child=data,
+        max_vals=np.ones_like(data) * 10,
+        min_vals=np.ones_like(data),
+        entity=ishan,
+        scalar_manager=reference_scalar_manager
+    )
+    output = reference_tensor.__matmul__(other)
+    assert output.shape[0] == reference_data.shape[0]
+    assert output.shape[1] == other.shape[1]
+    assert (output.child == reference_data.__matmul__(other.child)).all()
+
+
 # End of Ishan's tests
 
 

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1348,6 +1348,92 @@ def test_mod_sept(
     assert (output.max_vals == upper_bound % 6).all()
     assert (output.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
 
+
+def test_divmod_array(
+        reference_data: np.ndarray,
+        upper_bound: np.ndarray,
+        lower_bound: np.ndarray,
+        ishan: Entity,
+        traskmaster: Entity,
+        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+) -> None:
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+
+    other = np.ones_like(reference_data) * 4
+    quotient, remainder = reference_tensor.__divmod__(other)
+    assert isinstance(quotient, SEPT)
+    assert isinstance(remainder, SEPT)
+    assert quotient.shape == reference_tensor.shape
+    assert remainder.shape == reference_tensor.shape
+    assert (quotient.child == reference_data // 4).all()
+    assert (remainder.child == reference_data % 4).all()
+    assert (quotient.max_vals == upper_bound // 4).all()
+    assert (remainder.max_vals == upper_bound % 4).all()
+    assert (quotient.min_vals == lower_bound // 4).all()
+    assert (remainder.min_vals == lower_bound % 4).all()
+
+
+def test_divmod_sept(
+        reference_data: np.ndarray,
+        upper_bound: np.ndarray,
+        lower_bound: np.ndarray,
+        ishan: Entity,
+        traskmaster: Entity,
+        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+) -> None:
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+
+    other = SEPT(
+        child=np.ones_like(reference_data),
+        max_vals=np.ones_like(reference_data) * 5,
+        min_vals=np.ones_like(reference_data),
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+    quotient, remainder = reference_tensor.__divmod__(other)
+    assert isinstance(quotient, SEPT)
+    assert isinstance(remainder, SEPT)
+    assert quotient.shape == reference_tensor.shape
+    assert remainder.shape == reference_tensor.shape
+    assert (quotient.child == reference_data).all()
+    assert (remainder.child == np.zeros_like(reference_data)).all()
+    assert (quotient.max_vals == upper_bound // 5).all()
+    assert (remainder.max_vals == np.zeros_like(upper_bound)).all()
+    assert (quotient.min_vals == lower_bound).all()  # Beware of division by 0 error
+    assert (remainder.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
+
+    other = SEPT(
+        child=np.ones_like(reference_data) * 6,
+        max_vals=np.ones_like(reference_data) * 6,
+        min_vals=np.ones_like(reference_data),
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+
+    quotient, remainder = reference_tensor.__divmod__(other)
+    assert isinstance(quotient, SEPT)
+    assert isinstance(remainder, SEPT)
+    assert quotient.shape == reference_tensor.shape
+    assert remainder.shape == reference_tensor.shape
+    assert (quotient.child == reference_data // 6).all()
+    assert (remainder.child == reference_data % 6).all()
+    assert (quotient.max_vals == upper_bound // 6).all()
+    assert (remainder.max_vals == upper_bound % 6).all()
+    assert (quotient.min_vals == lower_bound).all()  # Beware of division by 0 error
+    assert (remainder.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
+
 # End of Ishan's tests
 
 

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1210,6 +1210,56 @@ def test_or(reference_binary_data: np.ndarray, ishan: Entity) -> None:
     assert (output.child == target).all()
 
 
+def test_floordiv_array(
+        reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity,
+        traskmaster: Entity, reference_scalar_manager: VirtualMachinePrivateScalarManager
+) -> None:
+    """ Test floordiv"""
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager
+    )
+
+    other = np.ones_like(reference_data)
+    output = reference_tensor // other
+    assert isinstance(output, SEPT)
+    assert output.shape == reference_tensor.shape
+    assert (output.child == reference_data).all()
+    assert (output.max_vals == upper_bound).all()
+    assert (output.min_vals == lower_bound).all()
+
+
+def test_floordiv_sept(
+        reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity,
+        traskmaster: Entity, reference_scalar_manager: VirtualMachinePrivateScalarManager
+) -> None:
+    """ Test floordiv with public SEPT"""
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager
+    )
+
+    other = SEPT(
+        child=np.ones_like(reference_data),
+        max_vals=np.ones_like(reference_data) * 5,
+        min_vals=np.ones_like(reference_data),
+        entity=ishan,
+        scalar_manager=reference_scalar_manager
+    )
+    output = reference_tensor // other
+    assert isinstance(output, SEPT)
+    assert output.shape == reference_tensor.shape
+    assert (output.child == reference_data).all()
+    assert (output.max_vals == upper_bound // 5).all()
+    assert (output.min_vals == lower_bound).all()  # Beware of division by 0 error
+
+
 # End of Ishan's tests
 
 

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1211,16 +1211,20 @@ def test_or(reference_binary_data: np.ndarray, ishan: Entity) -> None:
 
 
 def test_floordiv_array(
-        reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity,
-        traskmaster: Entity, reference_scalar_manager: VirtualMachinePrivateScalarManager
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
 ) -> None:
-    """ Test floordiv"""
+    """Test floordiv"""
     reference_tensor = SEPT(
         child=reference_data,
         max_vals=upper_bound,
         min_vals=lower_bound,
         entity=ishan,
-        scalar_manager=reference_scalar_manager
+        scalar_manager=reference_scalar_manager,
     )
 
     other = np.ones_like(reference_data)
@@ -1233,16 +1237,20 @@ def test_floordiv_array(
 
 
 def test_floordiv_sept(
-        reference_data: np.ndarray, upper_bound: np.ndarray, lower_bound: np.ndarray, ishan: Entity,
-        traskmaster: Entity, reference_scalar_manager: VirtualMachinePrivateScalarManager
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
 ) -> None:
-    """ Test floordiv with public SEPT"""
+    """Test floordiv with public SEPT"""
     reference_tensor = SEPT(
         child=reference_data,
         max_vals=upper_bound,
         min_vals=lower_bound,
         entity=ishan,
-        scalar_manager=reference_scalar_manager
+        scalar_manager=reference_scalar_manager,
     )
 
     other = SEPT(
@@ -1250,7 +1258,7 @@ def test_floordiv_sept(
         max_vals=np.ones_like(reference_data) * 5,
         min_vals=np.ones_like(reference_data),
         entity=ishan,
-        scalar_manager=reference_scalar_manager
+        scalar_manager=reference_scalar_manager,
     )
     output = reference_tensor // other
     assert isinstance(output, SEPT)

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1297,7 +1297,7 @@ def test_mod_array(
     output = reference_tensor % other
     assert isinstance(output, SEPT)
     assert output.shape == reference_tensor.shape
-    assert (output.child == reference_data % 4 ).all()
+    assert (output.child == reference_data % 4).all()
     assert (output.max_vals == upper_bound % 4).all()
     assert (output.min_vals == lower_bound % 4).all()
 
@@ -1331,8 +1331,9 @@ def test_mod_sept(
     assert output.shape == reference_tensor.shape
     assert (output.child == np.zeros_like(reference_data)).all()
     assert (output.max_vals == np.zeros_like(upper_bound) % 5).all()
-    assert (output.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
-
+    assert (
+        output.min_vals == np.zeros_like(lower_bound)
+    ).all()  # Beware of division by 0 error
 
     other = SEPT(
         child=np.ones_like(reference_data) * 6,
@@ -1346,16 +1347,18 @@ def test_mod_sept(
     assert output.shape == reference_tensor.shape
     assert (output.child == reference_data % 6).all()
     assert (output.max_vals == upper_bound % 6).all()
-    assert (output.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
+    assert (
+        output.min_vals == np.zeros_like(lower_bound)
+    ).all()  # Beware of division by 0 error
 
 
 def test_divmod_array(
-        reference_data: np.ndarray,
-        upper_bound: np.ndarray,
-        lower_bound: np.ndarray,
-        ishan: Entity,
-        traskmaster: Entity,
-        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
 ) -> None:
     reference_tensor = SEPT(
         child=reference_data,
@@ -1380,12 +1383,12 @@ def test_divmod_array(
 
 
 def test_divmod_sept(
-        reference_data: np.ndarray,
-        upper_bound: np.ndarray,
-        lower_bound: np.ndarray,
-        ishan: Entity,
-        traskmaster: Entity,
-        reference_scalar_manager: VirtualMachinePrivateScalarManager,
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
 ) -> None:
     reference_tensor = SEPT(
         child=reference_data,
@@ -1412,7 +1415,9 @@ def test_divmod_sept(
     assert (quotient.max_vals == upper_bound // 5).all()
     assert (remainder.max_vals == np.zeros_like(upper_bound)).all()
     assert (quotient.min_vals == lower_bound).all()  # Beware of division by 0 error
-    assert (remainder.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
+    assert (
+        remainder.min_vals == np.zeros_like(lower_bound)
+    ).all()  # Beware of division by 0 error
 
     other = SEPT(
         child=np.ones_like(reference_data) * 6,
@@ -1432,7 +1437,10 @@ def test_divmod_sept(
     assert (quotient.max_vals == upper_bound // 6).all()
     assert (remainder.max_vals == upper_bound % 6).all()
     assert (quotient.min_vals == lower_bound).all()  # Beware of division by 0 error
-    assert (remainder.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
+    assert (
+        remainder.min_vals == np.zeros_like(lower_bound)
+    ).all()  # Beware of division by 0 error
+
 
 # End of Ishan's tests
 

--- a/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/autodp/single_entity_phi_test.py
@@ -1268,6 +1268,86 @@ def test_floordiv_sept(
     assert (output.min_vals == lower_bound).all()  # Beware of division by 0 error
 
 
+def test_mod_array(
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
+) -> None:
+    """Test mod"""
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+
+    other = np.ones_like(reference_data)
+    output = reference_tensor % other
+    assert isinstance(output, SEPT)
+    assert output.shape == reference_tensor.shape
+    assert (output.child == np.zeros_like(reference_data)).all()
+    assert (output.max_vals == np.zeros_like(upper_bound)).all()
+    assert (output.min_vals == np.zeros_like(lower_bound)).all()
+
+    other = np.ones_like(reference_data) * 4
+    output = reference_tensor % other
+    assert isinstance(output, SEPT)
+    assert output.shape == reference_tensor.shape
+    assert (output.child == reference_data % 4 ).all()
+    assert (output.max_vals == upper_bound % 4).all()
+    assert (output.min_vals == lower_bound % 4).all()
+
+
+def test_mod_sept(
+    reference_data: np.ndarray,
+    upper_bound: np.ndarray,
+    lower_bound: np.ndarray,
+    ishan: Entity,
+    traskmaster: Entity,
+    reference_scalar_manager: VirtualMachinePrivateScalarManager,
+) -> None:
+    """Test mod with public SEPT"""
+    reference_tensor = SEPT(
+        child=reference_data,
+        max_vals=upper_bound,
+        min_vals=lower_bound,
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+
+    other = SEPT(
+        child=np.ones_like(reference_data),
+        max_vals=np.ones_like(reference_data) * 5,
+        min_vals=np.ones_like(reference_data),
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+    output = reference_tensor % other
+    assert isinstance(output, SEPT)
+    assert output.shape == reference_tensor.shape
+    assert (output.child == np.zeros_like(reference_data)).all()
+    assert (output.max_vals == np.zeros_like(upper_bound) % 5).all()
+    assert (output.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
+
+
+    other = SEPT(
+        child=np.ones_like(reference_data) * 6,
+        max_vals=np.ones_like(reference_data) * 6,
+        min_vals=np.ones_like(reference_data),
+        entity=ishan,
+        scalar_manager=reference_scalar_manager,
+    )
+    output = reference_tensor % other
+    assert isinstance(output, SEPT)
+    assert output.shape == reference_tensor.shape
+    assert (output.child == reference_data % 6).all()
+    assert (output.max_vals == upper_bound % 6).all()
+    assert (output.min_vals == np.zeros_like(lower_bound)).all()  # Beware of division by 0 error
+
 # End of Ishan's tests
 
 


### PR DESCRIPTION
## Description
Implemented the `floordiv(), divmod()`, and  `matmul()` operators for Week 3. This rounds up all the DP operators for Week 3.
I also had to implement the `mod()` operation from Week 4 in order to get `divmod()` working, so we're one operator ahead for Week 4. 

## Affected Dependencies
None.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

```
Pre-commit run --all-files
pytest -v single_entity_phi_test.py
pytest -v row_entity_phi_test.py

```


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
