### PR TITLE
Fix issue with worker crashing with larger numpy arrays

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -34,7 +34,6 @@ syft =
     autodp==0.2
     bcrypt==3.2.0
     cachetools==4.2.4
-    flask==1.1.4
     forbiddenfruit==0.1.4
     loguru==0.5.3
     names==0.3.0

--- a/packages/syft/src/syft/lib/numpy/array.py
+++ b/packages/syft/src/syft/lib/numpy/array.py
@@ -63,7 +63,11 @@ def protobuf_serialize(obj: np.ndarray) -> NumpyProto:
         # same original unsigned values on the other side
         obj = obj.astype(DTYPE_REFACTOR[original_dtype])
 
-    tensor = torch.from_numpy(obj).clone()
+    # Cloning seems to cause the worker to freeze if the array is larger than around
+    # 800k in data and since we are serializing it immediately afterwards I don't
+    # think its needed anyway
+    # tensor = torch.from_numpy(obj).clone()
+    tensor = torch.from_numpy(obj)
     tensor_bytes = tensor_serializer(tensor)
     dtype = original_dtype.name
     return NumpyProto(proto_data=tensor_bytes, dtype=dtype)


### PR DESCRIPTION
## Description
🥫

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
