### PR TITLE
Set docker log encoding to utf-8

### DIFF
--- a/.github/workflows/stack-integration_tests.yml
+++ b/.github/workflows/stack-integration_tests.yml
@@ -144,6 +144,7 @@ jobs:
       - name: Get current date
         id: date
         if: failure()
+        shell: bash
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Upload logs to GitHub
@@ -317,6 +318,7 @@ jobs:
       - name: Get current date
         id: date
         if: failure()
+        shell: bash
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Upload logs to GitHub
@@ -485,6 +487,7 @@ jobs:
       - name: Get current date
         id: date
         if: failure()
+        shell: bash
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Upload logs to GitHub
@@ -654,6 +657,7 @@ jobs:
       - name: Get current date
         id: date
         if: failure()
+        shell: bash
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Upload logs to GitHub
@@ -818,6 +822,7 @@ jobs:
       - name: Get current date
         id: date
         if: failure()
+        shell: bash
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Upload logs to GitHub
@@ -956,6 +961,7 @@ jobs:
       - name: Get current date
         id: date
         if: failure()
+        shell: bash
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Upload logs to GitHub

--- a/scripts/container_log_collector.py
+++ b/scripts/container_log_collector.py
@@ -34,7 +34,7 @@ for container in containers:
     path = job_path / container_name
     path.write_text(container_logs, encoding="utf-8")
 
-stored_files = list(job_path.iterdir())
-for file in stored_files:
+for file in job_path.iterdir():
     print(file)
+
 print("============Log export completed for job: ", job_name)

--- a/scripts/container_log_collector.py
+++ b/scripts/container_log_collector.py
@@ -32,7 +32,7 @@ for container in containers:
     ).decode("utf-8")
 
     path = job_path / container_name
-    path.write_text(container_logs)
+    path.write_text(container_logs, encoding="utf-8")
 
 stored_files = list(job_path.iterdir())
 for file in stored_files:


### PR DESCRIPTION
## Description
While running one of the windows integration test I got

closes: https://github.com/OpenMined/PySyft/issues/7078

```
Run python ./scripts/container_log_collector.py
Traceback (most recent call last):
  File "C:\Users\azureuser\actions-runner\_work\PySyft\PySyft\scripts\container_log_collector.py", line 35, in <module>
    path.write_text(container_logs)
  File "C:\Users\azureuser\actions-runner\_work\_tool\Python\3.10.5\x64\lib\pathlib.py", line 1155, in write_text
    return f.write(data)
  File "C:\Users\azureuser\actions-runner\_work\_tool\Python\3.10.5\x64\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 14927-14928: character maps to <undefined>
Error: Process completed with exit code 1.
```

Most likely due to docker log's encoding being UTF-8 which is not windows default encoding.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
