### PR TITLE
Misc improvements in user code submission implementation

### DIFF
--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -127,9 +127,11 @@ def add_credentials_for_key(key: str) -> Callable:
 
 
 def generate_signature(context: TransformContext) -> TransformContext:
-    for k in context.output["input_kwargs"]:
-        param = Parameter(name=k, kind=Parameter.POSITIONAL_OR_KEYWORD)
-    sig = Signature(parameters=[param])
+    params = [
+        Parameter(name=k, kind=Parameter.POSITIONAL_OR_KEYWORD)
+        for k in context.output["input_kwargs"]
+    ]
+    sig = Signature(parameters=params)
     context.output["signature"] = sig
     return context
 

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -30,9 +30,6 @@ from .user_code_parse import parse_and_wrap_code
 UserVerifyKeyPartitionKey = PartitionKey(key="user_verify_key", type_=SyftVerifyKey)
 CodeHashPartitionKey = PartitionKey(key="code_hash", type_=int)
 
-stdout_ = sys.stdout
-stderr_ = sys.stderr
-
 PyCodeObject = Any
 
 
@@ -163,8 +160,9 @@ class UserCodeExecutionResult(SyftObject):
 
 
 def execute_byte_code(code_item: UserCode, kwargs: Dict[str, Any]) -> Any:
-    global stdout_
-    global stderr_
+    stdout_ = sys.stdout
+    stderr_ = sys.stderr
+
     try:
         stdout = StringIO()
         stderr = StringIO()

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -168,16 +168,9 @@ def execute_byte_code(code_item: UserCode, kwargs: Dict[str, Any]) -> Any:
         result = None
 
         exec(code_item.byte_code)  # nosec
-        evil_string = f"result = {code_item.unique_func_name}(**kwargs)"
 
-        # copy locals
-        _locals = locals()
-
-        # pass in kwargs and evaluate
-        exec(evil_string, None, _locals)  # nosec
-
-        # assign result back to local scope
-        result = _locals["result"]
+        evil_string = f"{code_item.unique_func_name}(**kwargs)"
+        result = eval(evil_string, None, locals())
 
         # restore stdout and stderr
         sys.stdout = stdout_

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -12,9 +12,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-# third party
-from RestrictedPython import compile_restricted
-
 # relative
 from ....core.node.common.node_table.syft_object import SYFT_OBJECT_VERSION_1
 from ....core.node.common.node_table.syft_object import SyftObject
@@ -74,9 +71,6 @@ class SubmitUserCode(SyftObject):
     func_name: str
     input_kwargs: List[str]
     output_arg: str
-
-    def compile(self) -> PyCodeObject:
-        return compile_restricted(self.code, "<string>", "exec")
 
 
 def generate_unique_func_name(context: TransformContext) -> TransformContext:

--- a/packages/syft/src/syft/core/node/new/user_code_parse.py
+++ b/packages/syft/src/syft/core/node/new/user_code_parse.py
@@ -1,20 +1,6 @@
 # stdlib
 import ast
-import sys
-from typing import Any
 from typing import List
-
-# relative
-from .credentials import SyftVerifyKey
-from .document_store import PartitionKey
-
-UserVerifyKeyPartitionKey = PartitionKey(key="user_verify_key", type_=SyftVerifyKey)
-CodeHashPartitionKey = PartitionKey(key="code_hash", type_=int)
-
-stdout_ = sys.stdout
-stderr_ = sys.stderr
-
-PyCodeObject = Any
 
 
 class GlobalsVisitor(ast.NodeVisitor):

--- a/packages/syft/src/syft/core/node/new/user_code_service.py
+++ b/packages/syft/src/syft/core/node/new/user_code_service.py
@@ -1,6 +1,5 @@
 # stdlib
 from typing import Any
-from typing import Dict
 from typing import List
 from typing import Union
 
@@ -73,7 +72,7 @@ class UserCodeService(AbstractService):
 
     @service_method(path="code.call", name="call")
     def call(
-        self, context: AuthedServiceContext, uid: UID, **kwargs: Dict[str, Any]
+        self, context: AuthedServiceContext, uid: UID, **kwargs: Any
     ) -> Union[SyftSuccess, SyftError]:
         """Call a User Code Function"""
         result = self.stash.get_by_uid(uid=uid)


### PR DESCRIPTION
## Description
- Correct signature
- The use of `global` is not needed

Also looks like this part

https://github.com/OpenMined/PySyft/blob/bdf6bb0fabebe42dfd327dd09fdb1dc5f63cc91d/packages/syft/src/syft/core/node/new/user_code.py#L173-L186

is not needed?

`locals()` is a dictionary so `_locals = locals()` doesn't actually make a copy. `_locals` would point to the exact same dictionary as `locals()`? Thus `result = _locals["result"]`, `exec(evil_string, None, _locals)` automatically does that. The whole code block is equivalent to just

```py
exec(evil_string, None, locals())
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
