### PR TITLE
Fix apply_to_domain breaking due to multiprocessing lib in MacOS/Windows

### DIFF
--- a/packages/syft/src/syft/util.py
+++ b/packages/syft/src/syft/util.py
@@ -8,6 +8,7 @@ import functools
 from itertools import repeat
 import multiprocessing
 import multiprocessing as mp
+from multiprocessing import set_start_method
 from multiprocessing.synchronize import Event as EventClass
 from multiprocessing.synchronize import Lock as LockBase
 import operator
@@ -748,6 +749,9 @@ def print_dynamic_log(
     finish = multiprocessing.Event()
     success = multiprocessing.Event()
     lock = multiprocessing.Lock()
+
+    set_start_method("fork", force=True)
+
     multiprocessing.Process(
         target=print_process, args=(message, finish, success, lock)
     ).start()

--- a/packages/syft/src/syft/util.py
+++ b/packages/syft/src/syft/util.py
@@ -14,6 +14,7 @@ from multiprocessing.synchronize import Lock as LockBase
 import operator
 import os
 from pathlib import Path
+import platform
 from secrets import randbelow
 import sys
 import time
@@ -736,6 +737,14 @@ def print_process(  # type: ignore
         sys.stdout.flush()
 
 
+def os_name() -> str:
+    os_name = platform.system()
+    if os_name.lower() == "darwin":
+        return "macOS"
+    else:
+        return os_name
+
+
 def print_dynamic_log(
     message: str,
 ) -> Tuple[EventClass, EventClass]:
@@ -750,7 +759,9 @@ def print_dynamic_log(
     success = multiprocessing.Event()
     lock = multiprocessing.Lock()
 
-    set_start_method("fork", force=True)
+    if os_name() == "macOS":
+        # set start method to fork in case of MacOS
+        set_start_method("fork", force=True)
 
     multiprocessing.Process(
         target=print_process, args=(message, finish, success, lock)


### PR DESCRIPTION
## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

Fixes Issue: https://github.com/OpenMined/PySyft/issues/6891

When we use multiprocessing for Event creation (it happens specifically on MacOS/Windows)  there is file not found error because the parent thread is killed while the child is starting. This is because the MacOS/Windows use `spawn` mechanism to start new Events which breaks in Python 3.8+. 

Fix: use the `fork` mechanism to start new Events.

Python Issues: https://bugs.python.org/issue28965
Possible solutions: https://superfastpython.com/filenotfounderror-multiprocessing-python/


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
