### PR TITLE
Add dataset search

### DIFF
--- a/packages/syft/src/syft/__init__.py
+++ b/packages/syft/src/syft/__init__.py
@@ -32,6 +32,7 @@ __version__ = "0.8.0-beta.0"
 from pathlib import Path
 import sys
 from typing import Any
+from typing import List
 
 # third party
 from pkg_resources import DistributionNotFound  # noqa: F401
@@ -151,3 +152,18 @@ def _gateways() -> NetworkRegistry:
 @module_property
 def _settings() -> UserSettings:
     return settings
+
+
+def __search_one_node(client, name):
+    try:
+        return client.api.services.dataset.search(name=name)
+    except:  # noqa
+        return []
+
+
+def search(name: str) -> List[Any]:
+    results = (__search_one_node(client, name) for client in _gateways())
+    filtered = (result for result in results if result)  # filter out SyftError results
+    flattened = sum(filtered, start=[])
+
+    return flattened

--- a/packages/syft/src/syft/__init__.py
+++ b/packages/syft/src/syft/__init__.py
@@ -32,7 +32,6 @@ __version__ = "0.8.0-beta.0"
 from pathlib import Path
 import sys
 from typing import Any
-from typing import List
 
 # third party
 from pkg_resources import DistributionNotFound  # noqa: F401
@@ -111,6 +110,8 @@ from .oblv import get_oblv_public_key  # noqa: F401
 from .oblv import install_oblv_proxy  # noqa: F401
 from .oblv import login as oblv_login  # noqa: F401
 from .registry import NetworkRegistry  # noqa: F401
+from .search import Search  # noqa: F401
+from .search import SearchResults  # noqa: F401
 from .telemetry import instrument  # noqa: F401
 from .user_settings import UserSettings  # noqa: F401
 from .user_settings import settings  # noqa: F401
@@ -154,16 +155,5 @@ def _settings() -> UserSettings:
     return settings
 
 
-def __search_one_node(client, name):
-    try:
-        return client.api.services.dataset.search(name=name)
-    except:  # noqa
-        return []
-
-
-def search(name: str) -> List[Any]:
-    results = (__search_one_node(client, name) for client in _gateways())
-    filtered = (result for result in results if result)  # filter out SyftError results
-    flattened = sum(filtered, start=[])
-
-    return flattened
+def search(name: str) -> SearchResults:
+    return Search(_gateways()).search(name=name)

--- a/packages/syft/src/syft/core/node/new/dataset_service.py
+++ b/packages/syft/src/syft/core/node/new/dataset_service.py
@@ -52,6 +52,19 @@ class DatasetService(AbstractService):
             return results
         return SyftError(message=result.err())
 
+    @service_method(path="dataset.search", name="search")
+    def search(
+        self, context: AuthedServiceContext, name: str
+    ) -> Union[List[Dataset], SyftError]:
+        """Search a Dataset by name"""
+        results = self.get_all(context)
+
+        return (
+            results
+            if isinstance(results, SyftError)
+            else [dataset for dataset in results if name in dataset.name]
+        )
+
     @service_method(path="dataset.get_by_id", name="get_by_id")
     def get_by_id(
         self, context: AuthedServiceContext, uid: UID

--- a/packages/syft/src/syft/search.py
+++ b/packages/syft/src/syft/search.py
@@ -1,0 +1,46 @@
+# stdlib
+from typing import List
+from typing import Tuple
+
+# relative
+from .core.node.common.client import Client
+from .core.node.new.dataset import Dataset
+from .registry import NetworkRegistry
+
+
+class SearchResults:
+    def __init__(self, results: List[Tuple[Client, List[Dataset]]]):
+        self._results = results
+        self._clients = (client for client, _ in results)
+        self._datasets = sum((datasets for _, datasets in results), start=[])
+
+    def __getitem__(self, idx: int) -> Dataset:
+        return self._datasets[idx]
+
+    def __repr__(self) -> str:
+        return str(self._results)
+
+
+class Search:
+    def __init__(self, gateways: NetworkRegistry):
+        self.gateways = gateways
+
+    @staticmethod
+    def __search_one_node(client: Client, name: str) -> List[Dataset]:
+        try:
+            return client.api.services.dataset.search(name=name)
+        except:  # noqa
+            return []
+
+    def __search(self, name: str) -> List[Tuple[Client, List[Dataset]]]:
+        results = (
+            (client, self.__search_one_node(client, name)) for client in self.gateways
+        )
+
+        # filter out SyftError
+        filtered = ((client, result) for client, result in results if result)
+
+        return list(filtered)
+
+    def search(self, name: str) -> SearchResults:
+        return SearchResults(self.__search(name))


### PR DESCRIPTION
## Description

### Dataset API search endpoint

Added a `search` endpoint to the dataset api services here so users can do

```py
client.api.services.dataset.search(name="<search-string>")
```

Currently implemented by filtering outputs of `dataset.get_all`. A better way could be through the stash api, e.g. `query_all`?

### `sy.search`

Added `sy.search` which loops through the nodes in `sy.gateways` and call their dataset search endpoints and collecting the results.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
