### PR TITLE
Miscellaneous hagrid fixes

### DIFF
--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -392,7 +392,7 @@ def launch(args: TypeTuple[str], **kwargs: Any) -> None:
             node_name = verb.get_named_term_type(name="node_name").snake_input
             rich.get_console().print(
                 rich.panel.Panel.fit(
-                    f"🚨🚨🚨 To view container logs run [bold red] hagrid logs {node_name} [/bold red]\t"
+                    f"✨ To view container logs run [bold green]hagrid logs {node_name}[/bold green]\t"
                 )
             )
 

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -389,7 +389,7 @@ def launch(args: TypeTuple[str], **kwargs: Any) -> None:
                 port = match_port.group().replace("HTTP_PORT=", "")
                 check_status("localhost" + ":" + port)
 
-            node_name = verb.get_named_term_type(name="node_name").raw_input
+            node_name = verb.get_named_term_type(name="node_name").snake_input
             rich.get_console().print(
                 rich.panel.Panel.fit(
                     f"🚨🚨🚨 To view container logs run [bold red] hagrid logs {node_name} [/bold red]\t"

--- a/packages/hagrid/hagrid/deps.py
+++ b/packages/hagrid/hagrid/deps.py
@@ -36,6 +36,7 @@ from rich.console import Console
 
 # relative
 from .exceptions import MissingDependency
+from .lib import is_gitpod
 from .mode import EDITABLE_MODE
 from .nb_output import NBOutput
 from .version import __version__
@@ -546,7 +547,7 @@ def allowed_to_run_docker() -> Tuple[bool, str]:
             bool_result = True
 
         # Check if current user is member of docker group.
-        elif user not in "".join(line):
+        elif not is_gitpod() and user not in "".join(line):
             msg = f"""⚠️  User is not a member of docker group.
 {WHITE}You're currently not allowed to run docker, perform the following steps:\n
     1 - Run \'{GREEN}sudo usermod -a -G docker $USER\'{WHITE} to add docker permissions.


### PR DESCRIPTION
## Description
Fix #7114
Fix #7144
Fix #7151

- Disable docker group check if inside gitpod
- Fix issue where it show `hagrid logs None` when a node name is not specified in `hagrid launch`, i.e. `hagrid launch domain to docker:8801 ...`
- Better visual for hagrid logs message (no red text, police car revolving lights)

<img width="485" alt="Screenshot 2022-12-07 at 12 23 57 AM" src="https://user-images.githubusercontent.com/6521018/205968717-2addca99-11d0-4496-b233-a1366eb10f49.png">

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
