### PR TITLE
[WIP] Add `ndarray` serialization for `ShareTensor`

### DIFF
--- a/packages/syft/proto/lib/sympc/share_tensor.proto
+++ b/packages/syft/proto/lib/sympc/share_tensor.proto
@@ -2,12 +2,16 @@ syntax = "proto3";
 
 package syft.lib.sympc;
 
+import "proto/lib/numpy/array.proto";
 import "proto/lib/torch/tensor.proto";
 import "proto/lib/python/dict.proto";
 
 message ShareTensor {
-  syft.lib.torch.TensorProto tensor = 1;
-  syft.lib.python.Dict config = 2;
-  string session_uuid = 3;
-  bytes ring_size = 4;
+  oneof data {
+    syft.lib.torch.TensorProto tensor = 1;
+    syft.lib.numpy.NumpyProto array = 2;
+  };
+  syft.lib.python.Dict config = 3;
+  string session_uuid = 4;
+  bytes ring_size = 5;
 }

--- a/packages/syft/src/syft/proto/lib/sympc/share_tensor_pb2.py
+++ b/packages/syft/src/syft/proto/lib/sympc/share_tensor_pb2.py
@@ -14,6 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 # syft absolute
+from syft.proto.lib.numpy import array_pb2 as proto_dot_lib_dot_numpy_dot_array__pb2
 from syft.proto.lib.python import dict_pb2 as proto_dot_lib_dot_python_dot_dict__pb2
 from syft.proto.lib.torch import tensor_pb2 as proto_dot_lib_dot_torch_dot_tensor__pb2
 
@@ -23,8 +24,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n"proto/lib/sympc/share_tensor.proto\x12\x0esyft.lib.sympc\x1a\x1cproto/lib/torch/tensor.proto\x1a\x1bproto/lib/python/dict.proto"\x8a\x01\n\x0bShareTensor\x12+\n\x06tensor\x18\x01 \x01(\x0b\x32\x1b.syft.lib.torch.TensorProto\x12%\n\x06\x63onfig\x18\x02 \x01(\x0b\x32\x15.syft.lib.python.Dict\x12\x14\n\x0csession_uuid\x18\x03 \x01(\t\x12\x11\n\tring_size\x18\x04 \x01(\x0c\x62\x06proto3',
+    serialized_pb=b'\n"proto/lib/sympc/share_tensor.proto\x12\x0esyft.lib.sympc\x1a\x1bproto/lib/numpy/array.proto\x1a\x1cproto/lib/torch/tensor.proto\x1a\x1bproto/lib/python/dict.proto"\xc1\x01\n\x0bShareTensor\x12-\n\x06tensor\x18\x01 \x01(\x0b\x32\x1b.syft.lib.torch.TensorProtoH\x00\x12+\n\x05\x61rray\x18\x02 \x01(\x0b\x32\x1a.syft.lib.numpy.NumpyProtoH\x00\x12%\n\x06\x63onfig\x18\x03 \x01(\x0b\x32\x15.syft.lib.python.Dict\x12\x14\n\x0csession_uuid\x18\x04 \x01(\t\x12\x11\n\tring_size\x18\x05 \x01(\x0c\x42\x06\n\x04\x64\x61tab\x06proto3',
     dependencies=[
+        proto_dot_lib_dot_numpy_dot_array__pb2.DESCRIPTOR,
         proto_dot_lib_dot_torch_dot_tensor__pb2.DESCRIPTOR,
         proto_dot_lib_dot_python_dot_dict__pb2.DESCRIPTOR,
     ],
@@ -59,8 +61,8 @@ _SHARETENSOR = _descriptor.Descriptor(
             create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
-            name="config",
-            full_name="syft.lib.sympc.ShareTensor.config",
+            name="array",
+            full_name="syft.lib.sympc.ShareTensor.array",
             index=1,
             number=2,
             type=11,
@@ -78,10 +80,29 @@ _SHARETENSOR = _descriptor.Descriptor(
             create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
-            name="session_uuid",
-            full_name="syft.lib.sympc.ShareTensor.session_uuid",
+            name="config",
+            full_name="syft.lib.sympc.ShareTensor.config",
             index=2,
             number=3,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="session_uuid",
+            full_name="syft.lib.sympc.ShareTensor.session_uuid",
+            index=3,
+            number=4,
             type=9,
             cpp_type=9,
             label=1,
@@ -99,8 +120,8 @@ _SHARETENSOR = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="ring_size",
             full_name="syft.lib.sympc.ShareTensor.ring_size",
-            index=3,
-            number=4,
+            index=4,
+            number=5,
             type=12,
             cpp_type=9,
             label=1,
@@ -123,17 +144,37 @@ _SHARETENSOR = _descriptor.Descriptor(
     is_extendable=False,
     syntax="proto3",
     extension_ranges=[],
-    oneofs=[],
-    serialized_start=114,
-    serialized_end=252,
+    oneofs=[
+        _descriptor.OneofDescriptor(
+            name="data",
+            full_name="syft.lib.sympc.ShareTensor.data",
+            index=0,
+            containing_type=None,
+            create_key=_descriptor._internal_create_key,
+            fields=[],
+        ),
+    ],
+    serialized_start=143,
+    serialized_end=336,
 )
 
 _SHARETENSOR.fields_by_name[
     "tensor"
 ].message_type = proto_dot_lib_dot_torch_dot_tensor__pb2._TENSORPROTO
 _SHARETENSOR.fields_by_name[
+    "array"
+].message_type = proto_dot_lib_dot_numpy_dot_array__pb2._NUMPYPROTO
+_SHARETENSOR.fields_by_name[
     "config"
 ].message_type = proto_dot_lib_dot_python_dot_dict__pb2._DICT
+_SHARETENSOR.oneofs_by_name["data"].fields.append(_SHARETENSOR.fields_by_name["tensor"])
+_SHARETENSOR.fields_by_name["tensor"].containing_oneof = _SHARETENSOR.oneofs_by_name[
+    "data"
+]
+_SHARETENSOR.oneofs_by_name["data"].fields.append(_SHARETENSOR.fields_by_name["array"])
+_SHARETENSOR.fields_by_name["array"].containing_oneof = _SHARETENSOR.oneofs_by_name[
+    "data"
+]
 DESCRIPTOR.message_types_by_name["ShareTensor"] = _SHARETENSOR
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 


### PR DESCRIPTION
## Description

In order to be able to create a Rust backend for the SMPC approximations, we need to be able to call `.reconstruct()` on a `ShareTensor` instance, that has a Numpy `ndarray`, instead of a a `Torch.tensor`. For this, we need to be able to serialize/deserialize the `ndarray`.

## Affected Dependencies
.

## How has this been tested?
Locally.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
