### PR TITLE
Add login page

### DIFF
--- a/packages/grid/backend/grid/api/syft/syft.py
+++ b/packages/grid/backend/grid/api/syft/syft.py
@@ -18,6 +18,7 @@ from syft.core.common.message import SignedImmediateSyftMessageWithoutReply
 from syft.core.common.message import SignedMessage
 from syft.core.node.enums import RequestAPIFields
 from syft.telemetry import TRACE_MODE
+from syft.core.common.serde.recursive import TYPE_BANK
 
 # grid absolute
 from grid.api.dependencies.current_user import get_current_user
@@ -43,6 +44,13 @@ async def get_body(request: Request) -> bytes:
 def syft_version() -> Response:
     return JSONResponse(content={"version": __version__})
 
+
+@router.get("/serde")
+def syft_serde() -> Response:
+    bank = {}
+    for key,items in list(TYPE_BANK.items()):
+        bank[key]  = [item if not callable(item) else None for item in items[:-1]]
+    return JSONResponse(content={"bank": bank})
 
 @router.get("/metadata", response_model=str)
 def syft_metadata() -> Response:

--- a/packages/grid/frontend/package.json
+++ b/packages/grid/frontend/package.json
@@ -42,6 +42,7 @@
 	"type": "module",
 	"dependencies": {
 		"capnp-ts": "^0.7.0",
+		"svelte-heros-v2": "^0.3.18",
 		"uuid": "^9.0.0"
 	}
 }

--- a/packages/grid/frontend/src/components/LoginHeader.svelte
+++ b/packages/grid/frontend/src/components/LoginHeader.svelte
@@ -1,0 +1,50 @@
+<script>
+	export let version;
+</script>
+
+<div class="login-header">
+	<div style="grid-column: span 1;display:flex;justify-content:left">
+		<svg
+			style="margin-left: 10px;margin-right: 10px;"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			><path
+				d="m21 7.702-8.5 4.62v9.678c1.567-.865 6.379-3.517 7.977-4.399.323-.177.523-.519.523-.891zm-9.5 4.619-8.5-4.722v9.006c0 .37.197.708.514.887 1.59.898 6.416 3.623 7.986 4.508zm-8.079-5.629 8.579 4.763 8.672-4.713s-6.631-3.738-8.186-4.614c-.151-.085-.319-.128-.486-.128-.168 0-.335.043-.486.128-1.555.876-8.093 4.564-8.093 4.564z"
+				fill-rule="nonzero"
+			/></svg
+		>
+		<h4 style="color:gray;">Version : {version}</h4>
+	</div>
+	<div style="grid-column: 2 / span 1;display:flex;justify-content:right">
+		<a href="https://openmined.github.io/PySyft/index.html"
+			><h4 style="margin-right: 10px;">Docs</h4></a
+		>
+		<a href="https://www.openmined.org/"><h4 style="margin-right: 10px;">Community</h4></a>
+		<a href="https://github.com/OpenMined/PySyft"
+			><svg
+				style="margin-right: 30px;"
+				xmlns="http://www.w3.org/2000/svg"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				><path
+					d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+				/></svg
+			></a
+		>
+	</div>
+</div>
+
+<style>
+	.login-header {
+		margin-top: 10px;
+		width: 100%;
+		display: grid;
+		grid-auto-columns: 50%;
+		grid-auto-rows: 5vh;
+		position: absolute;
+		z-index: 2;
+	}
+</style>

--- a/packages/grid/frontend/src/components/RegisterModal.svelte
+++ b/packages/grid/frontend/src/components/RegisterModal.svelte
@@ -1,0 +1,74 @@
+<script>
+	import { Input, Label, Modal, Checkbox, Button, Helper } from 'flowbite-svelte';
+	import { SyftMessageWithoutReply } from '../lib/jsserde/objects/syftMessage.ts';
+	export let formModal;
+	export let jsserde;
+	export let nodeId;
+	let name;
+	let email;
+	$: password = undefined;
+	let passwordConfirmation;
+
+	async function createUser() {
+		let msg = new SyftMessageWithoutReply(
+			nodeId,
+			{ email: email, password: password, name: name, role: 'Data Scientist', institution: 'DPUK' },
+			'syft.core.node.common.node_service.user_manager.new_user_messages.CreateUserMessage'
+		);
+		console.log('JavaScript CreateUserMessage obj');
+		console.log('Serializing message object ... ');
+		let client_bytes = jsserde.serialize(msg);
+		const response = await fetch('http://localhost:8081/api/v1/syft/js', {
+			method: 'POST',
+			headers: { 'content-type': 'application/octect-stream' },
+			body: client_bytes
+		}).then((response) => response.arrayBuffer());
+		console.log('Serialized response: ', response);
+		console.log('Deserializing CreateUserMessage Response: ', jsserde.deserialize(response));
+	}
+</script>
+
+<Modal bind:open={formModal} size="xs" autoclose={true} class="w-full">
+	<form class="flex flex-col space-y-6" action="#">
+		<h3 class="text-xl font-medium text-gray-900 dark:text-white p-0" style="text-align:center">
+			Start Today!
+		</h3>
+		<Label class="space-y-2">
+			<Label class="block mb-2">Name</Label>
+			<Input bind:value={name} type="text" name="name" placeholder="Jana Doe" required />
+		</Label>
+		<Label class="space-y-2">
+			<span>Email</span>
+			<Input
+				bind:value={email}
+				type="email"
+				name="email"
+				placeholder="info@openmined.org"
+				required
+			/>
+		</Label>
+		<Label class="space-y-2">
+			<span>Password</span>
+			<Input bind:value={password} type="password" name="password" placeholder="•••••" required />
+			<Helper class="mt-2">Your password must have more than 8 characters</Helper>
+		</Label>
+
+		<Label class="space-y-2">
+			<span>Password Confirmation</span>
+			<Input
+				bind:value={passwordConfirmation}
+				type="password"
+				name="password"
+				placeholder="•••••"
+				required
+			/>
+		</Label>
+		<div class="flex items-start">
+			<Checkbox>Remember me</Checkbox>
+			<a href="/" class="ml-auto text-sm text-blue-700 hover:underline dark:text-blue-500"
+				>Lost password?</a
+			>
+		</div>
+		<Button type="submit" on:click={() => createUser()} class="w-full1">Register</Button>
+	</form>
+</Modal>

--- a/packages/grid/frontend/src/lib/jsserde/jsserde.svelte
+++ b/packages/grid/frontend/src/lib/jsserde/jsserde.svelte
@@ -8,7 +8,7 @@
 
 	export class JSSerde {
 		constructor(type_bank) {
-			var _this = this; 
+			var _this = this;
 			this.type_bank = type_bank;
 			this.type_bank['builtins.int'] = [
 				true,
@@ -319,7 +319,6 @@
 			const fieldsName = rs.getFieldsName();
 			const size = fieldsName.getLength();
 			const fqn = rs.getFullyQualifiedName();
-			console.log('FQN: ', fqn);
 			let objSerdeProps = this.type_bank[fqn];
 			if (size < 1) {
 				return this.type_bank[fqn][2](rs.getNonrecursiveBlob().toArrayBuffer());

--- a/packages/grid/frontend/src/lib/store.js
+++ b/packages/grid/frontend/src/lib/store.js
@@ -1,0 +1,29 @@
+import { writable } from 'svelte/store';
+import { JSSerde } from './jsserde/jsserde.svelte';
+
+export const credentials = writable('');
+export const jsSerde = writable('');
+
+export const store = writable({
+	user: {},
+	tenantDetail: {},
+	jsserde: {},
+	credentials: {}
+});
+
+export async function getSerde() {
+	let jsValue = '';
+	jsSerde.subscribe((value) => {
+		jsValue = value;
+	});
+
+	if (!jsValue) {
+		let type_bank = await fetch('http://localhost:8081/api/v1/syft/serde')
+			.then((response) => response.json())
+			.then(function (response) {
+				return response['bank'];
+			});
+		jsSerde.set(new JSSerde(type_bank));
+	}
+	return jsValue;
+}

--- a/packages/grid/frontend/src/routes/+page.svelte
+++ b/packages/grid/frontend/src/routes/+page.svelte
@@ -1,20 +1,20 @@
 <script>
-	import { JSSerde } from '../lib/jsserde/jsserde.svelte';
-	async function initJSSerde(url) {
-		let type_bank = await fetch(url)
-			.then((response) => response.json())
-			.then(function (response) {
-				return response['bank'];
-			});
-		return new JSSerde(type_bank);
-	}
+	import { store, getSerde } from '../lib/store.js';
+	import { goto } from '$app/navigation';
 
-	let promise = initJSSerde('http://localhost:8081/api/v1/syft/serde');
+	let credentials = null;
+
+	store.subscribe((value) => {
+		credentials = value.credentials;
+	});
 </script>
 
 <main>
-	{#await promise then jsserde}
-		<h1>Welcome to SvelteKit</h1>
-		<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+	{#await getSerde() then jsserde}
+		{#if JSON.stringify(credentials) === '{}'}
+			{goto('/login')}
+		{:else}
+			{goto('/home')}
+		{/if}
 	{/await}
 </main>

--- a/packages/grid/frontend/src/routes/home/+page.svelte
+++ b/packages/grid/frontend/src/routes/home/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+</script>
+
+<main>
+	<h1>Home Page</h1>
+</main>

--- a/packages/grid/frontend/src/routes/login/+page.svelte
+++ b/packages/grid/frontend/src/routes/login/+page.svelte
@@ -1,0 +1,263 @@
+<script>
+	import LoginHeader from '../../components/LoginHeader.svelte';
+	import RegisterModal from '../../components/RegisterModal.svelte';
+	import { Input, Label, Helper, Button } from 'flowbite-svelte';
+	import { getSerde, store } from '../../lib/store.js';
+
+	let email = '';
+	let password = '';
+	$: formModal = false;
+	let inputColor = 'base';
+	let displayError = 'none';
+	let localStore;
+	store.subscribe((value) => {
+		localStore = value;
+	});
+
+	async function loadScreenInfo(serde) {
+		let metadata = fetch('http://localhost:8081/api/v1/syft/metadata')
+			.then((response) => response.arrayBuffer())
+			.then(function (response) {
+				return serde.deserialize(response);
+			});
+		console.log('My Deserialized Metadata: ', metadata);
+		return metadata;
+	}
+
+	async function login(email, password) {
+		await fetch('http://localhost:8081/api/v1/login', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ email: email, password: password })
+		}).then((response) => {
+			if (response.status === 401) {
+				inputColor = 'red';
+				displayError = 'block';
+			} else {
+				response.json().then((body) => {
+					console.log(body);
+					localStore.credentials = body['access_token'];
+					store.set(localStore);
+				});
+			}
+		});
+	}
+
+	const copyToClipBoard = () => {
+		// Get the text field
+		var copyText = document.getElementById('gridUID');
+
+		// Copy the text inside the text field
+		navigator.clipboard.writeText(copyText?.textContent);
+
+		// Alert the copied text
+		alert('Domain UID copied!');
+	};
+
+	function prettyName(name) {
+		let nameList = name.split('_');
+		for (var i = 0; i < nameList.length; i++) {
+			nameList[i] = nameList[i].charAt(0).toUpperCase() + nameList[i].slice(1);
+		}
+		return nameList.join(' ');
+	}
+</script>
+
+<main>
+	{#await getSerde() then jsserde}
+		{#await loadScreenInfo(jsserde) then metadata}
+			<!-- Login Screen Header -->
+			<LoginHeader version={metadata.get('version')} />
+
+			<!-- Login Screen Body -->
+			<div id="login-screen">
+				<!-- Background Circles -->
+				<div id="login-orange-circle-bg" />
+				<div id="login-blue-circle-bg" />
+
+				<!-- Register Modal -->
+				<RegisterModal bind:formModal {jsserde} nodeId={metadata.get('id').get('value')} />
+
+				<!-- Login Window -->
+				<div id="login-window">
+					<div class="space-y-3" style="margin-top: 5%;">
+						<h1 style="font-size:20px; text-align:center"><b> Welcome </b></h1>
+						<h3 style="text-align:center;"><span class="dot" />Domain Online</h3>
+						<Label class="space-y-2" style="margin-top: 50px;width:60vh;">
+							<span>Email</span>
+							<Input
+								color={inputColor}
+								type="email"
+								bind:value={email}
+								placeholder="info@openmined.org"
+								size="md"
+							>
+								<svg
+									slot="left"
+									aria-hidden="true"
+									class="w-4 h-4"
+									fill="currentColor"
+									viewBox="0 0 20 20"
+									xmlns="http://www.w3.org/2000/svg"
+									><path
+										d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"
+									/><path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" /></svg
+								>
+							</Input>
+						</Label>
+						<Label class="space-y-2" style="width:60vh;">
+							<span>Password</span>
+							<Input
+								color={inputColor}
+								type="password"
+								placeholder="**********"
+								bind:value={password}
+								size="md"
+							>
+								<svg
+									slot="left"
+									width="24"
+									height="24"
+									xmlns="http://www.w3.org/2000/svg"
+									fill-rule="evenodd"
+									clip-rule="evenodd"
+									><path
+										d="M24 11.5c0 3.613-2.951 6.5-6.475 6.5-2.154 0-4.101-1.214-5.338-3h-2.882l-1.046-1.013-1.302 1.019-1.362-1.075-1.407 1.081-4.188-3.448 3.346-3.564h8.841c1.145-1.683 3.104-3 5.339-3 3.497 0 6.474 2.866 6.474 6.5zm-10.691 1.5c.98 1.671 2.277 3 4.217 3 2.412 0 4.474-1.986 4.474-4.5 0-2.498-2.044-4.5-4.479-4.5-2.055 0-3.292 1.433-4.212 3h-9.097l-1.293 1.376 1.312 1.081 1.38-1.061 1.351 1.066 1.437-1.123 1.715 1.661h3.195zm5.691-3.125c.828 0 1.5.672 1.5 1.5s-.672 1.5-1.5 1.5-1.5-.672-1.5-1.5.672-1.5 1.5-1.5z"
+									/></svg
+								>
+							</Input>
+							<Helper
+								color="red"
+								class="text-sm"
+								style="text-align: center;display: {displayError}"
+							>
+								Incorrect email or password
+							</Helper>
+							<Helper class="text-sm" style="text-align: center"
+								>Don't you have an account yet? Apply for an account <a
+									on:click={() => {
+										formModal = true;
+									}}
+									class="font-medium text-blue-600 hover:underline dark:text-blue-500">here</a
+								>.</Helper
+							>
+						</Label>
+						<div style="display:flex; justify-content:center">
+							<Button on:click={() => login(email, password)} style="width: 30vh;" color="dark"
+								>Login</Button
+							>
+						</div>
+					</div>
+				</div>
+
+				<!-- Domain Info Text -->
+				<div id="domain-info">
+					<div style="border-bottom: solid; height: 45vh;">
+						<h1 style="font-size: 45px;">
+							<b>{prettyName(metadata.get('name'))}</b>
+							<h1>
+								<h5 style="font-size: 15px;"><b> {metadata.get('organization')} </b></h5>
+								<p style="font-size:17px;">{metadata.get('description')}</p>
+							</h1>
+						</h1>
+					</div>
+					<h3 class="info-foot">
+						<b> ID# </b>
+						<p
+							id="gridUID"
+							on:click={() => copyToClipBoard()}
+							style="margin-left: 5px; color: black;padding-left:10px; padding-right:10px; background-color: gray"
+						>
+							{metadata.get('id').get('value')}
+						</p>
+					</h3>
+					<h3 class="info-foot"><b> DEPLOYED ON:&nbsp;&nbsp;</b> {metadata.get('deployed_on')}</h3>
+				</div>
+			</div>
+		{/await}
+	{/await}
+</main>
+
+<style>
+	#login-screen {
+		height: 100%;
+		width: 100%;
+		position: absolute;
+		overflow: hidden;
+	}
+
+	#login-window {
+		border-radius: 5px;
+		justify-content: center;
+		display: flex;
+		padding: 10px;
+		box-shadow: 5px 10px 18px #888888;
+		position: absolute;
+		top: 24%;
+		left: 50%;
+		width: 40%;
+		height: 55%;
+		z-index: 2;
+		background-color: white;
+	}
+
+	#domain-info {
+		position: absolute;
+		z-index: 2;
+		top: 24%;
+		left: 10%;
+		width: 30%;
+		height: 55%;
+	}
+
+	#login-orange-circle-bg {
+		height: 100vh;
+		width: 100vh;
+		border-radius: 50%;
+		position: absolute;
+		z-index: 1;
+		background: linear-gradient(90deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0) 100%),
+			#ec9913;
+		filter: blur(50px);
+		left: 50%;
+		z-index: 1;
+	}
+
+	#login-blue-circle-bg {
+		height: 40vh;
+		width: 40vh;
+		border-radius: 50%;
+		position: absolute;
+		z-index: 3;
+		background: linear-gradient(90deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0) 100%),
+			rgb(13, 110, 237);
+		filter: blur(50px);
+		top: -15%;
+		left: 90%;
+		z-index: 1;
+	}
+
+	.info-foot {
+		margin: 15px;
+		display: flex;
+		color: grey;
+		font-size: 11px;
+	}
+
+	.dot {
+		height: 10px;
+		width: 10px;
+		background-color: green;
+		border-radius: 50%;
+		display: inline-block;
+		margin-right: 5px;
+		box-shadow: 0px 0px 2px 2px green;
+		animation: glow 1.5s linear infinite alternate;
+	}
+
+	@keyframes glow {
+		to {
+			box-shadow: 0px 0px 1px 1px greenyellow;
+		}
+	}
+</style>

--- a/packages/grid/frontend/yarn.lock
+++ b/packages/grid/frontend/yarn.lock
@@ -1814,6 +1814,11 @@ svelte-check@^3.0.1:
     svelte-preprocess "^5.0.0"
     typescript "^4.9.4"
 
+svelte-heros-v2@^0.3.18:
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/svelte-heros-v2/-/svelte-heros-v2-0.3.18.tgz#752927421a72b35660ec4167bdd3ca9a8cb4f660"
+  integrity sha512-dUWlrXR7mFDgy0jquT2Q2oAnl1iP39QXATcoSAcYlXjZNpU9A2tuBcyXHYIGw3MFZHWqhIwq6vjQ6LVR0xRdIg==
+
 svelte-hmr@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.15.1.tgz#d11d878a0bbb12ec1cba030f580cd2049f4ec86b"

--- a/packages/syft/src/syft/core/node/common/metadata.py
+++ b/packages/syft/src/syft/core/node/common/metadata.py
@@ -5,7 +5,7 @@ from ...common.uid import UID
 
 @serializable(recursive_serde=True)
 class Metadata:
-    __attr_allowlist__ = ["name", "id", "node_type", "version"]
+    __attr_allowlist__ = ["name", "id", "node_type", "version", 'deployed_on', 'organization', 'description']
 
     def __init__(
         self,
@@ -14,6 +14,9 @@ class Metadata:
         name: str = "",
         node_type: str = "",
         version: str = "",
+        deployed_on: str = "",
+        organization: str = "",
+        description: str = "",
     ) -> None:
         super().__init__()
         self.name = name
@@ -22,3 +25,6 @@ class Metadata:
             raise Exception(f"Must have a id of type UID instead got {id}: {type(id)}")
         self.node_type = node_type
         self.version = version
+        self.deployed_on = deployed_on
+        self.description = description
+        self.organization = organization

--- a/packages/syft/src/syft/core/node/common/node.py
+++ b/packages/syft/src/syft/core/node/common/node.py
@@ -376,11 +376,14 @@ class Node(AbstractNode):
         return client
 
     def get_metadata_for_client(self) -> Metadata:
+        node_setup = self.setup.first()
         return Metadata(
             name=self.name if self.name else "",
             id=self.id,
             node_type=str(type(self).__name__),
             version=str(__version__),
+            description=node_setup.description,
+            deployed_on=node_setup.deployed_on,
         )
 
     def get_api(self) -> SyftAPI:


### PR DESCRIPTION
## Description
This PR aims to add the initial /login and /home routes and its components
The following files were changed/created
 - ADD /routes/login/+page.svelte (LoginScreen page)
 - ADD /routes/home/+page.svelte
- ADD /components/LoginHeader.svelte
 - ADD /components/RegisterModal.svelte
 - ADD /lib/store.js
 - UPDATE /+page.svelte (To make it redirect to /login if no credential is detected)
 - UPDATE /grid/api/syft  (create /serde endpoint to retrieve the type_bank dict with all serializable items)
 - UPDATE /syft/core/node/common/node.py  (to add deployed_on, description and organization fields in metadata)

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
