### PR TITLE
Modified version The default value is version object ,not None

### DIFF
--- a/packages/hagrid/hagrid/deps.py
+++ b/packages/hagrid/hagrid/deps.py
@@ -82,7 +82,7 @@ class Dependency:
     name: str = ""
     display: str = ""
     only_os: str = ""
-    version: Optional[Version] = None
+    version: Optional[Version] = version.parse("None")
     valid: bool = False
     issues: List[SetupIssue] = field(default_factory=list)
     output_in_text: bool = False
@@ -165,6 +165,7 @@ class DependencyGridDockerCompose(Dependency):
         binary_info = BinaryInfo(
             binary="docker", version_cmd="docker compose version"
         ).get_binary_info()
+
         if binary_info.path and binary_info.version > version.parse(
             MINIMUM_DOCKER_COMPOSE_VERSION
         ):
@@ -294,7 +295,7 @@ class BinaryInfo:
     version_cmd: str
     error: Optional[str] = None
     path: Optional[str] = None
-    version: Optional[Union[str, Version]] = None
+    version: Optional[Union[str, Version]] = version.parse("None")
     version_regex = (
         r"[^\d]*("
         + r"(0|[1-9][0-9]*)\.*(0|[1-9][0-9]*)\.*(0|[1-9][0-9]*)"


### PR DESCRIPTION
exec cmd "hagrid launch domain" ,ERROR log is "Error: '>' not supported between instances of 'NoneType' and 'Version'"

## Description

exec cmd "hagrid launch domain" ,check version error

![image](https://user-images.githubusercontent.com/56598312/195312685-7a7194b3-1754-4dd3-9541-d157a2f26b9f.png)

after change version define value , Execute successfully！！！


## Affected Dependencies
no

## How has this been tested?
exec cmd "hagrid launch domain"

local python and docker env version
![image](https://user-images.githubusercontent.com/56598312/195313275-a39f2e65-6900-491d-90f0-3c46488b1811.png)

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
