### PR TITLE
Fix ArgCache bug in QuickstartUI

### DIFF
--- a/packages/hagrid/hagrid/quickstart_ui.py
+++ b/packages/hagrid/hagrid/quickstart_ui.py
@@ -163,7 +163,7 @@ class QuickstartUI:
 
     def _repr_html_(self) -> str:
         html = ""
-        if not arg_cache.install_wizard_complete:
+        if not arg_cache["install_wizard_complete"]:
             html += "<h3>Step 1b: Install 🧙🏽‍♂️ Wizard (Recommended)</h3>"
             html += (
                 "It looks like this might be your first time running Quickstart.<br />"


### PR DESCRIPTION
## Description
Missed this spot when converting `ArgCache` from attribute to dict-like api in #7169 and #7185.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
