### PR TITLE
added getDuetId() function so that it can be directly with DuetID pas…

### DIFF
--- a/packages/syft/src/syft/__init__.py
+++ b/packages/syft/src/syft/__init__.py
@@ -65,6 +65,7 @@ from syft.grid.duet import bcolors  # noqa: F401
 from syft.grid.duet import duet  # noqa: F401
 from syft.grid.duet import join_duet  # noqa: F401
 from syft.grid.duet import launch_duet  # noqa: F401
+from syft.grid.duet import getDuetId  
 
 # Convenience Objects
 from syft.lib import lib_ast  # noqa: F401

--- a/packages/syft/src/syft/grid/duet/exchange_ids.py
+++ b/packages/syft/src/syft/grid/duet/exchange_ids.py
@@ -31,15 +31,17 @@ class DuetCredentialExchanger:
 
 
 class OpenGridTokenManualInputExchanger(DuetCredentialExchanger):
-    def run(self, credential: str) -> str:
+    def run(self, credential: str, client_id: str = '', server_id: str = '') -> str:
         self.credential = credential
+        self.client_id = client_id
+        self.server_id = server_id
         if self.join:
-            self._client_exchange(credential=self.credential)
+            self._client_exchange(credential=self.credential, )
             return self.responder_id
         else:
-            return self._server_exchange(credential=self.credential)
+            return self._server_exchange(credential=self.credential, client_id= self.client_id)
 
-    def _server_exchange(self, credential: str) -> str:
+    def _server_exchange(self, credential: str, client_id: str) -> str:
         # send Server ID
         info(
             "♫♫♫ > Duet Server ID: " + bcolors.BOLD + credential + bcolors.ENDC,
@@ -71,7 +73,10 @@ class OpenGridTokenManualInputExchanger(DuetCredentialExchanger):
             print=True,
         )
         while True:
-            client_id = input("♫♫♫ > Duet Partner's Client ID: ")  # nosec
+            if len(client_id) == 32 :
+                client_id = client_id  # nosec
+            else:
+                client_id = input("♫♫♫ > Duet Partner's Client ID: ")  # nosec
             if len(client_id) == 32:
                 break
             else:
@@ -79,7 +84,7 @@ class OpenGridTokenManualInputExchanger(DuetCredentialExchanger):
         info(print=True)
         return client_id
 
-    def _client_exchange(self, credential: str) -> None:
+    def _client_exchange(self, credential: str, server_id: str = '') -> None:
         # send client ID
         info(print=True)
         info(


### PR DESCRIPTION
…sed as argument in syft.launch_duet()

## Description
I wanted to use PySyft 0.5.0 in my Django Application but as I was launching duet it was asking for duet id at runtime so I was not able to use it that time but after thinking it through I came to a conclusion that I had to create the syft duet to be able to accept the duetId as a argument in syft.launch_duet() funtion and for that I will have to create a funtion to get the duet_id for of current device or session. So that is how I made all the changes to syft-0.5.0


## Affected Dependencies
Nothing will be affected

## How has this been tested?
- Tried to test manually by getting the duet Id of Data scientist and Data owner and passing these id to syft.launch_duet() and syft.duet() functions.


