### PR TITLE
Fixing empty gamma tensor state

### DIFF
--- a/packages/syft/src/syft/core/tensor/autodp/gamma_tensor.py
+++ b/packages/syft/src/syft/core/tensor/autodp/gamma_tensor.py
@@ -1334,6 +1334,9 @@ class GammaTensor:
         if fpt_values is not None:
             fpt_encode_func = fpt_values.encode
 
+        if not self.state:  # if state tree is empty (e.g. publishing a PhiTensor w/ public vals directly)
+            self.state[self.id] = self
+
         return vectorized_publish(
             min_vals=self.min_val,
             max_vals=self.max_val,

--- a/packages/syft/tests/syft/core/tensor/adp/gamma_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/gamma_tensor_test.py
@@ -120,7 +120,6 @@ def test_gamma_publish(
     def deduct_epsilon_for_user(*args: Any, **kwargs: Any) -> bool:
         return True
 
-    gamma_tensor1 = gamma_tensor1 + 1  # dummy operation to set state
     results = gamma_tensor1.publish(
         get_budget_for_user=get_budget_for_user,
         deduct_epsilon_for_user=deduct_epsilon_for_user,
@@ -129,6 +128,6 @@ def test_gamma_publish(
     )
 
     assert results.dtype == np.float64
-    assert results < upper_bound.sum() + 10
-    assert -10 + lower_bound.sum() < results
+    assert results < tensor1.child.encode(upper_bound.sum()) + 10
+    assert -10 + tensor1.child.encode(lower_bound.sum()) < results
     print(ledger_store.kv_store)


### PR DESCRIPTION
## Description
If a data scientist tries to publish a PhiTensor, or a PhiTensor with public values added to it, the state tree will be empty when `publish` is called, resulting in failures. This PR adds a small check for this and rectifies the state tree.

## Affected Dependencies
Nothing new.

## How has this been tested?
Re-running failed tests

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
