### PR TITLE
Make hagrid cli options `--hyphen-separated` instead of `--snake_case`

### DIFF
--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -656,7 +656,7 @@ Deploying to Azure
 
    .. code-block:: bash
 
-      $ hagrid launch node --username=azureuser --key_path=~/hagriddeploy_key.pem domain to 51.124.153.133
+      $ hagrid launch node --username=azureuser --key-path=~/hagriddeploy_key.pem domain to 51.124.153.133
 
 
    Additionally, you are being asked if you want to provide another repository and branch to fetch and update HAGrid, which you can skip by pressing ``Enter``.

--- a/notebooks/Experimental/medical-federated-learning-program/network-operators/00-network-operators-create-network.ipynb
+++ b/notebooks/Experimental/medical-federated-learning-program/network-operators/00-network-operators-create-network.ipynb
@@ -137,12 +137,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f52e90ac-2a2b-47ad-bcf3-128016f6f878",
    "metadata": {},
    "source": [
     "```\n",
-    "hagrid launch network to azure --image_name=domain_0.7.0 --node_count 3\n",
+    "hagrid launch network to azure --image-name=domain_0.7.0 --node-count 3\n",
     "```"
    ]
   },
@@ -220,7 +221,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -234,7 +235,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.3"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/Experimental/medical-federated-learning-program/network-operators/01-network-operators-create-empty-vm.ipynb
+++ b/notebooks/Experimental/medical-federated-learning-program/network-operators/01-network-operators-create-empty-vm.ipynb
@@ -43,12 +43,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cb74a71b-6d04-4c18-98dd-6ac3040cbfde",
    "metadata": {},
    "source": [
     "```\n",
-    "hagrid launch to azure --image_name=domain_0.7.0 --jupyter --ansible_extras=\"install=false,aa_demo=true\" --node_count 12\n",
+    "hagrid launch to azure --image-name=domain_0.7.0 --jupyter --ansible-extras=\"install=false,aa_demo=true\" --node-count 12\n",
     "```"
    ]
   },
@@ -1007,11 +1008,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "630449982b6186a6531308cd76ed4d510e9db65154e43844c2906c6a20ad2a6d"
-  },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syft-dev",
    "language": "python",
    "name": "python3"
   },
@@ -1025,7 +1023,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.8 (main, Nov  1 2022, 14:18:21) [GCC 12.2.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b15180e257705993099d172f184ff574feb25773139cdf2aab7056851b089d99"
+   }
   }
  },
  "nbformat": 4,

--- a/packages/grid/ansible/roles/containers/tasks/containers.yml
+++ b/packages/grid/ansible/roles/containers/tasks/containers.yml
@@ -41,6 +41,6 @@
 
 - name: Start Docker Containers with TLS
   shell:
-    cmd: runuser -l {{ om_user }} -c 'hagrid launch {{ node_name }} {{ node_type }} to docker:80 --release={{ release }} --tag={{ docker_tag }} --tls --cert_store_path={{ cert_store_path }}'
+    cmd: runuser -l {{ om_user }} -c 'hagrid launch {{ node_name }} {{ node_type }} to docker:80 --release={{ release }} --tag={{ docker_tag }} --tls --cert-store-path={{ cert_store_path }}'
   become: yes
   when: tls == "true" and install == "true"

--- a/packages/grid/scripts/redeploy.sh
+++ b/packages/grid/scripts/redeploy.sh
@@ -35,10 +35,10 @@ rm -rf ${8}
 cp -r ${1} ${8}
 chown -R ${4}:${5} ${8}
 /usr/sbin/runuser -l ${4} -c "pip install -e ${8}/packages/hagrid"
-# /usr/sbin/runuser -l ${4} -c "hagrid launch ${7} ${6} to localhost --repo=${2} --branch=${3} --ansible_extras='docker_volume_destroy=true'"
+# /usr/sbin/runuser -l ${4} -c "hagrid launch ${7} ${6} to localhost --repo=${2} --branch=${3} --ansible-extras='docker_volume_destroy=true'"
 if [[ "${9}" = "true" ]]; then
     echo "Starting Grid with TLS"
-    HAGRID_CMD="hagrid launch ${7} ${6} to localhost --repo=${2} --branch=${3} --release=${RELEASE} --tag=${DOCKER_TAG} --tls --cert_store_path=${10}"
+    HAGRID_CMD="hagrid launch ${7} ${6} to localhost --repo=${2} --branch=${3} --release=${RELEASE} --tag=${DOCKER_TAG} --tls --cert-store-path=${10}"
     echo $HAGRID_CMD
     /usr/sbin/runuser -l ${4} -c "$HAGRID_CMD"
 else

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -159,7 +159,7 @@ def clean(location: str) -> None:
     help="Username for provisioning the remote host",
 )
 @click.option(
-    "--key_path",
+    "--key-path",
     default=None,
     required=False,
     type=str,
@@ -212,24 +212,24 @@ def clean(location: str) -> None:
     help="Disable forcing re-build",
 )
 @click.option(
-    "--no_provision",
+    "--no-provision",
     is_flag=True,
     help="Disable provisioning VMs",
 )
 @click.option(
-    "--node_count",
+    "--node-count",
     default=1,
     required=False,
     type=click.IntRange(1, 250),
     help="Number of independent nodes/VMs to launch",
 )
 @click.option(
-    "--auth_type",
+    "--auth-type",
     default=None,
     type=click.Choice(["key", "password"], case_sensitive=False),
 )
 @click.option(
-    "--ansible_extras",
+    "--ansible-extras",
     default="",
     type=str,
 )
@@ -244,33 +244,33 @@ def clean(location: str) -> None:
     help="Choose between production and development release",
 )
 @click.option(
-    "--cert_store_path",
+    "--cert-store-path",
     default="/home/om/certs",
     required=False,
     type=str,
     help="Remote path to store and load TLS cert and key",
 )
 @click.option(
-    "--upload_tls_cert",
+    "--upload-tls-cert",
     default="",
     required=False,
     type=str,
-    help="Local path to TLS cert to upload and store at --cert_store_path",
+    help="Local path to TLS cert to upload and store at --cert-store-path",
 )
 @click.option(
-    "--upload_tls_key",
+    "--upload-tls-key",
     default="",
     required=False,
     type=str,
-    help="Local path to TLS private key to upload and store at --cert_store_path",
+    help="Local path to TLS private key to upload and store at --cert-store-path",
 )
 @click.option(
-    "--no_blob_storage",
+    "--no-blob-storage",
     is_flag=True,
     help="Disable blob storage",
 )
 @click.option(
-    "--image_name",
+    "--image-name",
     default=None,
     required=False,
     type=str,
@@ -284,7 +284,7 @@ def clean(location: str) -> None:
     help="Container image tag to use",
 )
 @click.option(
-    "--build_src",
+    "--build-src",
     default=DEFAULT_BRANCH,
     required=False,
     type=str,
@@ -298,7 +298,7 @@ def clean(location: str) -> None:
     help="Run docker with a different platform like linux/arm64",
 )
 @click.option(
-    "--no_vpn",
+    "--no-vpn",
     is_flag=True,
     help="Disable tailscale vpn container",
 )
@@ -308,12 +308,12 @@ def clean(location: str) -> None:
     help="Suppress extra launch outputs",
 )
 @click.option(
-    "--from_template",
+    "--from-template",
     is_flag=True,
     help="Launch node using the manifest template",
 )
 @click.option(
-    "--no_health_checks",
+    "--no-health-checks",
     is_flag=True,
     help="Turn off auto health checks post node launch",
 )
@@ -2537,12 +2537,12 @@ def create_land_docker_cmd(verb: GrammarVerb) -> str:
     help="Print the cmd without running it",
 )
 @click.option(
-    "--ansible_extras",
+    "--ansible-extras",
     default="",
     type=str,
 )
 @click.option(
-    "--build_src",
+    "--build-src",
     default=DEFAULT_BRANCH,
     required=False,
     type=str,

--- a/packages/hagrid/hagrid/lib.py
+++ b/packages/hagrid/hagrid/lib.py
@@ -254,7 +254,7 @@ def should_provision_remote(
     if username and password or username and key_path:
         return is_remote
     if is_remote:
-        raise Exception("--username requires either --password or --key_path")
+        raise Exception("--username requires either --password or --key-path")
     return is_remote
 
 

--- a/scripts/aa_demo/update_domain.sh
+++ b/scripts/aa_demo/update_domain.sh
@@ -15,7 +15,7 @@ hagrid land all
 echo "Launching Domain .. hahaha >:)";
 
 # re-launch domain
-hagrid launch ${DOMAIN_NAME} to docker:80 --dev --build_src="model_training_tests"
+hagrid launch ${DOMAIN_NAME} to docker:80 --dev --build-src="model_training_tests"
 
 # wait for domain to be up
 hagrid check --timeout=120

--- a/tox.ini
+++ b/tox.ini
@@ -152,7 +152,7 @@ commands =
     pip install -e packages/hagrid
     docker --version
     docker compose version
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --test --no_health_checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --test --no-health-checks'
     docker ps
 
     bash -c '(docker logs test_domain_1-backend_stream-1 -f &) | grep -q "Application startup complete" || true'
@@ -223,9 +223,9 @@ commands =
     bash -c "docker volume rm test_domain_2_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_headscale-data --force || true"
-    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 $HAGRID_FLAGS --no_health_checks'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 $HAGRID_FLAGS --no_health_checks'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no_vpn --no_health_checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 $HAGRID_FLAGS --no-health-checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 $HAGRID_FLAGS --no-health-checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no-vpn --no-health-checks'
 
     ; wait for nodes to start
     docker ps
@@ -347,9 +347,9 @@ commands =
     bash -c "docker volume rm test_domain_2_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_tailscale-data --force || true"
     bash -c "docker volume rm test_network_1_headscale-data --force || true"
-    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 $HAGRID_FLAGS --tls --test --cert_store_path=./traefik/certs --no_health_checks'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 $HAGRID_FLAGS --tls --test --cert_store_path=./traefik/certs --no_health_checks'
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no_vpn --tls --test --cert_store_path=./traefik/certs --no_health_checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART NETWORK_CHECK_INTERVAL=5 hagrid launch test_network_1 network to docker:9081 $HAGRID_FLAGS --tls --test --cert-store-path=./traefik/certs --no-health-checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9082 $HAGRID_FLAGS --tls --test --cert-store-path=./traefik/certs --no-health-checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no-vpn --tls --test --cert-store-path=./traefik/certs --no-health-checks'
 
     ; wait for nodes to start
     docker ps
@@ -463,9 +463,9 @@ commands =
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
     bash -c "docker volume rm test_domain_2_tailscale-data --force || true"
     bash -c "docker volume rm test_domain_3_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --headless $HAGRID_FLAGS --no_health_checks'
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no_health_checks'
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_3 domain to docker:9084 --headless $HAGRID_FLAGS --no_health_checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --headless $HAGRID_FLAGS --no-health-checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_2 domain to docker:9083 --headless $HAGRID_FLAGS --no-health-checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_3 domain to docker:9084 --headless $HAGRID_FLAGS --no-health-checks'
 
     ; wait for nodes to start
     docker ps
@@ -562,7 +562,7 @@ commands =
     bash -c "docker volume rm test_domain_1_seaweedfs-data --force || true"
     bash -c "docker volume rm test_domain_1_app-redis-data --force || true"
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9081 $HAGRID_FLAGS --headless --no_health_checks'
+    bash -c 'HAGRID_ART=$HAGRID_ART DOMAIN_CHECK_INTERVAL=5 hagrid launch test_domain_1 domain to docker:9081 $HAGRID_FLAGS --headless --no-health-checks'
 
     ; wait for nodes to start
     docker ps
@@ -750,7 +750,7 @@ commands =
     bash -c "docker volume rm test_domain_1_seaweedfs-data --force || true"
     bash -c "docker volume rm test_domain_1_app-redis-data --force || true"
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:8081 --tag=local --headless --test --no_health_checks --no_health_checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:8081 --tag=local --headless --test --no-health-checks --no-health-checks'
     bash -c 'rm -rf tests/course/courses'
     bash -c 'git clone https://github.com/OpenMined/courses.git tests/course/courses/ || true'
     bash -c 'cd tests/course/courses && git fetch && git checkout introduction-to-remote-data-science-dev && git pull || true'
@@ -802,7 +802,7 @@ commands =
     bash -c "docker volume rm test_domain_1_seaweedfs-data --force || true"
     bash -c "docker volume rm test_domain_1_app-redis-data --force || true"
     bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
-    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --test --no_health_checks'
+    bash -c 'HAGRID_ART=false hagrid launch test_domain_1 domain to docker:9082 --tag=local --test --no-health-checks'
     docker ps
 
     ; install packages


### PR DESCRIPTION
## Description
Fix #7140. Depends on #7168 (merge that one first).

This turns out to be a much easier fix than previously thoughts since `click` automatically assigns `@click.option(`--cli-option`)` to `kwargs["cli_option"]`.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
