### PR TITLE
Support extracting notebooks from a zip file for quickstart

### DIFF
--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -85,6 +85,7 @@ from .mode import EDITABLE_MODE
 from .parse_template import render_templates
 from .parse_template import setup_from_manifest_template
 from .quickstart_ui import fetch_notebooks_for_url
+from .quickstart_ui import fetch_notebooks_from_zipfile
 from .quickstart_ui import quickstart_download_notebook
 from .rand_sec import generate_sec_random_password
 from .style import RichGroup
@@ -3029,6 +3030,7 @@ def run_quickstart(
     branch: str = DEFAULT_BRANCH,
     commit: Optional[str] = None,
     python: Optional[str] = None,
+    zip_file: Optional[str] = None,
 ) -> None:
     try:
         quickstart_art()
@@ -3054,7 +3056,13 @@ def run_quickstart(
                 python=python,
             )
         downloaded_files = []
-        if url:
+        if zip_file:
+            downloaded_files = fetch_notebooks_from_zipfile(
+                zip_file,
+                directory=directory,
+                reset=reset,
+            )
+        elif url:
             downloaded_files = fetch_notebooks_for_url(
                 url=url,
                 directory=directory,
@@ -3401,26 +3409,9 @@ def add_intro_notebook(directory: str, reset: bool = False) -> str:
 
 
 @click.command(help="Walk the Path", context_settings={"show_default": True})
-@click.option(
-    "--repo",
-    default=DEFAULT_REPO,
-    help="Choose a repo to fetch the notebook from or just use OpenMined/PySyft",
-)
-@click.option(
-    "--branch",
-    default=DEFAULT_BRANCH,
-    help="Choose a branch to fetch from or just use dev",
-)
-@click.option(
-    "--commit",
-    help="Choose a specific commit to fetch the notebook from",
-)
-def dagobah(
-    repo: str = DEFAULT_REPO,
-    branch: str = DEFAULT_BRANCH,
-    commit: Optional[str] = None,
-) -> None:
-    return run_quickstart(url="padawan", repo=repo, branch=branch, commit=commit)
+@click.argument("zip_file", type=str, default="padawan.zip", metavar="ZIPFILE")
+def dagobah(zip_file: str) -> None:
+    return run_quickstart(zip_file=zip_file)
 
 
 cli.add_command(dagobah)

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -3411,6 +3411,15 @@ def add_intro_notebook(directory: str, reset: bool = False) -> str:
 @click.command(help="Walk the Path", context_settings={"show_default": True})
 @click.argument("zip_file", type=str, default="padawan.zip", metavar="ZIPFILE")
 def dagobah(zip_file: str) -> None:
+    if not os.path.exists(zip_file):
+        for text in (
+            f"{zip_file} does not exists.",
+            "Please specify the path to the zip file containing the notebooks.",
+            "hagrid dagobah [ZIPFILE]",
+        ):
+            print(text, file=sys.stderr)
+        sys.exit(1)
+
     return run_quickstart(zip_file=zip_file)
 
 

--- a/packages/hagrid/hagrid/quickstart_ui.py
+++ b/packages/hagrid/hagrid/quickstart_ui.py
@@ -126,7 +126,8 @@ def quickstart_extract_notebook(
     directory.mkdir(exist_ok=True)
     reset = overwrite_all
 
-    file_path = directory / os.path.basename(name)
+    base_name = os.path.basename(name)
+    file_path = directory / base_name
     file_name = file_path.name
     file_exists = file_path.exists()
 
@@ -150,7 +151,9 @@ def quickstart_extract_notebook(
     if not file_exists or file_exists and reset:
         print(f"Extracting notebook: {file_name}")
         with zipfile.ZipFile(zip_file, "r") as zf:
-            zf.extract(name, file_path)
+            zip_info = zf.getinfo(name)
+            zip_info.filename = base_name
+            zf.extract(zip_info, directory)
         extracted = True
     return str(file_path.absolute()), extracted, overwrite_all
 

--- a/packages/hagrid/hagrid/quickstart_ui.py
+++ b/packages/hagrid/hagrid/quickstart_ui.py
@@ -1,12 +1,14 @@
 # stdlib
 from dataclasses import dataclass
 import os
+from pathlib import Path
 import sys
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
 from urllib.parse import urlparse
+import zipfile
 
 # third party
 import click
@@ -112,6 +114,79 @@ def fetch_notebooks_for_url(
         )
         downloaded_files.append(file_path)
     return downloaded_files
+
+
+def quickstart_extract_notebook(
+    zip_file: str,
+    name: str,
+    directory: Path,
+    reset: bool = False,
+    overwrite_all: bool = False,
+) -> Tuple[str, bool, bool]:
+    directory.mkdir(exist_ok=True)
+    reset = overwrite_all
+
+    file_path = directory / os.path.basename(name)
+    file_name = file_path.name
+    file_exists = file_path.exists()
+
+    if file_exists and not reset:
+        response = click.prompt(
+            f"\nOverwrite {file_name}?",
+            prompt_suffix="(a/y/N)",
+            default="n",
+            show_default=False,
+        )
+        if response.lower() == "a":
+            reset = True
+            overwrite_all = True
+        elif response.lower() == "y":
+            reset = True
+        else:
+            print(f"Skipping {file_name}")
+            reset = False
+
+    extracted = False
+    if not file_exists or file_exists and reset:
+        print(f"Extracting notebook: {file_name}")
+        with zipfile.ZipFile(zip_file, "r") as zf:
+            zf.extract(name, file_path)
+        extracted = True
+    return str(file_path.absolute()), extracted, overwrite_all
+
+
+def fetch_notebooks_from_zipfile(
+    path: str, directory: str, reset: bool = False
+) -> List[str]:
+    dir_path = Path(directory)
+
+    with zipfile.ZipFile(path, "r") as zf:
+        notebooks = [f for f in zf.namelist() if f.endswith(".ipynb")]
+
+    notebook_files = [dir_path / os.path.basename(nb) for nb in notebooks]
+    existing_files = [nb for nb in notebook_files if nb.exists()]
+
+    existing_count = len(existing_files)
+
+    if existing_count > 0:
+        plural = "s" if existing_count > 1 else ""
+        print(f"You have {existing_count} existing notebook{plural}")
+        for nb in existing_files:
+            print(nb)
+
+    extracted_files = []
+    overwrite_all = False
+    for notebook in tqdm(notebooks):
+        file_path, _, overwrite_all = quickstart_extract_notebook(
+            zip_file=path,
+            name=notebook,
+            directory=dir_path,
+            reset=reset,
+            overwrite_all=overwrite_all,
+        )
+        extracted_files.append(file_path)
+
+    return extracted_files
 
 
 @dataclass


### PR DESCRIPTION
## Description
As title says. Also add the `hagrid dagobah [ZIPFILE]` command

Prepare a zip file containing the notebooks

```sh
git clone <repo>
cd <repo>/notebooks
zip -r padawan.zip padawan
```

Run `dagobah`

```sh
hagrid dagobah <path-to-zip-file>
```

or just `hagrid dagobah` if `padawan.zip` is in the current directory.

There are a lot of duplicated code between `fetch_notebooks_for_url` and `fetch_notebooks_from_zipfile`. I attempted to refactor earlier but it's more complicated than it looks and probably unnecessary. This works for now.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
