### PR TITLE
[Padawan Trial 1: Uchechukwu Emmanuel] Add name to skill_test 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
           )$
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort

--- a/packages/syft/tests/trials/skill_test.py
+++ b/packages/syft/tests/trials/skill_test.py
@@ -27,6 +27,7 @@ def get_padawans(cohort: str) -> Dict[str, str]:
             "Akshay": "PASSED",
             "Zarreen": "PASSED",
             "Mihir": "PASSED",
+            "Uche": "PASSED",
         },
         "R3Q1": {
             "skywalker": "PASSED",
@@ -60,8 +61,9 @@ def test_trial_of_skill() -> None:
     assert get_padawans("R2Q4")["Akshay"] == "PASSED"
     assert get_padawans("R2Q4")["Zarreen"] == "PASSED"
     assert get_padawans("R2Q4")["Mihir"] == "PASSED"
+    assert get_padawans("R2Q4")["Uche"] == "PASSED"
 
-    assert len(get_padawans("R2Q4")) == 20
+    assert len(get_padawans("R2Q4")) == 21
 
     assert get_padawans("R3Q1")["skywalker"] == "PASSED"
     assert get_padawans("R3Q1")["Zach"] == "PASSED"


### PR DESCRIPTION


## Description
- Added name in padawan trial 1.
- Bumped isort to 5.12.0 based on [this issue](https://github.com/PyCQA/isort/issues/2079)

## Affected Dependencies
- isort

## How has this been tested?
- Linting: pre-commit run --all-files
- Tests Ran: tox -e padawan.trials

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
