### PR TITLE
Default to linux/amd64 docker mode when on x86 machines

### DIFF
--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import json
 import os
 from pathlib import Path
+import platform
 from queue import Queue
 import re
 import shutil
@@ -1660,8 +1661,17 @@ def create_launch_docker_cmd(
         elif version_string is None:
             version_string = "latest"
 
+    if platform.uname().machine == "x86_64":
+        docker_platform = "linux/amd64"
+    else:
+        docker_platform = "linux/arm64"
+
+    if "platform" in kwargs and kwargs["platform"] is not None:
+        docker_platform = kwargs["platform"]
+
     print("  - NAME: " + str(snake_name))
     print("  - RELEASE: " + kwargs["release"])
+    print("  - ARCH: " + docker_platform)
     print("  - TYPE: " + str(node_type.input))
     print("  - DOCKER_TAG: " + version_string)
     if version_hash != "dockerhub":
@@ -1698,7 +1708,7 @@ def create_launch_docker_cmd(
     }
 
     if "platform" in kwargs and kwargs["platform"] is not None:
-        envs["DOCKER_DEFAULT_PLATFORM"] = kwargs["platform"]
+        envs["DOCKER_DEFAULT_PLATFORM"] = docker_platform
 
     if "tls" in kwargs and kwargs["tls"] is True and len(kwargs["cert_store_path"]) > 0:
         envs["TRAEFIK_TLS_CERTS"] = kwargs["cert_store_path"]


### PR DESCRIPTION
- This fixes an issue where the first image you get is arm64 and then running hagrid later without --platform won't override the default
- Added ARCH to the output so its easy to see which version is running

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
