### PR TITLE
Improve logging message on Connection and Timeout Errors

### DIFF
--- a/packages/syft/src/syft/grid/client/client.py
+++ b/packages/syft/src/syft/grid/client/client.py
@@ -104,7 +104,7 @@ def login(
     verbose: Optional[bool] = True,
     timeout: Optional[float] = None,
     retry: Optional[int] = None,
-) -> Optional[Client]:
+) -> Client:
 
     retry = 5 if retry is None else retry  # Default to 5 retries
     timeout = 10 if timeout is None else timeout  # Default to 10 seconds
@@ -113,12 +113,14 @@ def login(
 
         if email == "info@openmined.org":
             print(
-                f"{bcolors.YELLOW}WARNING:{bcolors.ENDC} CHANGE YOUR USERNAME AND PASSWORD!!! \n\nAnyone can login as an admin to your node"
+                f"{bcolors.YELLOW}WARNING:{bcolors.ENDC} CHANGE YOUR USERNAME AND PASSWORD!!! \n\n"
+                + "Anyone can login as an admin to your node"
                 + " right now because your password is still the default PySyft username and password!!!\n"
             )
         else:
             print(
-                f"{bcolors.YELLOW}WARNING:{bcolors.ENDC} CHANGE YOUR PASSWORD!!! \n\nAnyone can login into your account"
+                f"{bcolors.YELLOW}WARNING:{bcolors.ENDC} CHANGE YOUR PASSWORD!!! \n\n"
+                + "Anyone can login into your account"
                 + " right now because your password is the default PySyft password!!!\n"
             )
 
@@ -168,16 +170,19 @@ def login(
                 conn_type=conn_type,
                 timeout=timeout,
             )
-        except requests.ConnectTimeout as e:
+        except requests.ReadTimeout:
             print(
-                f"""\n{bcolors.BOLD}{bcolors.RED}ConnectTimeout:{bcolors.ENDC}
-            Connection to node with url: {grid_url.host_or_ip} timed out after {timeout} seconds.\t
-            Please try the following options:\t
-            - Please try increasing the timeout by passing it as an agrument to the login method.
-              `sy.login(email="", password="", url="", timeout="")`
-            - The domain/network node you're trying to connect could be offline at the current moment. Please try again later.\t"""
+                f"\n{bcolors.BOLD}{bcolors.RED}ReadTimeout:{bcolors.ENDC}\n"
+                f"\tConnection to node with url: {grid_url.host_or_ip}:{grid_url.port} "
+                f"timed out after {timeout} seconds.\n"
+                "\tPlease try the following options:\n"
+                "\t- Please try increasing the timeout by passing it as an argument to the login method.\n"
+                "\te.g. `sy.login(email='my@email.com', password='password', url='localhost', timeout=30)`\n"
+                "\t- The domain/network node you're trying to connect could be offline "
+                "at the current moment. Please try again later.\t"
             )
-            return
+            return  # type: ignore
+
         except requests.ConnectionError as e:
             if retry_attempt <= retry:
                 print(
@@ -191,14 +196,17 @@ def login(
 
     if node is None:
         print(
-            f"""\n{bcolors.BOLD}{bcolors.RED}ConnectionError:{bcolors.ENDC}
-        Oops !!! We can't seem to connect to the node: '{grid_url.host_or_ip}:{grid_url.port}'\t
-        Please try the following options:\t
-        - Are you sure the server at '{grid_url.host_or_ip}:{grid_url.port}' is running? Please check the `url`/`port` you entered are correct.\t
-        - Are you sure you can connect to the server at '{grid_url.host_or_ip}:{grid_url.port}'? Perhaps there's a firewall between you and the server?\t
-        - The domain/network node you're trying to connect could be offline at the current moment. Please try again later.\t"""
+            f"\n{bcolors.BOLD}{bcolors.RED}ConnectionError:{bcolors.ENDC}\n"
+            f"\tOops !!! We can't seem to connect to the node: '{grid_url.host_or_ip}:{grid_url.port}'\n"
+            "\tPlease try the following options:\n"
+            f"\t- Are you sure the server at '{grid_url.host_or_ip}:{grid_url.port}' is running? "
+            "Please check the `url`/`port` you entered are correct.\n"
+            f"\t- Are you sure you can connect to the server at '{grid_url.host_or_ip}:{grid_url.port}'? "
+            "Perhaps there's a firewall between you and the server?\n"
+            "\t- The domain/network node you're trying to connect could be offline "
+            "at the current moment. Please try again later.\n"
         )
-        return
+        return  # type: ignore
 
     if verbose:
         # bit of fanciness


### PR DESCRIPTION
update connection error with more user action steps fix improper printing when logging in with verbose False

## Description
Update connection error and timeout error messages to more verbose and friendly.

Fixes: https://github.com/OpenMined/PySyft/issues/6888

## Affected Dependencies
List any dependencies that are required for this change.

**Connection Error**
![ezgif com-gif-maker](https://user-images.githubusercontent.com/11032835/198572850-92f9893c-9cd9-4bc5-8626-3fe8f7319548.gif)


**Timeout Error**
![Screenshot from 2022-10-28 17-46-59](https://user-images.githubusercontent.com/11032835/198585025-a675e26c-a649-4449-9dd1-e1e2f206cf46.png)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
