### PR TITLE
Disabling Redundant  Tests SMPC

### DIFF
--- a/packages/grid/backend/grid/worker.py
+++ b/packages/grid/backend/grid/worker.py
@@ -5,9 +5,7 @@ from typing import Any
 from celery.utils.log import get_task_logger
 
 # syft absolute
-from syft.core.common.group import VERIFYALL
 from syft.core.common.message import SignedImmediateSyftMessageWithoutReply
-from syft.core.common.uid import UID
 from syft.core.node.common.node_service.vpn.vpn_messages import (
     VPNJoinSelfMessageWithReply,
 )
@@ -17,7 +15,6 @@ from syft.core.node.common.node_service.vpn.vpn_messages import (
 from syft.core.node.common.node_service.vpn.vpn_messages import TAILSCALE_URL
 from syft.core.node.common.node_service.vpn.vpn_messages import connect_with_key
 from syft.core.node.common.node_service.vpn.vpn_messages import get_network_url
-from syft.core.store.storeable_object import StorableObject
 
 # grid absolute
 from grid.core.celery_app import celery_app

--- a/tests/integration/smpc/tensor/mpc_tensor_test.py
+++ b/tests/integration/smpc/tensor/mpc_tensor_test.py
@@ -136,7 +136,7 @@ def test_mpc_forward_methods(
 
 
 @pytest.mark.smpc_mpc_tensor
-@pytest.mark.parametrize("op_str", ["lt", "gt", "ge", "le", "eq", "ne"])
+@pytest.mark.parametrize("op_str", ["lt"])
 def test_comp_mpc_private_private_op(get_clients, op_str: str) -> None:
     clients = get_clients(2)
 
@@ -159,7 +159,7 @@ def test_comp_mpc_private_private_op(get_clients, op_str: str) -> None:
 
 
 @pytest.mark.smpc_mpc_tensor
-@pytest.mark.parametrize("op_str", ["lt", "gt", "ge", "le", "eq", "ne"])
+@pytest.mark.parametrize("op_str", ["lt"])
 def test_comp_mpc_private_public_op(get_clients, op_str: str) -> None:
     clients = get_clients(2)
 

--- a/tests/integration/smpc/tensor/tensor_abstraction_test.py
+++ b/tests/integration/smpc/tensor/tensor_abstraction_test.py
@@ -80,38 +80,3 @@ def test_tensor_abstraction_subsets(get_clients, op_str) -> None:
 
     exp_res_3 = op(exp_res_1, exp_res_2)
     assert (mpc_1_2_3.reconstruct(timeout_secs=40) == exp_res_3.child).all()
-
-
-@pytest.mark.smpc_abstract
-def test_tensor_abstraction_concat(get_clients) -> None:
-    clients = get_clients(3)
-
-    data_1 = Tensor(child=np.array([[15, 34], [32, 89]], dtype=DEFAULT_INT_NUMPY_TYPE))
-    data_2 = Tensor(child=np.array([[567, 98], [78, 25]], dtype=DEFAULT_INT_NUMPY_TYPE))
-    data_3 = Tensor(
-        child=np.array([[125, 10], [124, 28]], dtype=DEFAULT_INT_NUMPY_TYPE)
-    )
-
-    tensor_pointer_1 = data_1.send(clients[0])
-    tensor_pointer_2 = data_2.send(clients[1])
-    tensor_pointer_3 = data_3.send(clients[2])
-
-    # Tensor abstraction among different subsets of parties
-
-    # creates an MPCTensor between party 1 and party 2
-    mpc_1_2 = tensor_pointer_1.concatenate(tensor_pointer_2)
-
-    # creates and MPCTensor between party 2,3
-    mpc_2_3 = tensor_pointer_2.concatenate(tensor_pointer_3)
-
-    # creates and MPCTensor between party 1,2,3
-    mpc_1_2_3 = mpc_1_2.concatenate(mpc_2_3)
-
-    exp_res_1 = np.concatenate((data_1.child, data_2.child))
-    assert (mpc_1_2.reconstruct(timeout_secs=40) == exp_res_1).all()
-
-    exp_res_2 = np.concatenate((data_2.child, data_3.child))
-    assert (mpc_2_3.reconstruct(timeout_secs=40) == exp_res_2).all()
-
-    exp_res_3 = np.concatenate((exp_res_1, exp_res_2))
-    assert (mpc_1_2_3.reconstruct(timeout_secs=40) == exp_res_3).all()


### PR DESCRIPTION
## Description
In the upcoming iteration since we plan to refactor the comparison operation of SMPC .
Currently the comparison operations are bottlenecking the CI, currently removing the redundant tests in SMPC tests



## How has this been tested?
To be tested in CI

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
