### PR TITLE
Make input_policy.assets compatible with Mongo

### DIFF
--- a/packages/syft/src/syft/core/node/new/document_store.py
+++ b/packages/syft/src/syft/core/node/new/document_store.py
@@ -167,6 +167,9 @@ class QueryKey(PartitionKey):
         key = self.key
         if key == "id":
             key = "_id"
+        if self.type_list:
+            # We want to search inside the list of values
+            return {key: {"$in": self.value}}
         return {key: self.value}
 
 
@@ -253,7 +256,11 @@ class QueryKeys(SyftBaseModel):
             qk_value = qk.value
             if qk_key == "id":
                 qk_key = "_id"
-            qk_dict[qk_key] = qk_value
+            if qk.type_list:
+                # We want to search inside the list of values
+                qk_dict[qk_key] = {"$in": qk_value}
+            else:
+                qk_dict[qk_key] = qk_value
         return qk_dict
 
 

--- a/packages/syft/src/syft/core/node/new/mongo_document_store.py
+++ b/packages/syft/src/syft/core/node/new/mongo_document_store.py
@@ -51,7 +51,11 @@ def to_mongo(context: TransformContext) -> TransformContext:
     all_dict.update(search_keys_dict)
     for k in all_dict:
         value = getattr(context.obj, k, "")
-        output[k] = value
+        # if the value is a method, store its value
+        if callable(value):
+            output[k] = value()
+        else:
+            output[k] = value
     blob = serialize(context.obj.to_dict(), to_bytes=True)
     output["_id"] = context.output["id"]
     output["__canonical_name__"] = context.obj.__canonical_name__


### PR DESCRIPTION
- if the searchable key is a method, call it and store its value in the mongo
- update as_mongo_dict method to use in query if the qk is of list_type

Test Notebooks: https://github.com/OpenMined/Heartbeat/pull/108

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
