### PR TITLE
Added support for > 512mb blobs in recursive serde

### DIFF
--- a/packages/syft/src/syft/capnp/iterable.capnp
+++ b/packages/syft/src/syft/capnp/iterable.capnp
@@ -1,5 +1,5 @@
 @0x979a7994b9718d24;
 
 struct Iterable {
-    values @0 :List(Data);
+    values @0 :List(List(Data));
 }

--- a/packages/syft/src/syft/capnp/kv_iterable.capnp
+++ b/packages/syft/src/syft/capnp/kv_iterable.capnp
@@ -2,5 +2,5 @@
 
 struct KVIterable {
     keys @0 :List(Data);
-    values @1: List(Data);
+    values @1: List(List(Data));
 }

--- a/packages/syft/src/syft/capnp/recursive_serde.capnp
+++ b/packages/syft/src/syft/capnp/recursive_serde.capnp
@@ -2,7 +2,7 @@
 
 struct RecursiveSerde {
     fieldsName @0 :List(Text);
-    fieldsData @1 :List(Data);
+    fieldsData @1 :List(List(Data));
     fullyQualifiedName @2 :Text;
-    nonrecursiveBlob @3 :Data;
+    nonrecursiveBlob @3 :List(Data);
 }

--- a/packages/syft/src/syft/core/common/serde/recursive.py
+++ b/packages/syft/src/syft/core/common/serde/recursive.py
@@ -66,6 +66,28 @@ def recursive_serde_register(
     )
 
 
+def chunk_bytes(
+    data: bytes, field_name: Union[str, int], builder: _DynamicStructBuilder
+) -> None:
+    CHUNK_SIZE = int(5.12e8)  # capnp max for a List(Data) field
+    list_size = len(data) // CHUNK_SIZE + 1
+    data_lst = builder.init(field_name, list_size)
+    END_INDEX = CHUNK_SIZE
+    for idx in range(list_size):
+        START_INDEX = idx * CHUNK_SIZE
+        END_INDEX = min(START_INDEX + CHUNK_SIZE, len(data))
+        data_lst[idx] = data[START_INDEX:END_INDEX]
+
+
+def combine_bytes(capnp_list: List[bytes]) -> bytes:
+    # TODO: make sure this doesn't copy, perhaps allocate a fixed size buffer
+    # and move the bytes into it as we go
+    bytes_value = b""
+    for value in capnp_list:
+        bytes_value += value
+    return bytes_value
+
+
 def rs_object2proto(self: Any) -> _DynamicStructBuilder:
     msg = recursive_scheme.new_message()
     fqn = get_fully_qualified_name(self)
@@ -73,16 +95,20 @@ def rs_object2proto(self: Any) -> _DynamicStructBuilder:
         raise Exception(f"{fqn} not in TYPE_BANK")
 
     msg.fullyQualifiedName = fqn
-    nonrecursive, serialize, deserialize, attribute_list, serde_overrides = TYPE_BANK[
-        fqn
-    ]
+    (
+        nonrecursive,
+        serialize,
+        deserialize,
+        attribute_list,
+        serde_overrides,
+    ) = TYPE_BANK[fqn]
 
     if nonrecursive:
         if serialize is None:
             raise Exception(
                 f"Cant serialize {type(self)} nonrecursive without serialize."
             )
-        msg.nonrecursiveBlob = serialize(self)
+        chunk_bytes(serialize(self), "nonrecursiveBlob", msg)
         return msg
 
     if attribute_list is None:
@@ -90,6 +116,7 @@ def rs_object2proto(self: Any) -> _DynamicStructBuilder:
 
     msg.init("fieldsName", len(attribute_list))
     msg.init("fieldsData", len(attribute_list))
+
     for idx, attr_name in enumerate(sorted(attribute_list)):
         if not hasattr(self, attr_name):
             raise ValueError(
@@ -106,9 +133,8 @@ def rs_object2proto(self: Any) -> _DynamicStructBuilder:
             continue
 
         serialized = sy.serialize(field_obj, to_bytes=True)
-
         msg.fieldsName[idx] = attr_name
-        msg.fieldsData[idx] = serialized
+        chunk_bytes(serialized, idx, msg.fieldsData)
 
     return msg
 
@@ -149,11 +175,13 @@ def rs_proto2object(proto: _DynamicStructBuilder) -> Any:
             raise Exception(
                 f"Cant serialize {type(proto)} nonrecursive without serialize."
             )
-        return deserialize(proto.nonrecursiveBlob)
+
+        return deserialize(combine_bytes(proto.nonrecursiveBlob))
 
     kwargs = {}
 
-    for attr_name, attr_bytes in zip(proto.fieldsName, proto.fieldsData):
+    for attr_name, attr_bytes_list in zip(proto.fieldsName, proto.fieldsData):
+        attr_bytes = combine_bytes(attr_bytes_list)
         attr_value = _deserialize(attr_bytes, from_bytes=True)
         transforms = serde_overrides.get(attr_name, None)
 

--- a/packages/syft/src/syft/core/common/serde/recursive_primitives.py
+++ b/packages/syft/src/syft/core/common/serde/recursive_primitives.py
@@ -19,6 +19,8 @@ from typing import cast
 
 # relative
 from .capnp import get_capnp_schema
+from .recursive import chunk_bytes
+from .recursive import combine_bytes
 from .recursive import recursive_serde_register
 
 # import types unsupported on python 3.8
@@ -41,7 +43,8 @@ def serialize_iterable(iterable: Collection) -> bytes:
     message.init("values", len(iterable))
 
     for idx, it in enumerate(iterable):
-        message.values[idx] = _serialize(it, to_bytes=True)
+        serialized = _serialize(it, to_bytes=True)
+        chunk_bytes(serialized, idx, message.values)
 
     return message.to_bytes()
 
@@ -57,7 +60,7 @@ def deserialize_iterable(iterable_type: type, blob: bytes) -> Collection:
         blob, traversal_limit_in_words=MAX_TRAVERSAL_LIMIT
     ) as msg:
         for element in msg.values:
-            values.append(_deserialize(element, from_bytes=True))
+            values.append(_deserialize(combine_bytes(element), from_bytes=True))
 
     return iterable_type(values)
 
@@ -73,7 +76,8 @@ def serialize_kv(map: Mapping) -> bytes:
 
     for index, (k, v) in enumerate(map.items()):
         message.keys[index] = _serialize(k, to_bytes=True)
-        message.values[index] = _serialize(v, to_bytes=True)
+        serialized = _serialize(v, to_bytes=True)
+        chunk_bytes(serialized, index, message.values)
 
     return message.to_bytes()
 
@@ -92,7 +96,7 @@ def get_deserialized_kv_pairs(blob: bytes) -> List[Any]:
             pairs.append(
                 (
                     _deserialize(key, from_bytes=True),
-                    _deserialize(value, from_bytes=True),
+                    _deserialize(combine_bytes(value), from_bytes=True),
                 )
             )
     return pairs

--- a/packages/syft/src/syft/core/common/serde/third_party.py
+++ b/packages/syft/src/syft/core/common/serde/third_party.py
@@ -1,11 +1,19 @@
 # stdlib
 
+# stdlib
+from datetime import date
+from datetime import datetime
+from datetime import time
+
 # third party
+from dateutil import parser
 from nacl.signing import SigningKey
 from nacl.signing import VerifyKey
 from oblv.oblv_client import OblvClient
 from pandas import DataFrame
 from pandas import Series
+from pandas._libs.tslibs.timestamps import Timestamp
+import pyarrow as pa
 import pydantic
 from pymongo.collection import Collection
 from result import Err
@@ -51,11 +59,33 @@ recursive_serde_register(cls=TypeError)
 recursive_serde_register_type(Collection)
 
 
+def serialize_dataframe(df: DataFrame) -> bytes:
+    table = pa.Table.from_pandas(df)
+    sink = pa.BufferOutputStream()
+    # 🟡 TODO 37: Should we warn about this?
+    parquet_args = {
+        "coerce_timestamps": "us",
+        "allow_truncated_timestamps": True,
+    }
+    pa.parquet.write_table(table, sink, **parquet_args)
+    buffer = sink.getvalue()
+    numpy_bytes = buffer.to_pybytes()
+    return numpy_bytes
+
+
+def deserialize_dataframe(buf: bytes) -> DataFrame:
+    reader = pa.BufferReader(buf)
+    numpy_bytes = reader.read_buffer()
+    result = pa.parquet.read_table(numpy_bytes)
+    df = result.to_pandas()
+    return df
+
+
 # pandas
 recursive_serde_register(
     DataFrame,
-    serialize=lambda x: serialize(x.to_dict(), to_bytes=True),
-    deserialize=lambda x: DataFrame.from_dict(deserialize(x, from_bytes=True)),
+    serialize=serialize_dataframe,
+    deserialize=deserialize_dataframe,
 )
 
 
@@ -69,6 +99,32 @@ recursive_serde_register(
     serialize=lambda x: serialize(DataFrame(x).to_dict(), to_bytes=True),
     deserialize=deserialize_series,
 )
+
+
+recursive_serde_register(
+    datetime,
+    serialize=lambda x: serialize(x.isoformat(), to_bytes=True),
+    deserialize=lambda x: parser.isoparse(deserialize(x, from_bytes=True)),
+)
+
+recursive_serde_register(
+    time,
+    serialize=lambda x: serialize(x.isoformat(), to_bytes=True),
+    deserialize=lambda x: parser.parse(deserialize(x, from_bytes=True)).time(),
+)
+
+recursive_serde_register(
+    date,
+    serialize=lambda x: serialize(x.isoformat(), to_bytes=True),
+    deserialize=lambda x: parser.parse(deserialize(x, from_bytes=True)).date(),
+)
+
+recursive_serde_register(
+    Timestamp,
+    serialize=lambda x: serialize(x.value, to_bytes=True),
+    deserialize=lambda x: Timestamp(deserialize(x, from_bytes=True)),
+)
+
 
 # how else do you import a relative file to execute it?
 NOTHING = None

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -241,6 +241,12 @@ class APIModule:
         setattr(self, attr_name, module_or_func)
         self._modules.append(attr_name)
 
+    def _repr_html_(self) -> Any:
+        if not hasattr(self, "get_all"):
+            return NotImplementedError
+        results = self.get_all()
+        return results._repr_html_()
+
 
 @instrument
 @serializable(recursive_serde=True)

--- a/packages/syft/src/syft/core/node/new/client.py
+++ b/packages/syft/src/syft/core/node/new/client.py
@@ -356,6 +356,12 @@ class SyftClient:
             return self.api.services.data_subject
         return None
 
+    @property
+    def datasets(self) -> Optional[APIModule]:
+        if self.api is not None and hasattr(self.api.services, "dataset"):
+            return self.api.services.dataset
+        return None
+
     def connect(self, email: str, password: str, cache: bool = True) -> None:
         signing_key = self.connection.connect(email=email, password=password)
         if signing_key is not None:

--- a/packages/syft/src/syft/core/node/worker.py
+++ b/packages/syft/src/syft/core/node/worker.py
@@ -169,6 +169,15 @@ class Worker(NewNode):
         key = SyftSigningKey(SigningKey(name_hash))
         return Worker(name=name, id=uid, signing_key=key, processes=processes)
 
+    @property
+    def root_client(self) -> Any:
+        # relative
+        from .new.client import PythonConnection
+        from .new.client import SyftClient
+
+        connection = PythonConnection(node=self)
+        return SyftClient(connection=connection, credentials=self.signing_key)
+
     def __repr__(self) -> str:
         return f"{type(self).__name__}: {self.name} - {self.id} {self.services}"
 


### PR DESCRIPTION
## Description
- Capnp has a max of 512mb per Data item so the outer recursive layer would hit the limit when a child is over 512mb
- Added datetime, time, date, pd.Timestamp serde types
- Changed DataFrame serde to use PyArrow
- Added root_client property to Worker
