### PR TITLE
Fix typo in attribute `networks` -> `all_networks`  in `NetworkRegistry`

### DIFF
--- a/packages/syft/src/syft/registry.py
+++ b/packages/syft/src/syft/registry.py
@@ -31,7 +31,7 @@ NETWORK_REGISTRY_REPO = "https://github.com/OpenMined/NetworkRegistry"
 
 class NetworkRegistry:
     def __init__(self) -> None:
-        self.networks: List[Dict] = []
+        self.all_networks: List[Dict] = []
         try:
             response = requests.get(NETWORK_REGISTRY_URL)
             network_json = response.json()


### PR DESCRIPTION
## Description
Should be a typo. `self.networks` is not reference anywhere

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
