### PR TITLE
making public test run on nightly alone

### DIFF
--- a/.github/workflows/nightlies-run.yml
+++ b/.github/workflows/nightlies-run.yml
@@ -49,3 +49,7 @@ jobs:
     if: github.repository == 'OpenMined/PySyft' # don't run on forks
     uses: OpenMined/PySyft/.github/workflows/benchmark.yml@dev
     secrets: inherit
+
+  call-stack-integration-public_tests:
+    if: github.repository == 'OpenMined/PySyft' # don't run on forks
+    uses: OpenMined/PySyft/.github/workflows/stack-integration-public_tests.yml@dev

--- a/.github/workflows/stack-integration-public_tests.yml
+++ b/.github/workflows/stack-integration-public_tests.yml
@@ -1,0 +1,66 @@
+
+# Stack Integration Tests
+name: Syft + Grid Stack Integration Tests (Public)
+
+on:
+  workflow_call:
+
+  workflow_dispatch:
+    inputs:
+      none:
+        description: "Run Stack Integration Tests Manually"
+        required: false
+
+jobs:
+stack-integration-tests-public:
+    strategy:
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade --user pip
+
+      - name: Install tox
+        run: |
+          pip install tox --upgrade
+
+      - name: Install Docker Compose
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          DOCKER_COMPOSE_VERSION=v2.3.4
+          curl -sSL https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+          chmod +x ~/.docker/cli-plugins/docker-compose
+
+      - name: Run integration tests
+        timeout-minutes: 30
+        continue-on-error: true
+        run: |
+          HAGRID_FLAGS="--tag=latest --test" tox -e stack.test.integration

--- a/.github/workflows/stack-integration_tests.yml
+++ b/.github/workflows/stack-integration_tests.yml
@@ -85,59 +85,6 @@ jobs:
         run: |
           tox -e stack.test.integration
 
-  stack-integration-tests-public:
-    strategy:
-      max-parallel: 3
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10"]
-
-    runs-on: ${{matrix.os}}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}
-          restore-keys: |
-            ${{ runner.os }}-pip-py${{ matrix.python-version }}
-
-      - name: Upgrade pip
-        run: |
-          pip install --upgrade --user pip
-
-      - name: Install tox
-        run: |
-          pip install tox --upgrade
-
-      - name: Install Docker Compose
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          mkdir -p ~/.docker/cli-plugins
-          DOCKER_COMPOSE_VERSION=v2.3.4
-          curl -sSL https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
-          chmod +x ~/.docker/cli-plugins/docker-compose
-
-      - name: Run integration tests
-        timeout-minutes: 30
-        continue-on-error: true
-        run: |
-          HAGRID_FLAGS="--tag=latest --test" tox -e stack.test.integration
-
   stack-integration-tests-tls:
     strategy:
       max-parallel: 3


### PR DESCRIPTION
This PR aims to separate Stack Integration tests for public deployments to be in its own workflow and run only in nightlies as it makes sense since we do not deploy new syft & hagrid per PR or merge. 