### PR TITLE
fix: install jupyer lab over notebook

### DIFF
--- a/docs/source/install_tutorials/linux.rst
+++ b/docs/source/install_tutorials/linux.rst
@@ -95,7 +95,7 @@ A very convenient way to interact with a deployed node is via Python, using a Ju
 
 .. code-block:: bash
 
-  pip install jupyter-notebook
+  pip install jupyterlab
 
 If you encounter issues, you can also install it using Conda:
 


### PR DESCRIPTION
## Description
As per the feedback received by @IrinaMBejan,
Download `jupyter lab` instead of `jupyter-notebook` in Linux as well and maintain consistency across all platforms

## Affected Dependencies
None

## How has this been tested?
Verified the further commands after doing lab install instead of notebook.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
