### PR TITLE
docs: fix notebooks location in monorepo tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ This repo contains multiple sub-projects which work together.
 ```
 OpenMined/PySyft
 ├── README.md     <-- You are here 📌
+├── notebooks     <-- Notebook Examples and Tutorials
 └── packages
     ├── grid      <-- Grid - A network aware, persistent & containerized node running Syft
-    ├── notebooks <-- Notebook Examples and Tutorials
     └── syft      <-- Syft - A package for doing remote data science on private data
 ```
 


### PR DESCRIPTION
## Description

The `notebooks` directory is in the root of the repo, not inside the `packages` directory, so I fixed the documentation to reflect that.

## Affected Dependencies
n/a

## How has this been tested?
n/a

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
