### PR TITLE
fixed issue with dorny file check expecting a base ref

### DIFF
--- a/.github/workflows/hagrid-pr_tests.yml
+++ b/.github/workflows/hagrid-pr_tests.yml
@@ -28,6 +28,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 

--- a/.github/workflows/nightlies-run.yml
+++ b/.github/workflows/nightlies-run.yml
@@ -12,7 +12,7 @@
   jobs:
     call-grid-backend_test:
       uses: OpenMined/PySyft/.github/workflows/grid-backend_tests.yml@dev
-      
+
     call-hagrid-pr_tests:
       uses: OpenMined/PySyft/.github/workflows/hagrid-pr_tests.yml@dev
 

--- a/.github/workflows/stack-integration_tests.yml
+++ b/.github/workflows/stack-integration_tests.yml
@@ -34,6 +34,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
@@ -99,6 +100,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
@@ -186,6 +188,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
@@ -283,6 +286,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
@@ -357,6 +361,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
@@ -424,6 +429,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 

--- a/.github/workflows/syft-merge_torch_tests.yml
+++ b/.github/workflows/syft-merge_torch_tests.yml
@@ -48,6 +48,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 

--- a/.github/workflows/syft-pr_tests.yml
+++ b/.github/workflows/syft-pr_tests.yml
@@ -35,6 +35,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 

--- a/.github/workflows/syft-security.yml
+++ b/.github/workflows/syft-security.yml
@@ -30,6 +30,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 


### PR DESCRIPTION
## Description
This fix adds a deterministic behavior for long-living branches. Dorny File path checker in the actions needs a ref for where to check file changes from if the workflow was not triggered from a pull request. |

In our case, our workflow is triggered by a scheduled call for nightlies so we need to add a `${{ github.ref }}` so even though the trigger is not from a PR, it checks for last file changes made to the branch. 

This is a gotcha for long-living branches

REF: https://github.com/dorny/paths-filter