### PR TITLE
Fix Github File Filter filepaths

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -65,9 +65,9 @@ frontend:
   - "**.mako"
   - "**.lock"
   - "**.json"
-  - packages/grid/backend/**/*.eslintrc
-  - packages/grid/backend/**/*.js
-  - packages/grid/backend/**/*.json
-  - packages/grid/backend/**/*.lock
-  - packages/grid/backend/**/*.ts
-  - packages/grid/backend/**/*.tsx
+  - packages/grid/frontend/**/*.eslintrc
+  - packages/grid/frontend/**/*.js
+  - packages/grid/frontend/**/*.json
+  - packages/grid/frontend/**/*.lock
+  - packages/grid/frontend/**/*.ts
+  - packages/grid/frontend/**/*.tsx


### PR DESCRIPTION
## Description
- Swapping "frontend" for "backend" for frontend file filters

## Affected Dependencies
- None

## How has this been tested?
- N/A

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
