### PR TITLE
Modify Container name in log collector

### DIFF
--- a/.github/workflows/stack-integration_tests.yml
+++ b/.github/workflows/stack-integration_tests.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: stack.test.integration-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -300,7 +300,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: stack.test.integration.tls-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -446,7 +446,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: stack.test.integration.tff-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -593,7 +593,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: stack.test.integration.smpc-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -735,7 +735,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: stack.test.integration.k8s-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -851,7 +851,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: stack.test.course-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup

--- a/.github/workflows/stack-integration_tests.yml
+++ b/.github/workflows/stack-integration_tests.yml
@@ -135,10 +135,10 @@ jobs:
 
       # Get Job name and url
       - name: Get job name and url
-        id: job
+        id: job_name
         if: failure()
         run: |
-          echo "::set-output name=job::$(echo ${{ github.job }})"
+          echo "::set-output name=job_name::$(echo ${{ github.job }})"
           echo "::set-output name=url::$(echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Get current date
@@ -285,10 +285,10 @@ jobs:
 
       # Get Job name and url
       - name: Get job name and url
-        id: job
+        id: job_name
         if: failure()
         run: |
-          echo "::set-output name=job::$(echo ${{ github.job }})"
+          echo "::set-output name=job_name::$(echo ${{ github.job }})"
           echo "::set-output name=url::$(echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Get current date
@@ -430,11 +430,12 @@ jobs:
 
       # Get Job name and url
       - name: Get job name and url
-        id: job
+        id: job_name
         if: failure()
         run: |
-          echo "::set-output name=job::$(echo ${{ github.job }})"
+          echo "::set-output name=job_name::$(echo ${{ github.job }})"
           echo "::set-output name=url::$(echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
 
       - name: Get current date
         id: date
@@ -574,13 +575,6 @@ jobs:
         run: |
           python ./scripts/container_log_collector.py
 
-      # Get Job name and url
-      - name: Get job name and url
-        id: job
-        if: failure()
-        run: |
-          echo "::set-output name=job::$(echo ${{ github.job }})"
-          echo "::set-output name=url::$(echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       # Get Job name and url
       - name: Get job name and url
@@ -723,13 +717,14 @@ jobs:
         run: |
           python ./scripts/container_log_collector.py
 
-      # Get Job name and url
+        # Get Job name and url
       - name: Get job name and url
-        id: job
+        id: job_name
         if: failure()
         run: |
-          echo "::set-output name=job::$(echo ${{ github.job }})"
+          echo "::set-output name=job_name::$(echo ${{ github.job }})"
           echo "::set-output name=url::$(echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
 
       - name: Get current date
         id: date

--- a/.github/workflows/stack-integration_tests.yml
+++ b/.github/workflows/stack-integration_tests.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: stack.test.integration-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -300,7 +300,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: stack.test.integration.tls-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -445,7 +445,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: stack.test.integration.tff-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -599,7 +599,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: stack.test.integration.smpc-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -740,7 +740,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: stack.test.integration.k8s-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -856,7 +856,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: stack.test.course-${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup

--- a/.github/workflows/stack-integration_tests.yml
+++ b/.github/workflows/stack-integration_tests.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-${{ matrix.pytest-modules }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -300,7 +300,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-${{ matrix.pytest-modules }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup
@@ -593,7 +593,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: failure()
         with:
-          name: ${{ steps.job_name.outputs.job_name }}-logs-${{ steps.date.outputs.date }}
+          name: ${{ matrix.os }}-${{ steps.job_name.outputs.job_name }}-${{ matrix.pytest-modules }}-logs-${{ steps.date.outputs.date }}
           path: ./logs/${{ steps.job_name.outputs.job_name}}/
 
       - name: Mandatory Container cleanup

--- a/scripts/container_log_collector.py
+++ b/scripts/container_log_collector.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import subprocess
 
 # Make a log directory
-log_path = Path("log")
+log_path = Path("logs")
 log_path.mkdir(exist_ok=True)
 
 # Get the github job name and create a directory for it

--- a/scripts/container_log_collector.py
+++ b/scripts/container_log_collector.py
@@ -14,27 +14,23 @@ job_path.mkdir(exist_ok=True)
 
 # Get all the containers running (per job)
 containers = (
-    subprocess.check_output("docker ps -a -q", shell=True).decode("utf-8").split()
+    subprocess.check_output("docker ps --format '{{.Names}}'", shell=True)
+    .decode("utf-8")
+    .split()
 )
 
 # Loop through the container ids and create a log file for each in the job directory
 for container in containers:
     # Get the container name
-    container_name = (
-        subprocess.check_output(
-            "docker inspect --format '{{.Name}}' " + container, shell=True
-        )
-        .decode("utf-8")
-        .strip()
-    )
+
+    container_name = container.replace("'", "")
 
     # Get the container logs
     container_logs = subprocess.check_output(
-        "docker logs " + container, shell=True
+        "docker logs " + container_name, shell=True, stderr=subprocess.STDOUT
     ).decode("utf-8")
 
-    unquoted_name = container_name.replace("'", "")
-    path = job_path / unquoted_name
+    path = job_path / container_name
     path.write_text(container_logs)
 
 print("============Log export completed for job: ", job_name)

--- a/scripts/container_log_collector.py
+++ b/scripts/container_log_collector.py
@@ -1,6 +1,7 @@
 # stdlib
 import os
 from pathlib import Path
+from pathlib import PosixPath
 import subprocess
 
 # Make a log directory
@@ -9,7 +10,7 @@ log_path.mkdir(exist_ok=True)
 
 # Get the github job name and create a directory for it
 job_name = os.getenv("GITHUB_JOB")
-job_path = log_path / job_name
+job_path: PosixPath = log_path / job_name
 job_path.mkdir(exist_ok=True)
 
 # Get all the containers running (per job)
@@ -33,4 +34,7 @@ for container in containers:
     path = job_path / container_name
     path.write_text(container_logs)
 
+stored_files = list(job_path.iterdir())
+for file in stored_files:
+    print(file)
 print("============Log export completed for job: ", job_name)

--- a/tests/integration/network/connect_nodes_test.py
+++ b/tests/integration/network/connect_nodes_test.py
@@ -188,7 +188,6 @@ def exec_node_command(command: str, node_name: str) -> None:
 
 @pytest.mark.network
 def test_auto_connect_network_to_self() -> None:
-    assert False  # Remove before merge.
     # wait for NETWORK_CHECK_INTERVAL to trigger auto reconnect
     retry_time = 20
     while retry_time > 0:

--- a/tests/integration/network/connect_nodes_test.py
+++ b/tests/integration/network/connect_nodes_test.py
@@ -188,6 +188,7 @@ def exec_node_command(command: str, node_name: str) -> None:
 
 @pytest.mark.network
 def test_auto_connect_network_to_self() -> None:
+    assert False  # Remove before merge.
     # wait for NETWORK_CHECK_INTERVAL to trigger auto reconnect
     retry_time = 20
     while retry_time > 0:


### PR DESCRIPTION
## Description
```py
"docker inspect --format '{{.Name}}' " + container, shell=True
```
would return container's name with backslash
```
like: `/canada-backend'
```
which when would appended would take it as a separate path which leads to permission error.
The PR fixes the same by removing backslash.
Example run: https://github.com/OpenMined/PySyft/actions/runs/3439644207/jobs/5737175631



## How has this been tested?
Existing tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
