### PR TITLE
Generate API docs as per latest commits

### DIFF
--- a/docs/source/api_reference/syft.core.adp.abstract_ledger_store.rst
+++ b/docs/source/api_reference/syft.core.adp.abstract_ledger_store.rst
@@ -1,0 +1,30 @@
+syft.core.adp.abstract\_ledger\_store
+=====================================
+
+.. automodule:: syft.core.adp.abstract_ledger_store
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AbstractDataSubjectLedger
+      AbstractLedgerStore
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.adp.data_subject.rst
+++ b/docs/source/api_reference/syft.core.adp.data_subject.rst
@@ -1,0 +1,30 @@
+syft.core.adp.data\_subject
+===========================
+
+.. automodule:: syft.core.adp.data_subject
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DataSubject
+      DataSubjectGroup
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.adp.data_subject_ledger.rst
+++ b/docs/source/api_reference/syft.core.adp.data_subject_ledger.rst
@@ -1,0 +1,43 @@
+syft.core.adp.data\_subject\_ledger
+===================================
+
+.. automodule:: syft.core.adp.data_subject_ledger
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      compute_rdp_constant
+      convert_constants_to_indices
+      convert_dsa_to_index_array
+      first_try_branch
+      get_budgets_and_mask
+      get_cache_path
+      get_unique_data_subjects
+      load_cache
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DataSubjectLedger
+      RDPParams
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.adp.data_subject_list.rst
+++ b/docs/source/api_reference/syft.core.adp.data_subject_list.rst
@@ -1,0 +1,39 @@
+syft.core.adp.data\_subject\_list
+=================================
+
+.. automodule:: syft.core.adp.data_subject_list
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      dslarraytonumpyutf8
+      liststrtonumpyutf8
+      numpyutf8todslarray
+      numpyutf8tolist
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DataSubjectArray
+      DataSubjectList
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.adp.ledger_store.rst
+++ b/docs/source/api_reference/syft.core.adp.ledger_store.rst
@@ -1,0 +1,30 @@
+syft.core.adp.ledger\_store
+===========================
+
+.. automodule:: syft.core.adp.ledger_store
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DictLedgerStore
+      RedisLedgerStore
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.adp.rst
+++ b/docs/source/api_reference/syft.core.adp.rst
@@ -1,58 +1,36 @@
-syft.core.adp package
-=====================
+syft.core.adp
+=============
 
 .. automodule:: syft.core.adp
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.adp.abstract\_ledger\_store module
---------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.adp.abstract_ledger_store
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.adp.data\_subject module
-----------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.adp.data_subject
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.adp.data\_subject\_ledger module
-------------------------------------------
 
-.. automodule:: syft.core.adp.data_subject_ledger
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
 
-syft.core.adp.data\_subject\_list module
-----------------------------------------
+.. autosummary::
+   :toctree:
+   :recursive:
 
-.. automodule:: syft.core.adp.data_subject_list
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   syft.core.adp.abstract_ledger_store
+   syft.core.adp.data_subject
+   syft.core.adp.data_subject_ledger
+   syft.core.adp.data_subject_list
+   syft.core.adp.ledger_store
+   syft.core.adp.vectorized_publish
 
-syft.core.adp.ledger\_store module
-----------------------------------
-
-.. automodule:: syft.core.adp.ledger_store
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.adp.vectorized\_publish module
-----------------------------------------
-
-.. automodule:: syft.core.adp.vectorized_publish
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_reference/syft.core.adp.vectorized_publish.rst
+++ b/docs/source/api_reference/syft.core.adp.vectorized_publish.rst
@@ -1,0 +1,30 @@
+syft.core.adp.vectorized\_publish
+=================================
+
+.. automodule:: syft.core.adp.vectorized_publish
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      calculate_bounds_for_mechanism
+      vectorized_publish
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.common.decorators.rst
+++ b/docs/source/api_reference/syft.core.common.decorators.rst
@@ -1,0 +1,29 @@
+syft.core.common.decorators
+===========================
+
+.. automodule:: syft.core.common.decorators
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      singleton
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.common.rst
+++ b/docs/source/api_reference/syft.core.common.rst
@@ -27,8 +27,8 @@ syft.core.common
    :toctree:
    :recursive:
 
+   syft.core.common.decorators
    syft.core.common.environment
-   syft.core.common.event_loop
    syft.core.common.group
    syft.core.common.message
    syft.core.common.object

--- a/docs/source/api_reference/syft.core.common.serde.capnp.rst
+++ b/docs/source/api_reference/syft.core.common.serde.capnp.rst
@@ -1,0 +1,32 @@
+syft.core.common.serde.capnp
+============================
+
+.. automodule:: syft.core.common.serde.capnp
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      chunk_bytes
+      combine_bytes
+      get_capnp_schema
+      serde_magic_header
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.common.serde.deserialize.rst
+++ b/docs/source/api_reference/syft.core.common.serde.deserialize.rst
@@ -9,6 +9,12 @@ syft.core.common.serde.deserialize
 
    
    
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      deserialize_capnp
+   
    
 
    
@@ -16,6 +22,12 @@ syft.core.common.serde.deserialize
    
 
    
+   
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      CapnpMagicBytesNotFound
    
    
 

--- a/docs/source/api_reference/syft.core.common.serde.rst
+++ b/docs/source/api_reference/syft.core.common.serde.rst
@@ -27,7 +27,10 @@ syft.core.common.serde
    :toctree:
    :recursive:
 
+   syft.core.common.serde.capnp
    syft.core.common.serde.deserialize
+   syft.core.common.serde.recursive
    syft.core.common.serde.serializable
    syft.core.common.serde.serialize
+   syft.core.common.serde.types
 

--- a/docs/source/api_reference/syft.core.common.serde.serializable.rst
+++ b/docs/source/api_reference/syft.core.common.serde.serializable.rst
@@ -13,17 +13,13 @@ syft.core.common.serde.serializable
 
    .. autosummary::
    
-      bind_protobuf
+      GenerateProtobufWrapper
+      GenerateWrapper
+      serializable
    
    
 
    
-   
-   .. rubric:: Classes
-
-   .. autosummary::
-   
-      Serializable
    
    
 

--- a/docs/source/api_reference/syft.core.common.serde.serialize.rst
+++ b/docs/source/api_reference/syft.core.common.serde.serialize.rst
@@ -9,6 +9,12 @@ syft.core.common.serde.serialize
 
    
    
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      create_protobuf_magic_header
+   
    
 
    

--- a/docs/source/api_reference/syft.core.common.serde.types.rst
+++ b/docs/source/api_reference/syft.core.common.serde.types.rst
@@ -1,0 +1,23 @@
+syft.core.common.serde.types
+============================
+
+.. automodule:: syft.core.common.serde.types
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.abstract.rst
+++ b/docs/source/api_reference/syft.core.node.abstract.rst
@@ -28,4 +28,5 @@ syft.core.node.abstract
    :recursive:
 
    syft.core.node.abstract.node
+   syft.core.node.abstract.node_service_interface
 

--- a/docs/source/api_reference/syft.core.node.abstract_node_msg_registry.rst
+++ b/docs/source/api_reference/syft.core.node.abstract_node_msg_registry.rst
@@ -1,0 +1,29 @@
+syft.core.node.abstract\_node\_msg\_registry
+============================================
+
+.. automodule:: syft.core.node.abstract_node_msg_registry
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AbstractNodeMessageRegistry
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.action.beaver_primitive_action.rst
+++ b/docs/source/api_reference/syft.core.node.common.action.beaver_primitive_action.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.action.beaver\_primitive\_action
+======================================================
+
+.. automodule:: syft.core.node.common.action.beaver_primitive_action
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      BeaverPrimitiveAction
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.action.greenlets_switch.rst
+++ b/docs/source/api_reference/syft.core.node.common.action.greenlets_switch.rst
@@ -14,6 +14,7 @@ syft.core.node.common.action.greenlets\_switch
    .. autosummary::
    
       beaver_retrieve_object
+      crypto_store_retrieve_object
       retrieve_object
    
    

--- a/docs/source/api_reference/syft.core.node.common.action.przs_action.rst
+++ b/docs/source/api_reference/syft.core.node.common.action.przs_action.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.action.przs\_action
+=========================================
+
+.. automodule:: syft.core.node.common.action.przs_action
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      PRZSAction
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.action.rst
+++ b/docs/source/api_reference/syft.core.node.common.action.rst
@@ -27,6 +27,9 @@ syft.core.node.common.action
    :toctree:
    :recursive:
 
+   syft.core.node.common.action.action_sequence
+   syft.core.node.common.action.beaver_action
+   syft.core.node.common.action.beaver_primitive_action
    syft.core.node.common.action.common
    syft.core.node.common.action.exception_action
    syft.core.node.common.action.function_or_constructor_action
@@ -36,6 +39,12 @@ syft.core.node.common.action
    syft.core.node.common.action.get_object_action
    syft.core.node.common.action.get_or_set_property_action
    syft.core.node.common.action.get_or_set_static_attribute_action
+   syft.core.node.common.action.greenlets_switch
+   syft.core.node.common.action.przs_action
    syft.core.node.common.action.run_class_method_action
+   syft.core.node.common.action.run_class_method_smpc_action
    syft.core.node.common.action.save_object_action
+   syft.core.node.common.action.smpc_action_functions
+   syft.core.node.common.action.smpc_action_message
+   syft.core.node.common.action.smpc_action_seq_batch_message
 

--- a/docs/source/api_reference/syft.core.node.common.action.smpc_action_functions.rst
+++ b/docs/source/api_reference/syft.core.node.common.action.smpc_action_functions.rst
@@ -13,12 +13,12 @@ syft.core.node.common.action.smpc\_action\_functions
 
    .. autosummary::
    
-      bit_decomposition
-      get_action_generator_from_op
+      divide_mask
+      divide_wrap_correction
       get_id_at_location_from_op
       local_decomposition
-      smpc_basic_op
-      smpc_mul
+      private_mul
+      public_divide
       spdz_mask
       spdz_multiply
    

--- a/docs/source/api_reference/syft.core.node.common.client_manager.domain_api.rst
+++ b/docs/source/api_reference/syft.core.node.common.client_manager.domain_api.rst
@@ -9,6 +9,12 @@ syft.core.node.common.client\_manager.domain\_api
 
    
    
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      check_domain_status
+   
    
 
    

--- a/docs/source/api_reference/syft.core.node.common.client_manager.new_request_api.rst
+++ b/docs/source/api_reference/syft.core.node.common.client_manager.new_request_api.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.client\_manager.new\_request\_api
+=======================================================
+
+.. automodule:: syft.core.node.common.client_manager.new_request_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NewRequestAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.client_manager.node_networking_api.rst
+++ b/docs/source/api_reference/syft.core.node.common.client_manager.node_networking_api.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.client\_manager.node\_networking\_api
+===========================================================
+
+.. automodule:: syft.core.node.common.client_manager.node_networking_api
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NodeNetworkingAPI
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.client_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.client_manager.rst
@@ -1,66 +1,39 @@
-syft.core.node.common.client\_manager package
-=============================================
+syft.core.node.common.client\_manager
+=====================================
 
 .. automodule:: syft.core.node.common.client_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.client\_manager.association\_api module
--------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.client_manager.association_api
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.client\_manager.dataset\_api module
----------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.client_manager.dataset_api
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.node.common.client\_manager.domain\_api module
---------------------------------------------------------
 
-.. automodule:: syft.core.node.common.client_manager.domain_api
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
 
-syft.core.node.common.client\_manager.request\_api module
----------------------------------------------------------
+.. autosummary::
+   :toctree:
+   :recursive:
 
-.. automodule:: syft.core.node.common.client_manager.request_api
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   syft.core.node.common.client_manager.association_api
+   syft.core.node.common.client_manager.dataset_api
+   syft.core.node.common.client_manager.domain_api
+   syft.core.node.common.client_manager.new_request_api
+   syft.core.node.common.client_manager.node_networking_api
+   syft.core.node.common.client_manager.request_api
+   syft.core.node.common.client_manager.role_api
+   syft.core.node.common.client_manager.user_api
+   syft.core.node.common.client_manager.vpn_api
 
-syft.core.node.common.client\_manager.role\_api module
-------------------------------------------------------
-
-.. automodule:: syft.core.node.common.client_manager.role_api
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.client\_manager.user\_api module
-------------------------------------------------------
-
-.. automodule:: syft.core.node.common.client_manager.user_api
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.client\_manager.vpn\_api module
------------------------------------------------------
-
-.. automodule:: syft.core.node.common.client_manager.vpn_api
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.exceptions.rst
+++ b/docs/source/api_reference/syft.core.node.common.exceptions.rst
@@ -25,18 +25,23 @@ syft.core.node.common.exceptions
       AssociationError
       AssociationRequestError
       AuthorizationError
+      BadPayloadException
       CycleNotFoundError
+      DatasetDownloadError
       DatasetNotFoundError
+      DatasetUploadError
       EnvironmentNotFoundError
       FLProcessConflict
       GroupNotFoundError
       InvalidCredentialsError
+      InvalidNodeCredentials
       InvalidParameterValueError
       InvalidRequestKeyError
       MaxCycleLimitExceededError
       MissingRequestKeyError
       ModelNotFoundError
       OwnerAlreadyExistsError
+      PermissionsNotDefined
       PlanInvalidError
       PlanNotFoundError
       PlanTranslationError

--- a/docs/source/api_reference/syft.core.node.common.node_manager.constants.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_manager.constants.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.node\_manager.constants
+=============================================
+
+.. automodule:: syft.core.node.common.node_manager.constants
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      UserApplicationStatus
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_manager.dict_store.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_manager.dict_store.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.node\_manager.dict\_store
+===============================================
+
+.. automodule:: syft.core.node.common.node_manager.dict_store
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DictStore
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_manager.redis_store.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_manager.redis_store.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.node\_manager.redis\_store
+================================================
+
+.. automodule:: syft.core.node.common.node_manager.redis_store
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      RedisStore
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_manager.rst
@@ -1,114 +1,43 @@
-syft.core.node.common.node\_manager package
-===========================================
+syft.core.node.common.node\_manager
+===================================
 
 .. automodule:: syft.core.node.common.node_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_manager.association\_request\_manager module
-------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_manager.association_request_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_manager.constants module
-----------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_manager.constants
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.node.common.node\_manager.database\_manager module
-------------------------------------------------------------
 
-.. automodule:: syft.core.node.common.node_manager.database_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
 
-syft.core.node.common.node\_manager.dataset\_manager module
------------------------------------------------------------
+.. autosummary::
+   :toctree:
+   :recursive:
 
-.. automodule:: syft.core.node.common.node_manager.dataset_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   syft.core.node.common.node_manager.association_request_manager
+   syft.core.node.common.node_manager.constants
+   syft.core.node.common.node_manager.database_manager
+   syft.core.node.common.node_manager.dataset_manager
+   syft.core.node.common.node_manager.dict_store
+   syft.core.node.common.node_manager.environment_manager
+   syft.core.node.common.node_manager.node_manager
+   syft.core.node.common.node_manager.node_route_manager
+   syft.core.node.common.node_manager.redis_store
+   syft.core.node.common.node_manager.request_manager
+   syft.core.node.common.node_manager.role_manager
+   syft.core.node.common.node_manager.setup_manager
+   syft.core.node.common.node_manager.user_manager
 
-syft.core.node.common.node\_manager.dict\_store module
-------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.dict_store
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.environment\_manager module
----------------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.environment_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.node\_manager module
---------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.node_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.node\_route\_manager module
----------------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.node_route_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.redis\_store module
--------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.redis_store
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.request\_manager module
------------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.request_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.role\_manager module
---------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.role_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.setup\_manager module
----------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.setup_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_manager.user\_manager module
---------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_manager.user_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_manager.user_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_manager.user_manager.rst
@@ -17,17 +17,19 @@ syft.core.node.common.node\_manager.user\_manager
 
    .. autosummary::
    
-      User
-      UserBase
-      UserCreate
-      UserInDB
-      UserInDBBase
       UserManager
-      UserUpdate
    
    
 
    
+   
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      NegativeBudgetException
+      NotEnoughBudgetException
+      RefreshBudgetException
    
    
 

--- a/docs/source/api_reference/syft.core.node.common.node_service.accept_or_deny_request.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.accept_or_deny_request.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.accept\_or\_deny\_request package
-=====================================================================
+syft.core.node.common.node\_service.accept\_or\_deny\_request
+=============================================================
 
 .. automodule:: syft.core.node.common.node_service.accept_or_deny_request
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.accept\_or\_deny\_request.accept\_or\_deny\_request\_messages module
---------------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.accept\_or\_deny\_request.accept\_or\_deny\_request\_service module
--------------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_messages
+   syft.core.node.common.node_service.accept_or_deny_request.accept_or_deny_request_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.association_request.association_request_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.association_request.association_request_service.rst
@@ -31,6 +31,7 @@ syft.core.node.common.node\_service.association\_request.association\_request\_s
    .. autosummary::
    
       AssociationRequestService
+      AssociationRequestWithoutReplyService
    
    
 

--- a/docs/source/api_reference/syft.core.node.common.node_service.association_request.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.association_request.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.association\_request package
-================================================================
+syft.core.node.common.node\_service.association\_request
+========================================================
 
 .. automodule:: syft.core.node.common.node_service.association_request
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.association\_request.association\_request\_messages module
-----------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.association_request.association_request_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.association\_request.association\_request\_service module
----------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.association_request.association_request_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.association_request.association_request_messages
+   syft.core.node.common.node_service.association_request.association_request_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.child_node_lifecycle.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.child_node_lifecycle.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.child\_node\_lifecycle package
-==================================================================
+syft.core.node.common.node\_service.child\_node\_lifecycle
+==========================================================
 
 .. automodule:: syft.core.node.common.node_service.child_node_lifecycle
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.child\_node\_lifecycle.child\_node\_lifecycle\_messages module
---------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.child\_node\_lifecycle.child\_node\_lifecycle\_service module
--------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_messages
+   syft.core.node.common.node_service.child_node_lifecycle.child_node_lifecycle_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.dataset_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.dataset_manager.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.dataset\_manager package
-============================================================
+syft.core.node.common.node\_service.dataset\_manager
+====================================================
 
 .. automodule:: syft.core.node.common.node_service.dataset_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.dataset\_manager.dataset\_manager\_messages module
---------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.dataset_manager.dataset_manager_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.dataset\_manager.dataset\_manager\_service module
--------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.dataset_manager.dataset_manager_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.dataset_manager.dataset_manager_messages
+   syft.core.node.common.node_service.dataset_manager.dataset_manager_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.generic_payload.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.generic_payload.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.generic\_payload package
-============================================================
+syft.core.node.common.node\_service.generic\_payload
+====================================================
 
 .. automodule:: syft.core.node.common.node_service.generic_payload
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.generic\_payload.messages module
---------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.generic_payload.messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.generic\_payload.syft\_message module
--------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.generic_payload.syft_message
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.generic_payload.messages
+   syft.core.node.common.node_service.generic_payload.syft_message
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.generic_payload.syft_message.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.generic_payload.syft_message.rst
@@ -1,0 +1,32 @@
+syft.core.node.common.node\_service.generic\_payload.syft\_message
+==================================================================
+
+.. automodule:: syft.core.node.common.node_service.generic_payload.syft_message
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NewSyftMessage
+      Payload
+      ReplyPayload
+      RequestPayload
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.get_remaining_budget.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.get_remaining_budget.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.get\_remaining\_budget package
-==================================================================
+syft.core.node.common.node\_service.get\_remaining\_budget
+==========================================================
 
 .. automodule:: syft.core.node.common.node_service.get_remaining_budget
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.get\_remaining\_budget.get\_remaining\_budget\_messages module
---------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.get\_remaining\_budget.get\_remaining\_budget\_service module
--------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_messages
+   syft.core.node.common.node_service.get_remaining_budget.get_remaining_budget_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.get_repr.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.get_repr.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.get\_repr package
-=====================================================
+syft.core.node.common.node\_service.get\_repr
+=============================================
 
 .. automodule:: syft.core.node.common.node_service.get_repr
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.get\_repr.get\_repr\_messages module
-------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.get_repr.get_repr_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.get\_repr.get\_repr\_service module
------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.get_repr.get_repr_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.get_repr.get_repr_messages
+   syft.core.node.common.node_service.get_repr.get_repr_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.heritage_update.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.heritage_update.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.heritage\_update package
-============================================================
+syft.core.node.common.node\_service.heritage\_update
+====================================================
 
 .. automodule:: syft.core.node.common.node_service.heritage_update
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.heritage\_update.heritage\_update\_messages module
---------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.heritage_update.heritage_update_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.heritage\_update.heritage\_update\_service module
--------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.heritage_update.heritage_update_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.heritage_update.heritage_update_messages
+   syft.core.node.common.node_service.heritage_update.heritage_update_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.msg_forwarding.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.msg_forwarding.rst
@@ -1,18 +1,31 @@
-syft.core.node.common.node\_service.msg\_forwarding package
-===========================================================
+syft.core.node.common.node\_service.msg\_forwarding
+===================================================
 
 .. automodule:: syft.core.node.common.node_service.msg_forwarding
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.msg\_forwarding.msg\_forwarding\_service module
------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.msg_forwarding.msg_forwarding_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.msg_forwarding.msg_forwarding_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.network_search.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.network_search.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.network\_search package
-===========================================================
+syft.core.node.common.node\_service.network\_search
+===================================================
 
 .. automodule:: syft.core.node.common.node_service.network_search
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.network\_search.network\_search\_messages module
-------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.network_search.network_search_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.network\_search.network\_search\_service module
------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.network_search.network_search_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.network_search.network_search_messages
+   syft.core.node.common.node_service.network_search.network_search_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_credential.node_credential_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_credential.node_credential_messages.rst
@@ -1,0 +1,30 @@
+syft.core.node.common.node\_service.node\_credential.node\_credential\_messages
+===============================================================================
+
+.. automodule:: syft.core.node.common.node_service.node_credential.node_credential_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ExchangeCredentialsWithNodeMessage
+      InitiateExchangeCredentialsWithNodeMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_credential.node_credentials.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_credential.node_credentials.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.node\_service.node\_credential.node\_credentials
+======================================================================
+
+.. automodule:: syft.core.node.common.node_service.node_credential.node_credentials
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NodeCredentials
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_credential.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_credential.rst
@@ -1,0 +1,32 @@
+syft.core.node.common.node\_service.node\_credential
+====================================================
+
+.. automodule:: syft.core.node.common.node_service.node_credential
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.node_credential.node_credential_messages
+   syft.core.node.common.node_service.node_credential.node_credentials
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_route.node_route_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_route.node_route_messages.rst
@@ -1,0 +1,32 @@
+syft.core.node.common.node\_service.node\_route.node\_route\_messages
+=====================================================================
+
+.. automodule:: syft.core.node.common.node_service.node_route.node_route_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      InitiateRouteUpdateToNodeMessage
+      NotifyNodeWithRouteUpdateMessage
+      RoutesListMessage
+      VerifyRouteUpdateMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_route.route_update.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_route.route_update.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.node\_service.node\_route.route\_update
+=============================================================
+
+.. automodule:: syft.core.node.common.node_service.node_route.route_update
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      RouteUpdate
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_route.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_route.rst
@@ -1,0 +1,32 @@
+syft.core.node.common.node\_service.node\_route
+===============================================
+
+.. automodule:: syft.core.node.common.node_service.node_route
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.node_route.node_route_messages
+   syft.core.node.common.node_service.node_route.route_update
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.node_setup.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.node_setup.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.node\_setup package
-=======================================================
+syft.core.node.common.node\_service.node\_setup
+===============================================
 
 .. automodule:: syft.core.node.common.node_service.node_setup
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.node\_setup.node\_setup\_messages module
-----------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.node_setup.node_setup_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.node\_setup.node\_setup\_service module
----------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.node_setup.node_setup_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.node_setup.node_setup_messages
+   syft.core.node.common.node_service.node_setup.node_setup_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_action.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_action.rst
@@ -1,18 +1,31 @@
-syft.core.node.common.node\_service.object\_action package
-==========================================================
+syft.core.node.common.node\_service.object\_action
+==================================================
 
 .. automodule:: syft.core.node.common.node_service.object_action
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_action.obj\_action\_service module
-------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_action.obj_action_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.object_action.obj_action_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_delete.object_delete_message.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_delete.object_delete_message.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.node\_service.object\_delete.object\_delete\_message
+==========================================================================
+
+.. automodule:: syft.core.node.common.node_service.object_delete.object_delete_message
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ObjectDeleteMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_delete.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_delete.rst
@@ -1,18 +1,31 @@
-syft.core.node.common.node\_service.object\_delete package
-==========================================================
+syft.core.node.common.node\_service.object\_delete
+==================================================
 
 .. automodule:: syft.core.node.common.node_service.object_delete
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_delete.object\_delete\_message module
----------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_delete.object_delete_message
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.object_delete.object_delete_message
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_request.object_request_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_request.object_request_messages.rst
@@ -22,6 +22,8 @@ syft.core.node.common.node\_service.object\_request.object\_request\_messages
       CreateRequestResponse
       DeleteRequestMessage
       DeleteRequestResponse
+      GetAllRequestsMessage
+      GetAllRequestsResponseMessage
       GetBudgetRequestsMessage
       GetBudgetRequestsResponse
       GetRequestMessage

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_request.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_request.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.object\_request package
-===========================================================
+syft.core.node.common.node\_service.object\_request
+===================================================
 
 .. automodule:: syft.core.node.common.node_service.object_request
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_request.object\_request\_messages module
-------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_request.object_request_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_request.object\_request\_service module
------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_request.object_request_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.object_request.object_request_messages
+   syft.core.node.common.node_service.object_request.object_request_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_search.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_search.rst
@@ -1,18 +1,31 @@
-syft.core.node.common.node\_service.object\_search package
-==========================================================
+syft.core.node.common.node\_service.object\_search
+==================================================
 
 .. automodule:: syft.core.node.common.node_service.object_search
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_search.obj\_search\_service module
-------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_search.obj_search_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.object_search.obj_search_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_search_permission_update.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_search_permission_update.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.object\_search\_permission\_update package
-==============================================================================
+syft.core.node.common.node\_service.object\_search\_permission\_update
+======================================================================
 
 .. automodule:: syft.core.node.common.node_service.object_search_permission_update
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_search\_permission\_update.obj\_search\_permission\_messages module
----------------------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_search\_permission\_update.obj\_search\_permission\_service module
---------------------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_messages
+   syft.core.node.common.node_service.object_search_permission_update.obj_search_permission_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.object_transfer.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.object_transfer.rst
@@ -1,18 +1,31 @@
-syft.core.node.common.node\_service.object\_transfer package
-============================================================
+syft.core.node.common.node\_service.object\_transfer
+====================================================
 
 .. automodule:: syft.core.node.common.node_service.object_transfer
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.object\_transfer.object\_transfer\_messages module
---------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.object_transfer.object_transfer_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.object_transfer.object_transfer_messages
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.peer_discovery.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.peer_discovery.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.peer\_discovery package
-===========================================================
+syft.core.node.common.node\_service.peer\_discovery
+===================================================
 
 .. automodule:: syft.core.node.common.node_service.peer_discovery
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.peer\_discovery.peer\_discovery\_messages module
-------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.peer_discovery.peer_discovery_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.peer\_discovery.peer\_discovery\_service module
------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.peer_discovery.peer_discovery_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.peer_discovery.peer_discovery_messages
+   syft.core.node.common.node_service.peer_discovery.peer_discovery_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.ping.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.ping.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.ping package
-================================================
+syft.core.node.common.node\_service.ping
+========================================
 
 .. automodule:: syft.core.node.common.node_service.ping
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.ping.ping\_messages module
---------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.ping.ping_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.ping.ping\_service module
--------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.ping.ping_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.ping.ping_messages
+   syft.core.node.common.node_service.ping.ping_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.request_answer.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.request_answer.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.request\_answer package
-===========================================================
+syft.core.node.common.node\_service.request\_answer
+===================================================
 
 .. automodule:: syft.core.node.common.node_service.request_answer
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.request\_answer.request\_answer\_messages module
-------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.request_answer.request_answer_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.request\_answer.request\_answer\_service module
------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.request_answer.request_answer_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.request_answer.request_answer_messages
+   syft.core.node.common.node_service.request_answer.request_answer_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.request_handler.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.request_handler.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.request\_handler package
-============================================================
+syft.core.node.common.node\_service.request\_handler
+====================================================
 
 .. automodule:: syft.core.node.common.node_service.request_handler
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.request\_handler.request\_handler\_messages module
---------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.request_handler.request_handler_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.request\_handler.request\_handler\_service module
--------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.request_handler.request_handler_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.request_handler.request_handler_messages
+   syft.core.node.common.node_service.request_handler.request_handler_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.request_receiver.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.request_receiver.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.request\_receiver package
-=============================================================
+syft.core.node.common.node\_service.request\_receiver
+=====================================================
 
 .. automodule:: syft.core.node.common.node_service.request_receiver
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.request\_receiver.request\_receiver\_messages module
-----------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.request_receiver.request_receiver_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.request\_receiver.request\_receiver\_service module
----------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.request_receiver.request_receiver_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.request_receiver.request_receiver_messages
+   syft.core.node.common.node_service.request_receiver.request_receiver_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_messages.rst
@@ -17,6 +17,7 @@ syft.core.node.common.node\_service.resolve\_pointer\_type.resolve\_pointer\_typ
 
    .. autosummary::
    
+      ResolvePointerTypeAnswerMessage
       ResolvePointerTypeMessage
    
    

--- a/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_service.rst
@@ -17,7 +17,6 @@ syft.core.node.common.node\_service.resolve\_pointer\_type.resolve\_pointer\_typ
 
    .. autosummary::
    
-      ResolvePointerTypeAnswerMessage
       ResolvePointerTypeService
    
    

--- a/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.resolve_pointer_type.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.resolve\_pointer\_type package
-==================================================================
+syft.core.node.common.node\_service.resolve\_pointer\_type
+==========================================================
 
 .. automodule:: syft.core.node.common.node_service.resolve_pointer_type
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.resolve\_pointer\_type.resolve\_pointer\_type\_messages module
---------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.resolve\_pointer\_type.resolve\_pointer\_type\_service module
--------------------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_messages
+   syft.core.node.common.node_service.resolve_pointer_type.resolve_pointer_type_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.role_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.role_manager.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.role\_manager package
-=========================================================
+syft.core.node.common.node\_service.role\_manager
+=================================================
 
 .. automodule:: syft.core.node.common.node_service.role_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.role\_manager.role\_manager\_messages module
---------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.role_manager.role_manager_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.role\_manager.role\_manager\_service module
--------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.role_manager.role_manager_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.role_manager.role_manager_messages
+   syft.core.node.common.node_service.role_manager.role_manager_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.rst
@@ -1,19 +1,35 @@
-syft.core.node.common.node\_service package
-===========================================
+syft.core.node.common.node\_service
+===================================
 
 .. automodule:: syft.core.node.common.node_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Subpackages
------------
+   
+   
+   
 
-.. toctree::
-   :maxdepth: 2
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
 
    syft.core.node.common.node_service.accept_or_deny_request
    syft.core.node.common.node_service.association_request
+   syft.core.node.common.node_service.auth
    syft.core.node.common.node_service.child_node_lifecycle
    syft.core.node.common.node_service.dataset_manager
    syft.core.node.common.node_service.generic_payload
@@ -22,6 +38,9 @@ Subpackages
    syft.core.node.common.node_service.heritage_update
    syft.core.node.common.node_service.msg_forwarding
    syft.core.node.common.node_service.network_search
+   syft.core.node.common.node_service.node_credential
+   syft.core.node.common.node_service.node_route
+   syft.core.node.common.node_service.node_service
    syft.core.node.common.node_service.node_setup
    syft.core.node.common.node_service.object_action
    syft.core.node.common.node_service.object_delete
@@ -38,6 +57,7 @@ Subpackages
    syft.core.node.common.node_service.role_manager
    syft.core.node.common.node_service.simple
    syft.core.node.common.node_service.sleep
+   syft.core.node.common.node_service.success_resp_message
    syft.core.node.common.node_service.tensor_manager
    syft.core.node.common.node_service.testing_services
    syft.core.node.common.node_service.upload_service
@@ -46,29 +66,3 @@ Subpackages
    syft.core.node.common.node_service.vm_request_service
    syft.core.node.common.node_service.vpn
 
-Submodules
-----------
-
-syft.core.node.common.node\_service.auth module
------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_service.auth
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_service.node\_service module
---------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_service.node_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_service.success\_resp\_message module
------------------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_service.success_resp_message
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.simple.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.simple.rst
@@ -1,34 +1,33 @@
-syft.core.node.common.node\_service.simple package
-==================================================
+syft.core.node.common.node\_service.simple
+==========================================
 
 .. automodule:: syft.core.node.common.node_service.simple
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.simple.obj\_exists module
--------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.simple.obj_exists
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.simple.simple\_messages module
-------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.simple.simple_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.node.common.node\_service.simple.simple\_service module
------------------------------------------------------------------
 
-.. automodule:: syft.core.node.common.node_service.simple.simple_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.simple.obj_exists
+   syft.core.node.common.node_service.simple.simple_messages
+   syft.core.node.common.node_service.simple.simple_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.sleep.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.sleep.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.sleep package
-=================================================
+syft.core.node.common.node\_service.sleep
+=========================================
 
 .. automodule:: syft.core.node.common.node_service.sleep
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.sleep.sleep\_messages module
-----------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.sleep.sleep_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.sleep.sleep\_service module
----------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.sleep.sleep_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.sleep.sleep_messages
+   syft.core.node.common.node_service.sleep.sleep_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.sleep.sleep_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.sleep.sleep_messages.rst
@@ -1,0 +1,31 @@
+syft.core.node.common.node\_service.sleep.sleep\_messages
+=========================================================
+
+.. automodule:: syft.core.node.common.node_service.sleep.sleep_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      SleepMessage
+      SleepMessageWithReply
+      SleepReplyMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.sleep.sleep_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.sleep.sleep_service.rst
@@ -1,0 +1,29 @@
+syft.core.node.common.node\_service.sleep.sleep\_service
+========================================================
+
+.. automodule:: syft.core.node.common.node_service.sleep.sleep_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      SleepService
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.success_resp_message.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.success_resp_message.rst
@@ -17,6 +17,7 @@ syft.core.node.common.node\_service.success\_resp\_message
 
    .. autosummary::
    
+      ErrorResponseMessage
       SuccessResponseMessage
    
    

--- a/docs/source/api_reference/syft.core.node.common.node_service.tensor_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.tensor_manager.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.tensor\_manager package
-===========================================================
+syft.core.node.common.node\_service.tensor\_manager
+===================================================
 
 .. automodule:: syft.core.node.common.node_service.tensor_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.tensor\_manager.tensor\_manager\_messages module
-------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.tensor_manager.tensor_manager_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.tensor\_manager.tensor\_manager\_service module
------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.tensor_manager.tensor_manager_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.tensor_manager.tensor_manager_messages
+   syft.core.node.common.node_service.tensor_manager.tensor_manager_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.tensor_manager.tensor_manager_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.tensor_manager.tensor_manager_service.rst
@@ -9,25 +9,9 @@ syft.core.node.common.node\_service.tensor\_manager.tensor\_manager\_service
 
    
    
-   .. rubric:: Functions
-
-   .. autosummary::
-   
-      create_tensor_msg
-      del_tensor_msg
-      get_tensor_msg
-      get_tensors_msg
-      update_tensor_msg
-   
    
 
    
-   
-   .. rubric:: Classes
-
-   .. autosummary::
-   
-      TensorManagerService
    
    
 

--- a/docs/source/api_reference/syft.core.node.common.node_service.testing_services.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.testing_services.rst
@@ -1,18 +1,31 @@
-syft.core.node.common.node\_service.testing\_services package
-=============================================================
+syft.core.node.common.node\_service.testing\_services
+=====================================================
 
 .. automodule:: syft.core.node.common.node_service.testing_services
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.testing\_services.repr\_service module
---------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.testing_services.repr_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.testing_services.repr_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.tff.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.tff.rst
@@ -1,0 +1,34 @@
+syft.core.node.common.node\_service.tff package
+===============================================
+
+.. automodule:: syft.core.node.common.node_service.tff
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+syft.core.node.common.node\_service.tff.tff\_messages module
+------------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.tff.tff_messages
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_service.tff.tff\_service module
+-----------------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.tff.tff_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+syft.core.node.common.node\_service.tff.utils module
+----------------------------------------------------
+
+.. automodule:: syft.core.node.common.node_service.tff.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_service.upload_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.upload_service.rst
@@ -1,18 +1,31 @@
-syft.core.node.common.node\_service.upload\_service package
-===========================================================
+syft.core.node.common.node\_service.upload\_service
+===================================================
 
 .. automodule:: syft.core.node.common.node_service.upload_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.upload\_service.upload\_service\_messages module
-------------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.upload_service.upload_service_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.upload_service.upload_service_messages
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.upload_service.upload_service_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.upload_service.upload_service_messages.rst
@@ -1,0 +1,31 @@
+syft.core.node.common.node\_service.upload\_service.upload\_service\_messages
+=============================================================================
+
+.. automodule:: syft.core.node.common.node_service.upload_service.upload_service_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AbortDataUploadMessage
+      UploadDataCompleteMessage
+      UploadDataMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.user_auth.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.user_auth.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.user\_auth package
-======================================================
+syft.core.node.common.node\_service.user\_auth
+==============================================
 
 .. automodule:: syft.core.node.common.node_service.user_auth
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.user\_auth.user\_auth\_messages module
---------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.user_auth.user_auth_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.user\_auth.user\_auth\_service module
--------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.user_auth.user_auth_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.user_auth.user_auth_messages
+   syft.core.node.common.node_service.user_auth.user_auth_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.user_manager.new_user_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.user_manager.new_user_messages.rst
@@ -1,0 +1,33 @@
+syft.core.node.common.node\_service.user\_manager.new\_user\_messages
+=====================================================================
+
+.. automodule:: syft.core.node.common.node_service.user_manager.new_user_messages
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      CreateUserMessage
+      DeleteUserMessage
+      GetUserMessage
+      GetUsersMessage
+      UpdateUserMessage
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.user_manager.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.user_manager.rst
@@ -1,34 +1,33 @@
-syft.core.node.common.node\_service.user\_manager package
-=========================================================
+syft.core.node.common.node\_service.user\_manager
+=================================================
 
 .. automodule:: syft.core.node.common.node_service.user_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.user\_manager.new\_user\_messages module
-----------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.user_manager.new_user_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.user\_manager.user\_manager\_service module
--------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.user_manager.user_manager_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.node.common.node\_service.user\_manager.user\_messages module
------------------------------------------------------------------------
 
-.. automodule:: syft.core.node.common.node_service.user_manager.user_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.user_manager.new_user_messages
+   syft.core.node.common.node_service.user_manager.user_manager_service
+   syft.core.node.common.node_service.user_manager.user_messages
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.vm_request_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.vm_request_service.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.vm\_request\_service package
-================================================================
+syft.core.node.common.node\_service.vm\_request\_service
+========================================================
 
 .. automodule:: syft.core.node.common.node_service.vm_request_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.vm\_request\_service.vm\_service module
----------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.vm_request_service.vm_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.vm\_request\_service.vm\_service\_test module
----------------------------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.vm_request_service.vm_service_test
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.vm_request_service.vm_service
+   syft.core.node.common.node_service.vm_request_service.vm_service_test
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.vpn.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.vpn.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.node\_service.vpn package
-===============================================
+syft.core.node.common.node\_service.vpn
+=======================================
 
 .. automodule:: syft.core.node.common.node_service.vpn
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_service.vpn.vpn\_messages module
-------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.vpn.vpn_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_service.vpn.vpn\_service module
------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_service.vpn.vpn_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.node_service.vpn.vpn_messages
+   syft.core.node.common.node_service.vpn.vpn_service
+

--- a/docs/source/api_reference/syft.core.node.common.node_service.vpn.vpn_messages.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.vpn.vpn_messages.rst
@@ -15,6 +15,7 @@ syft.core.node.common.node\_service.vpn.vpn\_messages
    
       clean_status_output
       connect_with_key
+      disconnect
       extract_nested_json
       generate_key
       get_result
@@ -35,6 +36,9 @@ syft.core.node.common.node\_service.vpn.vpn\_messages
       VPNJoinMessage
       VPNJoinMessageWithReply
       VPNJoinReplyMessage
+      VPNJoinSelfMessage
+      VPNJoinSelfMessageWithReply
+      VPNJoinSelfReplyMessage
       VPNRegisterMessage
       VPNRegisterMessageWithReply
       VPNRegisterReplyMessage

--- a/docs/source/api_reference/syft.core.node.common.node_service.vpn.vpn_service.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_service.vpn.vpn_service.rst
@@ -18,6 +18,7 @@ syft.core.node.common.node\_service.vpn.vpn\_service
    .. autosummary::
    
       VPNConnectService
+      VPNJoinSelfService
       VPNJoinService
       VPNRegisterService
       VPNStatusService

--- a/docs/source/api_reference/syft.core.node.common.node_table.entity.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_table.entity.rst
@@ -17,7 +17,7 @@ syft.core.node.common.node\_table.entity
 
    .. autosummary::
    
-      DataSubject
+      Entity
    
    
 

--- a/docs/source/api_reference/syft.core.node.common.node_table.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_table.rst
@@ -1,162 +1,49 @@
-syft.core.node.common.node\_table package
-=========================================
+syft.core.node.common.node\_table
+=================================
 
 .. automodule:: syft.core.node.common.node_table
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.node\_table.association\_request module
--------------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_table.association_request
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.node\_table.bin\_obj\_dataset module
-----------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.node_table.bin_obj_dataset
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.node.common.node\_table.bin\_obj\_metadata module
------------------------------------------------------------
 
-.. automodule:: syft.core.node.common.node_table.bin_obj_metadata
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
 
-syft.core.node.common.node\_table.dataset module
-------------------------------------------------
+.. autosummary::
+   :toctree:
+   :recursive:
 
-.. automodule:: syft.core.node.common.node_table.dataset
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   syft.core.node.common.node_table.association_request
+   syft.core.node.common.node_table.bin_obj_dataset
+   syft.core.node.common.node_table.bin_obj_metadata
+   syft.core.node.common.node_table.dataset
+   syft.core.node.common.node_table.dataset_group
+   syft.core.node.common.node_table.entity
+   syft.core.node.common.node_table.environment
+   syft.core.node.common.node_table.json_obj
+   syft.core.node.common.node_table.ledger
+   syft.core.node.common.node_table.metadata
+   syft.core.node.common.node_table.node
+   syft.core.node.common.node_table.node_route
+   syft.core.node.common.node_table.pdf
+   syft.core.node.common.node_table.request
+   syft.core.node.common.node_table.roles
+   syft.core.node.common.node_table.setup
+   syft.core.node.common.node_table.user
+   syft.core.node.common.node_table.user_environment
+   syft.core.node.common.node_table.utils
 
-syft.core.node.common.node\_table.dataset\_group module
--------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.dataset_group
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.entity module
------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.entity
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.environment module
-----------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.environment
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.json\_obj module
---------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.json_obj
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.ledger module
------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.ledger
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.metadata module
--------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.metadata
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.node module
----------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.node
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.node\_route module
-----------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.node_route
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.pdf module
---------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.pdf
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.request module
-------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.request
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.roles module
-----------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.roles
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.setup module
-----------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.setup
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.user module
----------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.user
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.user\_environment module
-----------------------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.user_environment
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.node.common.node\_table.utils module
-----------------------------------------------
-
-.. automodule:: syft.core.node.common.node_table.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_reference/syft.core.node.common.node_table.setup.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_table.setup.rst
@@ -9,12 +9,6 @@ syft.core.node.common.node\_table.setup
 
    
    
-   .. rubric:: Functions
-
-   .. autosummary::
-   
-      create_setup
-   
    
 
    

--- a/docs/source/api_reference/syft.core.node.common.node_table.utils.rst
+++ b/docs/source/api_reference/syft.core.node.common.node_table.utils.rst
@@ -14,7 +14,6 @@ syft.core.node.common.node\_table.utils
    .. autosummary::
    
       create_memory_db_engine
-      expand_user_object
       model_to_json
       seed_db
    

--- a/docs/source/api_reference/syft.core.node.common.permissions.permissions.rst
+++ b/docs/source/api_reference/syft.core.node.common.permissions.permissions.rst
@@ -1,0 +1,35 @@
+syft.core.node.common.permissions.permissions
+=============================================
+
+.. automodule:: syft.core.node.common.permissions.permissions
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AND
+      BasePermission
+      BasePermissionMetaclass
+      BinaryOperation
+      NOT
+      OR
+      UnaryOperation
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.permissions.rst
+++ b/docs/source/api_reference/syft.core.node.common.permissions.rst
@@ -1,26 +1,32 @@
-syft.core.node.common.permissions package
-=========================================
+syft.core.node.common.permissions
+=================================
 
 .. automodule:: syft.core.node.common.permissions
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.node.common.permissions.permissions module
-----------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.permissions.permissions
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.node.common.permissions.user\_permissions module
-----------------------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.node.common.permissions.user_permissions
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.node.common.permissions.permissions
+   syft.core.node.common.permissions.user_permissions
+

--- a/docs/source/api_reference/syft.core.node.common.permissions.user_permissions.rst
+++ b/docs/source/api_reference/syft.core.node.common.permissions.user_permissions.rst
@@ -1,0 +1,36 @@
+syft.core.node.common.permissions.user\_permissions
+===================================================
+
+.. automodule:: syft.core.node.common.permissions.user_permissions
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      IsNodeDaaEnabled
+      NoRestriction
+      UserCanCreateUsers
+      UserCanEditRoles
+      UserCanTriageRequest
+      UserCanUploadData
+      UserHasWritePermissionToData
+      UserIsOwner
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.common.rst
+++ b/docs/source/api_reference/syft.core.node.common.rst
@@ -9,6 +9,12 @@ syft.core.node.common
 
    
    
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      create_client_ast
+   
    
 
    
@@ -29,8 +35,13 @@ syft.core.node.common
 
    syft.core.node.common.action
    syft.core.node.common.client
+   syft.core.node.common.client_manager
+   syft.core.node.common.exceptions
    syft.core.node.common.metadata
    syft.core.node.common.node
-   syft.core.node.common.service
+   syft.core.node.common.node_manager
+   syft.core.node.common.node_service
+   syft.core.node.common.node_table
+   syft.core.node.common.permissions
    syft.core.node.common.util
 

--- a/docs/source/api_reference/syft.core.node.common.util.rst
+++ b/docs/source/api_reference/syft.core.node.common.util.rst
@@ -13,7 +13,13 @@ syft.core.node.common.util
 
    .. autosummary::
    
+      abort_s3_object_upload
+      check_send_to_blob_storage
+      get_s3_client
       listify
+      read_chunks
+      upload_result_to_s3
+      upload_to_s3_using_presigned
    
    
 

--- a/docs/source/api_reference/syft.core.node.device.rst
+++ b/docs/source/api_reference/syft.core.node.device.rst
@@ -13,6 +13,12 @@ syft.core.node.device
 
    
    
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Device
+   
    
 
    
@@ -20,14 +26,4 @@ syft.core.node.device
    
 
 
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.device.client
-   syft.core.node.device.device
-   syft.core.node.device.device_type
 

--- a/docs/source/api_reference/syft.core.node.device_client.rst
+++ b/docs/source/api_reference/syft.core.node.device_client.rst
@@ -1,0 +1,29 @@
+syft.core.node.device\_client
+=============================
+
+.. automodule:: syft.core.node.device_client
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DeviceClient
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain.rst
+++ b/docs/source/api_reference/syft.core.node.domain.rst
@@ -13,6 +13,12 @@ syft.core.node.domain
 
    
    
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Domain
+   
    
 
    
@@ -20,14 +26,4 @@ syft.core.node.domain
    
 
 
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.domain.client
-   syft.core.node.domain.domain
-   syft.core.node.domain.service
 

--- a/docs/source/api_reference/syft.core.node.domain_client.rst
+++ b/docs/source/api_reference/syft.core.node.domain_client.rst
@@ -1,0 +1,31 @@
+syft.core.node.domain\_client
+=============================
+
+.. automodule:: syft.core.node.domain_client
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DomainClient
+      RequestHandlerQueueClient
+      RequestQueueClient
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain_interface.rst
+++ b/docs/source/api_reference/syft.core.node.domain_interface.rst
@@ -1,0 +1,29 @@
+syft.core.node.domain\_interface
+================================
+
+.. automodule:: syft.core.node.domain_interface
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DomainInterface
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain_msg_registry.rst
+++ b/docs/source/api_reference/syft.core.node.domain_msg_registry.rst
@@ -1,0 +1,29 @@
+syft.core.node.domain\_msg\_registry
+====================================
+
+.. automodule:: syft.core.node.domain_msg_registry
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DomainMessageRegistry
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.domain_service.rst
+++ b/docs/source/api_reference/syft.core.node.domain_service.rst
@@ -1,0 +1,29 @@
+syft.core.node.domain\_service
+==============================
+
+.. automodule:: syft.core.node.domain_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      DomainServiceClass
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.enums.rst
+++ b/docs/source/api_reference/syft.core.node.enums.rst
@@ -1,0 +1,32 @@
+syft.core.node.enums
+====================
+
+.. automodule:: syft.core.node.enums
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AssociationRequestResponses
+      PyGridClientEnums
+      RequestAPIFields
+      ResponseObjectEnum
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.exceptions.rst
+++ b/docs/source/api_reference/syft.core.node.exceptions.rst
@@ -1,0 +1,30 @@
+syft.core.node.exceptions
+=========================
+
+.. automodule:: syft.core.node.exceptions
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Exceptions
+
+   .. autosummary::
+   
+      PyGridClientException
+      RequestAPIException
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.network.rst
+++ b/docs/source/api_reference/syft.core.node.network.rst
@@ -13,6 +13,12 @@ syft.core.node.network
 
    
    
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Network
+   
    
 
    
@@ -20,13 +26,4 @@ syft.core.node.network
    
 
 
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.network.client
-   syft.core.node.network.network
 

--- a/docs/source/api_reference/syft.core.node.network_client.rst
+++ b/docs/source/api_reference/syft.core.node.network_client.rst
@@ -1,0 +1,29 @@
+syft.core.node.network\_client
+==============================
+
+.. automodule:: syft.core.node.network_client
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NetworkClient
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.network_msg_registry.rst
+++ b/docs/source/api_reference/syft.core.node.network_msg_registry.rst
@@ -1,0 +1,29 @@
+syft.core.node.network\_msg\_registry
+=====================================
+
+.. automodule:: syft.core.node.network_msg_registry
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NetworkMessageRegistry
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.network_service.rst
+++ b/docs/source/api_reference/syft.core.node.network_service.rst
@@ -1,0 +1,29 @@
+syft.core.node.network\_service
+===============================
+
+.. automodule:: syft.core.node.network_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NetworkServiceClass
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.node_service.rst
+++ b/docs/source/api_reference/syft.core.node.node_service.rst
@@ -1,0 +1,29 @@
+syft.core.node.node\_service
+============================
+
+.. automodule:: syft.core.node.node_service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      NodeServiceClass
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.registry.rst
+++ b/docs/source/api_reference/syft.core.node.registry.rst
@@ -1,0 +1,29 @@
+syft.core.node.registry
+=======================
+
+.. automodule:: syft.core.node.registry
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      VMMessageRegistry
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.rst
+++ b/docs/source/api_reference/syft.core.node.rst
@@ -28,10 +28,24 @@ syft.core.node
    :recursive:
 
    syft.core.node.abstract
+   syft.core.node.abstract_node_msg_registry
    syft.core.node.common
    syft.core.node.device
+   syft.core.node.device_client
    syft.core.node.domain
+   syft.core.node.domain_client
+   syft.core.node.domain_interface
+   syft.core.node.domain_msg_registry
+   syft.core.node.domain_service
+   syft.core.node.enums
+   syft.core.node.exceptions
    syft.core.node.network
-   syft.core.node.pki
+   syft.core.node.network_client
+   syft.core.node.network_msg_registry
+   syft.core.node.network_service
+   syft.core.node.node_service
+   syft.core.node.registry
+   syft.core.node.service
    syft.core.node.vm
+   syft.core.node.vm_client
 

--- a/docs/source/api_reference/syft.core.node.service.rst
+++ b/docs/source/api_reference/syft.core.node.service.rst
@@ -1,0 +1,29 @@
+syft.core.node.service
+======================
+
+.. automodule:: syft.core.node.service
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      VMServiceClass
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.node.vm.rst
+++ b/docs/source/api_reference/syft.core.node.vm.rst
@@ -13,6 +13,12 @@ syft.core.node.vm
 
    
    
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      VirtualMachine
+   
    
 
    
@@ -20,14 +26,4 @@ syft.core.node.vm
    
 
 
-
-.. rubric:: Modules
-
-.. autosummary::
-   :toctree:
-   :recursive:
-
-   syft.core.node.vm.client
-   syft.core.node.vm.plan_vm
-   syft.core.node.vm.vm
 

--- a/docs/source/api_reference/syft.core.node.vm_client.rst
+++ b/docs/source/api_reference/syft.core.node.vm_client.rst
@@ -1,0 +1,29 @@
+syft.core.node.vm\_client
+=========================
+
+.. automodule:: syft.core.node.vm_client
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      VirtualMachineClient
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.rst
+++ b/docs/source/api_reference/syft.core.rst
@@ -27,11 +27,13 @@
    :toctree:
    :recursive:
 
+   syft.core.adp
    syft.core.common
    syft.core.io
    syft.core.node
-   syft.core.plan
    syft.core.pointer
-   syft.core.remote_dataloader
+   syft.core.smpc
    syft.core.store
+   syft.core.tensor
+   syft.core.test
 

--- a/docs/source/api_reference/syft.core.smpc.approximations.exp.rst
+++ b/docs/source/api_reference/syft.core.smpc.approximations.exp.rst
@@ -1,0 +1,6 @@
+syft.core.smpc.approximations.exp
+=================================
+
+.. currentmodule:: syft.core.smpc.approximations
+
+.. autofunction:: exp

--- a/docs/source/api_reference/syft.core.smpc.approximations.log.rst
+++ b/docs/source/api_reference/syft.core.smpc.approximations.log.rst
@@ -1,0 +1,6 @@
+syft.core.smpc.approximations.log
+=================================
+
+.. currentmodule:: syft.core.smpc.approximations
+
+.. autofunction:: log

--- a/docs/source/api_reference/syft.core.smpc.approximations.reciprocal.rst
+++ b/docs/source/api_reference/syft.core.smpc.approximations.reciprocal.rst
@@ -1,0 +1,6 @@
+syft.core.smpc.approximations.reciprocal
+========================================
+
+.. currentmodule:: syft.core.smpc.approximations
+
+.. autofunction:: reciprocal

--- a/docs/source/api_reference/syft.core.smpc.approximations.rst
+++ b/docs/source/api_reference/syft.core.smpc.approximations.rst
@@ -1,42 +1,34 @@
-syft.core.smpc.approximations package
-=====================================
+syft.core.smpc.approximations
+=============================
 
 .. automodule:: syft.core.smpc.approximations
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.smpc.approximations.exp module
-----------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.smpc.approximations.exp
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.smpc.approximations.log module
-----------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.smpc.approximations.log
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.smpc.approximations.reciprocal module
------------------------------------------------
 
-.. automodule:: syft.core.smpc.approximations.reciprocal
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
 
-syft.core.smpc.approximations.utils module
-------------------------------------------
+.. autosummary::
+   :toctree:
+   :recursive:
 
-.. automodule:: syft.core.smpc.approximations.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   syft.core.smpc.approximations.exp
+   syft.core.smpc.approximations.log
+   syft.core.smpc.approximations.reciprocal
+   syft.core.smpc.approximations.utils
+

--- a/docs/source/api_reference/syft.core.smpc.approximations.utils.rst
+++ b/docs/source/api_reference/syft.core.smpc.approximations.utils.rst
@@ -1,0 +1,30 @@
+syft.core.smpc.approximations.utils
+===================================
+
+.. automodule:: syft.core.smpc.approximations.utils
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      modulus
+      sign
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.smpc.protocol.aby3.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.aby3.rst
@@ -1,18 +1,31 @@
-syft.core.smpc.protocol.aby3 package
-====================================
+syft.core.smpc.protocol.aby3
+============================
 
 .. automodule:: syft.core.smpc.protocol.aby3
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.smpc.protocol.aby3.aby3 module
-----------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.smpc.protocol.aby3.aby3
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.smpc.protocol.aby3.aby3
+

--- a/docs/source/api_reference/syft.core.smpc.protocol.beaver.beaver.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.beaver.beaver.rst
@@ -13,12 +13,16 @@ syft.core.smpc.protocol.beaver.beaver
 
    .. autosummary::
    
+      count_wraps_rand
+      get_child
       get_triples_matmul
       get_triples_mul
       matmul_store_add
       matmul_store_get
       mul_store_add
       mul_store_get
+      wraps_store_add
+      wraps_store_get
    
    
 

--- a/docs/source/api_reference/syft.core.smpc.protocol.beaver.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.beaver.rst
@@ -1,18 +1,31 @@
-syft.core.smpc.protocol.beaver package
-======================================
+syft.core.smpc.protocol.beaver
+==============================
 
 .. automodule:: syft.core.smpc.protocol.beaver
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.smpc.protocol.beaver.beaver module
---------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.smpc.protocol.beaver.beaver
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.smpc.protocol.beaver.beaver
+

--- a/docs/source/api_reference/syft.core.smpc.protocol.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.rst
@@ -1,17 +1,33 @@
-syft.core.smpc.protocol package
-===============================
+syft.core.smpc.protocol
+=======================
 
 .. automodule:: syft.core.smpc.protocol
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Subpackages
------------
+   
+   
+   
 
-.. toctree::
-   :maxdepth: 2
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
 
    syft.core.smpc.protocol.aby3
    syft.core.smpc.protocol.beaver
    syft.core.smpc.protocol.spdz
+

--- a/docs/source/api_reference/syft.core.smpc.protocol.spdz.rst
+++ b/docs/source/api_reference/syft.core.smpc.protocol.spdz.rst
@@ -1,18 +1,31 @@
-syft.core.smpc.protocol.spdz package
-====================================
+syft.core.smpc.protocol.spdz
+============================
 
 .. automodule:: syft.core.smpc.protocol.spdz
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.smpc.protocol.spdz.spdz module
-----------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.smpc.protocol.spdz.spdz
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.smpc.protocol.spdz.spdz
+

--- a/docs/source/api_reference/syft.core.smpc.rst
+++ b/docs/source/api_reference/syft.core.smpc.rst
@@ -1,17 +1,39 @@
-syft.core.smpc package
-======================
+syft.core.smpc
+==============
 
 .. automodule:: syft.core.smpc
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Subpackages
------------
+   
+   
+   
 
-.. toctree::
-   :maxdepth: 2
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      create_smpc_ast
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
 
    syft.core.smpc.approximations
    syft.core.smpc.protocol
    syft.core.smpc.store
+

--- a/docs/source/api_reference/syft.core.smpc.store.rst
+++ b/docs/source/api_reference/syft.core.smpc.store.rst
@@ -1,34 +1,41 @@
-syft.core.smpc.store package
-============================
+syft.core.smpc.store
+====================
 
 .. automodule:: syft.core.smpc.store
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.smpc.store.crypto\_primitive\_provider module
--------------------------------------------------------
+   
+   
+   .. rubric:: Functions
 
-.. automodule:: syft.core.smpc.store.crypto_primitive_provider
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   .. autosummary::
+   
+      register_primitive_generator
+      register_primitive_store_add
+      register_primitive_store_get
+   
+   
 
-syft.core.smpc.store.crypto\_store module
------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.smpc.store.crypto_store
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.smpc.store.exceptions module
---------------------------------------
 
-.. automodule:: syft.core.smpc.store.exceptions
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.smpc.store.crypto_primitive_provider
+   syft.core.smpc.store.crypto_store
+   syft.core.smpc.store.exceptions
+

--- a/docs/source/api_reference/syft.core.store.proxy_dataset.rst
+++ b/docs/source/api_reference/syft.core.store.proxy_dataset.rst
@@ -1,0 +1,29 @@
+syft.core.store.proxy\_dataset
+==============================
+
+.. automodule:: syft.core.store.proxy_dataset
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      ProxyDataset
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.store.rst
+++ b/docs/source/api_reference/syft.core.store.rst
@@ -28,8 +28,7 @@ syft.core.store
    :recursive:
 
    syft.core.store.dataset
-   syft.core.store.store_disk
+   syft.core.store.proxy_dataset
    syft.core.store.store_interface
-   syft.core.store.store_memory
    syft.core.store.storeable_object
 

--- a/docs/source/api_reference/syft.core.tensor.ancestors.rst
+++ b/docs/source/api_reference/syft.core.tensor.ancestors.rst
@@ -13,7 +13,7 @@ syft.core.tensor.ancestors
 
    .. autosummary::
    
-      entity_creation_wizard
+      data_subject_creation_wizard
    
    
 
@@ -23,7 +23,6 @@ syft.core.tensor.ancestors
 
    .. autosummary::
    
-      AutogradTensorAncestor
       PhiTensorAncestor
    
    

--- a/docs/source/api_reference/syft.core.tensor.autodp.gamma_tensor.rst
+++ b/docs/source/api_reference/syft.core.tensor.autodp.gamma_tensor.rst
@@ -1,0 +1,41 @@
+syft.core.tensor.autodp.gamma\_tensor
+=====================================
+
+.. automodule:: syft.core.tensor.autodp.gamma_tensor
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      create_lookup_tables
+      create_new_lookup_tables
+      jax2numpy
+      no_op
+      numpy2jax
+      ones_like
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      GammaTensor
+      TensorWrappedGammaTensorPointer
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.autodp.phi_tensor.rst
+++ b/docs/source/api_reference/syft.core.tensor.autodp.phi_tensor.rst
@@ -1,0 +1,36 @@
+syft.core.tensor.autodp.phi\_tensor
+===================================
+
+.. automodule:: syft.core.tensor.autodp.phi_tensor
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      ones_like
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      PhiTensor
+      TensorWrappedPhiTensorPointer
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.autodp.rst
+++ b/docs/source/api_reference/syft.core.tensor.autodp.rst
@@ -1,34 +1,33 @@
-syft.core.tensor.autodp package
-===============================
+syft.core.tensor.autodp
+=======================
 
 .. automodule:: syft.core.tensor.autodp
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.tensor.autodp.adp\_tensor module
-------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.tensor.autodp.adp_tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.tensor.autodp.gamma\_tensor module
---------------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.tensor.autodp.gamma_tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.tensor.autodp.phi\_tensor module
-------------------------------------------
 
-.. automodule:: syft.core.tensor.autodp.phi_tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.tensor.autodp.adp_tensor
+   syft.core.tensor.autodp.gamma_tensor
+   syft.core.tensor.autodp.phi_tensor
+

--- a/docs/source/api_reference/syft.core.tensor.config.rst
+++ b/docs/source/api_reference/syft.core.tensor.config.rst
@@ -1,0 +1,23 @@
+syft.core.tensor.config
+=======================
+
+.. automodule:: syft.core.tensor.config
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.lazy_repeat_array.rst
+++ b/docs/source/api_reference/syft.core.tensor.lazy_repeat_array.rst
@@ -1,0 +1,35 @@
+syft.core.tensor.lazy\_repeat\_array
+====================================
+
+.. automodule:: syft.core.tensor.lazy_repeat_array
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      compute_min_max
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      lazyrepeatarray
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.activations.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.activations.rst
@@ -1,0 +1,36 @@
+syft.core.tensor.nn.activations
+===============================
+
+.. automodule:: syft.core.tensor.nn.activations
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      get
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Activation
+      leaky_ReLU
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.initializations.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.initializations.rst
@@ -1,0 +1,37 @@
+syft.core.tensor.nn.initializations
+===================================
+
+.. automodule:: syft.core.tensor.nn.initializations
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      decompose_size
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Initializer
+      Uniform
+      XavierInitialization
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.layers.base.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.layers.base.rst
@@ -1,0 +1,29 @@
+syft.core.tensor.nn.layers.base
+===============================
+
+.. automodule:: syft.core.tensor.nn.layers.base
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Layer
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.layers.convolution.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.layers.convolution.rst
@@ -1,0 +1,29 @@
+syft.core.tensor.nn.layers.convolution
+======================================
+
+.. automodule:: syft.core.tensor.nn.layers.convolution
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Convolution
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.layers.linear.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.layers.linear.rst
@@ -1,0 +1,29 @@
+syft.core.tensor.nn.layers.linear
+=================================
+
+.. automodule:: syft.core.tensor.nn.layers.linear
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Linear
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.layers.normalization.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.layers.normalization.rst
@@ -1,0 +1,29 @@
+syft.core.tensor.nn.layers.normalization
+========================================
+
+.. automodule:: syft.core.tensor.nn.layers.normalization
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      BatchNorm
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.layers.pooling.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.layers.pooling.rst
@@ -1,0 +1,30 @@
+syft.core.tensor.nn.layers.pooling
+==================================
+
+.. automodule:: syft.core.tensor.nn.layers.pooling
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      AvgPool
+      MaxPool
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.layers.reshaping.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.layers.reshaping.rst
@@ -1,0 +1,29 @@
+syft.core.tensor.nn.layers.reshaping
+====================================
+
+.. automodule:: syft.core.tensor.nn.layers.reshaping
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Flatten
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.layers.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.layers.rst
@@ -1,0 +1,36 @@
+syft.core.tensor.nn.layers
+==========================
+
+.. automodule:: syft.core.tensor.nn.layers
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.tensor.nn.layers.base
+   syft.core.tensor.nn.layers.convolution
+   syft.core.tensor.nn.layers.linear
+   syft.core.tensor.nn.layers.normalization
+   syft.core.tensor.nn.layers.pooling
+   syft.core.tensor.nn.layers.reshaping
+

--- a/docs/source/api_reference/syft.core.tensor.nn.loss.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.loss.rst
@@ -1,0 +1,30 @@
+syft.core.tensor.nn.loss
+========================
+
+.. automodule:: syft.core.tensor.nn.loss
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      BinaryCrossEntropy
+      Loss
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.model.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.model.rst
@@ -1,0 +1,29 @@
+syft.core.tensor.nn.model
+=========================
+
+.. automodule:: syft.core.tensor.nn.model
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Model
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.optimizers.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.optimizers.rst
@@ -1,0 +1,30 @@
+syft.core.tensor.nn.optimizers
+==============================
+
+.. automodule:: syft.core.tensor.nn.optimizers
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Adamax
+      Optimizer
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.nn.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.rst
@@ -1,0 +1,37 @@
+syft.core.tensor.nn
+===================
+
+.. automodule:: syft.core.tensor.nn
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.tensor.nn.activations
+   syft.core.tensor.nn.initializations
+   syft.core.tensor.nn.layers
+   syft.core.tensor.nn.loss
+   syft.core.tensor.nn.model
+   syft.core.tensor.nn.optimizers
+   syft.core.tensor.nn.utils
+

--- a/docs/source/api_reference/syft.core.tensor.nn.utils.rst
+++ b/docs/source/api_reference/syft.core.tensor.nn.utils.rst
@@ -1,0 +1,36 @@
+syft.core.tensor.nn.utils
+=========================
+
+.. automodule:: syft.core.tensor.nn.utils
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      col2im_indices
+      dp_add_at
+      dp_log
+      dp_maximum
+      dp_pad
+      dp_zeros
+      get_im2col_indices
+      im2col_indices
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.rst
+++ b/docs/source/api_reference/syft.core.tensor.rst
@@ -1,107 +1,50 @@
-syft.core.tensor package
-========================
+syft.core.tensor
+================
 
 .. automodule:: syft.core.tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Subpackages
------------
+   
+   
+   
 
-.. toctree::
-   :maxdepth: 2
+   
+   
+   .. rubric:: Functions
 
+   .. autosummary::
+   
+      create_tensor_ast
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.tensor.ancestors
    syft.core.tensor.autodp
+   syft.core.tensor.broadcastable
+   syft.core.tensor.config
+   syft.core.tensor.fixed_precision_tensor
+   syft.core.tensor.fixed_precision_tensor_ancestor
+   syft.core.tensor.functions
+   syft.core.tensor.lazy_repeat_array
+   syft.core.tensor.manager
+   syft.core.tensor.nn
+   syft.core.tensor.passthrough
    syft.core.tensor.smpc
+   syft.core.tensor.tensor
+   syft.core.tensor.util
 
-Submodules
-----------
-
-syft.core.tensor.ancestors module
----------------------------------
-
-.. automodule:: syft.core.tensor.ancestors
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.broadcastable module
--------------------------------------
-
-.. automodule:: syft.core.tensor.broadcastable
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.config module
-------------------------------
-
-.. automodule:: syft.core.tensor.config
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.fixed\_precision\_tensor module
-------------------------------------------------
-
-.. automodule:: syft.core.tensor.fixed_precision_tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.fixed\_precision\_tensor\_ancestor module
-----------------------------------------------------------
-
-.. automodule:: syft.core.tensor.fixed_precision_tensor_ancestor
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.functions module
----------------------------------
-
-.. automodule:: syft.core.tensor.functions
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.lazy\_repeat\_array module
--------------------------------------------
-
-.. automodule:: syft.core.tensor.lazy_repeat_array
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.manager module
--------------------------------
-
-.. automodule:: syft.core.tensor.manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.passthrough module
------------------------------------
-
-.. automodule:: syft.core.tensor.passthrough
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.tensor module
-------------------------------
-
-.. automodule:: syft.core.tensor.tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-syft.core.tensor.util module
-----------------------------
-
-.. automodule:: syft.core.tensor.util
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_reference/syft.core.tensor.smpc.context.rst
+++ b/docs/source/api_reference/syft.core.tensor.smpc.context.rst
@@ -1,0 +1,23 @@
+syft.core.tensor.smpc.context
+=============================
+
+.. automodule:: syft.core.tensor.smpc.context
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   
+
+
+

--- a/docs/source/api_reference/syft.core.tensor.smpc.rst
+++ b/docs/source/api_reference/syft.core.tensor.smpc.rst
@@ -1,50 +1,35 @@
-syft.core.tensor.smpc package
-=============================
+syft.core.tensor.smpc
+=====================
 
 .. automodule:: syft.core.tensor.smpc
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.tensor.smpc.context module
-------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.tensor.smpc.context
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
 
-syft.core.tensor.smpc.mpc\_tensor module
-----------------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.tensor.smpc.mpc_tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-syft.core.tensor.smpc.mpc\_tensor\_ancestor module
---------------------------------------------------
 
-.. automodule:: syft.core.tensor.smpc.mpc_tensor_ancestor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. rubric:: Modules
 
-syft.core.tensor.smpc.share\_tensor module
-------------------------------------------
+.. autosummary::
+   :toctree:
+   :recursive:
 
-.. automodule:: syft.core.tensor.smpc.share_tensor
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   syft.core.tensor.smpc.context
+   syft.core.tensor.smpc.mpc_tensor
+   syft.core.tensor.smpc.mpc_tensor_ancestor
+   syft.core.tensor.smpc.share_tensor
+   syft.core.tensor.smpc.utils
 
-syft.core.tensor.smpc.utils module
-----------------------------------
-
-.. automodule:: syft.core.tensor.smpc.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_reference/syft.core.tensor.smpc.utils.rst
+++ b/docs/source/api_reference/syft.core.tensor.smpc.utils.rst
@@ -13,6 +13,7 @@ syft.core.tensor.smpc.utils
 
    .. autosummary::
    
+      count_wraps
       get_nr_bits
       get_ring_size
       get_shape

--- a/docs/source/api_reference/syft.core.test.rst
+++ b/docs/source/api_reference/syft.core.test.rst
@@ -1,18 +1,31 @@
-syft.core.test package
-======================
+syft.core.test
+==============
 
 .. automodule:: syft.core.test
-   :members:
-   :undoc-members:
-   :show-inheritance:
 
-Submodules
-----------
+   
+   
+   
 
-syft.core.test.module\_test module
-----------------------------------
+   
+   
+   
 
-.. automodule:: syft.core.test.module_test
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   
+   
+   
+
+   
+   
+   
+
+
+
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+
+   syft.core.test.module_test
+

--- a/docs/source/api_reference/syft.grid.client.client.rst
+++ b/docs/source/api_reference/syft.grid.client.client.rst
@@ -15,16 +15,11 @@ syft.grid.client.client
    
       connect
       login
+      register
    
    
 
    
-   
-   .. rubric:: Classes
-
-   .. autosummary::
-   
-      GridClient
    
    
 

--- a/docs/source/api_reference/syft.grid.client.grid_connection.rst
+++ b/docs/source/api_reference/syft.grid.client.grid_connection.rst
@@ -18,6 +18,7 @@ syft.grid.client.grid\_connection
    .. autosummary::
    
       GridHTTPConnection
+      TimeoutHTTPAdapter
    
    
 

--- a/docs/source/api_reference/syft.grid.client.rst
+++ b/docs/source/api_reference/syft.grid.client.rst
@@ -28,8 +28,6 @@ syft.grid.client
    :recursive:
 
    syft.grid.client.client
-   syft.grid.client.enums
-   syft.grid.client.exceptions
    syft.grid.client.grid_connection
-   syft.grid.client.request_api
+   syft.grid.client.proxy_client
 

--- a/docs/source/api_reference/syft.grid.connections.rst
+++ b/docs/source/api_reference/syft.grid.connections.rst
@@ -28,5 +28,4 @@ syft.grid.connections
    :recursive:
 
    syft.grid.connections.http_connection
-   syft.grid.connections.webrtc
 

--- a/docs/source/api_reference/syft.grid.rst
+++ b/docs/source/api_reference/syft.grid.rst
@@ -29,7 +29,5 @@
 
    syft.grid.client
    syft.grid.connections
-   syft.grid.duet
-   syft.grid.messages
-   syft.grid.services
+   syft.grid.grid_url
 


### PR DESCRIPTION
## Description
We last generated and updated our API documentation a couple of months ago and since then our code has been added/modified/removed hence this PR generates the updated docs for the same.

In the longer run, I'm thinking of adding this as a part of our CI pipeline itself!

## Affected Dependencies
None

## How has this been tested?
As documented here on our [docs/README.md](https://github.com/OpenMined/PySyft/blob/dev/docs/README.md):
```sh
cd docs
pip install -r requirements.txt
cd source
sphinx-apidoc -f -M -d 2 -o ./api_reference/ ../../packages/syft/src/syft
cd ../
make html
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
