### PR TITLE
Fixed issue where __add__ on REPT with 1 row returns a SEPT

### DIFF
--- a/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
+++ b/packages/syft/src/syft/core/tensor/autodp/row_entity_phi.py
@@ -271,11 +271,7 @@ class RowEntityPhiTensor(PassthroughTensor, ADPTensor):
                 else:
                     # Private/Public and Private/Private are handled by the underlying SEPT self.child objects.
                     new_list.append(self.child[i] + other.child[i])
-            if len(new_list) != 1:
-                return RowEntityPhiTensor(rows=new_list, check_shape=False)
-            else:
-                return new_list[0]
-
+            return RowEntityPhiTensor(rows=new_list, check_shape=False)
         else:
             # Broadcasting is possible, but we're skipping that for now.
             raise Exception(

--- a/packages/syft/tests/syft/core/tensor/adp/row_entity_phi_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/row_entity_phi_test.py
@@ -1241,3 +1241,25 @@ def test_converter(
         output = REPT.convert_to_gamma([igt3, row_data_ishan[0]])
         assert isinstance(output, IGT)
         assert output._entities().shape == output.shape
+
+
+def test_rept_add_dims() -> None:
+    reference_data = np.array(
+        [[-62, -47, 17], [20, -48, 90], [-4, 97, -47]], dtype=np.int32
+    )
+
+    data = SEPT(
+        entity=Entity("Ishan"),
+        child=reference_data,
+        max_vals=reference_data,
+        min_vals=reference_data,
+    )
+    row_data_ishan = []
+    row_data_ishan.append(data)
+
+    """Test addition to REPT with 1 row still returns a REPT"""
+    tensor1 = REPT(rows=row_data_ishan)
+    tensor2 = REPT(rows=row_data_ishan) + 1
+
+    assert tensor1.shape == tensor2.shape
+    assert type(tensor1) == type(tensor2)


### PR DESCRIPTION
## Description
- Fixed issue where __add__ on REPT with 1 row returns a SEPT
- This violates the signature and causes some tests to fail which compare the shape etc
- Added new test to check for this edge case

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
