### PR TITLE
Deserialization bug with overriden `__init__` in `SyftObject`

### DIFF
--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -48,7 +48,7 @@ class UserCode(SyftObject):
     user_verify_key: SyftVerifyKey
     raw_code: str
     input_kwargs: List[str]
-    output_arg: str
+    output_kwargs: List[str]
     parsed_code: str
     service_func_name: str
     unique_func_name: str
@@ -207,7 +207,7 @@ def new_check_code(context: TransformContext) -> TransformContext:
 
     context.output["parsed_code"] = processed_code
     context.output["input_kwargs"] = input_kwargs
-    context.output["output_arg"] = outputs[0]
+    context.output["output_kwargs"] = outputs
 
     return context
 

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -175,7 +175,7 @@ def new_check_code(context: TransformContext) -> TransformContext:
 
     new_body = tree.body + [call_stmt, return_stmt]
 
-    return_annotation = ast.parse("Dict[str, Any]").body[0].value
+    return_annotation = ast.parse("Dict[str, Any]", mode="eval").body
 
     wrapper_function = ast.FunctionDef(
         name=func_name,

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -279,7 +279,7 @@ def execute_byte_code(code_item: UserCode, kwargs: Dict[str, Any]) -> Any:
         exec(code_item.byte_code)  # nosec
 
         evil_string = f"{code_item.unique_func_name}(**kwargs)"
-        result = eval(evil_string, None, locals())
+        result = eval(evil_string, None, locals())  # nosec
 
         # restore stdout and stderr
         sys.stdout = stdout_

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -309,9 +309,7 @@ def execute_byte_code(code_item: UserCode, kwargs: Dict[str, Any]) -> Any:
         )
 
     except Exception as e:
-        sys.stdout = stdout_
-        sys.stderr = stderr_
-        print("execute_byte_code failed", e)
+        print("execute_byte_code failed", e, file=stderr_)
     finally:
         sys.stdout = stdout_
         sys.stderr = stderr_

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -70,8 +70,8 @@ class ExactMatch(SyftObject):
     id: Optional[UID]
     inputs: Dict[str, Any]
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(inputs=kwargs)
+    # def __init__(self, *args: Any, **kwargs: Any) -> None:
+    #     super().__init__(inputs=kwargs)
 
 
 @serializable(recursive_serde=True)
@@ -143,14 +143,17 @@ def new_check_code(context: TransformContext) -> TransformContext:
     raw_code = context.output["raw_code"]
     func_name = context.output["unique_func_name"]
     service_func_name = context.output["service_func_name"]
+
     inputs = context.output["input_policy"].inputs
+    input_kwargs = list(inputs.keys())
+
     outputs = context.output["output_policy"].outputs
 
     tree = ast.parse(raw_code)
     f = tree.body[0]
     f.decorator_list = []
 
-    keywords = [ast.keyword(arg=i, value=[ast.Name(id=i)]) for i in inputs]
+    keywords = [ast.keyword(arg=i, value=[ast.Name(id=i)]) for i in input_kwargs]
     call_stmt = ast.Assign(
         targets=[ast.Name(id="result")],
         value=ast.Call(func=ast.Name(id=service_func_name), args=[], keywords=keywords),
@@ -187,7 +190,7 @@ def new_check_code(context: TransformContext) -> TransformContext:
     )
 
     context.output["parsed_code"] = ast.unparse(wrapper_function)
-    context.output["input_kwargs"] = inputs
+    context.output["input_kwargs"] = input_kwargs
     context.output["output_arg"] = outputs[0]
 
     return context


### PR DESCRIPTION
## Description
Looks like overriding `__init__` in `ExactMatch` messes with serialization

```py
@serializable(recursive_serde=True)
class ExactMatch(SyftObject):
    # version
    __canonical_name__ = "ExactMatch"
    __version__ = SYFT_OBJECT_VERSION_1

    id: Optional[UID]
    inputs: Dict[str, Any]

    def __init__(self, *args: Any, **kwargs: Any) -> None:
        super().__init__(inputs=kwargs)
```

In

```py
@syft_function(input_policy=ExactMatch(x=4), output_policy=SingleExecutionExactOutput(outputs=["y"]))
def func(x):
    return {"y": x}
```

`ExactMatch(x=4)` on the client works as intended

```py
class ExactMatch:
  id = None
  inputs = {'x': 4}
```

but on the server it deserializes into

```py
class ExactMatch:
  id = None
  inputs = {'inputs': {'x': 4}}
```

Comment out the overriden `__init__` for now. In the meantime use `ExactMatch(inputs={'x': 4})`

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
