### PR TITLE
Fix check for empty function parameter annotation

### DIFF
--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -152,7 +152,7 @@ def generate_remote_function(signature: Signature, path: str, make_call: Callabl
                 t = param.annotation
             msg = None
             try:
-                if not issubclass(t, inspect._empty):
+                if t is not inspect.Parameter.empty:
                     check_type(key, value, t)  # raises Exception
             except TypeError:
                 _type_str = getattr(t, "__name__", str(t))
@@ -173,7 +173,7 @@ def generate_remote_function(signature: Signature, path: str, make_call: Callabl
             t = param.annotation
             msg = None
             try:
-                if not issubclass(t, inspect._empty):
+                if t is not inspect.Parameter.empty:
                     check_type(param_key, arg, t)  # raises Exception
             except TypeError:
                 _type_str = getattr(t, "__name__", str(t))


### PR DESCRIPTION
## Description
The current check for empty function parameter annotation doesn't work since `param.annotation` is not a class/type and passing it to `issubclass` will throw `TypeError`. The idiomatic way to do this is to check if it is [`inspect.Parameter.empty`](https://docs.python.org/3/library/inspect.html#inspect.Parameter.empty), which is also the same as `inspect._empty` but actually documented. See https://stackoverflow.com/questions/62010367/python-check-if-signature-annotation-is-of-specific-class.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
