### PR TITLE
Partition key bug

### DIFF
--- a/notebooks/bugs/partition_key_duplication_error.ipynb
+++ b/notebooks/bugs/partition_key_duplication_error.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "kj/filesystem-disk-unix.c++:1690: warning: PWD environment variable doesn't match current directory; pwd = /home/teo/OpenMined/PySyft\n",
+      "2023-03-09 10:21:27.269514: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-11.5/lib64:/usr/local/cuda-11.5/lib64:\n",
+      "2023-03-09 10:21:27.283666: E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2023-03-09 10:21:27.726447: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvrtc.so.11.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-11.5/lib64:/usr/local/cuda-11.5/lib64:\n",
+      "2023-03-09 10:21:27.726590: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvrtc.so.11.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-11.5/lib64:/usr/local/cuda-11.5/lib64:\n",
+      "2023-03-09 10:21:27.726598: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n",
+      "Exception in thread Thread-5 (target_fn):\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/home/teo/anaconda3/envs/PySyft/lib/python3.10/threading.py\", line 1009, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"/home/teo/anaconda3/envs/PySyft/lib/python3.10/threading.py\", line 946, in run\n",
+      "    self._target(*self._args, **self._kwargs)\n",
+      "  File \"/home/teo/anaconda3/envs/PySyft/lib/python3.10/site-packages/tensorflow_federated/python/common_libs/async_utils.py\", line 206, in target_fn\n",
+      "    self._event_loop.run_forever()\n",
+      "  File \"/home/teo/anaconda3/envs/PySyft/lib/python3.10/asyncio/base_events.py\", line 600, in run_forever\n",
+      "    self._run_once()\n",
+      "  File \"/home/teo/anaconda3/envs/PySyft/lib/python3.10/asyncio/base_events.py\", line 1860, in _run_once\n",
+      "    event_list = self._selector.select(timeout)\n",
+      "  File \"/home/teo/anaconda3/envs/PySyft/lib/python3.10/site-packages/gevent/selectors.py\", line 201, in select\n",
+      "    self._ready.wait(timeout)\n",
+      "  File \"src/gevent/event.py\", line 163, in gevent._gevent_cevent.Event.wait\n",
+      "  File \"src/gevent/_abstract_linkable.py\", line 521, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait\n",
+      "  File \"src/gevent/_abstract_linkable.py\", line 487, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core\n",
+      "  File \"src/gevent/_abstract_linkable.py\", line 490, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core\n",
+      "  File \"src/gevent/_abstract_linkable.py\", line 442, in gevent._gevent_c_abstract_linkable.AbstractLinkable._AbstractLinkable__wait_to_be_notified\n",
+      "  File \"src/gevent/_abstract_linkable.py\", line 451, in gevent._gevent_c_abstract_linkable.AbstractLinkable._switch_to_hub\n",
+      "  File \"src/gevent/_greenlet_primitives.py\", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch\n",
+      "  File \"src/gevent/_greenlet_primitives.py\", line 65, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch\n",
+      "  File \"src/gevent/_gevent_c_greenlet_primitives.pxd\", line 35, in gevent._gevent_c_greenlet_primitives._greenlet_switch\n",
+      "gevent.exceptions.LoopExit: This operation would block forever\n",
+      "\tHub: <Hub '' at 0x7f98967bec80 epoll pending=0 ref=0 fileno=69 thread_ident=0x7f98965cf700>\n",
+      "\tHandles:\n",
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import syft as sy\n",
+    "import numpy as np\n",
+    "from syft.core.node.new.user_code import SubmitUserCode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Starting Worker: Silly Mironov - 558da387fee64b2a8ba6324e675b60c6 [<class 'syft.core.node.new.user_service.UserService'>, <class 'syft.core.node.new.action_service.ActionService'>, <class 'syft.core.node.new.test_service.TestService'>, <class 'syft.core.node.new.dataset_service.DatasetService'>, <class 'syft.core.node.new.user_code_service.UserCodeService'>, <class 'syft.core.node.new.request_service.RequestService'>, <class 'syft.core.node.new.data_subject_service.DataSubjectService'>, <class 'syft.core.node.new.network_service.NetworkService'>, <class 'syft.core.node.new.message_service.MessageService'>, <class 'syft.core.node.new.project_service.ProjectService'>, <class 'syft.core.node.new.data_subject_member_service.DataSubjectMemberService'>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "worker = sy.Worker()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Logged into Silly Mironov as <info@openmined.org>\n"
+     ]
+    }
+   ],
+   "source": [
+    "client = sy.login(node=worker, email=\"info@openmined.org\", password=\"changethis\", )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syft.core.node.new.twin_object import TwinObject\n",
+    "\n",
+    "x = np.array([1,2,3])\n",
+    "action_object = sy.ActionObject.from_obj(x)\n",
+    "twin_object = TwinObject(action_object, action_object)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syft.core.node.new.user_code import ExactMatch, SingleExecutionExactOutput\n",
+    "\n",
+    "@sy.syft_function(\n",
+    "    input_policy=ExactMatch(inputs={'x':twin_object}),\n",
+    "    output_policy=SingleExecutionExactOutput(outputs=['y']),\n",
+    ")\n",
+    "def func(x):\n",
+    "    return {\"y\": x}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"alert-success\" style=\"padding:5px;\"><strong>SyftSuccess</strong>: User Code Submitted</div><br />"
+      ],
+      "text/plain": [
+       "<class 'syft.core.node.new.response.SyftSuccess'>: User Code Submitted"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.api.services.code.submit(func)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syft.core.node.new.user_code import ExactMatch, SingleExecutionExactOutput\n",
+    "\n",
+    "@sy.syft_function(\n",
+    "    input_policy=ExactMatch(inputs={'x':twin_object}),\n",
+    "    output_policy=SingleExecutionExactOutput(outputs=['y']),\n",
+    ")\n",
+    "def func_plus_one(x):\n",
+    "    return {\"y\": x+1}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"alert-danger\" style=\"padding:5px;\"><strong>SyftError</strong>: Duplication Key Error: id=<UID: 7de8c30684614b7ba087905fddd55655> user_verify_key=79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23 raw_code='@sy.syft_function(\\n    input_policy=ExactMatch(inputs={\\'x\\':twin_object}),\\n    output_policy=SingleExecutionExactOutput(outputs=[\\'y\\']),\\n)\\ndef func_plus_one(x):\\n    return {\"y\": x+1}\\n' input_policy=syft.core.node.new.user_code.ExactMatch output_policy=syft.core.node.new.user_code.SingleExecutionExactOutput output_policy_state=syft.core.node.new.user_code.OutputPolicyStateExecuteOnce parsed_code=\"def user_func_func_plus_one_79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23_42e4ff1751a95ea59f716a95d08a4dc9fd2ef79b27df79ed51ea30d8a3ea916b(x):\\n\\n    def func_plus_one(x):\\n        return {'y': x + 1}\\n    result = func_plus_one(x=x)\\n    return {k: result[k] for k in ['y']}\" service_func_name='func_plus_one' unique_func_name='user_func_func_plus_one_79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23_42e4ff1751a95ea59f716a95d08a4dc9fd2ef79b27df79ed51ea30d8a3ea916b' user_unique_func_name='user_func_func_plus_one_79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23' code_hash='42e4ff1751a95ea59f716a95d08a4dc9fd2ef79b27df79ed51ea30d8a3ea916b' signature=<Signature (x) -> Dict[str, Any]> status=<UserCodeStatus.SUBMITTED: 'submitted'></div><br />"
+      ],
+      "text/plain": [
+       "<class 'syft.core.node.new.response.SyftError'>: Duplication Key Error: id=<UID: 7de8c30684614b7ba087905fddd55655> user_verify_key=79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23 raw_code='@sy.syft_function(\\n    input_policy=ExactMatch(inputs={\\'x\\':twin_object}),\\n    output_policy=SingleExecutionExactOutput(outputs=[\\'y\\']),\\n)\\ndef func_plus_one(x):\\n    return {\"y\": x+1}\\n' input_policy=syft.core.node.new.user_code.ExactMatch output_policy=syft.core.node.new.user_code.SingleExecutionExactOutput output_policy_state=syft.core.node.new.user_code.OutputPolicyStateExecuteOnce parsed_code=\"def user_func_func_plus_one_79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23_42e4ff1751a95ea59f716a95d08a4dc9fd2ef79b27df79ed51ea30d8a3ea916b(x):\\n\\n    def func_plus_one(x):\\n        return {'y': x + 1}\\n    result = func_plus_one(x=x)\\n    return {k: result[k] for k in ['y']}\" service_func_name='func_plus_one' unique_func_name='user_func_func_plus_one_79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23_42e4ff1751a95ea59f716a95d08a4dc9fd2ef79b27df79ed51ea30d8a3ea916b' user_unique_func_name='user_func_func_plus_one_79a1109a9d230b4d5149b5ad59a5981637d3f6394ff783e5e886f7cb782a1b23' code_hash='42e4ff1751a95ea59f716a95d08a4dc9fd2ef79b27df79ed51ea30d8a3ea916b' signature=<Signature (x) -> Dict[str, Any]> status=<UserCodeStatus.SUBMITTED: 'submitted'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.api.services.code.submit(func_plus_one)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "PySyft",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "4793a45c21657cf3d03167fad0b0286070df6dcd03825f60c6ea99cbb4eef702"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/packages/syft/src/syft/core/node/new/kv_document_store.py
+++ b/packages/syft/src/syft/core/node/new/kv_document_store.py
@@ -118,6 +118,10 @@ class KeyValueStorePartition(StorePartition):
             return UniqueKeyCheck.EMPTY
         elif len(matches) == len(qks):
             return UniqueKeyCheck.MATCHES
+        # if len(matches) == len(qks):
+        #     return UniqueKeyCheck.MATCHES
+        # elif len(matches) < len(qks):
+        #     return UniqueKeyCheck.EMPTY
 
         return UniqueKeyCheck.ERROR
 


### PR DESCRIPTION
## Description
When we try to create two objects that have the same user_verify_key but different other keys, the store will return an error because it will only match that key. I added a quick fix, but it seems the problem is deeper. 

## How has this been tested?
I have added a notebook to replicate the issue under notebooks/bugs

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
