### PR TITLE
docs: fix code block format in install tutorial

### DIFF
--- a/docs/source/install_tutorials/linux.rst
+++ b/docs/source/install_tutorials/linux.rst
@@ -23,7 +23,7 @@ We'll be working with Python 3.9 or newer. To check if you have it installed, yo
    $ python3 --version
    Python 3.9.0
 
-If you don't have the correct version of Python, installing it is as easy as running the following::
+If you don't have the correct version of Python, installing it is as easy as running the following:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Description

I was reading https://openmined.github.io/PySyft/install_tutorials/linux.html and saw a broken code block.

## Affected Dependencies
n/a

## How has this been tested?

Checked edit preview on github.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
