### PR TITLE
Fix doc deployment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# PySyft Documentation
+
+Welcome to the PySyft docs. You can setup the PySyft docs locally via 2 methods currently,
+
+- Natively using `sphinx-apidoc` command
+- Using `tox` command (this is what we also use for our deployments)
+
+## Setting it up natively
+
+1. Install dependencies:
+
+   ```sh
+   cd docs
+   pip install -r requirements.txt
+   ```
+
+2. Get into the source subdirectory now and generate `sphinx-apidoc`:
+
+   ```sh
+   cd source
+   sphinx-apidoc -f -M -d 2 -o ./api_reference/ ../../packages/syft/src/syft
+   ```
+
+3. Now go back one directory up and generate HTML docs:
+
+   ```sh
+   cd ../
+   make html
+   ```
+
+4. Voila! Now visit the PySyft/docs/build/html/index.html to view the docs locally
+
+## Setting it up using Tox
+
+1. Install tox:
+
+   ```sh
+    pip install tox
+   ```
+
+2. Run the following command:
+
+   ```sh
+   tox -e syft.docs
+   ```
+
+3. Voila! Now visit the PySyft/docs/build/html/index.html to view the docs locally.
+
+## Debugging
+
+If you want to start a fresh build, run:
+
+```sh
+make clean
+```
+
+as this will remove all the pre-exisitng files or directories in the build/ directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,5 @@ sphinx-autoapi==1.8.4
 sphinx-code-include==1.1.1
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
+syft
+markupsafe==2.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 ipython==8.1.0
+markupsafe==2.0.1
 pydata-sphinx-theme==0.7.2
 sphinx==4.3.0
 sphinx-autoapi==1.8.4
@@ -6,4 +7,3 @@ sphinx-code-include==1.1.1
 sphinx-copybutton==0.4.0
 sphinx-panels==0.6.0
 syft
-markupsafe==2.0.1

--- a/docs/source/api_reference/modules.rst
+++ b/docs/source/api_reference/modules.rst
@@ -1,0 +1,7 @@
+syft
+====
+
+.. toctree::
+   :maxdepth: 2
+
+   syft

--- a/docs/source/api_reference/syft.capnp.rst
+++ b/docs/source/api_reference/syft.capnp.rst
@@ -1,0 +1,7 @@
+syft.capnp package
+==================
+
+.. automodule:: syft.capnp
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.adp.rst
+++ b/docs/source/api_reference/syft.core.adp.rst
@@ -1,43 +1,58 @@
-syft.core.adp
-=============
+syft.core.adp package
+=====================
 
 .. automodule:: syft.core.adp
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   .. rubric:: Functions
+syft.core.adp.abstract\_ledger\_store module
+--------------------------------------------
 
-   .. autosummary::
-   
-      create_adp_ast
-   
-   
+.. automodule:: syft.core.adp.abstract_ledger_store
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.adp.data\_subject module
+----------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.adp.data_subject
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.adp.data\_subject\_ledger module
+------------------------------------------
 
+.. automodule:: syft.core.adp.data_subject_ledger
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. rubric:: Modules
+syft.core.adp.data\_subject\_list module
+----------------------------------------
 
-.. autosummary::
-   :toctree:
-   :recursive:
+.. automodule:: syft.core.adp.data_subject_list
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   syft.core.adp.adversarial_accountant
-   syft.core.adp.entity
-   syft.core.adp.idp_gaussian_mechanism
-   syft.core.adp.publish
-   syft.core.adp.scalar
-   syft.core.adp.search
-   syft.core.adp.vm_private_scalar_manager
+syft.core.adp.ledger\_store module
+----------------------------------
 
+.. automodule:: syft.core.adp.ledger_store
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.adp.vectorized\_publish module
+----------------------------------------
+
+.. automodule:: syft.core.adp.vectorized_publish
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.common.event_loop.rst
+++ b/docs/source/api_reference/syft.core.common.event_loop.rst
@@ -1,0 +1,35 @@
+syft.core.common.event\_loop
+============================
+
+.. automodule:: syft.core.common.event_loop
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      loop_in_thread
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      EventLoopThread
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.common.rst
+++ b/docs/source/api_reference/syft.core.common.rst
@@ -28,6 +28,7 @@ syft.core.common
    :recursive:
 
    syft.core.common.environment
+   syft.core.common.event_loop
    syft.core.common.group
    syft.core.common.message
    syft.core.common.object

--- a/docs/source/api_reference/syft.core.common.serde.rst
+++ b/docs/source/api_reference/syft.core.common.serde.rst
@@ -28,7 +28,6 @@ syft.core.common.serde
    :recursive:
 
    syft.core.common.serde.deserialize
-   syft.core.common.serde.recursive
    syft.core.common.serde.serializable
    syft.core.common.serde.serialize
 

--- a/docs/source/api_reference/syft.core.common.serde.serializable.rst
+++ b/docs/source/api_reference/syft.core.common.serde.serializable.rst
@@ -13,13 +13,17 @@ syft.core.common.serde.serializable
 
    .. autosummary::
    
-      GenerateProtobufWrapper
-      GenerateWrapper
-      serializable
+      bind_protobuf
    
    
 
    
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Serializable
    
    
 

--- a/docs/source/api_reference/syft.core.node.abstract.rst
+++ b/docs/source/api_reference/syft.core.node.abstract.rst
@@ -28,5 +28,4 @@ syft.core.node.abstract
    :recursive:
 
    syft.core.node.abstract.node
-   syft.core.node.abstract.node_service_interface
 

--- a/docs/source/api_reference/syft.core.node.common.action.rst
+++ b/docs/source/api_reference/syft.core.node.common.action.rst
@@ -27,11 +27,8 @@ syft.core.node.common.action
    :toctree:
    :recursive:
 
-   syft.core.node.common.action.action_sequence
-   syft.core.node.common.action.beaver_action
    syft.core.node.common.action.common
    syft.core.node.common.action.exception_action
-   syft.core.node.common.action.exceptions
    syft.core.node.common.action.function_or_constructor_action
    syft.core.node.common.action.garbage_collect_batched_action
    syft.core.node.common.action.garbage_collect_object_action
@@ -39,12 +36,6 @@ syft.core.node.common.action
    syft.core.node.common.action.get_object_action
    syft.core.node.common.action.get_or_set_property_action
    syft.core.node.common.action.get_or_set_static_attribute_action
-   syft.core.node.common.action.greenlets_switch
    syft.core.node.common.action.run_class_method_action
-   syft.core.node.common.action.run_class_method_smpc_action
    syft.core.node.common.action.save_object_action
-   syft.core.node.common.action.smpc_action_functions
-   syft.core.node.common.action.smpc_action_message
-   syft.core.node.common.action.smpc_action_seq_batch_message
-   syft.core.node.common.action.unfinished_task
 

--- a/docs/source/api_reference/syft.core.node.common.client_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.client_manager.rst
@@ -1,37 +1,66 @@
-syft.core.node.common.client\_manager
-=====================================
+syft.core.node.common.client\_manager package
+=============================================
 
 .. automodule:: syft.core.node.common.client_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.client\_manager.association\_api module
+-------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.client_manager.association_api
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.client\_manager.dataset\_api module
+---------------------------------------------------------
 
+.. automodule:: syft.core.node.common.client_manager.dataset_api
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.client\_manager.domain\_api module
+--------------------------------------------------------
 
-.. rubric:: Modules
+.. automodule:: syft.core.node.common.client_manager.domain_api
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autosummary::
-   :toctree:
-   :recursive:
+syft.core.node.common.client\_manager.request\_api module
+---------------------------------------------------------
 
-   syft.core.node.common.client_manager.association_api
-   syft.core.node.common.client_manager.dataset_api
-   syft.core.node.common.client_manager.domain_api
-   syft.core.node.common.client_manager.request_api
-   syft.core.node.common.client_manager.role_api
-   syft.core.node.common.client_manager.user_api
-   syft.core.node.common.client_manager.vpn_api
+.. automodule:: syft.core.node.common.client_manager.request_api
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.client\_manager.role\_api module
+------------------------------------------------------
+
+.. automodule:: syft.core.node.common.client_manager.role_api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.client\_manager.user\_api module
+------------------------------------------------------
+
+.. automodule:: syft.core.node.common.client_manager.user_api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.client\_manager.vpn\_api module
+-----------------------------------------------------
+
+.. automodule:: syft.core.node.common.client_manager.vpn_api
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_manager.rst
@@ -1,43 +1,114 @@
-syft.core.node.common.node\_manager
-===================================
+syft.core.node.common.node\_manager package
+===========================================
 
 .. automodule:: syft.core.node.common.node_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_manager.association\_request\_manager module
+------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_manager.association_request_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_manager.constants module
+----------------------------------------------------
 
+.. automodule:: syft.core.node.common.node_manager.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.node\_manager.database\_manager module
+------------------------------------------------------------
 
-.. rubric:: Modules
+.. automodule:: syft.core.node.common.node_manager.database_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autosummary::
-   :toctree:
-   :recursive:
+syft.core.node.common.node\_manager.dataset\_manager module
+-----------------------------------------------------------
 
-   syft.core.node.common.node_manager.association_request_manager
-   syft.core.node.common.node_manager.bin_obj_manager
-   syft.core.node.common.node_manager.database_manager
-   syft.core.node.common.node_manager.dataset_manager
-   syft.core.node.common.node_manager.environment_manager
-   syft.core.node.common.node_manager.group_manager
-   syft.core.node.common.node_manager.ledger_manager
-   syft.core.node.common.node_manager.node_manager
-   syft.core.node.common.node_manager.node_route_manager
-   syft.core.node.common.node_manager.request_manager
-   syft.core.node.common.node_manager.role_manager
-   syft.core.node.common.node_manager.setup_manager
-   syft.core.node.common.node_manager.user_manager
+.. automodule:: syft.core.node.common.node_manager.dataset_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.node\_manager.dict\_store module
+------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.dict_store
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.environment\_manager module
+---------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.environment_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.node\_manager module
+--------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.node_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.node\_route\_manager module
+---------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.node_route_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.redis\_store module
+-------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.redis_store
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.request\_manager module
+-----------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.request_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.role\_manager module
+--------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.role_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.setup\_manager module
+---------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.setup_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_manager.user\_manager module
+--------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_manager.user_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.accept_or_deny_request.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.accept_or_deny_request.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.accept\_or\_deny\_request
-=============================================================
+syft.core.node.common.node\_service.accept\_or\_deny\_request package
+=====================================================================
 
 .. automodule:: syft.core.node.common.node_service.accept_or_deny_request
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.accept\_or\_deny\_request.accept\_or\_deny\_request\_messages module
+--------------------------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.accept\_or\_deny\_request.accept\_or\_deny\_request\_service module
+-------------------------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_messages
-   syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_service
-
+.. automodule:: syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.association_request.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.association_request.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.association\_request
-========================================================
+syft.core.node.common.node\_service.association\_request package
+================================================================
 
 .. automodule:: syft.core.node.common.node_service.association_request
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.association\_request.association\_request\_messages module
+----------------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.association_request.association_request_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.association\_request.association\_request\_service module
+---------------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.association_request.association_request_messages
-   syft.core.node.common.node_service.association_request.association_request_service
-
+.. automodule:: syft.core.node.common.node_service.association_request.association_request_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.child_node_lifecycle.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.child_node_lifecycle.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.child\_node\_lifecycle
-==========================================================
+syft.core.node.common.node\_service.child\_node\_lifecycle package
+==================================================================
 
 .. automodule:: syft.core.node.common.node_service.child_node_lifecycle
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.child\_node\_lifecycle.child\_node\_lifecycle\_messages module
+--------------------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.child\_node\_lifecycle.child\_node\_lifecycle\_service module
+-------------------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_messages
-   syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_service
-
+.. automodule:: syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.dataset_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.dataset_manager.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.dataset\_manager
-====================================================
+syft.core.node.common.node\_service.dataset\_manager package
+============================================================
 
 .. automodule:: syft.core.node.common.node_service.dataset_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.dataset\_manager.dataset\_manager\_messages module
+--------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.dataset_manager.dataset_manager_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.dataset\_manager.dataset\_manager\_service module
+-------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.dataset_manager.dataset_manager_messages
-   syft.core.node.common.node_service.dataset_manager.dataset_manager_service
-
+.. automodule:: syft.core.node.common.node_service.dataset_manager.dataset_manager_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.generic_payload.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.generic_payload.rst
@@ -1,31 +1,26 @@
-syft.core.node.common.node\_service.generic\_payload
-====================================================
+syft.core.node.common.node\_service.generic\_payload package
+============================================================
 
 .. automodule:: syft.core.node.common.node_service.generic_payload
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.generic\_payload.messages module
+--------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.generic_payload.messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.generic\_payload.syft\_message module
+-------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.generic_payload.messages
-
+.. automodule:: syft.core.node.common.node_service.generic_payload.syft_message
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.get_remaining_budget.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.get_remaining_budget.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.get\_remaining\_budget
-==========================================================
+syft.core.node.common.node\_service.get\_remaining\_budget package
+==================================================================
 
 .. automodule:: syft.core.node.common.node_service.get_remaining_budget
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.get\_remaining\_budget.get\_remaining\_budget\_messages module
+--------------------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.get\_remaining\_budget.get\_remaining\_budget\_service module
+-------------------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_messages
-   syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_service
-
+.. automodule:: syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.get_repr.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.get_repr.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.get\_repr
-=============================================
+syft.core.node.common.node\_service.get\_repr package
+=====================================================
 
 .. automodule:: syft.core.node.common.node_service.get_repr
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.get\_repr.get\_repr\_messages module
+------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.get_repr.get_repr_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.get\_repr.get\_repr\_service module
+-----------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.get_repr.get_repr_messages
-   syft.core.node.common.node_service.get_repr.get_repr_service
-
+.. automodule:: syft.core.node.common.node_service.get_repr.get_repr_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.heritage_update.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.heritage_update.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.heritage\_update
-====================================================
+syft.core.node.common.node\_service.heritage\_update package
+============================================================
 
 .. automodule:: syft.core.node.common.node_service.heritage_update
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.heritage\_update.heritage\_update\_messages module
+--------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.heritage_update.heritage_update_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.heritage\_update.heritage\_update\_service module
+-------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.heritage_update.heritage_update_messages
-   syft.core.node.common.node_service.heritage_update.heritage_update_service
-
+.. automodule:: syft.core.node.common.node_service.heritage_update.heritage_update_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.msg_forwarding.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.msg_forwarding.rst
@@ -1,31 +1,18 @@
-syft.core.node.common.node\_service.msg\_forwarding
-===================================================
+syft.core.node.common.node\_service.msg\_forwarding package
+===========================================================
 
 .. automodule:: syft.core.node.common.node_service.msg_forwarding
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.msg\_forwarding.msg\_forwarding\_service module
+-----------------------------------------------------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.msg_forwarding.msg_forwarding_service
-
+.. automodule:: syft.core.node.common.node_service.msg_forwarding.msg_forwarding_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.network_search.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.network_search.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.network\_search
-===================================================
+syft.core.node.common.node\_service.network\_search package
+===========================================================
 
 .. automodule:: syft.core.node.common.node_service.network_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.network\_search.network\_search\_messages module
+------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.network_search.network_search_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.network\_search.network\_search\_service module
+-----------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.network_search.network_search_messages
-   syft.core.node.common.node_service.network_search.network_search_service
-
+.. automodule:: syft.core.node.common.node_service.network_search.network_search_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_setup.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_setup.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.node\_setup
-===============================================
+syft.core.node.common.node\_service.node\_setup package
+=======================================================
 
 .. automodule:: syft.core.node.common.node_service.node_setup
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.node\_setup.node\_setup\_messages module
+----------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.node_setup.node_setup_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.node\_setup.node\_setup\_service module
+---------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.node_setup.node_setup_messages
-   syft.core.node.common.node_service.node_setup.node_setup_service
-
+.. automodule:: syft.core.node.common.node_service.node_setup.node_setup_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_action.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_action.rst
@@ -1,31 +1,18 @@
-syft.core.node.common.node\_service.object\_action
-==================================================
+syft.core.node.common.node\_service.object\_action package
+==========================================================
 
 .. automodule:: syft.core.node.common.node_service.object_action
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.object\_action.obj\_action\_service module
+------------------------------------------------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.object_action.obj_action_service
-
+.. automodule:: syft.core.node.common.node_service.object_action.obj_action_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_delete.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_delete.rst
@@ -1,0 +1,18 @@
+syft.core.node.common.node\_service.object\_delete package
+==========================================================
+
+.. automodule:: syft.core.node.common.node_service.object_delete
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.core.node.common.node\_service.object\_delete.object\_delete\_message module
+---------------------------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.object_delete.object_delete_message
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_request.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_request.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.object\_request
-===================================================
+syft.core.node.common.node\_service.object\_request package
+===========================================================
 
 .. automodule:: syft.core.node.common.node_service.object_request
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.object\_request.object\_request\_messages module
+------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.object_request.object_request_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.object\_request.object\_request\_service module
+-----------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.object_request.object_request_messages
-   syft.core.node.common.node_service.object_request.object_request_service
-
+.. automodule:: syft.core.node.common.node_service.object_request.object_request_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_search.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_search.rst
@@ -1,31 +1,18 @@
-syft.core.node.common.node\_service.object\_search
-==================================================
+syft.core.node.common.node\_service.object\_search package
+==========================================================
 
 .. automodule:: syft.core.node.common.node_service.object_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.object\_search.obj\_search\_service module
+------------------------------------------------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.object_search.obj_search_service
-
+.. automodule:: syft.core.node.common.node_service.object_search.obj_search_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_search_permission_update.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_search_permission_update.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.object\_search\_permission\_update
-======================================================================
+syft.core.node.common.node\_service.object\_search\_permission\_update package
+==============================================================================
 
 .. automodule:: syft.core.node.common.node_service.object_search_permission_update
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.object\_search\_permission\_update.obj\_search\_permission\_messages module
+---------------------------------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.object\_search\_permission\_update.obj\_search\_permission\_service module
+--------------------------------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_messages
-   syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_service
-
+.. automodule:: syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_transfer.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_transfer.rst
@@ -1,32 +1,18 @@
-syft.core.node.common.node\_service.object\_transfer
-====================================================
+syft.core.node.common.node\_service.object\_transfer package
+============================================================
 
 .. automodule:: syft.core.node.common.node_service.object_transfer
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.object\_transfer.object\_transfer\_messages module
+--------------------------------------------------------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.object_transfer.object_transfer_messages
-   syft.core.node.common.node_service.object_transfer.object_transfer_service
-
+.. automodule:: syft.core.node.common.node_service.object_transfer.object_transfer_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.peer_discovery.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.peer_discovery.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.peer\_discovery
-===================================================
+syft.core.node.common.node\_service.peer\_discovery package
+===========================================================
 
 .. automodule:: syft.core.node.common.node_service.peer_discovery
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.peer\_discovery.peer\_discovery\_messages module
+------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.peer_discovery.peer_discovery_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.peer\_discovery.peer\_discovery\_service module
+-----------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.peer_discovery.peer_discovery_messages
-   syft.core.node.common.node_service.peer_discovery.peer_discovery_service
-
+.. automodule:: syft.core.node.common.node_service.peer_discovery.peer_discovery_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.ping.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.ping.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.ping
-========================================
+syft.core.node.common.node\_service.ping package
+================================================
 
 .. automodule:: syft.core.node.common.node_service.ping
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.ping.ping\_messages module
+--------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.ping.ping_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.ping.ping\_service module
+-------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.ping.ping_messages
-   syft.core.node.common.node_service.ping.ping_service
-
+.. automodule:: syft.core.node.common.node_service.ping.ping_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.request_answer.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.request_answer.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.request\_answer
-===================================================
+syft.core.node.common.node\_service.request\_answer package
+===========================================================
 
 .. automodule:: syft.core.node.common.node_service.request_answer
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.request\_answer.request\_answer\_messages module
+------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.request_answer.request_answer_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.request\_answer.request\_answer\_service module
+-----------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.request_answer.request_answer_messages
-   syft.core.node.common.node_service.request_answer.request_answer_service
-
+.. automodule:: syft.core.node.common.node_service.request_answer.request_answer_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.request_handler.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.request_handler.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.request\_handler
-====================================================
+syft.core.node.common.node\_service.request\_handler package
+============================================================
 
 .. automodule:: syft.core.node.common.node_service.request_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.request\_handler.request\_handler\_messages module
+--------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.request_handler.request_handler_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.request\_handler.request\_handler\_service module
+-------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.request_handler.request_handler_messages
-   syft.core.node.common.node_service.request_handler.request_handler_service
-
+.. automodule:: syft.core.node.common.node_service.request_handler.request_handler_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.request_receiver.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.request_receiver.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.request\_receiver
-=====================================================
+syft.core.node.common.node\_service.request\_receiver package
+=============================================================
 
 .. automodule:: syft.core.node.common.node_service.request_receiver
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.request\_receiver.request\_receiver\_messages module
+----------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.request_receiver.request_receiver_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.request\_receiver.request\_receiver\_service module
+---------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.request_receiver.request_receiver_messages
-   syft.core.node.common.node_service.request_receiver.request_receiver_service
-
+.. automodule:: syft.core.node.common.node_service.request_receiver.request_receiver_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.resolve\_pointer\_type
-==========================================================
+syft.core.node.common.node\_service.resolve\_pointer\_type package
+==================================================================
 
 .. automodule:: syft.core.node.common.node_service.resolve_pointer_type
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.resolve\_pointer\_type.resolve\_pointer\_type\_messages module
+--------------------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.resolve\_pointer\_type.resolve\_pointer\_type\_service module
+-------------------------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_messages
-   syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_service
-
+.. automodule:: syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.role_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.role_manager.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.role\_manager
-=================================================
+syft.core.node.common.node\_service.role\_manager package
+=========================================================
 
 .. automodule:: syft.core.node.common.node_service.role_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.role\_manager.role\_manager\_messages module
+--------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.role_manager.role_manager_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.role\_manager.role\_manager\_service module
+-------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.role_manager.role_manager_messages
-   syft.core.node.common.node_service.role_manager.role_manager_service
-
+.. automodule:: syft.core.node.common.node_service.role_manager.role_manager_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.rst
@@ -1,47 +1,30 @@
-syft.core.node.common.node\_service
-===================================
+syft.core.node.common.node\_service package
+===========================================
 
 .. automodule:: syft.core.node.common.node_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Subpackages
+-----------
 
-   
-   
-   
-
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
+.. toctree::
+   :maxdepth: 2
 
    syft.core.node.common.node_service.accept_or_deny_request
    syft.core.node.common.node_service.association_request
-   syft.core.node.common.node_service.auth
    syft.core.node.common.node_service.child_node_lifecycle
    syft.core.node.common.node_service.dataset_manager
    syft.core.node.common.node_service.generic_payload
-   syft.core.node.common.node_service.get_all_requests
    syft.core.node.common.node_service.get_remaining_budget
    syft.core.node.common.node_service.get_repr
    syft.core.node.common.node_service.heritage_update
    syft.core.node.common.node_service.msg_forwarding
    syft.core.node.common.node_service.network_search
-   syft.core.node.common.node_service.node_service
    syft.core.node.common.node_service.node_setup
    syft.core.node.common.node_service.object_action
+   syft.core.node.common.node_service.object_delete
    syft.core.node.common.node_service.object_request
    syft.core.node.common.node_service.object_search
    syft.core.node.common.node_service.object_search_permission_update
@@ -54,11 +37,38 @@ syft.core.node.common.node\_service
    syft.core.node.common.node_service.resolve_pointer_type
    syft.core.node.common.node_service.role_manager
    syft.core.node.common.node_service.simple
-   syft.core.node.common.node_service.success_resp_message
+   syft.core.node.common.node_service.sleep
    syft.core.node.common.node_service.tensor_manager
    syft.core.node.common.node_service.testing_services
+   syft.core.node.common.node_service.upload_service
    syft.core.node.common.node_service.user_auth
    syft.core.node.common.node_service.user_manager
    syft.core.node.common.node_service.vm_request_service
    syft.core.node.common.node_service.vpn
 
+Submodules
+----------
+
+syft.core.node.common.node\_service.auth module
+-----------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.auth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_service.node\_service module
+--------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.node_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_service.success\_resp\_message module
+-----------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.success_resp_message
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.simple.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.simple.rst
@@ -1,33 +1,34 @@
-syft.core.node.common.node\_service.simple
-==========================================
+syft.core.node.common.node\_service.simple package
+==================================================
 
 .. automodule:: syft.core.node.common.node_service.simple
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.simple.obj\_exists module
+-------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.simple.obj_exists
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.simple.simple\_messages module
+------------------------------------------------------------------
 
+.. automodule:: syft.core.node.common.node_service.simple.simple_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.node\_service.simple.simple\_service module
+-----------------------------------------------------------------
 
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.simple.obj_exists
-   syft.core.node.common.node_service.simple.simple_messages
-   syft.core.node.common.node_service.simple.simple_service
-
+.. automodule:: syft.core.node.common.node_service.simple.simple_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.sleep.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.sleep.rst
@@ -1,0 +1,26 @@
+syft.core.node.common.node\_service.sleep package
+=================================================
+
+.. automodule:: syft.core.node.common.node_service.sleep
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.core.node.common.node\_service.sleep.sleep\_messages module
+----------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.sleep.sleep_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_service.sleep.sleep\_service module
+---------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.sleep.sleep_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.tensor_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.tensor_manager.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.tensor\_manager
-===================================================
+syft.core.node.common.node\_service.tensor\_manager package
+===========================================================
 
 .. automodule:: syft.core.node.common.node_service.tensor_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.tensor\_manager.tensor\_manager\_messages module
+------------------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.tensor_manager.tensor_manager_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.tensor\_manager.tensor\_manager\_service module
+-----------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.tensor_manager.tensor_manager_messages
-   syft.core.node.common.node_service.tensor_manager.tensor_manager_service
-
+.. automodule:: syft.core.node.common.node_service.tensor_manager.tensor_manager_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.testing_services.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.testing_services.rst
@@ -1,31 +1,18 @@
-syft.core.node.common.node\_service.testing\_services
-=====================================================
+syft.core.node.common.node\_service.testing\_services package
+=============================================================
 
 .. automodule:: syft.core.node.common.node_service.testing_services
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.testing\_services.repr\_service module
+--------------------------------------------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.testing_services.repr_service
-
+.. automodule:: syft.core.node.common.node_service.testing_services.repr_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.upload_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.upload_service.rst
@@ -1,0 +1,18 @@
+syft.core.node.common.node\_service.upload\_service package
+===========================================================
+
+.. automodule:: syft.core.node.common.node_service.upload_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.core.node.common.node\_service.upload\_service.upload\_service\_messages module
+------------------------------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.upload_service.upload_service_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.user_auth.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.user_auth.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.user\_auth
-==============================================
+syft.core.node.common.node\_service.user\_auth package
+======================================================
 
 .. automodule:: syft.core.node.common.node_service.user_auth
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.user\_auth.user\_auth\_messages module
+--------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.user_auth.user_auth_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.user\_auth.user\_auth\_service module
+-------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.user_auth.user_auth_messages
-   syft.core.node.common.node_service.user_auth.user_auth_service
-
+.. automodule:: syft.core.node.common.node_service.user_auth.user_auth_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.user_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.user_manager.rst
@@ -1,32 +1,34 @@
-syft.core.node.common.node\_service.user\_manager
-=================================================
+syft.core.node.common.node\_service.user\_manager package
+=========================================================
 
 .. automodule:: syft.core.node.common.node_service.user_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.user\_manager.new\_user\_messages module
+----------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.user_manager.new_user_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.user\_manager.user\_manager\_service module
+-------------------------------------------------------------------------------
 
+.. automodule:: syft.core.node.common.node_service.user_manager.user_manager_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.node\_service.user\_manager.user\_messages module
+-----------------------------------------------------------------------
 
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.user_manager.user_manager_service
-   syft.core.node.common.node_service.user_manager.user_messages
-
+.. automodule:: syft.core.node.common.node_service.user_manager.user_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.vm_request_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.vm_request_service.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.vm\_request\_service
-========================================================
+syft.core.node.common.node\_service.vm\_request\_service package
+================================================================
 
 .. automodule:: syft.core.node.common.node_service.vm_request_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.vm\_request\_service.vm\_service module
+---------------------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.vm_request_service.vm_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.vm\_request\_service.vm\_service\_test module
+---------------------------------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.vm_request_service.vm_service
-   syft.core.node.common.node_service.vm_request_service.vm_service_test
-
+.. automodule:: syft.core.node.common.node_service.vm_request_service.vm_service_test
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.vpn.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.vpn.rst
@@ -1,32 +1,26 @@
-syft.core.node.common.node\_service.vpn
-=======================================
+syft.core.node.common.node\_service.vpn package
+===============================================
 
 .. automodule:: syft.core.node.common.node_service.vpn
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_service.vpn.vpn\_messages module
+------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_service.vpn.vpn_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_service.vpn.vpn\_service module
+-----------------------------------------------------------
 
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.common.node_service.vpn.vpn_messages
-   syft.core.node.common.node_service.vpn.vpn_service
-
+.. automodule:: syft.core.node.common.node_service.vpn.vpn_service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_table.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_table.rst
@@ -1,53 +1,162 @@
-syft.core.node.common.node\_table
-=================================
+syft.core.node.common.node\_table package
+=========================================
 
 .. automodule:: syft.core.node.common.node_table
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.node.common.node\_table.association\_request module
+-------------------------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.node.common.node_table.association_request
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.node.common.node\_table.bin\_obj\_dataset module
+----------------------------------------------------------
 
+.. automodule:: syft.core.node.common.node_table.bin_obj_dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.node\_table.bin\_obj\_metadata module
+-----------------------------------------------------------
 
-.. rubric:: Modules
+.. automodule:: syft.core.node.common.node_table.bin_obj_metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autosummary::
-   :toctree:
-   :recursive:
+syft.core.node.common.node\_table.dataset module
+------------------------------------------------
 
-   syft.core.node.common.node_table.association_request
-   syft.core.node.common.node_table.bin_obj
-   syft.core.node.common.node_table.bin_obj_dataset
-   syft.core.node.common.node_table.bin_obj_metadata
-   syft.core.node.common.node_table.dataset
-   syft.core.node.common.node_table.dataset_group
-   syft.core.node.common.node_table.entity
-   syft.core.node.common.node_table.environment
-   syft.core.node.common.node_table.groups
-   syft.core.node.common.node_table.json_obj
-   syft.core.node.common.node_table.ledger
-   syft.core.node.common.node_table.mechanism
-   syft.core.node.common.node_table.metadata
-   syft.core.node.common.node_table.node
-   syft.core.node.common.node_table.node_route
-   syft.core.node.common.node_table.pdf
-   syft.core.node.common.node_table.request
-   syft.core.node.common.node_table.roles
-   syft.core.node.common.node_table.setup
-   syft.core.node.common.node_table.user
-   syft.core.node.common.node_table.user_environment
-   syft.core.node.common.node_table.usergroup
-   syft.core.node.common.node_table.utils
+.. automodule:: syft.core.node.common.node_table.dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.node.common.node\_table.dataset\_group module
+-------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.dataset_group
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.entity module
+-----------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.entity
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.environment module
+----------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.environment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.json\_obj module
+--------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.json_obj
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.ledger module
+-----------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.ledger
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.metadata module
+-------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.node module
+---------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.node
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.node\_route module
+----------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.node_route
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.pdf module
+--------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.pdf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.request module
+------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.request
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.roles module
+----------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.roles
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.setup module
+----------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.setup
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.user module
+---------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.user
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.user\_environment module
+----------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.user_environment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_table.utils module
+----------------------------------------------
+
+.. automodule:: syft.core.node.common.node_table.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.permissions.rst
+++ b/docs/source/api_reference/syft.core.node.common.permissions.rst
@@ -1,0 +1,26 @@
+syft.core.node.common.permissions package
+=========================================
+
+.. automodule:: syft.core.node.common.permissions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.core.node.common.permissions.permissions module
+----------------------------------------------------
+
+.. automodule:: syft.core.node.common.permissions.permissions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.permissions.user\_permissions module
+----------------------------------------------------------
+
+.. automodule:: syft.core.node.common.permissions.user_permissions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.rst
+++ b/docs/source/api_reference/syft.core.node.common.rst
@@ -9,12 +9,6 @@ syft.core.node.common
 
    
    
-   .. rubric:: Functions
-
-   .. autosummary::
-   
-      create_client_ast
-   
    
 
    
@@ -35,12 +29,8 @@ syft.core.node.common
 
    syft.core.node.common.action
    syft.core.node.common.client
-   syft.core.node.common.client_manager
-   syft.core.node.common.exceptions
    syft.core.node.common.metadata
    syft.core.node.common.node
-   syft.core.node.common.node_manager
-   syft.core.node.common.node_service
-   syft.core.node.common.node_table
+   syft.core.node.common.service
    syft.core.node.common.util
 

--- a/docs/source/api_reference/syft.core.node.common.service.auth.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.auth.rst
@@ -1,0 +1,35 @@
+syft.core.node.common.service.auth
+==================================
+
+.. automodule:: syft.core.node.common.service.auth
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      service_auth
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      AuthorizationException
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.child_node_lifecycle_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.child_node_lifecycle_service.rst
@@ -1,0 +1,30 @@
+syft.core.node.common.service.child\_node\_lifecycle\_service
+=============================================================
+
+.. automodule:: syft.core.node.common.service.child_node_lifecycle_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ChildNodeLifecycleService
+      RegisterChildNodeMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.get_repr_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.get_repr_service.rst
@@ -1,0 +1,31 @@
+syft.core.node.common.service.get\_repr\_service
+================================================
+
+.. automodule:: syft.core.node.common.service.get_repr_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GetReprMessage
+      GetReprReplyMessage
+      GetReprService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.heritage_update_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.heritage_update_service.rst
@@ -1,0 +1,30 @@
+syft.core.node.common.service.heritage\_update\_service
+=======================================================
+
+.. automodule:: syft.core.node.common.service.heritage_update_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      HeritageUpdateMessage
+      HeritageUpdateService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.msg_forwarding_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.msg_forwarding_service.rst
@@ -1,0 +1,30 @@
+syft.core.node.common.service.msg\_forwarding\_service
+======================================================
+
+.. automodule:: syft.core.node.common.service.msg_forwarding_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      SignedMessageWithReplyForwardingService
+      SignedMessageWithoutReplyForwardingService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.node_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.node_service.rst
@@ -1,0 +1,36 @@
+syft.core.node.common.service.node\_service
+===========================================
+
+.. automodule:: syft.core.node.common.service.node_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      EventualNodeService
+      EventualNodeServiceWithoutReply
+      ImmediateNodeService
+      ImmediateNodeServiceWithReply
+      ImmediateNodeServiceWithoutReply
+      NodeService
+      SignedNodeServiceWithReply
+      SignedNodeServiceWithoutReply
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.obj_action_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.obj_action_service.rst
@@ -1,0 +1,31 @@
+syft.core.node.common.service.obj\_action\_service
+==================================================
+
+.. automodule:: syft.core.node.common.service.obj_action_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      EventualObjectActionServiceWithoutReply
+      ImmediateObjectActionServiceWithReply
+      ImmediateObjectActionServiceWithoutReply
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.obj_search_permission_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.obj_search_permission_service.rst
@@ -1,0 +1,30 @@
+syft.core.node.common.service.obj\_search\_permission\_service
+==============================================================
+
+.. automodule:: syft.core.node.common.service.obj_search_permission_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ImmediateObjectSearchPermissionUpdateService
+      ObjectSearchPermissionUpdateMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.obj_search_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.obj_search_service.rst
@@ -1,0 +1,31 @@
+syft.core.node.common.service.obj\_search\_service
+==================================================
+
+.. automodule:: syft.core.node.common.service.obj_search_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ImmediateObjectSearchService
+      ObjectSearchMessage
+      ObjectSearchReplyMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.repr_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.repr_service.rst
@@ -1,0 +1,30 @@
+syft.core.node.common.service.repr\_service
+===========================================
+
+.. automodule:: syft.core.node.common.service.repr_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ReprMessage
+      ReprService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.resolve_pointer_type_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.resolve_pointer_type_service.rst
@@ -1,0 +1,31 @@
+syft.core.node.common.service.resolve\_pointer\_type\_service
+=============================================================
+
+.. automodule:: syft.core.node.common.service.resolve_pointer_type_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ResolvePointerTypeAnswerMessage
+      ResolvePointerTypeMessage
+      ResolvePointerTypeService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.rst
@@ -1,0 +1,42 @@
+syft.core.node.common.service
+=============================
+
+.. automodule:: syft.core.node.common.service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.service.auth
+   syft.core.node.common.service.child_node_lifecycle_service
+   syft.core.node.common.service.get_repr_service
+   syft.core.node.common.service.heritage_update_service
+   syft.core.node.common.service.msg_forwarding_service
+   syft.core.node.common.service.node_service
+   syft.core.node.common.service.obj_action_service
+   syft.core.node.common.service.obj_search_permission_service
+   syft.core.node.common.service.obj_search_service
+   syft.core.node.common.service.repr_service
+   syft.core.node.common.service.resolve_pointer_type_service
+   syft.core.node.common.service.solve_pointer_type_service
+

--- a/docs/source/api_reference/syft.core.node.common.service.solve_pointer_type_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.service.solve_pointer_type_service.rst
@@ -1,0 +1,31 @@
+syft.core.node.common.service.solve\_pointer\_type\_service
+===========================================================
+
+.. automodule:: syft.core.node.common.service.solve_pointer_type_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ResolvePointerTypeAnswerMessage
+      ResolvePointerTypeMessage
+      ResolvePointerTypeService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.device_type.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.device_type.rst
@@ -1,0 +1,29 @@
+syft.core.node.device.device\_type.device\_type
+===============================================
+
+.. automodule:: syft.core.node.device.device_type.device_type
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DeviceType
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.rst
@@ -1,0 +1,33 @@
+syft.core.node.device.device\_type
+==================================
+
+.. automodule:: syft.core.node.device.device_type
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.device.device_type.device_type
+   syft.core.node.device.device_type.specs
+   syft.core.node.device.device_type.unknown
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.specs.cpu.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.specs.cpu.rst
@@ -1,0 +1,30 @@
+syft.core.node.device.device\_type.specs.cpu
+============================================
+
+.. automodule:: syft.core.node.device.device_type.specs.cpu
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CPU
+      CpuArchitectureTypes
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.specs.gpu.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.specs.gpu.rst
@@ -1,0 +1,29 @@
+syft.core.node.device.device\_type.specs.gpu
+============================================
+
+.. automodule:: syft.core.node.device.device_type.specs.gpu
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GPU
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.specs.network.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.specs.network.rst
@@ -1,0 +1,29 @@
+syft.core.node.device.device\_type.specs.network
+================================================
+
+.. automodule:: syft.core.node.device.device_type.specs.network
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Network
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.specs.provider.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.specs.provider.rst
@@ -1,0 +1,29 @@
+syft.core.node.device.device\_type.specs.provider
+=================================================
+
+.. automodule:: syft.core.node.device.device_type.specs.provider
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Provider
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.specs.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.specs.rst
@@ -1,0 +1,35 @@
+syft.core.node.device.device\_type.specs
+========================================
+
+.. automodule:: syft.core.node.device.device_type.specs
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.device.device_type.specs.cpu
+   syft.core.node.device.device_type.specs.gpu
+   syft.core.node.device.device_type.specs.network
+   syft.core.node.device.device_type.specs.provider
+   syft.core.node.device.device_type.specs.storage
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.specs.storage.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.specs.storage.rst
@@ -1,0 +1,31 @@
+syft.core.node.device.device\_type.specs.storage
+================================================
+
+.. automodule:: syft.core.node.device.device_type.specs.storage
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Drive
+      DriveType
+      Storage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.device_type.unknown.rst
+++ b/docs/source/api_reference/syft.core.node.device.device_type.unknown.rst
@@ -1,0 +1,23 @@
+syft.core.node.device.device\_type.unknown
+==========================================
+
+.. automodule:: syft.core.node.device.device_type.unknown
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.device.rst
+++ b/docs/source/api_reference/syft.core.node.device.rst
@@ -29,4 +29,5 @@ syft.core.node.device
 
    syft.core.node.device.client
    syft.core.node.device.device
+   syft.core.node.device.device_type
 

--- a/docs/source/api_reference/syft.core.node.domain.rst
+++ b/docs/source/api_reference/syft.core.node.domain.rst
@@ -29,7 +29,5 @@ syft.core.node.domain
 
    syft.core.node.domain.client
    syft.core.node.domain.domain
-   syft.core.node.domain.domain_interface
-   syft.core.node.domain.enums
-   syft.core.node.domain.exceptions
+   syft.core.node.domain.service
 

--- a/docs/source/api_reference/syft.core.node.domain.service.accept_or_deny_request_service.rst
+++ b/docs/source/api_reference/syft.core.node.domain.service.accept_or_deny_request_service.rst
@@ -1,0 +1,30 @@
+syft.core.node.domain.service.accept\_or\_deny\_request\_service
+================================================================
+
+.. automodule:: syft.core.node.domain.service.accept_or_deny_request_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AcceptOrDenyRequestMessage
+      AcceptOrDenyRequestService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain.service.get_all_requests_service.rst
+++ b/docs/source/api_reference/syft.core.node.domain.service.get_all_requests_service.rst
@@ -1,0 +1,31 @@
+syft.core.node.domain.service.get\_all\_requests\_service
+=========================================================
+
+.. automodule:: syft.core.node.domain.service.get_all_requests_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GetAllRequestsMessage
+      GetAllRequestsResponseMessage
+      GetAllRequestsService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain.service.request_answer_message.rst
+++ b/docs/source/api_reference/syft.core.node.domain.service.request_answer_message.rst
@@ -1,0 +1,31 @@
+syft.core.node.domain.service.request\_answer\_message
+======================================================
+
+.. automodule:: syft.core.node.domain.service.request_answer_message
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      RequestAnswerMessage
+      RequestAnswerMessageService
+      RequestAnswerResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain.service.request_handler_service.rst
+++ b/docs/source/api_reference/syft.core.node.domain.service.request_handler_service.rst
@@ -1,0 +1,33 @@
+syft.core.node.domain.service.request\_handler\_service
+=======================================================
+
+.. automodule:: syft.core.node.domain.service.request_handler_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GetAllRequestHandlersMessage
+      GetAllRequestHandlersResponseMessage
+      GetAllRequestHandlersService
+      UpdateRequestHandlerMessage
+      UpdateRequestHandlerService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain.service.request_message.rst
+++ b/docs/source/api_reference/syft.core.node.domain.service.request_message.rst
@@ -1,0 +1,31 @@
+syft.core.node.domain.service.request\_message
+==============================================
+
+.. automodule:: syft.core.node.domain.service.request_message
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      RequestMessage
+      RequestService
+      RequestStatus
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain.service.rst
+++ b/docs/source/api_reference/syft.core.node.domain.service.rst
@@ -1,0 +1,36 @@
+syft.core.node.domain.service
+=============================
+
+.. automodule:: syft.core.node.domain.service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.domain.service.accept_or_deny_request_service
+   syft.core.node.domain.service.get_all_requests_service
+   syft.core.node.domain.service.request_answer_message
+   syft.core.node.domain.service.request_handler_service
+   syft.core.node.domain.service.request_message
+   syft.core.node.domain.service.vm_service
+

--- a/docs/source/api_reference/syft.core.node.domain.service.vm_service.rst
+++ b/docs/source/api_reference/syft.core.node.domain.service.vm_service.rst
@@ -1,0 +1,30 @@
+syft.core.node.domain.service.vm\_service
+=========================================
+
+.. automodule:: syft.core.node.domain.service.vm_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      VMRequestAnswerMessageService
+      VMRequestService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.pki.rst
+++ b/docs/source/api_reference/syft.core.node.pki.rst
@@ -1,0 +1,23 @@
+syft.core.node.pki
+==================
+
+.. automodule:: syft.core.node.pki
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.rst
+++ b/docs/source/api_reference/syft.core.node.rst
@@ -32,5 +32,6 @@ syft.core.node
    syft.core.node.device
    syft.core.node.domain
    syft.core.node.network
+   syft.core.node.pki
    syft.core.node.vm
 

--- a/docs/source/api_reference/syft.core.plan.plan.rst
+++ b/docs/source/api_reference/syft.core.plan.plan.rst
@@ -1,0 +1,29 @@
+syft.core.plan.plan
+===================
+
+.. automodule:: syft.core.plan.plan
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Plan
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.plan.plan_builder.rst
+++ b/docs/source/api_reference/syft.core.plan.plan_builder.rst
@@ -1,0 +1,31 @@
+syft.core.plan.plan\_builder
+============================
+
+.. automodule:: syft.core.plan.plan_builder
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      build_plan_inputs
+      make_plan
+      map_in2out
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.plan.rst
+++ b/docs/source/api_reference/syft.core.plan.rst
@@ -1,0 +1,33 @@
+syft.core.plan
+==============
+
+.. automodule:: syft.core.plan
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.plan.plan
+   syft.core.plan.plan_builder
+   syft.core.plan.translation
+

--- a/docs/source/api_reference/syft.core.plan.translation.rst
+++ b/docs/source/api_reference/syft.core.plan.translation.rst
@@ -1,0 +1,31 @@
+syft.core.plan.translation
+==========================
+
+.. automodule:: syft.core.plan.translation
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.plan.translation.torchscript
+

--- a/docs/source/api_reference/syft.core.plan.translation.torchscript.plan.rst
+++ b/docs/source/api_reference/syft.core.plan.translation.torchscript.plan.rst
@@ -1,0 +1,29 @@
+syft.core.plan.translation.torchscript.plan
+===========================================
+
+.. automodule:: syft.core.plan.translation.torchscript.plan
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      PlanTorchscript
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.plan.translation.torchscript.plan_translate.rst
+++ b/docs/source/api_reference/syft.core.plan.translation.torchscript.plan_translate.rst
@@ -1,0 +1,32 @@
+syft.core.plan.translation.torchscript.plan\_translate
+======================================================
+
+.. automodule:: syft.core.plan.translation.torchscript.plan_translate
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      get_pointer_to_data_in_store
+      is_dict
+      is_list
+      translate
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.plan.translation.torchscript.rst
+++ b/docs/source/api_reference/syft.core.plan.translation.torchscript.rst
@@ -1,0 +1,32 @@
+syft.core.plan.translation.torchscript
+======================================
+
+.. automodule:: syft.core.plan.translation.torchscript
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.plan.translation.torchscript.plan
+   syft.core.plan.translation.torchscript.plan_translate
+

--- a/docs/source/api_reference/syft.core.remote_dataloader.remote_dataloader.rst
+++ b/docs/source/api_reference/syft.core.remote_dataloader.remote_dataloader.rst
@@ -1,0 +1,30 @@
+syft.core.remote\_dataloader.remote\_dataloader
+===============================================
+
+.. automodule:: syft.core.remote_dataloader.remote_dataloader
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      RemoteDataLoader
+      RemoteDataset
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.remote_dataloader.rst
+++ b/docs/source/api_reference/syft.core.remote_dataloader.rst
@@ -1,0 +1,31 @@
+syft.core.remote\_dataloader
+============================
+
+.. automodule:: syft.core.remote_dataloader
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.remote_dataloader.remote_dataloader
+

--- a/docs/source/api_reference/syft.core.rst
+++ b/docs/source/api_reference/syft.core.rst
@@ -27,13 +27,11 @@
    :toctree:
    :recursive:
 
-   syft.core.adp
    syft.core.common
    syft.core.io
    syft.core.node
+   syft.core.plan
    syft.core.pointer
-   syft.core.smpc
+   syft.core.remote_dataloader
    syft.core.store
-   syft.core.tensor
-   syft.core.test
 

--- a/docs/source/api_reference/syft.core.smpc.approximations.rst
+++ b/docs/source/api_reference/syft.core.smpc.approximations.rst
@@ -1,0 +1,42 @@
+syft.core.smpc.approximations package
+=====================================
+
+.. automodule:: syft.core.smpc.approximations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.core.smpc.approximations.exp module
+----------------------------------------
+
+.. automodule:: syft.core.smpc.approximations.exp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.smpc.approximations.log module
+----------------------------------------
+
+.. automodule:: syft.core.smpc.approximations.log
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.smpc.approximations.reciprocal module
+-----------------------------------------------
+
+.. automodule:: syft.core.smpc.approximations.reciprocal
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.smpc.approximations.utils module
+------------------------------------------
+
+.. automodule:: syft.core.smpc.approximations.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.smpc.protocol.aby3.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.aby3.rst
@@ -1,31 +1,18 @@
-syft.core.smpc.protocol.aby3
-============================
+syft.core.smpc.protocol.aby3 package
+====================================
 
 .. automodule:: syft.core.smpc.protocol.aby3
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.smpc.protocol.aby3.aby3 module
+----------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.smpc.protocol.aby3.aby3
-
+.. automodule:: syft.core.smpc.protocol.aby3.aby3
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.smpc.protocol.beaver.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.beaver.rst
@@ -1,31 +1,18 @@
-syft.core.smpc.protocol.beaver
-==============================
+syft.core.smpc.protocol.beaver package
+======================================
 
 .. automodule:: syft.core.smpc.protocol.beaver
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.smpc.protocol.beaver.beaver module
+--------------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.smpc.protocol.beaver.beaver
-
+.. automodule:: syft.core.smpc.protocol.beaver.beaver
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.smpc.protocol.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.rst
@@ -1,33 +1,17 @@
-syft.core.smpc.protocol
-=======================
+syft.core.smpc.protocol package
+===============================
 
 .. automodule:: syft.core.smpc.protocol
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Subpackages
+-----------
 
-   
-   
-   
-
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
+.. toctree::
+   :maxdepth: 2
 
    syft.core.smpc.protocol.aby3
    syft.core.smpc.protocol.beaver
    syft.core.smpc.protocol.spdz
-

--- a/docs/source/api_reference/syft.core.smpc.protocol.spdz.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.spdz.rst
@@ -1,31 +1,18 @@
-syft.core.smpc.protocol.spdz
-============================
+syft.core.smpc.protocol.spdz package
+====================================
 
 .. automodule:: syft.core.smpc.protocol.spdz
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.smpc.protocol.spdz.spdz module
+----------------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.smpc.protocol.spdz.spdz
-
+.. automodule:: syft.core.smpc.protocol.spdz.spdz
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.smpc.rst
+++ b/docs/source/api_reference/syft.core.smpc.rst
@@ -1,38 +1,17 @@
-syft.core.smpc
-==============
+syft.core.smpc package
+======================
 
 .. automodule:: syft.core.smpc
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Subpackages
+-----------
 
-   
-   
-   .. rubric:: Functions
+.. toctree::
+   :maxdepth: 2
 
-   .. autosummary::
-   
-      create_smpc_ast
-   
-   
-
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
+   syft.core.smpc.approximations
    syft.core.smpc.protocol
    syft.core.smpc.store
-

--- a/docs/source/api_reference/syft.core.smpc.store.rst
+++ b/docs/source/api_reference/syft.core.smpc.store.rst
@@ -1,41 +1,34 @@
-syft.core.smpc.store
-====================
+syft.core.smpc.store package
+============================
 
 .. automodule:: syft.core.smpc.store
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   .. rubric:: Functions
+syft.core.smpc.store.crypto\_primitive\_provider module
+-------------------------------------------------------
 
-   .. autosummary::
-   
-      register_primitive_generator
-      register_primitive_store_add
-      register_primitive_store_get
-   
-   
+.. automodule:: syft.core.smpc.store.crypto_primitive_provider
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.smpc.store.crypto\_store module
+-----------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.smpc.store.crypto_store
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.smpc.store.exceptions module
+--------------------------------------
 
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.smpc.store.crypto_primitive_provider
-   syft.core.smpc.store.crypto_store
-   syft.core.smpc.store.exceptions
-
+.. automodule:: syft.core.smpc.store.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.store.rst
+++ b/docs/source/api_reference/syft.core.store.rst
@@ -28,6 +28,7 @@ syft.core.store
    :recursive:
 
    syft.core.store.dataset
+   syft.core.store.store_disk
    syft.core.store.store_interface
    syft.core.store.store_memory
    syft.core.store.storeable_object

--- a/docs/source/api_reference/syft.core.store.store_disk.rst
+++ b/docs/source/api_reference/syft.core.store.store_disk.rst
@@ -1,0 +1,29 @@
+syft.core.store.store\_disk
+===========================
+
+.. automodule:: syft.core.store.store_disk
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DiskObjectStore
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.autodp.rst
+++ b/docs/source/api_reference/syft.core.tensor.autodp.rst
@@ -1,36 +1,34 @@
-syft.core.tensor.autodp
-=======================
+syft.core.tensor.autodp package
+===============================
 
 .. automodule:: syft.core.tensor.autodp
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.tensor.autodp.adp\_tensor module
+------------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.tensor.autodp.adp_tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.tensor.autodp.gamma\_tensor module
+--------------------------------------------
 
+.. automodule:: syft.core.tensor.autodp.gamma_tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.tensor.autodp.phi\_tensor module
+------------------------------------------
 
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.tensor.autodp.adp_tensor
-   syft.core.tensor.autodp.dp_tensor_converter
-   syft.core.tensor.autodp.initial_gamma
-   syft.core.tensor.autodp.intermediate_gamma
-   syft.core.tensor.autodp.row_entity_phi
-   syft.core.tensor.autodp.single_entity_phi
-
+.. automodule:: syft.core.tensor.autodp.phi_tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.tensor.rst
+++ b/docs/source/api_reference/syft.core.tensor.rst
@@ -1,50 +1,107 @@
-syft.core.tensor
-================
+syft.core.tensor package
+========================
 
 .. automodule:: syft.core.tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Subpackages
+-----------
 
-   
-   
-   .. rubric:: Functions
+.. toctree::
+   :maxdepth: 2
 
-   .. autosummary::
-   
-      create_tensor_ast
-   
-   
-
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.tensor.ancestors
    syft.core.tensor.autodp
-   syft.core.tensor.autograd
-   syft.core.tensor.broadcastable
-   syft.core.tensor.fixed_precision_tensor
-   syft.core.tensor.fixed_precision_tensor_ancestor
-   syft.core.tensor.functions
-   syft.core.tensor.manager
-   syft.core.tensor.passthrough
-   syft.core.tensor.scalar_tensor
    syft.core.tensor.smpc
-   syft.core.tensor.tensor
-   syft.core.tensor.types
-   syft.core.tensor.util
 
+Submodules
+----------
+
+syft.core.tensor.ancestors module
+---------------------------------
+
+.. automodule:: syft.core.tensor.ancestors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.broadcastable module
+-------------------------------------
+
+.. automodule:: syft.core.tensor.broadcastable
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.config module
+------------------------------
+
+.. automodule:: syft.core.tensor.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.fixed\_precision\_tensor module
+------------------------------------------------
+
+.. automodule:: syft.core.tensor.fixed_precision_tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.fixed\_precision\_tensor\_ancestor module
+----------------------------------------------------------
+
+.. automodule:: syft.core.tensor.fixed_precision_tensor_ancestor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.functions module
+---------------------------------
+
+.. automodule:: syft.core.tensor.functions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.lazy\_repeat\_array module
+-------------------------------------------
+
+.. automodule:: syft.core.tensor.lazy_repeat_array
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.manager module
+-------------------------------
+
+.. automodule:: syft.core.tensor.manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.passthrough module
+-----------------------------------
+
+.. automodule:: syft.core.tensor.passthrough
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.tensor module
+------------------------------
+
+.. automodule:: syft.core.tensor.tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.tensor.util module
+----------------------------
+
+.. automodule:: syft.core.tensor.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.tensor.smpc.rst
+++ b/docs/source/api_reference/syft.core.tensor.smpc.rst
@@ -1,34 +1,50 @@
-syft.core.tensor.smpc
-=====================
+syft.core.tensor.smpc package
+=============================
 
 .. automodule:: syft.core.tensor.smpc
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.tensor.smpc.context module
+------------------------------------
 
-   
-   
-   
+.. automodule:: syft.core.tensor.smpc.context
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+syft.core.tensor.smpc.mpc\_tensor module
+----------------------------------------
 
+.. automodule:: syft.core.tensor.smpc.mpc_tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.tensor.smpc.mpc\_tensor\_ancestor module
+--------------------------------------------------
 
-.. rubric:: Modules
+.. automodule:: syft.core.tensor.smpc.mpc_tensor_ancestor
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autosummary::
-   :toctree:
-   :recursive:
+syft.core.tensor.smpc.share\_tensor module
+------------------------------------------
 
-   syft.core.tensor.smpc.mpc_tensor
-   syft.core.tensor.smpc.mpc_tensor_ancestor
-   syft.core.tensor.smpc.share_tensor
-   syft.core.tensor.smpc.utils
+.. automodule:: syft.core.tensor.smpc.share_tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
+syft.core.tensor.smpc.utils module
+----------------------------------
+
+.. automodule:: syft.core.tensor.smpc.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.test.rst
+++ b/docs/source/api_reference/syft.core.test.rst
@@ -1,31 +1,18 @@
-syft.core.test
-==============
+syft.core.test package
+======================
 
 .. automodule:: syft.core.test
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   
-   
-   
+Submodules
+----------
 
-   
-   
-   
+syft.core.test.module\_test module
+----------------------------------
 
-   
-   
-   
-
-   
-   
-   
-
-
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.test.module_test
-
+.. automodule:: syft.core.test.module_test
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.grid.client.client.rst
+++ b/docs/source/api_reference/syft.grid.client.client.rst
@@ -15,11 +15,16 @@ syft.grid.client.client
    
       connect
       login
-      register
    
    
 
    
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GridClient
    
    
 

--- a/docs/source/api_reference/syft.grid.client.enums.rst
+++ b/docs/source/api_reference/syft.grid.client.enums.rst
@@ -1,0 +1,32 @@
+syft.grid.client.enums
+======================
+
+.. automodule:: syft.grid.client.enums
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AssociationRequestResponses
+      PyGridClientEnums
+      RequestAPIFields
+      ResponseObjectEnum
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.exceptions.rst
+++ b/docs/source/api_reference/syft.grid.client.exceptions.rst
@@ -1,0 +1,30 @@
+syft.grid.client.exceptions
+===========================
+
+.. automodule:: syft.grid.client.exceptions
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      PyGridClientException
+      RequestAPIException
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.grid_connection.rst
+++ b/docs/source/api_reference/syft.grid.client.grid_connection.rst
@@ -18,7 +18,6 @@ syft.grid.client.grid\_connection
    .. autosummary::
    
       GridHTTPConnection
-      TimeoutHTTPAdapter
    
    
 

--- a/docs/source/api_reference/syft.grid.client.request_api.association_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.association_api.rst
@@ -1,0 +1,29 @@
+syft.grid.client.request\_api.association\_api
+==============================================
+
+.. automodule:: syft.grid.client.request_api.association_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AssociationRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.request_api.dataset_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.dataset_api.rst
@@ -1,0 +1,30 @@
+syft.grid.client.request\_api.dataset\_api
+==========================================
+
+.. automodule:: syft.grid.client.request_api.dataset_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Dataset
+      DatasetRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.request_api.group_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.group_api.rst
@@ -1,0 +1,29 @@
+syft.grid.client.request\_api.group\_api
+========================================
+
+.. automodule:: syft.grid.client.request_api.group_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GroupRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.request_api.request_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.request_api.rst
@@ -1,0 +1,29 @@
+syft.grid.client.request\_api.request\_api
+==========================================
+
+.. automodule:: syft.grid.client.request_api.request_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GridRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.request_api.role_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.role_api.rst
@@ -1,0 +1,29 @@
+syft.grid.client.request\_api.role\_api
+=======================================
+
+.. automodule:: syft.grid.client.request_api.role_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      RoleRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.request_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.rst
@@ -1,0 +1,37 @@
+syft.grid.client.request\_api
+=============================
+
+.. automodule:: syft.grid.client.request_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.grid.client.request_api.association_api
+   syft.grid.client.request_api.dataset_api
+   syft.grid.client.request_api.group_api
+   syft.grid.client.request_api.request_api
+   syft.grid.client.request_api.role_api
+   syft.grid.client.request_api.user_api
+   syft.grid.client.request_api.worker_api
+

--- a/docs/source/api_reference/syft.grid.client.request_api.user_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.user_api.rst
@@ -1,0 +1,29 @@
+syft.grid.client.request\_api.user\_api
+=======================================
+
+.. automodule:: syft.grid.client.request_api.user_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      UserRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.request_api.worker_api.rst
+++ b/docs/source/api_reference/syft.grid.client.request_api.worker_api.rst
@@ -1,0 +1,29 @@
+syft.grid.client.request\_api.worker\_api
+=========================================
+
+.. automodule:: syft.grid.client.request_api.worker_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      WorkerRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.client.rst
+++ b/docs/source/api_reference/syft.grid.client.rst
@@ -28,6 +28,8 @@ syft.grid.client
    :recursive:
 
    syft.grid.client.client
+   syft.grid.client.enums
+   syft.grid.client.exceptions
    syft.grid.client.grid_connection
-   syft.grid.client.proxy_client
+   syft.grid.client.request_api
 

--- a/docs/source/api_reference/syft.grid.connections.rst
+++ b/docs/source/api_reference/syft.grid.connections.rst
@@ -28,4 +28,5 @@ syft.grid.connections
    :recursive:
 
    syft.grid.connections.http_connection
+   syft.grid.connections.webrtc
 

--- a/docs/source/api_reference/syft.grid.connections.webrtc.rst
+++ b/docs/source/api_reference/syft.grid.connections.webrtc.rst
@@ -1,0 +1,30 @@
+syft.grid.connections.webrtc
+============================
+
+.. automodule:: syft.grid.connections.webrtc
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      OrderedChunk
+      WebRTCConnection
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.duet.bcolors.rst
+++ b/docs/source/api_reference/syft.grid.duet.bcolors.rst
@@ -1,0 +1,35 @@
+syft.grid.duet.bcolors
+======================
+
+.. currentmodule:: syft.grid.duet
+
+.. autoclass:: bcolors
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~bcolors.__init__
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~bcolors.BOLD
+      ~bcolors.ENDC
+      ~bcolors.FAIL
+      ~bcolors.HEADER
+      ~bcolors.OKBLUE
+      ~bcolors.OKGREEN
+      ~bcolors.UNDERLINE
+      ~bcolors.WARNING
+   
+   

--- a/docs/source/api_reference/syft.grid.duet.exchange_ids.rst
+++ b/docs/source/api_reference/syft.grid.duet.exchange_ids.rst
@@ -1,0 +1,37 @@
+syft.grid.duet.exchange\_ids
+============================
+
+.. automodule:: syft.grid.duet.exchange_ids
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      get_loopback_path
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DuetCredentialExchanger
+      OpenGridTokenFileExchanger
+      OpenGridTokenManualInputExchanger
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.duet.om_signaling_client.rst
+++ b/docs/source/api_reference/syft.grid.duet.om_signaling_client.rst
@@ -1,0 +1,29 @@
+syft.grid.duet.om\_signaling\_client
+====================================
+
+.. automodule:: syft.grid.duet.om_signaling_client
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      register
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.duet.rst
+++ b/docs/source/api_reference/syft.grid.duet.rst
@@ -1,0 +1,47 @@
+syft.grid.duet
+==============
+
+.. automodule:: syft.grid.duet
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      begin_duet_logger
+      duet
+      generate_donation_msg
+      get_available_network
+      join_duet
+      launch_duet
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.grid.duet.bcolors
+   syft.grid.duet.exchange_ids
+   syft.grid.duet.om_signaling_client
+   syft.grid.duet.signaling_client
+   syft.grid.duet.ui
+   syft.grid.duet.webrtc_duet
+

--- a/docs/source/api_reference/syft.grid.duet.signaling_client.rst
+++ b/docs/source/api_reference/syft.grid.duet.signaling_client.rst
@@ -1,0 +1,29 @@
+syft.grid.duet.signaling\_client
+================================
+
+.. automodule:: syft.grid.duet.signaling_client
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      SignalingClient
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.duet.ui.rst
+++ b/docs/source/api_reference/syft.grid.duet.ui.rst
@@ -1,0 +1,23 @@
+syft.grid.duet.ui
+=================
+
+.. automodule:: syft.grid.duet.ui
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.duet.webrtc_duet.rst
+++ b/docs/source/api_reference/syft.grid.duet.webrtc_duet.rst
@@ -1,0 +1,29 @@
+syft.grid.duet.webrtc\_duet
+===========================
+
+.. automodule:: syft.grid.duet.webrtc_duet
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Duet
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.association_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.association_messages.rst
@@ -1,0 +1,40 @@
+syft.grid.messages.association\_messages
+========================================
+
+.. automodule:: syft.grid.messages.association_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DeleteAssociationRequestMessage
+      DeleteAssociationRequestResponse
+      GetAssociationRequestMessage
+      GetAssociationRequestResponse
+      GetAssociationRequestsMessage
+      GetAssociationRequestsResponse
+      ReceiveAssociationRequestMessage
+      ReceiveAssociationRequestResponse
+      RespondAssociationRequestMessage
+      RespondAssociationRequestResponse
+      SendAssociationRequestMessage
+      SendAssociationRequestResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.dataset_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.dataset_messages.rst
@@ -1,0 +1,42 @@
+syft.grid.messages.dataset\_messages
+====================================
+
+.. automodule:: syft.grid.messages.dataset_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateDatasetMessage
+      CreateDatasetResponse
+      DeleteDatasetMessage
+      DeleteDatasetResponse
+      GetDatasetInfoMessage
+      GetDatasetInfoResponse
+      GetDatasetMessage
+      GetDatasetResponse
+      GetDatasetsInfoMessage
+      GetDatasetsInfoResponse
+      GetDatasetsMessage
+      GetDatasetsResponse
+      UpdateDatasetMessage
+      UpdateDatasetResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.group_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.group_messages.rst
@@ -1,0 +1,38 @@
+syft.grid.messages.group\_messages
+==================================
+
+.. automodule:: syft.grid.messages.group_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateGroupMessage
+      CreateGroupResponse
+      DeleteGroupMessage
+      DeleteGroupResponse
+      GetGroupMessage
+      GetGroupResponse
+      GetGroupsMessage
+      GetGroupsResponse
+      UpdateGroupMessage
+      UpdateGroupResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.infra_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.infra_messages.rst
@@ -1,0 +1,40 @@
+syft.grid.messages.infra\_messages
+==================================
+
+.. automodule:: syft.grid.messages.infra_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateWorkerMessage
+      CreateWorkerResponse
+      DeleteWorkerMessage
+      DeleteWorkerResponse
+      GetWorkerInstanceTypesMessage
+      GetWorkerInstanceTypesResponse
+      GetWorkerMessage
+      GetWorkerResponse
+      GetWorkersMessage
+      GetWorkersResponse
+      UpdateWorkerMessage
+      UpdateWorkerResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.network_search_message.rst
+++ b/docs/source/api_reference/syft.grid.messages.network_search_message.rst
@@ -1,0 +1,30 @@
+syft.grid.messages.network\_search\_message
+===========================================
+
+.. automodule:: syft.grid.messages.network_search_message
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NetworkSearchMessage
+      NetworkSearchResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.request_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.request_messages.rst
@@ -1,0 +1,38 @@
+syft.grid.messages.request\_messages
+====================================
+
+.. automodule:: syft.grid.messages.request_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateRequestMessage
+      CreateRequestResponse
+      DeleteRequestMessage
+      DeleteRequestResponse
+      GetRequestMessage
+      GetRequestResponse
+      GetRequestsMessage
+      GetRequestsResponse
+      UpdateRequestMessage
+      UpdateRequestResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.role_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.role_messages.rst
@@ -1,0 +1,38 @@
+syft.grid.messages.role\_messages
+=================================
+
+.. automodule:: syft.grid.messages.role_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateRoleMessage
+      CreateRoleResponse
+      DeleteRoleMessage
+      DeleteRoleResponse
+      GetRoleMessage
+      GetRoleResponse
+      GetRolesMessage
+      GetRolesResponse
+      UpdateRoleMessage
+      UpdateRoleResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.rst
@@ -1,0 +1,41 @@
+syft.grid.messages
+==================
+
+.. automodule:: syft.grid.messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.grid.messages.association_messages
+   syft.grid.messages.dataset_messages
+   syft.grid.messages.group_messages
+   syft.grid.messages.infra_messages
+   syft.grid.messages.network_search_message
+   syft.grid.messages.request_messages
+   syft.grid.messages.role_messages
+   syft.grid.messages.setup_messages
+   syft.grid.messages.tensor_messages
+   syft.grid.messages.transfer_messages
+   syft.grid.messages.user_messages
+

--- a/docs/source/api_reference/syft.grid.messages.setup_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.setup_messages.rst
@@ -1,0 +1,34 @@
+syft.grid.messages.setup\_messages
+==================================
+
+.. automodule:: syft.grid.messages.setup_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateInitialSetUpMessage
+      CreateInitialSetUpResponse
+      GetSetUpMessage
+      GetSetUpResponse
+      UpdateSetupMessage
+      UpdateSetupResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.tensor_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.tensor_messages.rst
@@ -1,0 +1,38 @@
+syft.grid.messages.tensor\_messages
+===================================
+
+.. automodule:: syft.grid.messages.tensor_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateTensorMessage
+      CreateTensorResponse
+      DeleteTensorMessage
+      DeleteTensorResponse
+      GetTensorMessage
+      GetTensorResponse
+      GetTensorsMessage
+      GetTensorsResponse
+      UpdateTensorMessage
+      UpdateTensorResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.transfer_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.transfer_messages.rst
@@ -1,0 +1,32 @@
+syft.grid.messages.transfer\_messages
+=====================================
+
+.. automodule:: syft.grid.messages.transfer_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      LoadObjectMessage
+      LoadObjectResponse
+      SaveObjectMessage
+      SaveObjectResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.messages.user_messages.rst
+++ b/docs/source/api_reference/syft.grid.messages.user_messages.rst
@@ -1,0 +1,40 @@
+syft.grid.messages.user\_messages
+=================================
+
+.. automodule:: syft.grid.messages.user_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateUserMessage
+      CreateUserResponse
+      DeleteUserMessage
+      DeleteUserResponse
+      GetUserMessage
+      GetUserResponse
+      GetUsersMessage
+      GetUsersResponse
+      SearchUsersMessage
+      SearchUsersResponse
+      UpdateUserMessage
+      UpdateUserResponse
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.grid.rst
+++ b/docs/source/api_reference/syft.grid.rst
@@ -29,5 +29,7 @@
 
    syft.grid.client
    syft.grid.connections
-   syft.grid.grid_url
+   syft.grid.duet
+   syft.grid.messages
+   syft.grid.services
 

--- a/docs/source/api_reference/syft.grid.services.rst
+++ b/docs/source/api_reference/syft.grid.services.rst
@@ -1,0 +1,31 @@
+syft.grid.services
+==================
+
+.. automodule:: syft.grid.services
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.grid.services.signaling_service
+

--- a/docs/source/api_reference/syft.grid.services.signaling_service.rst
+++ b/docs/source/api_reference/syft.grid.services.signaling_service.rst
@@ -1,0 +1,40 @@
+syft.grid.services.signaling\_service
+=====================================
+
+.. automodule:: syft.grid.services.signaling_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AnswerPullRequestMessage
+      CloseConnectionMessage
+      InvalidLoopBackRequest
+      OfferPullRequestMessage
+      PeerSuccessfullyRegistered
+      PullSignalingService
+      PushSignalingService
+      RegisterDuetPeerService
+      RegisterNewPeerMessage
+      SignalingAnswerMessage
+      SignalingOfferMessage
+      SignalingRequestsNotFound
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.lib.misc.rst
+++ b/docs/source/api_reference/syft.lib.misc.rst
@@ -1,0 +1,18 @@
+syft.lib.misc package
+=====================
+
+.. automodule:: syft.lib.misc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.lib.misc.union module
+--------------------------
+
+.. automodule:: syft.lib.misc.union
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.lib.numpy.rst
+++ b/docs/source/api_reference/syft.lib.numpy.rst
@@ -1,0 +1,18 @@
+syft.lib.numpy package
+======================
+
+.. automodule:: syft.lib.numpy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.lib.numpy.array module
+---------------------------
+
+.. automodule:: syft.lib.numpy.array
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.lib.python.collections.rst
+++ b/docs/source/api_reference/syft.lib.python.collections.rst
@@ -1,0 +1,26 @@
+syft.lib.python.collections package
+===================================
+
+.. automodule:: syft.lib.python.collections
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.lib.python.collections.collections module
+----------------------------------------------
+
+.. automodule:: syft.lib.python.collections.collections
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.collections.ordered\_dict module
+------------------------------------------------
+
+.. automodule:: syft.lib.python.collections.ordered_dict
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.lib.python.rst
+++ b/docs/source/api_reference/syft.lib.python.rst
@@ -1,0 +1,170 @@
+syft.lib.python package
+=======================
+
+.. automodule:: syft.lib.python
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 2
+
+   syft.lib.python.collections
+
+Submodules
+----------
+
+syft.lib.python.bool module
+---------------------------
+
+.. automodule:: syft.lib.python.bool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.bytes module
+----------------------------
+
+.. automodule:: syft.lib.python.bytes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.complex module
+------------------------------
+
+.. automodule:: syft.lib.python.complex
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.dict module
+---------------------------
+
+.. automodule:: syft.lib.python.dict
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.float module
+----------------------------
+
+.. automodule:: syft.lib.python.float
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.int module
+--------------------------
+
+.. automodule:: syft.lib.python.int
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.iterator module
+-------------------------------
+
+.. automodule:: syft.lib.python.iterator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.list module
+---------------------------
+
+.. automodule:: syft.lib.python.list
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.none module
+---------------------------
+
+.. automodule:: syft.lib.python.none
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.primitive\_container module
+-------------------------------------------
+
+.. automodule:: syft.lib.python.primitive_container
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.primitive\_factory module
+-----------------------------------------
+
+.. automodule:: syft.lib.python.primitive_factory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.primitive\_interface module
+-------------------------------------------
+
+.. automodule:: syft.lib.python.primitive_interface
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.range module
+----------------------------
+
+.. automodule:: syft.lib.python.range
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.set module
+--------------------------
+
+.. automodule:: syft.lib.python.set
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.slice module
+----------------------------
+
+.. automodule:: syft.lib.python.slice
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.string module
+-----------------------------
+
+.. automodule:: syft.lib.python.string
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.tuple module
+----------------------------
+
+.. automodule:: syft.lib.python.tuple
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.types module
+----------------------------
+
+.. automodule:: syft.lib.python.types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.python.util module
+---------------------------
+
+.. automodule:: syft.lib.python.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.lib.rst
+++ b/docs/source/api_reference/syft.lib.rst
@@ -1,0 +1,29 @@
+syft.lib package
+================
+
+.. automodule:: syft.lib
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 2
+
+   syft.lib.misc
+   syft.lib.numpy
+   syft.lib.python
+   syft.lib.torch
+
+Submodules
+----------
+
+syft.lib.util module
+--------------------
+
+.. automodule:: syft.lib.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.lib.torch.rst
+++ b/docs/source/api_reference/syft.lib.torch.rst
@@ -1,0 +1,66 @@
+syft.lib.torch package
+======================
+
+.. automodule:: syft.lib.torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.lib.torch.allowlist module
+-------------------------------
+
+.. automodule:: syft.lib.torch.allowlist
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.torch.device module
+----------------------------
+
+.. automodule:: syft.lib.torch.device
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.torch.parameter module
+-------------------------------
+
+.. automodule:: syft.lib.torch.parameter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.torch.return\_types module
+-----------------------------------
+
+.. automodule:: syft.lib.torch.return_types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.torch.size module
+--------------------------
+
+.. automodule:: syft.lib.torch.size
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.torch.tensor\_util module
+----------------------------------
+
+.. automodule:: syft.lib.torch.tensor_util
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.lib.torch.uppercase\_tensor module
+---------------------------------------
+
+.. automodule:: syft.lib.torch.uppercase_tensor
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.rst
+++ b/docs/source/api_reference/syft.rst
@@ -1,0 +1,70 @@
+syft package
+============
+
+.. automodule:: syft
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 2
+
+   syft.ast
+   syft.capnp
+   syft.core
+   syft.grid
+   syft.lib
+
+Submodules
+----------
+
+syft.experimental\_flags module
+-------------------------------
+
+.. automodule:: syft.experimental_flags
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.filterwarnings module
+--------------------------
+
+.. automodule:: syft.filterwarnings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.jax\_settings module
+-------------------------
+
+.. automodule:: syft.jax_settings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.logger module
+------------------
+
+.. automodule:: syft.logger
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.registry module
+--------------------
+
+.. automodule:: syft.registry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.util module
+----------------
+
+.. automodule:: syft.util
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
## Description
This PR should fix the current issue where we weren't able to compile and deploy the currently written docstrings, convert them to RST files, and then use sphinx to generate HTML for the same, and then deploy them via our CI.

The PR has 3 atomic commits:
- 867a949: Add missing dependency for the deployment of the docs
- e1109fe: Regenerate the API docs and update the existing ones
- f3433e6: Documented the local setup guide for beginners to start with easily without any hassle
- c8a80a5: Adds a new empty line at the end of `requirements.txt` to satisfy linting (which I forgot :(( )

## Affected Dependencies
This has added 2 dependencies to our docs/requirements.txt:
- syft
- markupsafe==2.0.1

Markupsafe is needed for syft's installation hence technically, we are not affecting or adding any dependencies per se.

## How has this been tested?
- Cleaned the existing pysyft repo locally.
- Cloned the pysyft repo again
- Ran `tox -e syft.docs`
- Now go visit the Pysyft/docs/build/html and now navigate to any page and get the docs for the same.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
