### PR TITLE
Downgrading protobuf for Apple Silicon

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -39,7 +39,7 @@ syft =
     matplotlib==3.5.2 # https://github.com/matplotlib/matplotlib/issues/23604
     packaging==21.3
     pandas>=1.3.5 # python 3.7 google colab
-    protobuf==3.19.5
+    protobuf==3.19.4
     pyarrow==7.0.0
     pycapnp==1.2.1
     pydantic[email]==1.9.0


### PR DESCRIPTION
## Description
Higher versions of protobuf 3.19.x seem to fail on Apple Silicon.