### PR TITLE
Make it so jupyter installs regardless of install=true/false

### DIFF
--- a/packages/grid/ansible/roles/jupyter/tasks/main.yml
+++ b/packages/grid/ansible/roles/jupyter/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: Install Tox
   shell: "runuser -l {{ om_user }} -c 'pip install tox'"
   become: yes
-  when: vagrant is not defined and install == "true" and jupyter == "true"
+  when: vagrant is not defined and jupyter == "true"
 
 - name: Keep Jupyter Notebooks server running
   ansible.builtin.cron:
-    disabled: "{{ not install | bool }}"
+    disabled: "{{ (jupyter == 'true') | ternary('false', 'true') }}"
     name: "Jupyter Notebooks server"
     job: "{{ syft_dir }}/packages/grid/scripts/jupyter.sh {{ syft_dir }} {{ om_user }} {{ jupyter_token }}"
   become: yes

--- a/packages/grid/ansible/site.yml
+++ b/packages/grid/ansible/site.yml
@@ -6,6 +6,6 @@
   become: yes
   roles:
     - node
-    - containers
     - jupyter
+    - containers
     - update


### PR DESCRIPTION
- Make jupyter cron job start sooner so that the packages can be ready

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
