### PR TITLE
Convert hagrid options to flags

### DIFF
--- a/docs/source/guides/data-owner/00-deploy-domain.rst
+++ b/docs/source/guides/data-owner/00-deploy-domain.rst
@@ -3,15 +3,15 @@ Deploying your own Domain Server
 
 **Data Owner Tutorials**
 
-◻️ 00-deploy-domain 👈 
+◻️ 00-deploy-domain 👈
 
 ◻️ 01-upload-data
 
-.. note:: 
+.. note::
    **TIP:** To run this tutorial interactively in Jupyter Lab on your own machine type:
 
-:: 
-   
+::
+
    pip install -U hagrid
    hagrid quickstart data-owner
 
@@ -23,7 +23,7 @@ study by an outside party.
 This tutorial will help you understand how a Data Owner can
 ``launch`` their own Domain Server to securely host private datasets.
 
-   **Note:** Throughout the tutorials, we also mean Domain Servers whenever we refer to Domain Node. Both mean the same and are used interchangeably. 
+   **Note:** Throughout the tutorials, we also mean Domain Servers whenever we refer to Domain Node. Both mean the same and are used interchangeably.
 
 Why do Data Owners Deploy Domain Servers?
 -----------------------------------------
@@ -42,35 +42,35 @@ The advantage of using a Domain Server is that you can catalyze the impact your 
 |00-deploy-domain-00|
 
 
-This means that by having your organization retain governance over the information they steward without 
-needing to share direct ``copies`` of data to collaborators, domain servers create an opportunity for more 
+This means that by having your organization retain governance over the information they steward without
+needing to share direct ``copies`` of data to collaborators, domain servers create an opportunity for more
 collaboration and more research to happen without losing ``control`` of your data and risking things like IP.
 
 Steps To Deploy a Domain
 ------------------------
 
-How collaboration gets streamlined will be covered in our tutorials about connecting to a ``"Network Node."`` We will discuss 
-how control is maintained in our tutorials about ``"How to assign a Privacy Budget."`` For this tutorial, however, 
+How collaboration gets streamlined will be covered in our tutorials about connecting to a ``"Network Node."`` We will discuss
+how control is maintained in our tutorials about ``"How to assign a Privacy Budget."`` For this tutorial, however,
 let's start by learning how to deploy a domain server.
 
-📒 Overview of this tutorial: 
+📒 Overview of this tutorial:
 
-* **Installing** the required software 
-* **Running** the servers 
+* **Installing** the required software
+* **Running** the servers
 * **Checking** the status of deployed server
 
 |00-deploy-domain-01|
 
-Few things to make a note of before starting: 
+Few things to make a note of before starting:
 
-- **PySyft** = Privacy-Preserving Library 
-- **PyGrid** = Networking and Management Platform 
+- **PySyft** = Privacy-Preserving Library
+- **PyGrid** = Networking and Management Platform
 - **HAGrid** = Deployment and Command Line Tool
 
 Step 1: Install wizard
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-To simplify the installation process, we have an `install wizard` that will help you 
+To simplify the installation process, we have an `install wizard` that will help you
 setup the latest versions of `hagrid` and `syft` on your machine.
 
 You can go to the install wizard at any time by running the below command:
@@ -80,7 +80,7 @@ You can go to the install wizard at any time by running the below command:
    hagrid quickstart
 
 
-.. warning:: 
+.. warning::
    The next step will show you how to launch a domain node. If
    you run into any ``issue`` running the above installation wizard, consider
    looking for the ``error`` you are getting on our
@@ -99,15 +99,15 @@ Great work, people!! Once you have installed all the dependencies, it is
 time to use ``HAGrid`` to launch your Domain Node.
 
 To launch a domain node, there are three things that you
-need to know: 
+need to know:
 
-1. **What type of node do you need to deploy?** 
+1. **What type of node do you need to deploy?**
 There are two different types of nodes: Domain Node and Network Node. By
-default, HAGrid launches the ``primary`` node that is our Domain Node. 
+default, HAGrid launches the ``primary`` node that is our Domain Node.
 
-2. **Where are you going to launch this node to?** 
+2. **Where are you going to launch this node to?**
 We need to specify that we want to launch it to the ``docker container`` at
-port ``8081``. 
+port ``8081``.
 
 3. **What is the name of your Domain Node going to be?**
 For that, don’t forget to specify the ``DOMAIN_NAME`` to your
@@ -117,13 +117,13 @@ After completing the Install Wizard, run the cell below to launch your very firs
 
 ::
 
-   In: 
+   In:
 
    # edit DOMAIN_NAME and run this cell
 
    DOMAIN_NAME = "My Domain"
 
-   !hagrid launch {DOMAIN_NAME} to docker:8081 --tag=latest --tail=false
+   !hagrid launch {DOMAIN_NAME} to docker:8081 --tag=latest
 
 While this command runs, you will see various ``volumes`` and
 ``containers`` being created. Once this step is complete, move on to
@@ -133,8 +133,8 @@ our Domain Node.
 Step 3: Checking your Domain Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-One exciting benefit of HAGrid is that it makes it easier for your organization/ IT department 
-to ``monitor`` & ``maintain`` the status of your system as you move forward with other steps. 
+One exciting benefit of HAGrid is that it makes it easier for your organization/ IT department
+to ``monitor`` & ``maintain`` the status of your system as you move forward with other steps.
 Let's do a quick health check to ensure the Domain is up and running.
 
 
@@ -145,7 +145,7 @@ Let's do a quick health check to ensure the Domain is up and running.
    # run this cell
    !hagrid check localhost:8081
 
-   Out: 
+   Out:
 
    Detecting External IP...
    ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━┓
@@ -177,10 +177,10 @@ Congratulations 👏 You have now successfully deployed a Domain Server!
 Now what?
 ---------
 
-Once you, as a Data Owner, have deployed your Domain Node representing your theoretical organization's 
+Once you, as a Data Owner, have deployed your Domain Node representing your theoretical organization's
 private data server, the next step is to :doc:`Upload Private Data to a Domain Server <01-upload-data>` for research or project use.
 
-   In our following tutorial, we will see how you as a Data Owners can preprocess the data, mark it with correct 
+   In our following tutorial, we will see how you as a Data Owners can preprocess the data, mark it with correct
    metadata and upload it to the Domain Node you've just deployed.
 
 .. |00-deploy-domain-00| image:: ../../_static/personas-image/data-owner/00-deploy-domain-00.gif

--- a/notebooks/Experimental/Ishan/AA/update_syft.sh
+++ b/notebooks/Experimental/Ishan/AA/update_syft.sh
@@ -3,6 +3,5 @@ echo "Domain Name: ${DOMAIN_NAME}"
 echo "Nuking  Domain ..  >:)";
 hagrid land all;
 echo "Launching Domain .. hahaha >:)";
-hagrid launch ${DOMAIN_NAME} to docker:80  --tail=false --dev
+hagrid launch ${DOMAIN_NAME} to docker:80 --dev
 echo "finished"
-

--- a/notebooks/Experimental/Shubham/TradeDemoE2E/Trade-demo-data-owners.ipynb
+++ b/notebooks/Experimental/Shubham/TradeDemoE2E/Trade-demo-data-owners.ipynb
@@ -213,7 +213,7 @@
     "\n",
     "DOMAIN_NAME = \"\"\n",
     "\n",
-    "! hagrid launch {DOMAIN_NAME} to docker:80 --tag=latest --tail=false\n",
+    "! hagrid launch {DOMAIN_NAME} to docker:80 --tag=latest\n",
     "\n",
     "! echo \"\\n✅ Step Complete\\n\""
    ]
@@ -1543,7 +1543,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('python39-FyWEp-Wu')",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -1557,12 +1557,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
   },
   "toc-autonumbering": false,
   "vscode": {
    "interpreter": {
-    "hash": "450446d9358bec00bc7ecb1d6fb0a8764360b382210f2637a3413e3aac83c9e5"
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
    }
   }
  },

--- a/notebooks/Experimental/medical-federated-learning-program/data-owners-full/02-data-owners-setup-domain.ipynb
+++ b/notebooks/Experimental/medical-federated-learning-program/data-owners-full/02-data-owners-setup-domain.ipynb
@@ -270,6 +270,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "66c1e67c-87d9-4a91-afec-f396a9d6cdae",
    "metadata": {},
@@ -282,9 +283,8 @@
     "**target_host**: Since we are already logged into the VM we use `docker` <br />\n",
     "**node_name**: is the name of the Domain and is an optional argument. If you don't specify a unique <node_name>, then HAGrid generates one automatically <br />\n",
     "**--tag=latest**: this flag ensures we use the `latest` pre-built containers from `dockerhub` <br />\n",
-    "**--tail=false**: this flag launches everything in the background <br />\n",
     "\n",
-    "**NOTE**: You can run almost any `hagrid launch` command with `--cmd=true` and it will do a dry run, print commands instead of running them."
+    "**NOTE**: You can run almost any `hagrid launch` command with `--cmd` and it will do a dry run, print commands instead of running them."
    ]
   },
   {
@@ -304,12 +304,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cfe031ac-53ff-4c72-8801-c98f832a80d1",
    "metadata": {},
    "source": [
     "```shell\n",
-    "hagrid launch to docker:80 --tag=latest --tail=false\n",
+    "hagrid launch to docker:80 --tag=latest\n",
     "```"
    ]
   },
@@ -563,7 +564,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -577,7 +578,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/Experimental/medical-federated-learning-program/data-owners/data-owners-presentation.ipynb
+++ b/notebooks/Experimental/medical-federated-learning-program/data-owners/data-owners-presentation.ipynb
@@ -229,7 +229,7 @@
     "\n",
     "DOMAIN_NAME = \"My Institution Name\"\n",
     "\n",
-    "! hagrid launch {DOMAIN_NAME} to docker:80 --tag=latest --tail=false\n",
+    "! hagrid launch {DOMAIN_NAME} to docker:80 --tag=latest\n",
     "\n",
     "! echo \"\\n✅ Step Complete\\n\""
    ]
@@ -885,7 +885,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('python39-FyWEp-Wu')",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -899,12 +899,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
   },
   "toc-autonumbering": false,
   "vscode": {
    "interpreter": {
-    "hash": "450446d9358bec00bc7ecb1d6fb0a8764360b382210f2637a3413e3aac83c9e5"
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
    }
   }
  },

--- a/notebooks/Experimental/mflp_sessions/Project3_Hagrid_Deep_Dive/Playing with Pets - Session 3.ipynb
+++ b/notebooks/Experimental/mflp_sessions/Project3_Hagrid_Deep_Dive/Playing with Pets - Session 3.ipynb
@@ -382,7 +382,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -396,7 +396,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/PySyTFF/DO.ipynb
+++ b/notebooks/PySyTFF/DO.ipynb
@@ -23,10 +23,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main requirement for running this notebook and the data scientist notebook is having a domain node running. For that you can either use the commented `hagrid` command straight in the notebook or run them in a terminal. Running the command in the terminal will also allow you to see the logs by deleting the `--tail=false` and `--silent` parameters."
+    "The main requirement for running this notebook and the data scientist notebook is having a domain node running. For that you can either use the commented `hagrid` command straight in the notebook or run them in a terminal. Running the command in the terminal will also allow you to see the logs by removing the `--silent` and adding the `--tail` parameters."
    ]
   },
   {
@@ -36,8 +37,8 @@
    "outputs": [],
    "source": [
     "# in the release we will have:\n",
-    "# !hagrid launch <domain_name> --tag=latest --tff --tail=false --silent\n",
-    "# !hagrid launch test_domain domain to docker:8081 --tag=local --tff --tail=false --silent"
+    "# !hagrid launch <domain_name> --tag=latest --tff --silent\n",
+    "# !hagrid launch test_domain domain to docker:8081 --tag=local --tff --silent"
    ]
   },
   {
@@ -539,7 +540,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('python39-FyWEp-Wu')",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -553,11 +554,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "450446d9358bec00bc7ecb1d6fb0a8764360b382210f2637a3413e3aac83c9e5"
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
    }
   }
  },

--- a/notebooks/petlab_sessions/TradeDemoE2E/Trade-demo-data-owners.ipynb
+++ b/notebooks/petlab_sessions/TradeDemoE2E/Trade-demo-data-owners.ipynb
@@ -213,7 +213,7 @@
     "\n",
     "DOMAIN_NAME = \"\"\n",
     "\n",
-    "! hagrid launch {DOMAIN_NAME} to docker:80 --tag=latest --tail=false --silent\n",
+    "! hagrid launch {DOMAIN_NAME} to docker:80 --tag=latest --silent\n",
     "\n",
     "! echo \"\\n✅ Step Complete\\n\""
    ]
@@ -859,7 +859,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('python39-FyWEp-Wu')",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -873,12 +873,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
   },
   "toc-autonumbering": false,
   "vscode": {
    "interpreter": {
-    "hash": "450446d9358bec00bc7ecb1d6fb0a8764360b382210f2637a3413e3aac83c9e5"
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
    }
   }
  },

--- a/notebooks/quickstart/01-install-wizard.ipynb
+++ b/notebooks/quickstart/01-install-wizard.ipynb
@@ -191,7 +191,7 @@
    },
    "outputs": [],
    "source": [
-    "!hagrid launch test_domain domain to docker:8081 --tag=latest --tail=false"
+    "!hagrid launch test_domain domain to docker:8081 --tag=latest"
    ]
   },
   {
@@ -292,7 +292,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -306,7 +306,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/quickstart/data-owner/00-deploy-domain.ipynb
+++ b/notebooks/quickstart/data-owner/00-deploy-domain.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "DOMAIN_NAME = \"My Domain\"\n",
     "\n",
-    "!hagrid launch {DOMAIN_NAME} to docker:8081 --tag=latest --tail=false"
+    "!hagrid launch {DOMAIN_NAME} to docker:8081 --tag=latest"
    ]
   },
   {
@@ -193,7 +193,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -207,11 +207,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
    }
   }
  },

--- a/packages/grid/ansible/roles/aa_demo/tasks/main.yml
+++ b/packages/grid/ansible/roles/aa_demo/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Start Docker Containers
   shell:
-    cmd: runuser -l {{ om_user }} -c 'hagrid launch domain to docker:80 --tag=latest --tail=false'
+    cmd: runuser -l {{ om_user }} -c 'hagrid launch domain to docker:80 --tag=latest'
   become: yes
   when: aa_demo is defined and aa_demo == "true"
 

--- a/packages/grid/ansible/roles/containers/tasks/containers.yml
+++ b/packages/grid/ansible/roles/containers/tasks/containers.yml
@@ -35,12 +35,12 @@
 
 - name: Start Docker Containers
   shell:
-    cmd: runuser -l {{ om_user }} -c 'hagrid launch {{ node_name }} {{ node_type }} to docker:80 --release={{ release }} --tag={{ docker_tag }} --tail=false'
+    cmd: runuser -l {{ om_user }} -c 'hagrid launch {{ node_name }} {{ node_type }} to docker:80 --release={{ release }} --tag={{ docker_tag }}'
   become: yes
   when: tls == "false" and install == "true"
 
 - name: Start Docker Containers with TLS
   shell:
-    cmd: runuser -l {{ om_user }} -c 'hagrid launch {{ node_name }} {{ node_type }} to docker:80 --release={{ release }} --tag={{ docker_tag }} --tail=false --tls --cert_store_path={{ cert_store_path }}'
+    cmd: runuser -l {{ om_user }} -c 'hagrid launch {{ node_name }} {{ node_type }} to docker:80 --release={{ release }} --tag={{ docker_tag }} --tls --cert_store_path={{ cert_store_path }}'
   become: yes
   when: tls == "true" and install == "true"

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -152,60 +152,60 @@ def clean(location: str) -> None:
     default=None,
     required=False,
     type=str,
-    help="Optional: the username for provisioning the remote host",
+    help="Username for provisioning the remote host",
 )
 @click.option(
     "--key_path",
     default=None,
     required=False,
     type=str,
-    help="Optional: the path to the key file for provisioning the remote host",
+    help="Path to the key file for provisioning the remote host",
 )
 @click.option(
     "--password",
     default=None,
     required=False,
     type=str,
-    help="Optional: the password for provisioning the remote host",
+    help="Password for provisioning the remote host",
 )
 @click.option(
     "--repo",
     default=None,
     required=False,
     type=str,
-    help="Optional: repo to fetch source from",
+    help="Repo to fetch source from",
 )
 @click.option(
     "--branch",
     default=None,
     required=False,
     type=str,
-    help="Optional: branch to monitor for updates",
+    help="Branch to monitor for updates",
 )
 @click.option(
     "--tail",
     is_flag=True,
-    help="Optional: tail logs on launch",
+    help="Tail logs on launch",
 )
 @click.option(
     "--headless",
     is_flag=True,
-    help="Optional: start the frontend container",
+    help="Start the frontend container",
 )
 @click.option(
     "--cmd",
     is_flag=True,
-    help="Optional: print the cmd without running it",
+    help="Print the cmd without running it",
 )
 @click.option(
     "--jupyter",
     is_flag=True,
-    help="Optional: enable Jupyter Notebooks",
+    help="Enable Jupyter Notebooks",
 )
 @click.option(
     "--build",
     is_flag=True,
-    help="Optional: enable or disable forcing re-build",
+    help="Disable forcing re-build",
 )
 @click.option(
     "--no_provision",
@@ -217,7 +217,7 @@ def clean(location: str) -> None:
     default=1,
     required=False,
     type=click.IntRange(1, 250),
-    help="Optional: number of independent nodes/VMs to launch",
+    help="Number of independent nodes/VMs to launch",
 )
 @click.option(
     "--auth_type",
@@ -237,28 +237,28 @@ def clean(location: str) -> None:
     default="production",
     required=False,
     type=click.Choice(["production", "development"], case_sensitive=False),
-    help="Optional: choose between production and development release",
+    help="Choose between production and development release",
 )
 @click.option(
     "--cert_store_path",
     default="/home/om/certs",
     required=False,
     type=str,
-    help="Optional: remote path to store and load TLS cert and key",
+    help="Remote path to store and load TLS cert and key",
 )
 @click.option(
     "--upload_tls_cert",
     default="",
     required=False,
     type=str,
-    help="Optional: local path to TLS cert to upload and store at --cert_store_path",
+    help="Local path to TLS cert to upload and store at --cert_store_path",
 )
 @click.option(
     "--upload_tls_key",
     default="",
     required=False,
     type=str,
-    help="Optional: local path to TLS private key to upload and store at --cert_store_path",
+    help="Local path to TLS private key to upload and store at --cert_store_path",
 )
 @click.option(
     "--no_blob_storage",
@@ -270,48 +270,48 @@ def clean(location: str) -> None:
     default=None,
     required=False,
     type=str,
-    help="Optional: image to use for the VM",
+    help="Image to use for the VM",
 )
 @click.option(
     "--tag",
     default=None,
     required=False,
     type=str,
-    help="Optional: container image tag to use",
+    help="Container image tag to use",
 )
 @click.option(
     "--build_src",
     default=DEFAULT_BRANCH,
     required=False,
     type=str,
-    help="Optional: git branch to use for launch / build operations",
+    help="Git branch to use for launch / build operations",
 )
 @click.option(
     "--platform",
     default=None,
     required=False,
     type=str,
-    help="Optional: run docker with a different platform like linux/arm64",
+    help="Run docker with a different platform like linux/arm64",
 )
 @click.option(
     "--no_vpn",
     is_flag=True,
-    help="Optional: disable tailscale vpn container",
+    help="Disable tailscale vpn container",
 )
 @click.option(
     "--silent",
     is_flag=True,
-    help="Optional: prevent lots of launch output",
+    help="Suppress extra launch outputs",
 )
 @click.option(
     "--from_template",
     is_flag=True,
-    help="Optional: launch node using the manifest template",
+    help="Launch node using the manifest template",
 )
 @click.option(
     "--no_health_checks",
     is_flag=True,
-    help="Optional: turn off auto health checks post node launch",
+    help="Turn off auto health checks post node launch",
 )
 def launch(args: TypeTuple[str], **kwargs: Any) -> None:
     verb = get_launch_verb()
@@ -2545,7 +2545,7 @@ def create_land_docker_cmd(verb: GrammarVerb) -> str:
 @click.option(
     "--cmd",
     is_flag=True,
-    help="Optional: print the cmd without running it",
+    help="Print the cmd without running it",
 )
 @click.option(
     "--ansible_extras",
@@ -2557,17 +2557,17 @@ def create_land_docker_cmd(verb: GrammarVerb) -> str:
     default=DEFAULT_BRANCH,
     required=False,
     type=str,
-    help="Optional: git branch to use for launch / build operations",
+    help="Git branch to use for launch / build operations",
 )
 @click.option(
     "--silent",
     is_flag=True,
-    help="Optional: prevent lots of land output",
+    help="Suppress extra outputs",
 )
 @click.option(
     "--force",
     is_flag=True,
-    help="Optional: bypass the prompt during hagrid land ",
+    help="Bypass the prompt during hagrid land",
 )
 def land(args: TypeTuple[str], **kwargs: Any) -> None:
     verb = get_land_verb()
@@ -2846,12 +2846,12 @@ def get_syft_install_status(host_name: str) -> bool:
 @click.option(
     "--timeout",
     default=300,
-    help="Timeout for hagrid check command,Default: 300 seconds",
+    help="Timeout for hagrid check command",
 )
 @click.option(
     "--verbose",
     is_flag=True,
-    help="Refresh output,Defaults True",
+    help="Refresh output",
 )
 def check(
     ip_addresses: TypeList[str], verbose: bool = False, timeout: Union[int, str] = 300

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -124,7 +124,8 @@ def cli() -> None:
 
 
 @click.command(
-    help="Restore some part of the hagrid installation or deployment to its initial/starting state."
+    help="Restore some part of the hagrid installation or deployment to its initial/starting state.",
+    context_settings={"show_default": True},
 )
 @click.argument("location", type=str, nargs=1)
 def clean(location: str) -> None:
@@ -145,7 +146,10 @@ def clean(location: str) -> None:
         subprocess.call("docker rmi $(docker images -q)", shell=True)  # nosec
 
 
-@click.command(help="Start a new PyGrid domain/network node!")
+@click.command(
+    help="Start a new PyGrid domain/network node!",
+    context_settings={"show_default": True},
+)
 @click.argument("args", type=str, nargs=-1)
 @click.option(
     "--username",
@@ -2540,7 +2544,10 @@ def create_land_docker_cmd(verb: GrammarVerb) -> str:
     return cmd
 
 
-@click.command(help="Stop a running PyGrid domain/network node.")
+@click.command(
+    help="Stop a running PyGrid domain/network node.",
+    context_settings={"show_default": True},
+)
 @click.argument("args", type=str, nargs=-1)
 @click.option(
     "--cmd",
@@ -2632,7 +2639,9 @@ cli.add_command(land)
 cli.add_command(clean)
 
 
-@click.command(help="Show HAGrid debug information")
+@click.command(
+    help="Show HAGrid debug information", context_settings={"show_default": True}
+)
 @click.argument("args", type=str, nargs=-1)
 def debug(args: TypeTuple[str], **kwargs: TypeDict[str, Any]) -> None:
     debug_info = gather_debug()
@@ -2841,7 +2850,10 @@ def get_syft_install_status(host_name: str) -> bool:
         return True
 
 
-@click.command(help="Check health of an IP address/addresses or a resource group")
+@click.command(
+    help="Check health of an IP address/addresses or a resource group",
+    context_settings={"show_default": True},
+)
 @click.argument("ip_addresses", type=str, nargs=-1)
 @click.option(
     "--timeout",
@@ -2980,7 +2992,7 @@ cli.add_command(check)
 
 
 # add Hagrid info to the cli
-@click.command(help="Show HAGrid info")
+@click.command(help="Show HAGrid info", context_settings={"show_default": True})
 def version() -> None:
     print(f"HAGRID_VERSION: {get_version_string()}")
     if EDITABLE_MODE:
@@ -3148,12 +3160,14 @@ def run_quickstart(
         raise e
 
 
-@click.command(help="Launch a Syft + Jupyter Session with a Notebook URL / Path")
+@click.command(
+    help="Launch a Syft + Jupyter Session with a Notebook URL / Path",
+    context_settings={"show_default": True},
+)
 @click.argument("url", type=str, required=False)
 @click.option(
     "--reset",
     is_flag=True,
-    show_default=True,
     default=False,
     help="Force hagrid quickstart to setup a fresh virtualenv",
 )
@@ -3370,7 +3384,7 @@ def add_intro_notebook(directory: str, reset: bool = False) -> str:
     return os.path.abspath(f"{directory}/{filename}")
 
 
-@click.command(help="Walk the Path")
+@click.command(help="Walk the Path", context_settings={"show_default": True})
 @click.option(
     "--repo",
     help="Obi-Wan will guide you to Dagobah",
@@ -3422,7 +3436,10 @@ def ssh_into_remote_machine(
         raise e
 
 
-@click.command(help="SSH into the IP address or a resource group")
+@click.command(
+    help="SSH into the IP address or a resource group",
+    context_settings={"show_default": True},
+)
 @click.argument("ip_address", type=str)
 @click.option(
     "--cmd",
@@ -3484,7 +3501,9 @@ cli.add_command(ssh)
 
 
 # Add hagrid logs command to the CLI
-@click.command(help="Get the logs of the HAGrid node")
+@click.command(
+    help="Get the logs of the HAGrid node", context_settings={"show_default": True}
+)
 @click.argument("domain_name", type=str)
 def logs(domain_name: str) -> None:  # nosec
 

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -185,12 +185,12 @@ def clean(location: str) -> None:
 @click.option(
     "--tail",
     is_flag=True,
-    help="Optional: don't tail logs on launch",
+    help="Optional: tail logs on launch",
 )
 @click.option(
     "--headless",
     is_flag=True,
-    help="Optional: don't start the frontend container",
+    help="Optional: start the frontend container",
 )
 @click.option(
     "--cmd",
@@ -296,7 +296,7 @@ def clean(location: str) -> None:
 @click.option(
     "--no_vpn",
     is_flag=True,
-    help="Disable tailscale vpn container",
+    help="Optional: disable tailscale vpn container",
 )
 @click.option(
     "--silent",
@@ -311,7 +311,7 @@ def clean(location: str) -> None:
 @click.option(
     "--no_health_checks",
     is_flag=True,
-    help="Optional: turn on or off auto health checks post node launch",
+    help="Optional: turn off auto health checks post node launch",
 )
 def launch(args: TypeTuple[str], **kwargs: Any) -> None:
     verb = get_launch_verb()

--- a/packages/hagrid/tests/hagrid/cli_test.py
+++ b/packages/hagrid/tests/hagrid/cli_test.py
@@ -1,4 +1,5 @@
 # stdlib
+from collections import defaultdict
 from typing import List
 from typing import Tuple
 
@@ -18,7 +19,9 @@ def test_hagrid_launch() -> None:
     verb = cli.get_launch_verb()
     grammar = cli.parse_grammar(args=tuple(args), verb=verb)
     verb.load_grammar(grammar=grammar)
-    cmd = cli.create_launch_cmd(verb=verb, kwargs={}, ignore_docker_version_check=True)
+    cmd = cli.create_launch_cmd(
+        verb=verb, kwargs=defaultdict(lambda: None), ignore_docker_version_check=True
+    )
 
     cmd = cmd["Launching"][0]  # type: ignore
 
@@ -56,7 +59,9 @@ def test_hagrid_launch_without_name_with_preposition() -> None:
     verb = cli.get_launch_verb()
     grammar = cli.parse_grammar(args=tuple(args), verb=verb)
     verb.load_grammar(grammar=grammar)
-    cmd = cli.create_launch_cmd(verb=verb, kwargs={}, ignore_docker_version_check=True)
+    cmd = cli.create_launch_cmd(
+        verb=verb, kwargs=defaultdict(lambda: None), ignore_docker_version_check=True
+    )
 
     cmd = cmd["Launching"][0]  # type: ignore
     # check that it's a domain by default
@@ -93,7 +98,9 @@ def test_launch_with_multiword_domain_name() -> None:
     verb = cli.get_launch_verb()
     grammar = cli.parse_grammar(args=tuple(args), verb=verb)
     verb.load_grammar(grammar=grammar)
-    cmd = cli.create_launch_cmd(verb=verb, kwargs={}, ignore_docker_version_check=True)
+    cmd = cli.create_launch_cmd(
+        verb=verb, kwargs=defaultdict(lambda: None), ignore_docker_version_check=True
+    )
 
     cmd = cmd["Launching"][0]  # type: ignore
 
@@ -117,7 +124,9 @@ def test_launch_with_longer_multiword_domain_name() -> None:
     verb = cli.get_launch_verb()
     grammar = cli.parse_grammar(args=tuple(args), verb=verb)
     verb.load_grammar(grammar=grammar)
-    cmd = cli.create_launch_cmd(verb=verb, kwargs={}, ignore_docker_version_check=True)
+    cmd = cli.create_launch_cmd(
+        verb=verb, kwargs=defaultdict(lambda: None), ignore_docker_version_check=True
+    )
 
     cmd = cmd["Launching"][0]  # type: ignore
 
@@ -144,7 +153,9 @@ def test_launch_with_longer_multiword_domain_name_with_preposition() -> None:
     verb = cli.get_launch_verb()
     grammar = cli.parse_grammar(args=tuple(args), verb=verb)
     verb.load_grammar(grammar=grammar)
-    cmd = cli.create_launch_cmd(verb=verb, kwargs={}, ignore_docker_version_check=True)
+    cmd = cli.create_launch_cmd(
+        verb=verb, kwargs=defaultdict(lambda: None), ignore_docker_version_check=True
+    )
 
     cmd = cmd["Launching"][0]  # type: ignore
 

--- a/scripts/aa_demo/update_domain.sh
+++ b/scripts/aa_demo/update_domain.sh
@@ -15,7 +15,7 @@ hagrid land all
 echo "Launching Domain .. hahaha >:)";
 
 # re-launch domain
-hagrid launch ${DOMAIN_NAME} to docker:80  --tail=false --dev --build_src="model_training_tests"
+hagrid launch ${DOMAIN_NAME} to docker:80 --dev --build_src="model_training_tests"
 
 # wait for domain to be up
 hagrid check --timeout=120

--- a/tox.ini
+++ b/tox.ini
@@ -152,7 +152,7 @@ commands =
     pip install -e packages/hagrid
     docker --version
     docker compose version
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --tail=false --test --health_checks=false'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --test --no_health_checks'
     docker ps
 
     bash -c '(docker logs test_domain_1-backend_stream-1 -f &) | grep -q "Application startup complete" || true'
@@ -223,9 +223,9 @@ commands =
     bash -c "docker volume rm test_domain_2_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_headscale-data --force || true"
-    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 --tail=false $HAGRID_FLAGS --health_checks=false'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 --tail=false $HAGRID_FLAGS --health_checks=false'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless=true --tail=false $HAGRID_FLAGS --vpn=false --health_checks=false'
+    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 $HAGRID_FLAGS --no_health_checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 $HAGRID_FLAGS --no_health_checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no_vpn --no_health_checks'
 
     ; wait for nodes to start
     docker ps
@@ -347,9 +347,9 @@ commands =
     bash -c "docker volume rm test_domain_2_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_headscale-data --force || true"
-    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 --tail=false $HAGRID_FLAGS --tls --test --cert_store_path=./traefik/certs --health_checks=false'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 --tail=false $HAGRID_FLAGS --tls --test --cert_store_path=./traefik/certs --health_checks=false'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless=true --tail=false $HAGRID_FLAGS --vpn=false --tls --test --cert_store_path=./traefik/certs --health_checks=false'
+    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 $HAGRID_FLAGS --tls --test --cert_store_path=./traefik/certs --no_health_checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 $HAGRID_FLAGS --tls --test --cert_store_path=./traefik/certs --no_health_checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no_vpn --tls --test --cert_store_path=./traefik/certs --no_health_checks'
 
     ; wait for nodes to start
     docker ps
@@ -463,9 +463,9 @@ commands =
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
     bash -c "docker volume rm test_domain_2_tailscale-data --force || true"
     bash -c "docker volume rm test_domain_3_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tail=false --headless=true $HAGRID_FLAGS --health_checks=false'
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_2 domain to docker:9083 --tail=false --headless=true $HAGRID_FLAGS --health_checks=false'
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_3 domain to docker:9084 --tail=false --headless=true $HAGRID_FLAGS --health_checks=false'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --headless $HAGRID_FLAGS --no_health_checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no_health_checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_3 domain to docker:9084 --headless $HAGRID_FLAGS --no_health_checks'
 
     ; wait for nodes to start
     docker ps
@@ -562,7 +562,7 @@ commands =
     bash -c "docker volume rm test_domain_1_seaweedfs-data --force || true"
     bash -c "docker volume rm test_domain_1_app-redis-data --force || true"
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9081 --tail=false $HAGRID_FLAGS --headless=true --health_checks=false'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9081 $HAGRID_FLAGS --headless --no_health_checks'
 
     ; wait for nodes to start
     docker ps
@@ -750,7 +750,7 @@ commands =
     bash -c "docker volume rm test_domain_1_seaweedfs-data --force || true"
     bash -c "docker volume rm test_domain_1_app-redis-data --force || true"
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:8081 --tag=local --tail=false --headless=true --test --health_checks=false --health_checks=false'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:8081 --tag=local --headless --test --no_health_checks --no_health_checks'
     bash -c 'rm -rf tests/course/courses'
     bash -c 'git clone https://github.com/OpenMined/courses.git tests/course/courses/ || true'
     bash -c 'cd tests/course/courses && git fetch && git checkout introduction-to-remote-data-science-dev && git pull || true'
@@ -802,7 +802,7 @@ commands =
     bash -c "docker volume rm test_domain_1_seaweedfs-data --force || true"
     bash -c "docker volume rm test_domain_1_app-redis-data --force || true"
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --build=false --tail=false --test --health_checks=false'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --test --no_health_checks'
     docker ps
 
     ; install packages


### PR DESCRIPTION
## Description
Fix #7141

- Convert command line bool options to flags, *e.g.* `--cmd=True` to `--cmd`
- Bool options that were default to `True`, *e.g.* `--use_blob_storage`, `--health_checks`, `--provision` were converted to `--no_blob_storage`, `--no_health_checks`, `--no_provision`.
- Make `tail` disabled by default. To tail just specify `--tail`.
- Forcing container image rebuilding is now always enabled in `development` or `--tag=local`. Otherwise depends on whether the `--build` flag is enabled.
- Remove the `Optional: ...` prefix in some of the help texts. In the help message required arguments are tagged with `[required]` anyway.
- Use `context_settings={"show_default": True}` in `@click.command` to always show the default values for command line options.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
