### PR TITLE
python 3.7 for google colab

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -35,9 +35,9 @@ syft =
     importlib_metadata==4.11.3
     loguru==0.6.0
     names==0.3.0
-    numpy==1.22.3
+    numpy>=1.21.5 # python 3.7 google colab
     packaging==21.3
-    pandas==1.4.2
+    pandas>=1.3.5 # python 3.7 google colab
     primesieve==2.3.0
     protobuf==3.20.0
     pyarrow==7.0.0
@@ -57,12 +57,6 @@ syft =
     typing_extensions==4.1.1 # backport to older python 3
     werkzeug==2.1.1
 
-# primesieve numpy support requires numpy to be installed during build time and
-# sequence of pip package installation is not ordered
-# https://stackoverflow.com/questions/4996589/in-setup-py-or-pip-requirements-file-how-to-control-order-of-installing-package
-setup_requires =
-    numpy==1.22.3
-
 install_requires =
     %(syft)s
 
@@ -70,7 +64,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.8
+python_requires = >=3.7
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Description
Dropping requirements back to python 3.7 for google colab

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
