### PR TITLE
Fix min_val and max_val inconsistency

### DIFF
--- a/packages/syft/src/syft/core/tensor/autodp/gamma_tensor.py
+++ b/packages/syft/src/syft/core/tensor/autodp/gamma_tensor.py
@@ -1044,8 +1044,8 @@ class TensorWrappedGammaTensorPointer(Pointer, PassthroughTensor):
             child=GammaTensor(
                 child=FixedPrecisionTensor(value=None),
                 data_subjects=self.data_subjects,
-                min_val=self.min_vals,  # type: ignore
-                max_val=self.max_vals,  # type: ignore
+                min_vals=self.min_vals,  # type: ignore
+                max_vals=self.max_vals,  # type: ignore
             ),
             public_shape=public_shape,
             public_dtype=public_dtype,


### PR DESCRIPTION
## Description
We found a bug that prevented SMPC addition, it arose because of a typo in the TensorWrappedGammaTensor code (`min_val` instead of `min_vals`.

We should add tests that check the TensorPointers are working correctly.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
