### PR TITLE
[scripts] dev_tools improve win support & performance

### DIFF
--- a/packages/grid/docker-compose.dev.yml
+++ b/packages/grid/docker-compose.dev.yml
@@ -30,8 +30,8 @@ services:
   queue:
     image: rabbitmq:3-management
     ports:
-      - "5672"
-      - "15672"
+      - "15672" # admin web port
+      # - "5672" # AMQP port
 
   backend:
     volumes:
@@ -89,6 +89,6 @@ services:
     # volumes:
     #   - ./data/seaweedfs:/data
     ports:
-      - "9333" # admin
-      - "8888" # filer
-      - "8333" # S3
+      - "9333" # admin web port
+      - "8888" # filer web port
+      # - "8333" # S3 API port


### PR DESCRIPTION
## Description
Improve `dev_tools.sh` support on Windows for launching specific ports in using the `start.exe` command. Script's dependency on `python3` was also causing it to fail on systems that did not have `python3` command available. Instead of fixing the python/python3 conflict, a more robust fix is to use the faster [`docker inspect --format`](https://docs.docker.com/engine/reference/commandline/inspect/#list-all-port-bindings) that uses [Go Templates](https://pkg.go.dev/text/template). The script has also been refactored in a little to support any future docker-specific additions.

![image](https://user-images.githubusercontent.com/11070218/201441594-b4e0cea4-4e04-44c6-86bb-c179bad9e41e.png)


## Affected Dependencies
- Padawan notebooks may need to be updated to reflect the new output.

## How has this been tested?
- Verified by running the dev tools script on Windows, WSL2 & Linux.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
