### PR TITLE
Fixed issue with Apple Silicon M1 and primesieve package

### DIFF
--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9.9-slim as build
 
 RUN --mount=type=cache,target=/var/cache/apt \
   apt-get update && \
-  apt-get install -y --no-install-recommends curl python3-dev gcc make
+  apt-get install -y --no-install-recommends curl python3-dev gcc make build-essential
 
 WORKDIR /app
 COPY grid/backend/requirements.txt /app
@@ -17,7 +17,9 @@ RUN if [ $(uname -m) = "x86_64" ]; then \
 
 # apple m1 build PyNaCl for aarch64
 RUN if [ $(uname -m) != "x86_64" ]; then \
-  pip install --user PyNaCl; \
+  pip install --user numpy==1.22.2; \
+  pip install --user primesieve==2.3.0 --force-reinstall --no-cache-dir; \
+  python -c "from primesieve.numpy._numpy import primes"; \
   pip install --user torch==1.10.0 -f https://download.pytorch.org/whl/torch_stable.html; \
   fi
 

--- a/packages/hagrid/setup.py
+++ b/packages/hagrid/setup.py
@@ -7,6 +7,8 @@ DATA_FILES = {
     "img": ["hagrid/img/*.png"],
 }
 
+# Pillow binary wheels for Apple Silicon on Python 3.8 don't seem to work well
+# try using Python 3.9+ for HAGrid on Apple Silicon
 setup(
     name="hagrid",
     description="Happy Automation for Grid",

--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -28,33 +28,38 @@ syft =
     ascii_magic==1.6
     autodp==0.2
     bcrypt==3.2.0
-    cachetools==4.2.4
+    cachetools==5.0.0
     forbiddenfruit==0.1.4
-    gevent==21.8.0
-    importlib_metadata==4.8.2
-    loguru==0.5.3
+    gevent==21.12.0
+    importlib_metadata==4.11.1
+    loguru==0.6.0
     names==0.3.0
     numpy==1.22.2
-    packaging==21.2
-    pandas==1.3.4
+    packaging==21.3
+    pandas==1.4.1
     primesieve==2.3.0
-    protobuf==3.19.1
-    pyarrow==6.0.1
-    pydantic[email]==1.8.2
+    protobuf==3.19.4
+    pyarrow==7.0.0
+    pydantic[email]==1.9.0
     PyJWT==2.3.0
     pymbolic==2021.1
     pympler==1.0.1
-    PyNaCl==1.4.0
-    redis==4.1.2
+    PyNaCl==1.5.0
+    redis==4.1.4
     requests_toolbelt==0.9.1
-    requests==2.26.0
-    SQLAlchemy==1.4.27
+    requests==2.27.1
+    SQLAlchemy==1.4.31
     sympy==1.9
     torch>=1.8.1,<=1.10.0
     tqdm==4.62.3
-    typing_extensions==4.0.0 # backport to older python 3
-    werkzeug==2.0.2
+    typing_extensions==4.1.1 # backport to older python 3
+    werkzeug==2.0.3
 
+# primesieve numpy support requires numpy to be installed during build time and
+# sequence of pip package installation is not ordered
+# https://stackoverflow.com/questions/4996589/in-setup-py-or-pip-requirements-file-how-to-control-order-of-installing-package
+setup_requires =
+    numpy==1.22.2
 
 install_requires =
     %(syft)s

--- a/packages/syft/tests/syft/core/common/message_test.py
+++ b/packages/syft/tests/syft/core/common/message_test.py
@@ -1,6 +1,7 @@
 # third party
 from nacl.signing import SigningKey
 from nacl.signing import VerifyKey
+import pytest
 
 # syft absolute
 import syft as sy
@@ -170,7 +171,9 @@ def test_verify_message_fails_sig() -> None:
     assert sig_msg.is_valid is True
 
     # change signature
-    sig_msg.signature += b"a"
+    sig = list(sig_msg.signature)
+    sig[-1] = 0  # change last byte
+    sig_msg.signature = bytes(sig)
 
     # not so good
     assert sig_msg.is_valid is False
@@ -205,7 +208,8 @@ def test_verify_message_fails_empty() -> None:
     sig_msg.signature = b""
 
     # not so good
-    assert sig_msg.is_valid is False
+    with pytest.raises(ValueError):
+        assert sig_msg.is_valid is False
 
 
 def test_decode_message() -> None:


### PR DESCRIPTION
## Description
- binary wheels are not available and numpy support at compile time
  requires numpy to be installed first which is non-deterministic
- upgrade setup.cfg packages

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
