### PR TITLE
fix typo on the docs index page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,7 @@ use and development of PySyft!
     User guide
     ^^^^^^^^^^
 
-    The user guide provides in-depth explanation ok the key concepts used by PySyft
+    The user guide provides in-depth explanation on the key concepts used by PySyft
     and a glossary of terms you may encounter.
 
     +++


### PR DESCRIPTION
## Description
Fixes typo on the Pysyft documentation website here [here](https://openmined.github.io/PySyft/)

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
