### PR TITLE
Removal of PassthroughTensor from DP TensorPointer

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,21 +3,21 @@ current_version = 0.7.0-beta.59
 tag = False
 tag_name = {new_version}
 commit = True
-parse = 
+parse =
 	(?P<major>\d+)
 	\.
 	(?P<minor>\d+)
 	\.
 	(?P<patch>\d+)
 	(\-(?P<pre>[a-z]+)\.(?P<prenum>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{pre}.{prenum}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:pre]
 optional_value = placeholder
 first_value = alpha
-values = 
+values =
 	alpha
 	beta
 	rc

--- a/packages/syft/src/syft/core/tensor/autodp/gamma_tensor.py
+++ b/packages/syft/src/syft/core/tensor/autodp/gamma_tensor.py
@@ -80,7 +80,7 @@ INPLACE_OPS = {"resize", "sort"}
 
 
 @serializable(recursive_serde=True)
-class TensorWrappedGammaTensorPointer(Pointer, PassthroughTensor):
+class TensorWrappedGammaTensorPointer(Pointer):
     __name__ = "TensorWrappedGammaTensorPointer"
     __module__ = "syft.core.tensor.autodp.gamma_tensor"
     __attr_allowlist__ = [

--- a/packages/syft/src/syft/core/tensor/autodp/phi_tensor.py
+++ b/packages/syft/src/syft/core/tensor/autodp/phi_tensor.py
@@ -67,7 +67,7 @@ INPLACE_OPS = {"resize", "sort"}
 
 
 @serializable(recursive_serde=True)
-class TensorWrappedPhiTensorPointer(Pointer, PassthroughTensor):
+class TensorWrappedPhiTensorPointer(Pointer):
     __name__ = "TensorWrappedPhiTensorPointer"
     __module__ = "syft.core.tensor.autodp.phi_tensor"
     __attr_allowlist__ = [


### PR DESCRIPTION
## Description
The PR aims to remove passthrough from DP tensor Pointers, 
Subclassing pointers from PassthroughTensor makes unimplemented methods available on the client side.
Fixes #6922 

## How has this been tested?
Local Testing

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented on my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
