### PR TITLE
Adding cache to manifest for python wheel

### DIFF
--- a/packages/syft/MANIFEST.in
+++ b/packages/syft/MANIFEST.in
@@ -1,2 +1,3 @@
 include src/syft/VERSION
 include src/syft/capnp/*
+include src/syft/cache/*


### PR DESCRIPTION
## Description
The cache file is missing which means the public wheels won't work.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
