### PR TITLE
Adding DEBIAN_FRONTEND=noninteractive to prevent tzdata from hanging

### DIFF
--- a/packages/grid/.env
+++ b/packages/grid/.env
@@ -25,7 +25,7 @@ DOCKER_IMAGE_TRAEFIK=traefik:v2.5
 DOCKER_IMAGE_SEAWEEDFS=chrislusf/seaweedfs:latest
 VERSION=latest
 VERSION_HASH=unknown
-STACK_API_KEY=`pwgen -B1 12`
+STACK_API_KEY=hex_key_value
 
 # Backend
 BACKEND_CORS_ORIGINS='["http://localhost","http://localhost:4200","http://localhost:3000","http://localhost:8080","https://localhost","https://localhost:4200","https://localhost:3000","https://localhost:8080","http://dev.grid.openmined.org","https://stag.grid.openmined.org","https://grid.openmined.org"]'

--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.9.9-slim as build
 
 RUN --mount=type=cache,target=/var/cache/apt \
+  DEBIAN_FRONTEND=noninteractive \
   apt-get update && \
-  apt-get install -y --no-install-recommends curl python3-dev gcc make build-essential \
-                                             cmake
+  apt-get install -y --no-install-recommends \
+  curl python3-dev gcc make build-essential cmake
 
 WORKDIR /app
 COPY grid/backend/requirements.txt /app

--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.9.9-slim as build
 
+# set UTC timezone
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN --mount=type=cache,target=/var/cache/apt \
   DEBIAN_FRONTEND=noninteractive \
   apt-get update && \

--- a/packages/grid/vpn/requirements.txt
+++ b/packages/grid/vpn/requirements.txt
@@ -1,2 +1,2 @@
-flask
-flask_shell2http
+flask==2.0.3
+flask_shell2http==1.9.0

--- a/packages/hagrid/hagrid.dockerfile
+++ b/packages/hagrid/hagrid.dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.9-slim
 
 
-RUN apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update && \
     apt-get install -yqq \
     git && \
     rm -rf /var/lib/apt/lists/*

--- a/packages/hagrid/hagrid.dockerfile
+++ b/packages/hagrid/hagrid.dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9-slim
 
+# set UTC timezone
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -992,7 +992,6 @@ def create_launch_docker_cmd(
         "VERSION": version_string,
         "VERSION_HASH": GRID_SRC_VERSION[1],
         "USE_BLOB_STORAGE": use_blob_storage,
-        "STACK_API_KEY": "pwgen -B1 12",
     }
 
     if "tls" in kwargs and kwargs["tls"] is True and len(kwargs["cert_store_path"]) > 0:

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -992,7 +992,7 @@ def create_launch_docker_cmd(
         "VERSION": version_string,
         "VERSION_HASH": GRID_SRC_VERSION[1],
         "USE_BLOB_STORAGE": use_blob_storage,
-        "STACK_API_KEY": 'pwgen -B1 12'
+        "STACK_API_KEY": "pwgen -B1 12",
     }
 
     if "tls" in kwargs and kwargs["tls"] is True and len(kwargs["cert_store_path"]) > 0:


### PR DESCRIPTION
## Description
Fixing issue that occurred on 0.6.0 with tzdata hanging docker apt-get update.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
