### PR TITLE
[W.I.P.] Add more granular Publish tests

### DIFF
--- a/packages/syft/src/syft/core/adp/vectorized_publish.py
+++ b/packages/syft/src/syft/core/adp/vectorized_publish.py
@@ -117,14 +117,14 @@ def publish(
         sigma=sigma,
     )
 
-    # its important that its the same type so that eq comparisons below dont break
+    # its important that it's the same type so that eq comparisons below don't break
     zeros_like = tensor.zeros_like()
 
     # this prevents us from running in an infinite loop
     previous_budget = None
     previous_spend = None
 
-    # if we dont return below we will terminate if the tensor gets replaced with zeros
+    # if we don't return below we will terminate if the tensor gets replaced with zeros
     prev_tensor = None
     while not (tensor.child == zeros_like).all():  # tensor.shape != ():
 

--- a/packages/syft/tests/syft/core/tensor/adp/publish_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/publish_test.py
@@ -26,6 +26,21 @@ def test_phi_inputs() -> None:
     pass
 
 
+def test_imaginary_bounds_for_mechanism() -> None:
+    """Test that the system fails with grace when l2_norm is imaginary for some reason"""
+    pass
+
+
+def test_sigma_too_large() -> None:
+    """Test that sigma being too large results in low PB spend"""
+    pass
+
+
+def test_sigma_too_small() -> None:
+    """Test that sigma being too small results in high PB spend"""
+    pass
+
+
 def test_ledger_creating() -> None:
     """Test that a new Data Subject Ledger was initialized properly"""
     pass
@@ -74,4 +89,32 @@ def test_cache_gigantic_expansion() -> None:
 
 def test_cache_index_negative() -> None:
     """Test the cache throws an Exception of some kind when the indices are negative."""
+    pass
+
+
+def test_cache_correct_mapping() -> None:
+    """Test that the cache maps RDP_constants to the proper indices."""
+    pass
+
+
+def test_cache_rounding_small_numbers() -> None:
+    """Test the error in epsilon spend when rdp_constant is a float, and has to be
+    turned into an integer for the index."""
+    pass
+
+
+def test_cache_rounding_large_numbers() -> None:
+    """Test the error in epsilon spend when rdp_constant is a float, and has to be
+    turned into an integer for the index."""
+    pass
+
+
+def test_correct_epsilon_spends() -> None:
+    """Test that for a given value, the epsilon is as expected."""
+    pass
+
+
+def test_multiple_publish_single_value() -> None:
+    """Test that when publish filters values, and we're only publishing a single value,
+    calling .all() doesn't result in system failure"""
     pass

--- a/packages/syft/tests/syft/core/tensor/adp/publish_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/publish_test.py
@@ -1,0 +1,77 @@
+# # stdlib
+# from typing import Any
+#
+# # third party
+# import numpy as np
+# from numpy.typing import ArrayLike
+# import pytest
+#
+# # syft absolute
+# import syft as sy
+# from syft.core.adp.data_subject_ledger import DataSubjectLedger
+# from syft.core.adp.data_subject_list import DataSubjectArray
+# from syft.core.adp.ledger_store import DictLedgerStore
+# from syft.core.tensor.autodp.gamma_tensor import GammaTensor
+# from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
+# from syft.core.tensor.lazy_repeat_array import lazyrepeatarray as lra
+
+
+def test_gamma_inputs() -> None:
+    """Test that exceptions are thrown for incorrect inputs when calling GT.publish()"""
+    pass
+
+
+def test_phi_inputs() -> None:
+    """Test that exceptions are thrown for incorrect inputs when calling PT.publish()"""
+    pass
+
+
+def test_ledger_creating() -> None:
+    """Test that a new Data Subject Ledger was initialized properly"""
+    pass
+
+
+def test_ledger_fetching() -> None:
+    """Test that an old Data Subject Ledger was fetched properly"""
+    pass
+
+
+def test_publish_high_values() -> None:
+    """Test that publish works when the Tensor has gigantic values"""
+    pass
+
+
+def test_publish_single_value() -> None:
+    """Test that publish works when the Tensor only has 1 value in it"""
+    pass
+
+
+def test_rdp_constants_gigantic() -> None:
+    """Test that rdp_constants work if they're gigantic."""
+    pass
+
+
+def test_rdp_constants_negative() -> None:
+    """Test that the system doesn't break if RDP_constants are negative"""
+    pass
+
+
+def test_cache_index_conversion() -> None:
+    """Test that the function to convert RDP_constants to Cache Indices doesn't generate invalid outputs."""
+    pass
+
+
+def test_cache_expansion() -> None:
+    """Test the cache operates reasonably when the index provided is greater than its size."""
+    pass
+
+
+def test_cache_gigantic_expansion() -> None:
+    """If the cache needs to become a gigantic size, compute its values in a 1-off way."""
+    # Note: Also test that PB for Data Subjects is accurate recomputed.
+    pass
+
+
+def test_cache_index_negative() -> None:
+    """Test the cache throws an Exception of some kind when the indices are negative."""
+    pass


### PR DESCRIPTION
## Description
At the moment we only test the output of our DP system- i.e. the output of calling `.publish()` on a DP tensor. This results in  the `publish` method being a black box where things may break and go undetected. Examples of this include `jnp.take` changing behaviour and not raising Out of Bounds/IndexErrors, or privacy budgets not spending properly.

This PR with @curt-mitch aims to test the internals of the publish method, and ensure that it fails gracefully and with some trace of the associated error. This will hopefully give us more confidence about the reliability of the DP system and the publish method.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
