### PR TITLE
Add support for Hagrid logs & set --tail=false to default

### DIFF
--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -3522,7 +3522,7 @@ cli.add_command(ssh)
 
 
 # Add hagrid logs command to the CLI
-@click.command(help="Get the logs of the HAGrid service")
+@click.command(help="Get the logs of the HAGrid node")
 @click.argument("domain_name", type=str)
 def logs(domain_name: str) -> None:  # nosec
 


### PR DESCRIPTION
## Description
fixes #6971 

This PR adds a new command to hagrid, which is `hagrid logs`, and generates an output like so. 

Also, this PR sets --tail=false to the default behavior in hagrid when launching domain nodes.

<img width="501" alt="Screenshot 2022-11-10 at 02 18 33" src="https://user-images.githubusercontent.com/11381249/200977432-13c6a10a-b0a5-4faf-be07-898170aec45c.png">
