### PR TITLE
Fix /new router to work with the last changes

### DIFF
--- a/packages/grid/backend/grid/api/router.py
+++ b/packages/grid/backend/grid/api/router.py
@@ -23,9 +23,11 @@ from grid.api.syft import syft
 from grid.api.tasks.routes import router as task_router
 from grid.api.users.routes import router as user_router
 from grid.api.vpn import vpn
+from grid.api.new.new import router as new_router
 
 api_router = APIRouter()
 api_router.include_router(task_router, prefix="/task", tags=["task"])
+api_router.include_router(new_router, prefix="/new", tags=["new"])
 api_router.include_router(login.router, tags=["login"])
 api_router.include_router(register.router, tags=["register"])
 api_router.include_router(user_router, prefix="/users", tags=["users"])

--- a/packages/grid/backend/grid/api/router.py
+++ b/packages/grid/backend/grid/api/router.py
@@ -16,6 +16,7 @@ from grid.api.datasets import datasets
 from grid.api.meta import exam
 from grid.api.meta import ping
 from grid.api.meta import status
+from grid.api.new.new import router as new_router
 from grid.api.requests.routes import router as requests_router
 from grid.api.roles import roles
 from grid.api.settings import settings
@@ -23,7 +24,6 @@ from grid.api.syft import syft
 from grid.api.tasks.routes import router as task_router
 from grid.api.users.routes import router as user_router
 from grid.api.vpn import vpn
-from grid.api.new.new import router as new_router
 
 api_router = APIRouter()
 api_router.include_router(task_router, prefix="/task", tags=["task"])


### PR DESCRIPTION
## Description
The recent changes moved `/new` routes definition to another source file, disabling it from the API. This PR aims to fix this by adding the router created in new.py to our API router.
