### PR TITLE
feat: #6509 Set requests sidebar icon to Epsilon

### DIFF
--- a/packages/grid/frontend/src/components/Epsilon.tsx
+++ b/packages/grid/frontend/src/components/Epsilon.tsx
@@ -1,0 +1,19 @@
+export function Epsilon(props) {
+  return (
+    <svg
+      width="12"
+      height="16"
+      viewBox="0 0 12 16"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+      role="img"
+      {...props}
+    >
+      <path
+        d="M8.54004 8.38477L4.34766 13.8164H11.2207V15.8643H0.858398V14.5371L5.86816 8.23535L0.858398 2.03027V0.703125H10.9131V2.75977H4.37402L8.54004 8.09473V8.38477Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/packages/grid/frontend/src/components/SidebarNav.tsx
+++ b/packages/grid/frontend/src/components/SidebarNav.tsx
@@ -13,7 +13,6 @@ import { DomainStatus } from './DomainStatus'
 import {
   faUsers,
   faCheck,
-  faLemon,
   faHandsHelping,
   faChevronDown,
   faUserCircle,
@@ -22,6 +21,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useMe, useSettings } from '@/lib/data'
 import { t } from '@/i18n'
 import { logout } from '@/lib/auth'
+import { Epsilon } from '@/components/Epsilon'
 
 const navItems = [
   { name: 'Users', link: '/users', icon: faUsers },
@@ -29,7 +29,7 @@ const navItems = [
   {
     name: 'Requests',
     link: '/requests/data',
-    icon: faLemon,
+    customIcon: <Epsilon className="text-white" />,
     children: [
       { name: 'Data Requests', link: '/requests/data' },
       { name: 'Upgrade Requests', link: '/requests/upgrade' },
@@ -59,20 +59,39 @@ const SidebarNav = () => {
               <div key={navItem.link}>
                 <Link href={navItem.link}>
                   <a>
-                    <ListFAIconItem
-                      key={navItem.link}
-                      icon={navItem.icon}
-                      iconColor="text-white"
-                      className={cn(
-                        'hover:bg-gray-800 hover:no-underline',
-                        isSelected && 'bg-gray-800 text-gray-200',
-                        !isSelected &&
-                          currRoute === navItem &&
-                          'bg-gray-800 text-white'
-                      )}
-                    >
-                      {navItem.name}
-                    </ListFAIconItem>
+                    {navItem.icon && (
+                      <ListFAIconItem
+                        icon={navItem.icon}
+                        iconColor="text-white"
+                        className={cn(
+                          'hover:bg-gray-800 hover:no-underline',
+                          isSelected && 'bg-gray-800 text-gray-200',
+                          !isSelected &&
+                            currRoute === navItem &&
+                            'bg-gray-800 text-white'
+                        )}
+                      >
+                        {navItem.name}
+                      </ListFAIconItem>
+                    )}
+                    {navItem.customIcon && (
+                      <li
+                        className={cn(
+                          'flex items-center space-x-2 hover:bg-gray-800 hover:no-underline',
+                          isSelected && 'bg-gray-800 text-gray-200',
+                          !isSelected &&
+                            currRoute === navItem &&
+                            'bg-gray-800 text-white'
+                        )}
+                      >
+                        <div className="flex items-center justify-center w-14 h-14">
+                          {navItem.customIcon}
+                        </div>
+                        <span className="font-roboto font-normal text-md">
+                          {navItem.name}
+                        </span>
+                      </li>
+                    )}
                   </a>
                 </Link>
                 {isSelected && (
@@ -85,7 +104,6 @@ const SidebarNav = () => {
                         <Link key={subItem.link} href={subItem.link}>
                           <a className="group">
                             <ListFAIconItem
-                              key={navItem.link}
                               icon={navItem.icon}
                               iconColor={cn(
                                 currSubRoute


### PR DESCRIPTION
## Description
- Sets the `Requests` to Epsilon

## How has this been tested?
<img width="227" alt="Screen Shot 2022-05-27 at 14 27 50" src="https://user-images.githubusercontent.com/802731/170708710-128aad82-ef84-4807-9047-b49806f270ee.png">

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
~- [ ] My changes are covered by tests~
