### PR TITLE
Disable checking all domain health by default

### DIFF
--- a/packages/grid/backend/grid/api/syft/syft.py
+++ b/packages/grid/backend/grid/api/syft/syft.py
@@ -29,8 +29,12 @@ router = APIRouter()
 tracer = get_tracer("API")
 
 
+async def get_body(request: Request) -> bytes:
+    return await request.body()
+
+
 @router.get("/metadata", response_model=str)
-async def syft_metadata() -> Response:
+def syft_metadata() -> Response:
     return Response(
         node.get_metadata_for_client()._object2proto().SerializeToString(),
         media_type="application/octet-stream",
@@ -38,7 +42,7 @@ async def syft_metadata() -> Response:
 
 
 @router.delete("", response_model=str)
-async def delete(current_user: UserPrivate = Depends(get_current_user)) -> Response:
+def delete(current_user: UserPrivate = Depends(get_current_user)) -> Response:
     # If current user is the node owner ...
     success = node.clear(current_user.role)
     if success:
@@ -52,14 +56,9 @@ async def delete(current_user: UserPrivate = Depends(get_current_user)) -> Respo
 
 
 @router.post("", response_model=str)
-async def syft_route(
-    request: Request,
-    #    skip: int = 0,
-    #    limit: int = 100,
-    #    current_user: models.User = Depends(get_current_active_user),
-) -> Any:
+def syft_route(data: bytes = Depends(get_body)) -> Any:
+    print("got a new incoming request")
     with tracer.start_as_current_span("POST syft_route"):
-        data = await request.body()
         obj_msg = deserialize(blob=data, from_bytes=True)
         is_isr = isinstance(obj_msg, SignedImmediateSyftMessageWithReply) or isinstance(
             obj_msg, SignedMessage
@@ -79,12 +78,8 @@ async def syft_route(
 
 
 @router.post("/stream", response_model=str)
-async def syft_stream(
-    request: Request,
-) -> Any:
+def syft_stream(data: bytes = Depends(get_body)) -> Any:
     with tracer.start_as_current_span("POST syft_route /stream"):
-        data = await request.body()
-
         if settings.STREAM_QUEUE:
             print("Queuing streaming message for processing on worker node")
             try:

--- a/packages/grid/backend/grid/core/config.py
+++ b/packages/grid/backend/grid/core/config.py
@@ -120,7 +120,9 @@ class Settings(BaseSettings):
     LEDGER_DB_ID: int = int(os.getenv("LEDGER_DB_ID", 1))
     NETWORK_CHECK_INTERVAL: int = int(os.getenv("NETWORK_CHECK_INTERVAL", 60))
     CONTAINER_HOST: str = str(os.getenv("CONTAINER_HOST", "docker"))
-    TEST_MODE: bool = False
+    TEST_MODE: bool = (
+        True if os.getenv("TEST_MODE", "false").lower() == "true" else False
+    )
 
     class Config:
         case_sensitive = True

--- a/packages/grid/backend/grid/core/config.py
+++ b/packages/grid/backend/grid/core/config.py
@@ -120,6 +120,7 @@ class Settings(BaseSettings):
     LEDGER_DB_ID: int = int(os.getenv("LEDGER_DB_ID", 1))
     NETWORK_CHECK_INTERVAL: int = int(os.getenv("NETWORK_CHECK_INTERVAL", 60))
     CONTAINER_HOST: str = str(os.getenv("CONTAINER_HOST", "docker"))
+    TEST_MODE: bool = False
 
     class Config:
         case_sensitive = True

--- a/packages/grid/devspace.yaml
+++ b/packages/grid/devspace.yaml
@@ -428,7 +428,7 @@ deployments:
               - name: USE_BLOB_STORAGE
                 value: ${USE_BLOB_STORAGE}
               - name: TEST_MODE
-                value: ${TEST_MODE}
+                value: $!{TEST_MODE}
         service:
           name: ${SERVICE_NAME_BACKEND}
           ports:
@@ -526,7 +526,7 @@ deployments:
               - name: USE_BLOB_STORAGE
                 value: ${USE_BLOB_STORAGE}
               - name: TEST_MODE
-                value: ${TEST_MODE}
+                value: $!{TEST_MODE}
         service:
           name: ${SERVICE_NAME_BACKEND_STREAM}
           ports:
@@ -612,7 +612,7 @@ deployments:
               - name: USE_BLOB_STORAGE
                 value: ${USE_BLOB_STORAGE}
               - name: TEST_MODE
-                value: ${TEST_MODE}
+                value: $!{TEST_MODE}
 
   - name: frontend
     helm:

--- a/packages/grid/devspace.yaml
+++ b/packages/grid/devspace.yaml
@@ -85,6 +85,8 @@ vars:
     value: traefik-domain.yaml
   - name: NETWORK_CHECK_INTERVAL
     value: "60"
+  - name: TEST_MODE
+    value: "0"
 
 images:
   backend:
@@ -425,6 +427,8 @@ deployments:
                 value: ${RELEASE}
               - name: USE_BLOB_STORAGE
                 value: ${USE_BLOB_STORAGE}
+              - name: TEST_MODE
+                value: ${TEST_MODE}
         service:
           name: ${SERVICE_NAME_BACKEND}
           ports:
@@ -521,6 +525,8 @@ deployments:
                 value: ${RELEASE}
               - name: USE_BLOB_STORAGE
                 value: ${USE_BLOB_STORAGE}
+              - name: TEST_MODE
+                value: ${TEST_MODE}
         service:
           name: ${SERVICE_NAME_BACKEND_STREAM}
           ports:
@@ -605,6 +611,8 @@ deployments:
                 value: $!{NETWORK_CHECK_INTERVAL}
               - name: USE_BLOB_STORAGE
                 value: ${USE_BLOB_STORAGE}
+              - name: TEST_MODE
+                value: ${TEST_MODE}
 
   - name: frontend
     helm:

--- a/packages/grid/docker-compose.test.yml
+++ b/packages/grid/docker-compose.test.yml
@@ -32,3 +32,15 @@ services:
       - "9333" # admin
       - "8888" # filer
       - "8333" # S3
+
+  backend:
+    environment:
+      - TEST_MODE=1
+
+  backend_stream:
+    environment:
+      - TEST_MODE=1
+
+  celeryworker:
+    environment:
+      - TEST_MODE=1

--- a/packages/syft/src/syft/core/node/abstract/node.py
+++ b/packages/syft/src/syft/core/node/abstract/node.py
@@ -36,7 +36,9 @@ class AbstractNodeClient(Address):
     def send_immediate_msg_without_reply(self, msg: Any) -> Any:
         raise NotImplementedError
 
-    def send_immediate_msg_with_reply(self, msg: Any) -> Any:
+    def send_immediate_msg_with_reply(
+        self, msg: Any, timeout: Optional[float] = None
+    ) -> Any:
         raise NotImplementedError
 
 

--- a/packages/syft/src/syft/core/node/common/client.py
+++ b/packages/syft/src/syft/core/node/common/client.py
@@ -216,8 +216,8 @@ class Client(AbstractNodeClient):
             ImmediateSyftMessageWithReply,
             Any,  # TEMPORARY until we switch everything to NodeRunnableMessage types.
         ],
-        route_index: int = 0,
         timeout: Optional[float] = None,
+        route_index: int = 0,
     ) -> SyftMessage:
 
         # relative

--- a/packages/syft/src/syft/core/node/common/client_manager/dataset_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/dataset_api.py
@@ -133,7 +133,7 @@ class DatasetRequestAPI(RequestAPI):
         result = [
             content
             for content in self.perform_api_request(
-                syft_msg=self._get_all_message
+                syft_msg=self._get_all_message, timeout=1
             ).metadatas
         ]
 

--- a/packages/syft/src/syft/core/node/common/client_manager/domain_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/domain_api.py
@@ -101,7 +101,9 @@ class DomainRequestAPI(RequestAPI):
             error(msg)
             raise Exception(msg)
         response = self.perform_api_request_generic(
-            syft_msg=GetPeerInfoMessageWithReply, content={"uid": node_uid}, timeout=timeout
+            syft_msg=GetPeerInfoMessageWithReply,
+            content={"uid": node_uid},
+            timeout=timeout,
         )
 
         result = response.payload.kwargs.upcast()  # type: ignore

--- a/packages/syft/src/syft/core/node/common/client_manager/domain_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/domain_api.py
@@ -1,6 +1,5 @@
 # stdlib
 import sys
-import time
 from typing import Any
 from typing import List
 from typing import Optional
@@ -41,34 +40,33 @@ class DomainRequestAPI(RequestAPI):
         result = response.payload.kwargs  # type: ignore
 
         if result["status"] == "ok":
-            _data = result["data"]
-            if (
-                self.cache is None
-                or (time.time() - self.cache_time > self.timeout)
-                or len(_data) != self.num_known_domains_even_offline_ones
-            ):
-                # check for logged in domains if the number of possible domains changes (if a new domain shows up)
-                self.num_known_domains_even_offline_ones = len(_data)
-                n = len(_data)
-                data = list()
-                args = [
-                    (self, i, n, domain_metadata["id"])
-                    for i, domain_metadata in enumerate(_data)
-                ]
+            data = result["data"]
+            # if (
+            #     self.cache is None
+            #     or (time.time() - self.cache_time > self.timeout)
+            #     or len(_data) != self.num_known_domains_even_offline_ones
+            # ):
+            #     # check for logged in domains if the number of possible domains changes (if a new domain shows up)
+            #     self.num_known_domains_even_offline_ones = len(_data)
+            #     # n = len(_data)
+            #     # data = list()
+            #     # args = [
+            #     #     (self, i, n, domain_metadata["id"])
+            #     #     for i, domain_metadata in enumerate(_data)
+            #     # ]
 
-                # # Check domain status sequentially
-                # for i, arg in enumerate(args):
-                #     if check_domain_status(*arg):
-                #         data.append(_data[i])
+            #     # # Check domain status sequentially
+            #     # for i, arg in enumerate(args):
+            #     #     if check_domain_status(*arg):
+            #     #         data.append(_data[i])
 
-                # do not check domain status - assume network will drop stale domains
-                data = _data
-                sys.stdout.write("\r                                             ")
+            #     # do not check domain status - assume network will drop stale domains
+            #     sys.stdout.write("\r                                             ")
 
-                self.cache = data
-                self.cache_time = time.time()
-            else:
-                data = self.cache
+            #     self.cache = _data
+            #     self.cache_time = time.time()
+            # else:
+            #     data = self.cache
 
             if pandas:
                 data = DataFrame(data)
@@ -133,7 +131,7 @@ def check_domain_status(
     status = False
     try:
         stop()
-        status = self.get(domain_uid, timeout=None).ping
+        status = self.get(domain_uid, timeout=1).ping
         start()
     except Exception as e:  # nosec
         # if pinging the domain causes an exception we just wont

--- a/packages/syft/src/syft/core/node/common/client_manager/domain_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/domain_api.py
@@ -51,25 +51,18 @@ class DomainRequestAPI(RequestAPI):
                 self.num_known_domains_even_offline_ones = len(_data)
                 n = len(_data)
                 data = list()
-
                 args = [
                     (self, i, n, domain_metadata["id"])
                     for i, domain_metadata in enumerate(_data)
                 ]
 
-                # Check domain status in parallel
-                # check_status = parallel_execution(check_domain_status)
-                # result = check_status(args=args) if args else []
-
-                # for i, status in enumerate(result):
-                #     if status is True:
+                # # Check domain status sequentially
+                # for i, arg in enumerate(args):
+                #     if check_domain_status(*arg):
                 #         data.append(_data[i])
 
-                # Check domain status sequentially
-                for i, arg in enumerate(args):
-                    if check_domain_status(*arg):
-                        data.append(_data[i])
-
+                # do not check domain status - assume network will drop stale domains
+                data = _data
                 sys.stdout.write("\r                                             ")
 
                 self.cache = data
@@ -83,7 +76,7 @@ class DomainRequestAPI(RequestAPI):
             return data
         return []
 
-    def get(self, key: Union[str, int, UID, String]) -> ProxyClient:  # type: ignore
+    def get(self, key: Union[str, int, UID, String], timeout: Optional[int] = None) -> ProxyClient:  # type: ignore
         # to make sure we target the remote Domain through the proxy we need to
         # construct an 💠 Address which includes the correct UID for the Domain
         # position in the 4 hierarchical locations
@@ -108,7 +101,7 @@ class DomainRequestAPI(RequestAPI):
             error(msg)
             raise Exception(msg)
         response = self.perform_api_request_generic(
-            syft_msg=GetPeerInfoMessageWithReply, content={"uid": node_uid}
+            syft_msg=GetPeerInfoMessageWithReply, content={"uid": node_uid}, timeout=timeout
         )
 
         result = response.payload.kwargs.upcast()  # type: ignore
@@ -138,7 +131,7 @@ def check_domain_status(
     status = False
     try:
         stop()
-        status = self.get(domain_uid).ping
+        status = self.get(domain_uid, timeout=None).ping
         start()
     except Exception as e:  # nosec
         # if pinging the domain causes an exception we just wont

--- a/packages/syft/src/syft/core/node/common/client_manager/request_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/request_api.py
@@ -119,6 +119,7 @@ class RequestAPI:
         self,
         syft_msg: Optional[Type[SyftMessage]],
         content: Optional[Dict[Any, Any]] = None,
+        timeout: Optional[int] = None,
     ) -> Any:
         if syft_msg is None:
             raise ValueError(
@@ -135,7 +136,9 @@ class RequestAPI:
         signed_msg = syft_msg_constructor(**content).sign(
             signing_key=self.client.signing_key
         )  # type: ignore
-        response = self.client.send_immediate_msg_with_reply(msg=signed_msg)
+        response = self.client.send_immediate_msg_with_reply(
+            msg=signed_msg, timeout=timeout
+        )
         if isinstance(response, ExceptionMessage):
             raise response.exception_type
         else:
@@ -145,7 +148,7 @@ class RequestAPI:
         self,
         syft_msg: Optional[Type[GenericPayloadMessageWithReply] | Type[NewSyftMessage]],  # type: ignore
         content: Optional[Dict[Any, Any]] = None,
-        timeout: Optional[int] = None
+        timeout: Optional[int] = None,
     ) -> Any:
         if syft_msg is None:
             raise ValueError(
@@ -171,7 +174,9 @@ class RequestAPI:
                 )
                 .sign(signing_key=self.client.signing_key)
             )
-        response = self.client.send_immediate_msg_with_reply(msg=signed_msg, timeout=timeout)
+        response = self.client.send_immediate_msg_with_reply(
+            msg=signed_msg, timeout=timeout
+        )
         if isinstance(response, ExceptionMessage):
             raise response.exception_type
         else:

--- a/packages/syft/src/syft/core/node/common/client_manager/request_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/request_api.py
@@ -145,6 +145,7 @@ class RequestAPI:
         self,
         syft_msg: Optional[Type[GenericPayloadMessageWithReply] | Type[NewSyftMessage]],  # type: ignore
         content: Optional[Dict[Any, Any]] = None,
+        timeout: Optional[int] = None
     ) -> Any:
         if syft_msg is None:
             raise ValueError(
@@ -170,7 +171,7 @@ class RequestAPI:
                 )
                 .sign(signing_key=self.client.signing_key)
             )
-        response = self.client.send_immediate_msg_with_reply(msg=signed_msg)
+        response = self.client.send_immediate_msg_with_reply(msg=signed_msg, timeout=timeout)
         if isinstance(response, ExceptionMessage):
             raise response.exception_type
         else:

--- a/packages/syft/src/syft/core/node/common/node_service/sleep/sleep_messages.py
+++ b/packages/syft/src/syft/core/node/common/node_service/sleep/sleep_messages.py
@@ -1,0 +1,49 @@
+# future
+from __future__ import annotations
+
+# stdlib
+import time
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+# third party
+from nacl.signing import VerifyKey
+from typing_extensions import final
+
+# relative
+from .....common.serde.serializable import serializable
+from ....abstract.node import AbstractNode
+from ..generic_payload.messages import GenericPayloadMessage
+from ..generic_payload.messages import GenericPayloadMessageWithReply
+from ..generic_payload.messages import GenericPayloadReplyMessage
+
+
+@serializable(recursive_serde=True)
+@final
+class SleepMessage(GenericPayloadMessage):
+    ...
+
+
+@serializable(recursive_serde=True)
+@final
+class SleepReplyMessage(GenericPayloadReplyMessage):
+    ...
+
+
+@serializable(recursive_serde=True)
+@final
+class SleepMessageWithReply(GenericPayloadMessageWithReply):
+    message_type = SleepMessage
+    message_reply_type = SleepReplyMessage
+
+    def run(
+        self, node: AbstractNode, verify_key: Optional[VerifyKey] = None
+    ) -> Dict[str, Any]:
+        seconds = float(self.kwargs["seconds"])
+        time.sleep(seconds)
+        return {
+            "seconds": seconds,
+            "result": f"Finished Sleeping for {seconds}",
+            "status_code": 200,
+        }

--- a/packages/syft/src/syft/core/node/common/node_service/sleep/sleep_service.py
+++ b/packages/syft/src/syft/core/node/common/node_service/sleep/sleep_service.py
@@ -1,0 +1,37 @@
+# stdlib
+from typing import List
+from typing import Optional
+from typing import Type
+
+# third party
+from nacl.signing import VerifyKey
+
+# relative
+from ......util import traceback_and_raise
+from ....abstract.node_service_interface import NodeServiceInterface
+from ..auth import service_auth
+from ..node_service import ImmediateNodeServiceWithReply
+from .sleep_messages import SleepMessage
+from .sleep_messages import SleepMessageWithReply
+from .sleep_messages import SleepReplyMessage
+
+
+class SleepService(ImmediateNodeServiceWithReply):
+
+    # TODO: Change this to not be available for guests
+    @staticmethod
+    @service_auth(guests_welcome=True)
+    def process(
+        node: NodeServiceInterface,
+        msg: SleepMessage,
+        verify_key: Optional[VerifyKey] = None,
+    ) -> SleepReplyMessage:
+        if verify_key is None:
+            traceback_and_raise("Can't process PingService with no verification key.")
+
+        result = msg.payload.run(node=node, verify_key=verify_key)
+        return SleepMessageWithReply(kwargs=result).back_to(address=msg.reply_to)
+
+    @staticmethod
+    def message_handler_types() -> List[Type[SleepMessage]]:
+        return [SleepMessage]

--- a/packages/syft/src/syft/core/node/domain.py
+++ b/packages/syft/src/syft/core/node/domain.py
@@ -74,6 +74,7 @@ from .common.node_service.request_receiver.request_receiver_messages import (
 )
 from .common.node_service.role_manager.role_manager_service import RoleManagerService
 from .common.node_service.simple.simple_service import SimpleService
+from .common.node_service.sleep.sleep_service import SleepService
 from .common.node_service.user_auth.user_auth_service import UserLoginService
 from .common.node_service.user_manager.user_manager_service import UserManagerService
 from .common.node_service.vpn.vpn_service import VPNConnectService
@@ -177,6 +178,11 @@ class Domain(Node):
 
         # TODO: @Madhava change to a map of accountants that are created on first
         # use of the DS key
+
+        if getattr(self.settings, "TEST_MODE", False):
+            print("Loading TEST_MODE services")
+            # only add in test mode
+            self.immediate_services_with_reply.append(SleepService)
 
         self.requests: List[RequestMessage] = list()
         # available_device_types = set()

--- a/packages/syft/src/syft/core/node/domain_client.py
+++ b/packages/syft/src/syft/core/node/domain_client.py
@@ -337,7 +337,7 @@ class DomainClient(Client):
     @property
     def privacy_budget(self) -> float:
         msg = GetRemainingBudgetMessage(address=self.address, reply_to=self.address)
-        return self.send_immediate_msg_with_reply(msg).budget  # type: ignore
+        return self.send_immediate_msg_with_reply(msg=msg).budget  # type: ignore
 
     def request_budget(
         self,

--- a/packages/syft/src/syft/grid/client/grid_connection.py
+++ b/packages/syft/src/syft/grid/client/grid_connection.py
@@ -33,7 +33,7 @@ from ...proto.grid.connections.http_connection_pb2 import (
 from ...util import verify_tls
 from ..connections.http_connection import HTTPConnection
 
-DEFAULT_TIMEOUT = 5  # seconds
+DEFAULT_TIMEOUT = 30  # seconds
 
 
 class TimeoutHTTPAdapter(HTTPAdapter):
@@ -116,7 +116,7 @@ class GridHTTPConnection(HTTPConnection):
         msg_bytes: bytes = _serialize(obj=msg, to_bytes=True)  # type: ignore
 
         # timeout = None will wait forever
-        timeout = timeout if timeout is not None else 1
+        timeout = timeout if timeout is not None else DEFAULT_TIMEOUT
 
         # if sys.getsizeof(msg_bytes) < GridHTTPConnection.SIZE_THRESHOLD:
         # if True:

--- a/packages/syft/src/syft/grid/client/grid_connection.py
+++ b/packages/syft/src/syft/grid/client/grid_connection.py
@@ -91,7 +91,7 @@ class GridHTTPConnection(HTTPConnection):
         return _header
 
     def _send_msg(
-        self, msg: SyftMessage, timeout: Optional[float] = 10
+        self, msg: SyftMessage, timeout: Optional[float] = None
     ) -> requests.Response:
         """
         Serializes Syft messages in json format and send it using HTTP protocol.
@@ -114,6 +114,9 @@ class GridHTTPConnection(HTTPConnection):
 
         # Perform HTTP request using base_url as a root address
         msg_bytes: bytes = _serialize(obj=msg, to_bytes=True)  # type: ignore
+
+        # timeout = None will wait forever
+        timeout = timeout if timeout is not None else 1
 
         # if sys.getsizeof(msg_bytes) < GridHTTPConnection.SIZE_THRESHOLD:
         # if True:

--- a/packages/syft/src/syft/grid/client/proxy_client.py
+++ b/packages/syft/src/syft/grid/client/proxy_client.py
@@ -44,7 +44,7 @@ class ProxyClient(DomainClient):
                 .to(address=self.address, reply_to=self.address)
                 .sign(signing_key=self.signing_key)
             )
-            self.send_immediate_msg_with_reply(msg)
+            self.send_immediate_msg_with_reply(msg, timeout=1)
             return True
         except Exception:
             return False

--- a/packages/syft/src/syft/grid/connections/http_connection.py
+++ b/packages/syft/src/syft/grid/connections/http_connection.py
@@ -102,6 +102,9 @@ class HTTPConnection(ClientConnection):
         :rtype: requests.Response
         """
 
+        # timeout = None will wait forever
+        timeout = timeout if timeout is not None else 1
+
         # Perform HTTP request using base_url as a root address
         data_bytes: bytes = _serialize(msg, to_bytes=True)  # type: ignore
         r = requests.post(

--- a/packages/syft/src/syft/grid/connections/http_connection.py
+++ b/packages/syft/src/syft/grid/connections/http_connection.py
@@ -20,6 +20,8 @@ from ...core.node.enums import RequestAPIFields
 from ...core.node.exceptions import RequestAPIException
 from ...proto.core.node.common.metadata_pb2 import Metadata as Metadata_PB
 
+DEFAULT_TIMEOUT = 30  # seconds
+
 
 class HTTPConnection(ClientConnection):
     proxies: TypeDict[str, str] = {}
@@ -103,7 +105,7 @@ class HTTPConnection(ClientConnection):
         """
 
         # timeout = None will wait forever
-        timeout = timeout if timeout is not None else 1
+        timeout = timeout if timeout is not None else DEFAULT_TIMEOUT
 
         # Perform HTTP request using base_url as a root address
         data_bytes: bytes = _serialize(msg, to_bytes=True)  # type: ignore

--- a/packages/syft/tests/syft/core/io/route_test.py
+++ b/packages/syft/tests/syft/core/io/route_test.py
@@ -114,7 +114,7 @@ def test_solo_route_send_immediate_msg_with_reply() -> None:
 
     h_solo = SoloRoute(destination=destination, connection=connection)
     msg = construct_dummy_message(SignedImmediateSyftMessageWithReply)
-    ret = h_solo.send_immediate_msg_with_reply(msg)
+    ret = h_solo.send_immediate_msg_with_reply(msg=msg)
 
     assert isinstance(
         ret,

--- a/packages/syft/tests/syft/core/node/common/service/simple_service_test.py
+++ b/packages/syft/tests/syft/core/node/common/service/simple_service_test.py
@@ -11,5 +11,5 @@ def test_simple_service() -> None:
     d = sy.Domain("asdf", store_type=DictStore, ledger_store_type=DictLedgerStore)
     c = d.get_root_client()
     msg = NodeRunnableMessageWithReply("My Favourite")
-    reply_msg = c.send_immediate_msg_with_reply(msg)
+    reply_msg = c.send_immediate_msg_with_reply(msg=msg)
     assert reply_msg.payload == "Nothing to see here...My Favourite"

--- a/tests/integration/network/request_load_test.py
+++ b/tests/integration/network/request_load_test.py
@@ -1,0 +1,39 @@
+# stdlib
+from concurrent import futures
+import os
+
+# syft absolute
+import syft as sy
+from syft import DomainClient
+from syft.core.node.common.node_service.object_search.obj_search_service import (
+    ObjectSearchMessage,
+)
+from syft.core.node.common.node_service.object_search.obj_search_service import (
+    ObjectSearchReplyMessage,
+)
+
+NETWORK_PORT = 9081
+HOST_IP = os.environ.get("HOST_IP", "localhost")
+NETWORK_PUBLIC_HOST = f"{HOST_IP}:{NETWORK_PORT}"
+print("Network IP", NETWORK_PUBLIC_HOST)
+DOMAIN1_PORT = 9082
+NETWORK_VPN_IP = "100.64.0.1"
+DOMAIN1_VPN_IP = "100.64.0.2"
+TEST_ROOT_EMAIL = "info@openmined.org"
+TEST_ROOT_PASS = "changethis"
+
+
+def send_msg(domain: DomainClient) -> ObjectSearchReplyMessage:
+    msg = ObjectSearchMessage(address=domain.address, reply_to=domain.address)
+    return domain.send_immediate_msg_with_reply(msg=msg)
+
+
+def test_parallel_sync_io_requests() -> None:
+    domain = sy.login(port=DOMAIN1_PORT, email=TEST_ROOT_EMAIL, password=TEST_ROOT_PASS)
+
+    with futures.ThreadPoolExecutor(max_workers=100) as executor:
+        res = list(executor.map(send_msg, [domain] * 300))
+
+    assert len(res) == 300
+    for i in res:
+        assert isinstance(i, ObjectSearchReplyMessage)

--- a/tests/integration/network/request_load_test.py
+++ b/tests/integration/network/request_load_test.py
@@ -3,6 +3,9 @@ from concurrent import futures
 import os
 import time
 
+# third party
+import pytest
+
 # syft absolute
 import syft as sy
 from syft import DomainClient
@@ -29,6 +32,7 @@ def send_msg(domain: DomainClient) -> SleepMessageWithReply:
     return domain.send_immediate_msg_with_reply(msg=msg)
 
 
+@pytest.mark.network
 def test_parallel_sync_io_requests() -> None:
     domain = sy.login(port=DOMAIN1_PORT, email=TEST_ROOT_EMAIL, password=TEST_ROOT_PASS)
 

--- a/tests/integration/network/request_load_test.py
+++ b/tests/integration/network/request_load_test.py
@@ -51,4 +51,4 @@ def test_parallel_sync_io_requests() -> None:
     for i in res:
         assert isinstance(i, SleepReplyMessage)
 
-    assert abs(total - 1.0) < 0.2
+    assert total <= 2

--- a/tests/integration/network/request_load_test.py
+++ b/tests/integration/network/request_load_test.py
@@ -23,7 +23,7 @@ TEST_ROOT_PASS = "changethis"
 
 
 def send_msg(domain: DomainClient) -> SleepMessageWithReply:
-    msg = SleepMessageWithReply(kwargs={"seconds": 0.9}).to(
+    msg = SleepMessageWithReply(kwargs={"seconds": 0.5}).to(
         address=domain.address, reply_to=domain.address
     )
     return domain.send_immediate_msg_with_reply(msg=msg)
@@ -47,4 +47,4 @@ def test_parallel_sync_io_requests() -> None:
     for i in res:
         assert isinstance(i, SleepReplyMessage)
 
-    assert abs(total - 1.0) < 0.1
+    assert abs(total - 1.0) < 0.2

--- a/tests/integration/network/request_load_test.py
+++ b/tests/integration/network/request_load_test.py
@@ -6,12 +6,10 @@ import time
 # syft absolute
 import syft as sy
 from syft import DomainClient
-from syft.core.node.common.node_service.object_search.obj_search_service import (
-    ObjectSearchMessage,
+from syft.core.node.common.node_service.sleep.sleep_messages import (
+    SleepMessageWithReply,
 )
-from syft.core.node.common.node_service.object_search.obj_search_service import (
-    ObjectSearchReplyMessage,
-)
+from syft.core.node.common.node_service.sleep.sleep_messages import SleepReplyMessage
 
 NETWORK_PORT = 9081
 HOST_IP = os.environ.get("HOST_IP", "localhost")
@@ -24,8 +22,10 @@ TEST_ROOT_EMAIL = "info@openmined.org"
 TEST_ROOT_PASS = "changethis"
 
 
-def send_msg(domain: DomainClient) -> ObjectSearchReplyMessage:
-    msg = ObjectSearchMessage(address=domain.address, reply_to=domain.address)
+def send_msg(domain: DomainClient) -> SleepMessageWithReply:
+    msg = SleepMessageWithReply(kwargs={"seconds": 0.9}).to(
+        address=domain.address, reply_to=domain.address
+    )
     return domain.send_immediate_msg_with_reply(msg=msg)
 
 
@@ -45,6 +45,6 @@ def test_parallel_sync_io_requests() -> None:
 
     assert len(res) == request_count
     for i in res:
-        assert isinstance(i, ObjectSearchReplyMessage)
+        assert isinstance(i, SleepReplyMessage)
 
     assert abs(total - 1.0) < 0.1

--- a/tox.ini
+++ b/tox.ini
@@ -410,6 +410,7 @@ commands =
         devspace --no-warn --kube-context "k3d-$NODE_NAME" --namespace $NODE_NAME \
         --var DOMAIN_NAME=$NODE_NAME \
         --var NETWORK_CHECK_INTERVAL=5 \
+        --var TEST_MODE=1 \
         --var CONTAINER_REGISTRY=k3d-registry.localhost:12345/ \
         build -b'
 
@@ -418,6 +419,7 @@ commands =
         devspace --no-warn --kube-context "k3d-$NODE_NAME" --namespace $NODE_NAME \
         --var DOMAIN_NAME=$NODE_NAME \
         --var NETWORK_CHECK_INTERVAL=5 \
+        --var TEST_MODE=1 \
         --var CONTAINER_REGISTRY=k3d-registry.localhost:12345/ \
         deploy -b -p network'
 
@@ -430,6 +432,7 @@ commands =
         devspace --no-warn --kube-context "k3d-$NODE_NAME" --namespace $NODE_NAME \
         --var DOMAIN_NAME=$NODE_NAME \
         --var NETWORK_CHECK_INTERVAL=5 \
+        --var TEST_MODE=1 \
         --var CONTAINER_REGISTRY=k3d-registry.localhost:12345/ \
         deploy -b -p domain'
 
@@ -442,6 +445,7 @@ commands =
         devspace --no-warn --kube-context "k3d-$NODE_NAME" --namespace $NODE_NAME \
         --var DOMAIN_NAME=$NODE_NAME \
         --var NETWORK_CHECK_INTERVAL=5 \
+        --var TEST_MODE=1 \
         --var CONTAINER_REGISTRY=k3d-registry.localhost:12345/ \
         deploy -b -p domain'
 


### PR DESCRIPTION
normally when we run network_client.domains it checks the health of all the domains before doing anything. as the number of domains increases (and we also discover some bugs/issues) this seems to be causing problems by default - disabling for now