### PR TITLE
Fix __array_func__ and disable __array_ufunc__ for passthrough tensors

### DIFF
--- a/packages/syft/src/syft/core/tensor/passthrough.py
+++ b/packages/syft/src/syft/core/tensor/passthrough.py
@@ -708,14 +708,8 @@ class PassthroughTensor(np.lib.mixins.NDArrayOperatorsMixin):
 
         return NotImplemented
 
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        implementation = query_implementation(self.__class__, ufunc)
-        if implementation:
-            return implementation(*inputs, **kwargs)
-
-        method_name = ufunc.__name__
-        implementation = getattr(self.__class__, method_name, None)
-        return implementation(*inputs, **kwargs) if implementation else NotImplemented
+    # Set __array_ufunc_ = None for now until we can implement this properly
+    __array_ufunc__ = None
 
     def __repr__(self):
         return f"{self.__class__.__name__}(child={self.child})"

--- a/packages/syft/src/syft/core/tensor/passthrough.py
+++ b/packages/syft/src/syft/core/tensor/passthrough.py
@@ -696,13 +696,26 @@ class PassthroughTensor(np.lib.mixins.NDArrayOperatorsMixin):
         implementation = query_implementation(self.__class__, func)
         if implementation:
             return implementation(*args, **kwargs)
-        return self.__class__(func(*args, **kwargs))
+
+        method_name = func.__name__
+        implementation = getattr(self.__class__, method_name, None)
+        if implementation:
+            return (
+                implementation(*args, **kwargs)
+                if callable(implementation)
+                else self.__getattribute__(method_name)
+            )
+
+        return NotImplemented
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         implementation = query_implementation(self.__class__, ufunc)
         if implementation:
             return implementation(*inputs, **kwargs)
-        return self.__class__(ufunc(*inputs, **kwargs))
+
+        method_name = ufunc.__name__
+        implementation = getattr(self.__class__, method_name, None)
+        return implementation(*inputs, **kwargs) if implementation else NotImplemented
 
     def __repr__(self):
         return f"{self.__class__.__name__}(child={self.child})"

--- a/packages/syft/tests/syft/core/tensor/passthrough_test.py
+++ b/packages/syft/tests/syft/core/tensor/passthrough_test.py
@@ -8,6 +8,7 @@ import torch
 
 # syft absolute
 from syft.core.tensor.passthrough import PassthroughTensor
+from syft.core.tensor.tensor import Tensor
 from syft.core.tensor.util import implements
 
 
@@ -933,6 +934,7 @@ def test__array_function__() -> None:
     assert result_c == expected_c.child
 
 
+@pytest.mark.xfail
 def test__array_ufunc__() -> None:
     data_a = np.array([1, 2, 3], dtype=np.int32)
     tensor_a = PtTensorSubclass(child=data_a, unit="Hedgehogs")
@@ -964,6 +966,7 @@ def test_repr() -> None:
     assert type(result) == str
 
 
+@pytest.mark.xfail
 def test_square() -> None:
     data = np.array([[0, 1], [-2, 3]], dtype=np.int32)
     expected = np.array([[0, 1], [4, 9]], dtype=np.int32)
@@ -972,3 +975,20 @@ def test_square() -> None:
     result = np.square(tensor_a)
 
     assert result == tensor_b
+
+
+def test_unimplemented_array_func() -> None:
+    # test if unimplemented ops correctly return TypeError: no implementation found
+    tensor = Tensor(np.array([0, 1, 2, 3], dtype=np.int32))
+
+    # change to some op other than full_like if this ends up being implemented
+    with pytest.raises(TypeError, match="no implementation found"):
+        np.full_like(tensor, 7)
+
+
+def test_unsupported_ufunc() -> None:
+    # we don't currently support ufunc
+    tensor = Tensor(np.array([0, 1, 2, 3], dtype=np.int32))
+
+    with pytest.raises(TypeError, match="does not support ufuncs"):
+        np.sin(tensor)


### PR DESCRIPTION
## Description
FIx #7042.

Unimplemented methods on tensors now correctly raise no implementation error instead of going into an infinite loop

```py
np.full_like(sy.Tensor(np.array([1, 2, 3])).annotate_with_dp_metadata(-1, 11000, data_subjects="Bob"), 7)

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In [7], line 1
----> 1 np.full_like(sy.Tensor(np.array([1, 2, 3])).annotate_with_dp_metadata(-1, 11000, data_subjects="Bob"), 7)

File <__array_function__ internals>:180, in full_like(*args, **kwargs)

TypeError: no implementation found for 'numpy.full_like' on types that implement __array_function__: [<class 'syft.core.tensor.tensor.Tensor'>]
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
