### PR TITLE
Replace Ctop explanation hyperlink with raw url in hagrid

### DIFF
--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -2998,9 +2998,7 @@ def check_status(
         )
         print("You can view your container logs using the following tool:")
         print("Tool: [link=https://ctop.sh]Ctop[/link]")
-        print(
-            "Video Explanation: https://youtu.be/BJhlCxerQP4 \n"
-        )
+        print("Video Explanation: https://youtu.be/BJhlCxerQP4 \n")
 
 
 cli.add_command(check)

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -2999,7 +2999,7 @@ def check_status(
         print("You can view your container logs using the following tool:")
         print("Tool: [link=https://ctop.sh]Ctop[/link]")
         print(
-            "Video Explanation: [link=https://youtu.be/BJhlCxerQP4]How to use Ctop[/link]\n"
+            "Video Explanation: https://youtu.be/BJhlCxerQP4 \n"
         )
 
 


### PR DESCRIPTION
## Description
Users had issues with clicking the hyperlink provided during the launch of hagrid that explains how to use ctop. This pull request replaces the hyperlink with the raw URL of the video.

Closes #6975 

## Affected Dependencies
None

## How has this been tested?
None

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
