### PR TITLE
Remove redundant white spaces in tensor init message

### DIFF
--- a/packages/syft/src/syft/core/tensor/tensor.py
+++ b/packages/syft/src/syft/core/tensor/tensor.py
@@ -517,8 +517,8 @@ class Tensor(
         self.public_dtype = public_dtype
 
         print(
-            "Tensor created! You can activate Differential Privacy protection by calling .private() or \
-            .annotate_with_dp_metadata()."
+            "Tensor created! You can activate Differential Privacy protection by calling .private() or "
+            ".annotate_with_dp_metadata()."
         )
 
     def tag(self, name: str) -> Tensor:


### PR DESCRIPTION
## Description
Fix #7109.

<img width="969" alt="Screenshot 2022-11-24 at 3 47 23 PM" src="https://user-images.githubusercontent.com/6521018/203724277-7c4ae9d0-5975-428f-9144-e76685336930.png">

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
