### PR TITLE
ignoring py safety warning

### DIFF
--- a/.github/workflows/hagrid-pr_tests.yml
+++ b/.github/workflows/hagrid-pr_tests.yml
@@ -73,14 +73,14 @@ jobs:
         run: |
           pip install importlib-metadata==4.13.0
           bandit -r hagrid
-          safety check -i 42923
+          safety check -i 42923 -i 51457
 
       - name: Scan for security issues python 3.7
         if: steps.changes.outputs.hagrid == 'true' && matrix.python-version == '3.7'
         run: |
           pip install importlib-metadata==4.13.0
           bandit -r hagrid
-          safety check -i 42923
+          safety check -i 42923 -i 51457
 
       - name: Build Wheel
         if: steps.changes.outputs.hagrid == 'true'


### PR DESCRIPTION
## Description
Fixing the Hagrid PR failing due to safety warnings about `py`