### PR TITLE
#7015 | Refactored tensor package and updated documentation for "lazy_repeat_array".

### DIFF
--- a/docs/source/api_reference/syft.core.common.lazy_repeat_array.rst
+++ b/docs/source/api_reference/syft.core.common.lazy_repeat_array.rst
@@ -1,7 +1,7 @@
-syft.core.tensor.lazy\_repeat\_array
+syft.core.common.lazy\_repeat\_array
 ====================================
 
-.. automodule:: syft.core.tensor.lazy_repeat_array
+.. automodule:: syft.core.common.lazy_repeat_array
 
    
    

--- a/docs/source/api_reference/syft.core.node.common.rst
+++ b/docs/source/api_reference/syft.core.node.common.rst
@@ -37,6 +37,7 @@ syft.core.node.common
    syft.core.node.common.client
    syft.core.node.common.client_manager
    syft.core.node.common.exceptions
+   syft.core.common.lazy_repeat_array
    syft.core.node.common.metadata
    syft.core.node.common.node
    syft.core.node.common.node_manager

--- a/docs/source/api_reference/syft.core.tensor.rst
+++ b/docs/source/api_reference/syft.core.tensor.rst
@@ -40,7 +40,6 @@ syft.core.tensor
    syft.core.tensor.fixed_precision_tensor
    syft.core.tensor.fixed_precision_tensor_ancestor
    syft.core.tensor.functions
-   syft.core.tensor.lazy_repeat_array
    syft.core.tensor.manager
    syft.core.tensor.nn
    syft.core.tensor.passthrough

--- a/packages/syft/src/syft/__init__.py
+++ b/packages/syft/src/syft/__init__.py
@@ -77,7 +77,7 @@ from .core.tensor import autodp  # noqa: F401
 from .core.tensor import nn  # noqa: F401
 from .core.tensor.autodp.gamma_tensor import GammaTensor  # noqa: F401
 from .core.tensor.autodp.phi_tensor import PhiTensor  # noqa: F401
-from .core.tensor.lazy_repeat_array import lazyrepeatarray  # noqa: F401
+from .core.common.lazy_repeat_array import lazyrepeatarray  # noqa: F401
 from .core.tensor.tensor import Tensor  # noqa: F401
 from .experimental_flags import flags  # noqa: F401
 from .grid.client.client import connect  # noqa: F401

--- a/packages/syft/src/syft/core/common/lazy_repeat_array.py
+++ b/packages/syft/src/syft/core/common/lazy_repeat_array.py
@@ -15,12 +15,12 @@ import numpy as np
 from scipy.ndimage import rotate
 
 # relative
-from .serde.serializable import serializable
 from ..tensor.broadcastable import is_broadcastable
 from ..tensor.config import DEFAULT_FLOAT_NUMPY_TYPE
 from ..tensor.config import DEFAULT_INT_NUMPY_TYPE
 from ..tensor.passthrough import is_acceptable_simple_type  # type: ignore
 from ..tensor.smpc.utils import get_shape
+from .serde.serializable import serializable
 
 if TYPE_CHECKING:
     # relative

--- a/packages/syft/src/syft/core/common/lazy_repeat_array.py
+++ b/packages/syft/src/syft/core/common/lazy_repeat_array.py
@@ -15,16 +15,16 @@ import numpy as np
 from scipy.ndimage import rotate
 
 # relative
-from ..common.serde.serializable import serializable
-from .broadcastable import is_broadcastable
-from .config import DEFAULT_FLOAT_NUMPY_TYPE
-from .config import DEFAULT_INT_NUMPY_TYPE
-from .passthrough import is_acceptable_simple_type  # type: ignore
-from .smpc.utils import get_shape
+from .serde.serializable import serializable
+from ..tensor.broadcastable import is_broadcastable
+from ..tensor.config import DEFAULT_FLOAT_NUMPY_TYPE
+from ..tensor.config import DEFAULT_INT_NUMPY_TYPE
+from ..tensor.passthrough import is_acceptable_simple_type  # type: ignore
+from ..tensor.smpc.utils import get_shape
 
 if TYPE_CHECKING:
     # relative
-    from .autodp.phi_tensor import PhiTensor
+    from ..tensor.autodp.phi_tensor import PhiTensor
 
 
 @serializable(recursive_serde=True)
@@ -543,7 +543,7 @@ def compute_min_max(
         max_vals = lazyrepeatarray(data=max_v, shape=dummy_res.shape)
     elif op_str == "choose":
         # relative
-        from .tensor import Pointer
+        from ..tensor.tensor import Pointer
 
         dummy_res = np.ones(x_min_vals.shape, dtype=np.int64)
         if isinstance(args[0], Pointer):

--- a/packages/syft/src/syft/core/common/lazy_repeat_array.py
+++ b/packages/syft/src/syft/core/common/lazy_repeat_array.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 @serializable(recursive_serde=True)
 class lazyrepeatarray:
     """
-    A class representing Differential Privacy metadata (minimum and maximum values) in a way that saves RAM/CPU.
+    A class representing metadata(minimum and maximum) values in a way that saves RAM/CPU.
 
     We store large arrays of a single repeating value as a single tuple (shape) and a single value (int/float/etc)
     e.g. np.array([8,8,8,8,8,8]) = lazyrepeatarray(data=8, shape=(6,))

--- a/packages/syft/src/syft/core/tensor/ancestors.py
+++ b/packages/syft/src/syft/core/tensor/ancestors.py
@@ -22,9 +22,9 @@ from ...user_settings import settings
 from ..adp.data_subject import DataSubject
 from ..adp.data_subject_ledger import DataSubjectLedger
 from ..adp.data_subject_list import DataSubjectArray
+from ..common.lazy_repeat_array import lazyrepeatarray
 from .config import DEFAULT_FLOAT_NUMPY_TYPE
 from .config import DEFAULT_INT_NUMPY_TYPE
-from ..common.lazy_repeat_array import lazyrepeatarray
 from .manager import TensorChainManager
 from .passthrough import PassthroughTensor  # type: ignore
 

--- a/packages/syft/src/syft/core/tensor/ancestors.py
+++ b/packages/syft/src/syft/core/tensor/ancestors.py
@@ -24,7 +24,7 @@ from ..adp.data_subject_ledger import DataSubjectLedger
 from ..adp.data_subject_list import DataSubjectArray
 from .config import DEFAULT_FLOAT_NUMPY_TYPE
 from .config import DEFAULT_INT_NUMPY_TYPE
-from .lazy_repeat_array import lazyrepeatarray
+from ..common.lazy_repeat_array import lazyrepeatarray
 from .manager import TensorChainManager
 from .passthrough import PassthroughTensor  # type: ignore
 

--- a/packages/syft/src/syft/core/tensor/autodp/phi_tensor.py
+++ b/packages/syft/src/syft/core/tensor/autodp/phi_tensor.py
@@ -42,8 +42,8 @@ from ...pointer.pointer import Pointer
 # from ..broadcastable import is_broadcastable
 from ..config import DEFAULT_INT_NUMPY_TYPE
 from ..fixed_precision_tensor import FixedPrecisionTensor
-from ..lazy_repeat_array import compute_min_max
-from ..lazy_repeat_array import lazyrepeatarray
+from ...common.lazy_repeat_array import compute_min_max
+from ...common.lazy_repeat_array import lazyrepeatarray
 from ..passthrough import AcceptableSimpleType  # type: ignore
 from ..passthrough import PassthroughTensor  # type: ignore
 from ..passthrough import SupportedChainType  # type: ignore

--- a/packages/syft/src/syft/core/tensor/nn/utils.py
+++ b/packages/syft/src/syft/core/tensor/nn/utils.py
@@ -12,7 +12,7 @@
 # from ...adp.data_subject_list import DataSubjectArray
 # from ..autodp.gamma_tensor import GammaTensor
 # from ..autodp.phi_tensor import PhiTensor
-# from ..lazy_repeat_array import lazyrepeatarray
+# from packages.syft.src.syft.core.common.lazy_repeat_array import lazyrepeatarray
 #
 #
 # def dp_maximum(

--- a/packages/syft/src/syft/core/tensor/nn/utils.py
+++ b/packages/syft/src/syft/core/tensor/nn/utils.py
@@ -12,7 +12,7 @@
 # from ...adp.data_subject_list import DataSubjectArray
 # from ..autodp.gamma_tensor import GammaTensor
 # from ..autodp.phi_tensor import PhiTensor
-# from packages.syft.src.syft.core.common.lazy_repeat_array import lazyrepeatarray
+# from ...core.common.lazy_repeat_array import lazyrepeatarray
 #
 #
 # def dp_maximum(

--- a/packages/syft/tests/syft/core/common/lazy_repeat_array_test.py
+++ b/packages/syft/tests/syft/core/common/lazy_repeat_array_test.py
@@ -4,8 +4,8 @@ import pytest
 
 # syft absolute
 import syft as sy
-from syft.core.tensor.lazy_repeat_array import has_nans_inf
-from syft.core.tensor.lazy_repeat_array import lazyrepeatarray
+from syft.core.common.lazy_repeat_array import has_nans_inf
+from syft.core.common.lazy_repeat_array import lazyrepeatarray
 
 
 def test_create_lazy_repeat_array() -> None:

--- a/packages/syft/tests/syft/core/tensor/adp/gamma_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/gamma_tensor_test.py
@@ -7,9 +7,9 @@ import pytest
 # syft absolute
 import syft as sy
 from syft.core.adp.data_subject_list import DataSubject
+from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
 from syft.core.tensor.autodp.gamma_tensor import GammaTensor
 from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
-from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
 
 
 @pytest.fixture

--- a/packages/syft/tests/syft/core/tensor/adp/gamma_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/gamma_tensor_test.py
@@ -9,7 +9,7 @@ import syft as sy
 from syft.core.adp.data_subject_list import DataSubject
 from syft.core.tensor.autodp.gamma_tensor import GammaTensor
 from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
-from syft.core.tensor.lazy_repeat_array import lazyrepeatarray as lra
+from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
 
 
 @pytest.fixture

--- a/packages/syft/tests/syft/core/tensor/adp/phi_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/phi_tensor_test.py
@@ -9,9 +9,9 @@ import pytest
 # syft absolute
 import syft as sy
 from syft.core.adp.data_subject_list import DataSubject
+from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
 from syft.core.tensor.autodp.gamma_tensor import GammaTensor
 from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
-from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
 from syft.core.tensor.tensor import Tensor
 
 

--- a/packages/syft/tests/syft/core/tensor/adp/phi_tensor_test.py
+++ b/packages/syft/tests/syft/core/tensor/adp/phi_tensor_test.py
@@ -11,7 +11,7 @@ import syft as sy
 from syft.core.adp.data_subject_list import DataSubject
 from syft.core.tensor.autodp.gamma_tensor import GammaTensor
 from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
-from syft.core.tensor.lazy_repeat_array import lazyrepeatarray as lra
+from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
 from syft.core.tensor.tensor import Tensor
 
 

--- a/packages/syft/tests/syft/core/tensor/private_test.py
+++ b/packages/syft/tests/syft/core/tensor/private_test.py
@@ -6,7 +6,7 @@ import pytest
 import syft as sy
 from syft.core.adp.data_subject import DataSubject
 from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
-from syft.core.tensor.lazy_repeat_array import lazyrepeatarray as lra
+from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
 from syft.core.tensor.tensor import Tensor
 
 

--- a/packages/syft/tests/syft/core/tensor/private_test.py
+++ b/packages/syft/tests/syft/core/tensor/private_test.py
@@ -5,8 +5,8 @@ import pytest
 # syft absolute
 import syft as sy
 from syft.core.adp.data_subject import DataSubject
-from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
 from syft.core.common.lazy_repeat_array import lazyrepeatarray as lra
+from syft.core.tensor.autodp.phi_tensor import PhiTensor as PT
 from syft.core.tensor.tensor import Tensor
 
 


### PR DESCRIPTION
## Description
Refactor the tensor package by moving the lazy_repeat_array class to the common package       
Updated the documentation for "lazy_repeat_array". Fixes #7015 

## Affected Dependencies
There should be no affected dependencies.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented on my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
