### PR TITLE
pin pytest to 7.1.3

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -93,7 +93,7 @@ dev =
     faker==13.15.1
 
 test_plugins =
-    pytest
+    pytest==7.1.3
     pytest-cov
     pytest-xdist[psutil]
     pytest-asyncio


### PR DESCRIPTION
## Description
This PR will fix the flakiness in **grid.test.backend** noticed with the new Pytest release `7.2.0`.