### PR TITLE
Added instrumentation to requests in old & new client

### DIFF
--- a/packages/syft/src/syft/core/node/common/client_manager/association_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/association_api.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Dict
 
 # relative
+from .....telemetry import instrument
 from ...abstract.node import AbstractNodeClient
 from ...enums import AssociationRequestResponses
 from ...enums import RequestAPIFields
@@ -27,6 +28,7 @@ from ..node_service.success_resp_message import ErrorResponseMessage
 from .request_api import RequestAPI
 
 
+@instrument
 class AssociationRequestAPI(RequestAPI):
     def __init__(self, client: AbstractNodeClient):
         super().__init__(

--- a/packages/syft/src/syft/core/node/common/client_manager/dataset_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/dataset_api.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 # relative
 from .....core.tensor.tensor import Tensor
+from .....telemetry import instrument
 from ....common import UID
 from ....common.serde.serialize import _serialize as serialize  # noqa: F401
 from ...abstract.node import AbstractNodeClient
@@ -106,6 +107,7 @@ end_boilerplate = """
         </script>"""
 
 
+@instrument
 class DatasetRequestAPI(RequestAPI):
     def __init__(self, client: AbstractNodeClient):
         super().__init__(

--- a/packages/syft/src/syft/core/node/common/client_manager/oblv_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/oblv_api.py
@@ -9,6 +9,7 @@ from typing import Union
 from .....core.pointer.pointer import Pointer
 from .....oblv.deployment_client import DeploymentClient
 from .....oblv.oblv_enclave_pointer import OblvEnclavePointer
+from .....telemetry import instrument
 from ....common.message import SyftMessage  # type: ignore
 from ...abstract.node import AbstractNodeClient
 from ...enums import RequestAPIFields
@@ -23,6 +24,7 @@ from ..node_service.oblv.oblv_messages import TransferDatasetMessage
 from .request_api import RequestAPI
 
 
+@instrument
 class OblvAPI(RequestAPI):
     def __init__(self, client: AbstractNodeClient):
         super().__init__(

--- a/packages/syft/src/syft/core/node/common/client_manager/role_api.py
+++ b/packages/syft/src/syft/core/node/common/client_manager/role_api.py
@@ -2,6 +2,7 @@
 from typing import Any
 
 # relative
+from .....telemetry import instrument
 from ...abstract.node import AbstractNodeClient
 from ...enums import ResponseObjectEnum
 from ..node_service.role_manager.role_manager_messages import CreateRoleMessage
@@ -12,6 +13,7 @@ from ..node_service.role_manager.role_manager_messages import UpdateRoleMessage
 from .request_api import RequestAPI
 
 
+@instrument
 class RoleRequestAPI(RequestAPI):
     def __init__(self, client: AbstractNodeClient):
         super().__init__(

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -241,7 +241,7 @@ class SyftAPI(SyftObject):
         signed_call = api_call.sign(credentials=self.signing_key)
         msg_bytes: bytes = _serialize(obj=signed_call, to_bytes=True)
         response = requests.post(
-            url=self.api_url,
+            url=str(self.api_url),
             data=msg_bytes,
         )
 

--- a/packages/syft/src/syft/core/node/new/client.py
+++ b/packages/syft/src/syft/core/node/new/client.py
@@ -21,6 +21,7 @@ from .... import __version__
 from ....core.common.serde.deserialize import _deserialize
 from ....grid import GridURL
 from ....logger import debug
+from ....telemetry import instrument
 from ....util import verify_tls
 from ...common.uid import UID
 from ...node.new.credentials import UserLoginCredentials
@@ -60,6 +61,7 @@ DEFAULT_PYGRID_PORT = 80
 DEFAULT_PYGRID_ADDRESS = f"http://127.0.0.1:{DEFAULT_PYGRID_PORT}"
 
 
+@instrument
 class SyftClient:
     proxies: Dict[str, str] = {}
     url: GridURL
@@ -131,7 +133,7 @@ class SyftClient:
     def _make_get(self, path: str) -> bytes:
         url = self.url.with_path(path)
         response = self.session.get(
-            url, verify=verify_tls(), proxies=SyftClient.proxies
+            str(url), verify=verify_tls(), proxies=SyftClient.proxies
         )
         if response.status_code != 200:
             raise requests.ConnectionError(
@@ -146,7 +148,7 @@ class SyftClient:
     def _make_post(self, path: str, json: Dict[str, Any]) -> bytes:
         url = self.url.with_path(path)
         response = self.session.post(
-            url, verify=verify_tls(), json=json, proxies=SyftClient.proxies
+            str(url), verify=verify_tls(), json=json, proxies=SyftClient.proxies
         )
         if response.status_code != 200:
             raise requests.ConnectionError(
@@ -199,6 +201,7 @@ class SyftClient:
         )
 
 
+@instrument
 def connect(
     url: Union[str, GridURL] = DEFAULT_PYGRID_ADDRESS,
     port: Optional[int] = None,

--- a/packages/syft/src/syft/grid/client/client.py
+++ b/packages/syft/src/syft/grid/client/client.py
@@ -23,6 +23,7 @@ from ...core.node.common.client import Client
 from ...core.node.domain_client import DomainClient
 from ...core.node.network_client import NetworkClient
 from ...core.node.new.client import SyftClient
+from ...telemetry import instrument
 from ...util import bcolors
 from ...util import verify_tls
 from .grid_connection import GridHTTPConnection
@@ -31,6 +32,7 @@ DEFAULT_PYGRID_PORT = 80
 DEFAULT_PYGRID_ADDRESS = f"http://127.0.0.1:{DEFAULT_PYGRID_PORT}"
 
 
+@instrument
 def connect(
     url: Union[str, GridURL] = DEFAULT_PYGRID_ADDRESS,
     conn_type: Type[ClientConnection] = GridHTTPConnection,
@@ -77,6 +79,7 @@ def connect(
     return node
 
 
+@instrument
 def login(
     url: Optional[Union[str, GridURL]] = None,
     port: Optional[int] = None,
@@ -215,6 +218,7 @@ def login(
     return node
 
 
+@instrument
 def register(
     name: Optional[str] = None,
     email: Optional[str] = None,


### PR DESCRIPTION

## Description
Added instrumentation to requests in old client and new client 
Closes https://github.com/OpenMined/Heartbeat/issues/7#issue-1548597417

However, the following part was not done: "Optionally figure out a way to enable tracing easily without having to set an environment variable, but easily leave off in production, perhaps a special import like from syft.tracing import autoenable". Perhaps we can create a separate issue and track this.



## How has this been tested?
- Tested some common methods such as login, connect, create user, fetch all users, datasets, etc., in the old client, and tested new_connect in the new client.
- Tested on M1 MacBook Air

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
