### PR TITLE
install cmake in mac M1

### DIFF
--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -38,6 +38,15 @@ FROM python:3.9.9-slim as backend
 ENV PYTHONPATH=/app
 ENV PATH=/root/.local/bin:$PATH
 
+RUN if [ $(uname -m) != "x86_64" ]; then \
+  apt-get update \
+  && apt-get install --assume-yes --no-install-recommends \
+  cmake \
+  g++ \
+  make \
+  libzip-dev \
+  && apt-get clean all
+
 # copy start scripts and gunicorn conf
 COPY grid/backend/docker-scripts/start.sh /start.sh
 COPY grid/backend/docker-scripts/gunicorn_conf.py /gunicorn_conf.py


### PR DESCRIPTION
## Description
Hagrid was failing when launching in M1 Macs, as discussed [here](https://openmined.slack.com/archives/C6EEFN3A8/p1646913448288879).

## How has this been tested?
`hagrid launch` now runs in M1

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
