### PR TITLE
Add signature validation for responses

### DIFF
--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -149,12 +149,6 @@ class SyftAPIData(SyftBaseObject):
             signature=signed_message.signature,
         )
 
-    def unwrap(self) -> Any:
-        if isinstance(self.data, SignedSyftAPICall):
-            return self.data.message.data
-
-        return self.data
-
 
 def generate_remote_function(
     node_uid: UID,
@@ -347,7 +341,7 @@ class SyftAPI(SyftObject):
         if not signed_result.is_valid:
             return SyftError(message="The result signature is invalid")  # type: ignore
 
-        result = signed_result.message.unwrap()
+        result = signed_result.message.data
 
         if isinstance(result, OkErr):
             if result.is_ok():

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -354,7 +354,6 @@ class SyftAPI(SyftObject):
                 return result.ok()
             else:
                 return result.err()
-
         return result
 
     @staticmethod

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -338,7 +338,7 @@ class SyftAPI(SyftObject):
         if not isinstance(signed_result, SignedSyftAPICall):
             return SyftError(message="The result is not signed")  # type: ignore
 
-        if not signed_result.is_valid:
+        if not signed_result.is_valid.is_ok():
             return SyftError(message="The result signature is invalid")  # type: ignore
 
         result = signed_result.message.data

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -132,13 +132,13 @@ class SyftAPICall(SyftObject):
 
 @instrument
 @serializable(recursive_serde=True)
-class SyftAPIResponse(SyftBaseObject):
+class SyftAPIData(SyftBaseObject):
     # version
-    __canonical_name__ = "SyftAPIResponse"
+    __canonical_name__ = "SyftAPIData"
     __version__ = SYFT_OBJECT_VERSION_1
 
     # fields
-    result: Any
+    data: Any
 
     def sign(self, credentials: SyftSigningKey) -> SignedSyftAPICall:
         signed_message = credentials.signing_key.sign(_serialize(self, to_bytes=True))
@@ -150,10 +150,10 @@ class SyftAPIResponse(SyftBaseObject):
         )
 
     def unwrap(self) -> Any:
-        if isinstance(self.result, SignedSyftAPICall):
-            return self.result.message.result
+        if isinstance(self.data, SignedSyftAPICall):
+            return self.data.message.data
 
-        return self.result
+        return self.data
 
 
 def generate_remote_function(

--- a/packages/syft/src/syft/core/node/worker.py
+++ b/packages/syft/src/syft/core/node/worker.py
@@ -392,7 +392,7 @@ class Worker(NewNode):
                 message=f"You sent a {type(api_call)}. This node requires SignedSyftAPICall."  # type: ignore
             )
         else:
-            if not api_call.is_valid:
+            if not api_call.is_valid.is_ok():
                 return SyftError(message="Your message signature is invalid")  # type: ignore
 
         if api_call.message.node_uid != self.id:
@@ -444,7 +444,8 @@ class Worker(NewNode):
             )
             if api_call.message.blocking:
                 gevent.joinall([thread])
-                result = thread.value
+                signed_result = thread.value
+                result = signed_result.message.data
             else:
                 result = item
         return result

--- a/packages/syft/src/syft/core/node/worker.py
+++ b/packages/syft/src/syft/core/node/worker.py
@@ -38,6 +38,7 @@ from .new.action_store import SQLiteActionStore
 from .new.api import SignedSyftAPICall
 from .new.api import SyftAPI
 from .new.api import SyftAPICall
+from .new.api import SyftAPIResponse
 from .new.context import AuthedServiceContext
 from .new.context import NodeServiceContext
 from .new.context import UnauthedServiceContext
@@ -374,6 +375,16 @@ class Worker(NewNode):
         return SyftError(message=(f"Node has no route to {node_uid}"))
 
     def handle_api_call(
+        self, api_call: Union[SyftAPICall, SignedSyftAPICall]
+    ) -> Result[SignedSyftAPICall, Err]:
+        # Get the result
+        result = self._handle_api_call_with_unsigned_result(api_call)
+        # Sign the result
+        signed_result = SyftAPIResponse(result=result).sign(self.signing_key)
+
+        return signed_result
+
+    def _handle_api_call_with_unsigned_result(
         self, api_call: Union[SyftAPICall, SignedSyftAPICall]
     ) -> Result[Union[QueueItem, SyftObject], Err]:
         if self.required_signed_calls and isinstance(api_call, SyftAPICall):

--- a/packages/syft/src/syft/core/node/worker.py
+++ b/packages/syft/src/syft/core/node/worker.py
@@ -38,7 +38,7 @@ from .new.action_store import SQLiteActionStore
 from .new.api import SignedSyftAPICall
 from .new.api import SyftAPI
 from .new.api import SyftAPICall
-from .new.api import SyftAPIResponse
+from .new.api import SyftAPIData
 from .new.context import AuthedServiceContext
 from .new.context import NodeServiceContext
 from .new.context import UnauthedServiceContext
@@ -378,13 +378,13 @@ class Worker(NewNode):
         self, api_call: Union[SyftAPICall, SignedSyftAPICall]
     ) -> Result[SignedSyftAPICall, Err]:
         # Get the result
-        result = self._handle_api_call_with_unsigned_result(api_call)
+        result = self.handle_api_call_with_unsigned_result(api_call)
         # Sign the result
-        signed_result = SyftAPIResponse(result=result).sign(self.signing_key)
+        signed_result = SyftAPIData(data=result).sign(self.signing_key)
 
         return signed_result
 
-    def _handle_api_call_with_unsigned_result(
+    def handle_api_call_with_unsigned_result(
         self, api_call: Union[SyftAPICall, SignedSyftAPICall]
     ) -> Result[Union[QueueItem, SyftObject], Err]:
         if self.required_signed_calls and isinstance(api_call, SyftAPICall):
@@ -503,6 +503,7 @@ def task_runner(
     try:
         with pipe:
             api_call = pipe.get()
+
             result = worker.handle_api_call(api_call)
             if blocking:
                 pipe.put(result)

--- a/packages/syft/src/syft/core/node/worker.py
+++ b/packages/syft/src/syft/core/node/worker.py
@@ -445,6 +445,10 @@ class Worker(NewNode):
             if api_call.message.blocking:
                 gevent.joinall([thread])
                 signed_result = thread.value
+
+                if not signed_result.is_valid.is_ok():
+                    return SyftError(message="The result signature is invalid")  # type: ignore
+
                 result = signed_result.message.data
             else:
                 result = item


### PR DESCRIPTION
## Description
 - Added generic SyftAPIData object used for signing responses
 - Fix validation issue with the request signature.
 - Added unit tests for the handle_api_call changes

fixes https://github.com/OpenMined/Heartbeat/issues/115

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
