### PR TITLE
Fixing issue where CONTAINER_HASH fails if docker isn't running

### DIFF
--- a/packages/grid/scripts/cron.sh
+++ b/packages/grid/scripts/cron.sh
@@ -39,7 +39,7 @@ then
     git remote add origin https://github.com/$2
     git fetch origin
     echo "Checking out branch: ${3}"
-    git reset --hard
+    git reset --hard "origin/${3}"
     git checkout "origin/${3}" --force
     chown -R $4:$5 .
 fi
@@ -49,13 +49,13 @@ then
     echo "Checking out branch: ${3}"
 fi
 
-git reset --hard
 git fetch origin
+git reset --hard "origin/${3}"
 git checkout "origin/${3}" --force
 chown -R $4:$5 .
 
 END_HASH=$(git rev-parse HEAD)
-CONTAINER_HASH=$(docker exec $(docker ps --format "{{.Names}}" | grep backend-1) env | grep VERSION_HASH | sed 's/VERSION_HASH=//')
+CONTAINER_HASH=$(docker ps --format "{{.Names}}" | grep backend-1 | xargs -I {} docker exec {} env | grep VERSION_HASH | sed 's/VERSION_HASH=//')
 
 # set a default if its missing
 if [ ! -z ${11} ]; then


### PR DESCRIPTION
## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
