### PR TITLE
[WIP] FIX ast.Attribute circular import

### DIFF
--- a/packages/syft/src/syft/ast/attribute.py
+++ b/packages/syft/src/syft/ast/attribute.py
@@ -6,12 +6,17 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import TYPE_CHECKING
 from typing import Union
 
 # relative
-from .. import ast
 from ..core.node.abstract.node import AbstractNodeClient
 from ..logger import traceback_and_raise
+
+if TYPE_CHECKING:
+    # relative
+    from .klass import Class
+    from .property import Property
 
 
 class Attribute:
@@ -75,11 +80,7 @@ class Attribute:
 
     def _extract_attr_type(
         self,
-        container: Union[
-            List["ast.klass.Class"],
-            List["ast.module.Module"],
-            List["ast.property.Property"],
-        ],
+        container: List["Attribute"],
         field: str,
     ) -> None:
         """Helper function to extract a class of nodes whose parent is the current node.
@@ -96,34 +97,38 @@ class Attribute:
             container.extend(sub_prop)
 
     @property
-    def classes(self) -> List["ast.klass.Class"]:
+    def classes(self) -> List["Class"]:  # type: ignore
         """Extract all classes from the current node attributes.
 
         Returns:
             The list of classes in the current AST node attributes.
         """
+
         out = []
 
-        if isinstance(self, ast.klass.Class):
+        # TODO: Maybe replace it by self.__class__.__name__ == "Class"
+        if getattr(self, "instance_type", None) == "class":
             out.append(self)
 
         self._extract_attr_type(out, "classes")
-        return out
+        return out  # type: ignore
 
     @property
-    def properties(self) -> List["ast.property.Property"]:
+    def properties(self) -> List["Property"]:  # type: ignore
         """Extract all properties from the current node attributes.
 
         Returns:
             The list of properties in the current AST node attributes.
         """
+
         out = []
 
-        if isinstance(self, ast.property.Property):
+        # TODO: Maybe replace it by self.__class__.__name__ == "Property"
+        if getattr(self, "instance_type", None) == "property":
             out.append(self)
 
         self._extract_attr_type(out, "properties")
-        return out
+        return out  # type: ignore
 
     def query(
         self, path: Union[List[str], str], obj_type: Optional[type] = None

--- a/packages/syft/src/syft/ast/klass.py
+++ b/packages/syft/src/syft/ast/klass.py
@@ -540,6 +540,9 @@ class Class(Callable):
             client=client,
             parent=parent,
         )
+
+        self.instance_type = "class"
+
         if self.path_and_name is not None:
             self.pointer_name = self.path_and_name.split(".")[-1] + "Pointer"
 

--- a/packages/syft/src/syft/ast/module.py
+++ b/packages/syft/src/syft/ast/module.py
@@ -69,6 +69,8 @@ class Module(ast.attribute.Attribute):
             parent=parent,
         )
 
+        self.instance_type = "module"
+
         if object_ref is None and self.name:
             try:
                 self.object_ref = sys.modules[path_and_name if path_and_name else ""]

--- a/packages/syft/src/syft/ast/property.py
+++ b/packages/syft/src/syft/ast/property.py
@@ -8,11 +8,11 @@ from typing import Optional
 from typing import Union
 
 # relative
-from .. import ast
 from ..logger import traceback_and_raise
+from .attribute import Attribute
 
 
-class Property(ast.attribute.Attribute):
+class Property(Attribute):
     """Creates property objects which implements getter and setter objects.
 
     Each valid action on AST triggers GetSetPropertyAction.
@@ -21,7 +21,7 @@ class Property(ast.attribute.Attribute):
     def __init__(
         self,
         path_and_name: str,
-        parent: ast.attribute.Attribute,
+        parent: Attribute,
         object_ref: Optional[Any] = None,
         return_type_name: Optional[str] = None,
         client: Optional[Any] = None,
@@ -42,7 +42,7 @@ class Property(ast.attribute.Attribute):
             return_type_name=return_type_name,
             client=client,
         )
-
+        self.instance_type = "property"
         self.is_static = False
 
     def __call__(


### PR DESCRIPTION
## Description
This PR proposes a solution for circular import issue created between `attribute.py` `klass.py` and `callable.py`.

`ast.AttributeClass` is a important class for the AST Data Structure and is used as a parent class  by `ast.Module`, `ast.Callable` and `ast.Class` classes. but at the same time it requires import `ast.Class` and `ast.Module` inside of itself in order to check which type the object instance is. This creates a circular import problem as we can see in the following diagram.


<img width="765" alt="circular_import_attribute_error" src="https://user-images.githubusercontent.com/26658472/201509880-113fce4e-5ce3-438c-a0b5-aef3ccefed0e.png">

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
