### PR TITLE
Add GitPod instructions in case there's not enough memory allocated for Docker

### DIFF
--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -932,7 +932,10 @@ def create_launch_cmd(
                     f"\tWindows Help: https://docs.docker.com/desktop/windows/\n\n"
                     f"Then re-run your hagrid command.\n\n"
                     f"If you see this warning on Linux then something isn't right. "
-                    f"Please file a Github Issue on PySyft's Github"
+                    f"Please file a Github Issue on PySyft's Github.\n\n"
+                    f"Alternatively in case no more memory could be allocated, "
+                    f"you can run hagrid on the cloud with GitPod by visiting "
+                    f"https://gitpod.io/#https://github.com/OpenMined/PySyft."
                 )
 
             if is_windows() and not DEPENDENCIES["wsl"]:


### PR DESCRIPTION
## Description
Fix #6835

```
You appear to be using Docker Desktop but don't have enough memory allocated. It appears you've configured Memory:4 MB when 8192MB (8GB) is required. Please open Docker Desktop Preferences panel and set Memory to 8GB or higher.

	OSX Help: https://docs.docker.com/desktop/mac/
	Windows Help: https://docs.docker.com/desktop/windows/

Then re-run your hagrid command.

If you see this warning on Linux then something isn't right. Please file a Github Issue on PySyft's Github.

Alternatively in case no more memory could be allocated, you can run hagrid on the cloud with GitPod by visiting https://gitpod.io/#https://github.com/OpenMined/PySyft.
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
