### PR TITLE
Update pointer.py

### DIFF
--- a/packages/syft/src/syft/core/pointer/pointer.py
+++ b/packages/syft/src/syft/core/pointer/pointer.py
@@ -162,7 +162,7 @@ class Pointer(AbstractPointer):
     def __repr__(self) -> str:
         return f"<{self.__name__} -> {self.client.name}:{self.id_at_location.no_dash}>"
 
-    def _get(self, delete_obj: bool = True, verbose: bool = False) -> StorableObject:
+    def _get(self, delete_obj: bool = False, verbose: bool = False) -> StorableObject:
         """Method to download a remote object from a pointer object if you have the right
         permissions.
 
@@ -287,7 +287,7 @@ class Pointer(AbstractPointer):
         request_block: bool = False,
         timeout_secs: int = 20,
         reason: str = "",
-        delete_obj: bool = True,
+        delete_obj: bool = False,
         verbose: bool = False,
     ) -> Optional[StorableObject]:
         """Method to download a remote object from a pointer object if you have the right


### PR DESCRIPTION
There may be a non-obvious reason for this, but `get` probably shouldn't delete the gotten object by default, correct?

## Description
Changing default on pointer `get` calls to *not* delete the gotten object after download.

## How has this been tested?
I verified the desired behavior (i.e. not deleting the object) by passing delete_obj=False to the function during user testing.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
