### PR TITLE
Fix publish breaking when not enough PB

### DIFF
--- a/packages/syft/src/syft/core/adp/vectorized_publish.py
+++ b/packages/syft/src/syft/core/adp/vectorized_publish.py
@@ -121,7 +121,7 @@ def publish(
     )
 
     # its important that its the same type so that eq comparisons below dont break
-    zeros_like = tensor.zeros_like()
+    zeros_like = jnp.zeros_like(tensor.child)
 
     # this prevents us from running in an infinite loop
     previous_budget = None


### PR DESCRIPTION
## Description
Publish breaks when there is not sufficient budget cause the comparison `value != zero_like` in `can_reduce_further` method return NotImplemented as output.

This is because zero_like is a GammaTensor tensor and JAX doesn't know how to interact with it.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Tested locally.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
