### PR TITLE
remove python 3.7 from CI

### DIFF
--- a/.github/workflows/syft-version_tests.yml
+++ b/.github/workflows/syft-version_tests.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         branches: ["dev"]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         torch-version: [1.8.1, 1.9.1, 1.10.0]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Description
Dropping Python 3.7 from CI Due to a Security issue where Numpy doesn't support python 3.7.