### PR TITLE
Refactor domain online status icon

### DIFF
--- a/packages/grid/frontend/src/lib/components/DomainOnlineIndicator.svelte
+++ b/packages/grid/frontend/src/lib/components/DomainOnlineIndicator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  type DomainOnlineStatus = 'online' | 'offline' | 'pending';
+  import type { DomainOnlineStatus } from '../../types/domain/onlineIndicator';
   let status: DomainOnlineStatus = 'online';
 </script>
 
@@ -10,11 +10,4 @@
     class:bg-red-500={status === 'offline'}
     class:bg-yellow-500={status === 'pending'}
   />
-  <p class="text-600">
-    {#if status === 'pending'}
-      Checking connection
-    {:else}
-      Domain {status}
-    {/if}
-  </p>
 </div>

--- a/packages/grid/frontend/src/lib/components/authentication/DomainMetadataPanel.svelte
+++ b/packages/grid/frontend/src/lib/components/authentication/DomainMetadataPanel.svelte
@@ -2,6 +2,7 @@
   import Avatar from '$lib/components/Avatar.svelte';
   import Badge from '$lib/components/Badge.svelte';
   import TagCloud from '$lib/components/TagCloud.svelte';
+  import DomainOnlineIndicator from '$lib/components/DomainOnlineIndicator.svelte';
   import { prettyName } from '$lib/utils';
   import type { DomainMetadata } from '../../../types/domain/metadata';
   export let metadata: DomainMetadata;
@@ -10,7 +11,10 @@
 
 <section class="flex flex-col w-full sm:w-[36%] sm:min-w-[544px] max-w-[784px] gap-4 py-11 px-8">
   <TagCloud tags={metadata.tags} />
-  <div class="w-[97.5px]">
+  <div class="w-[97.5px] relative">
+    <div class="absolute right-0">
+      <DomainOnlineIndicator />
+    </div>
     <Avatar {initials} />
   </div>
   <h2>{prettyName(metadata.name)}</h2>
@@ -24,7 +28,11 @@
   {/if}
   <hr />
   <div class="flex flex-col gap-2.5 flex-shrink-0 pt-2 pb-4">
-    <div class="flex gap-1 items-center">
+    <div class="flex gap-1 items-center group relative">
+      <span
+        class="group-hover:opacity-100 bg-gray-800 px-2 text-sm text-gray-100 rounded-md absolute left-1/4 opacity-0 m-4 mx-auto -top-9"
+        >Copy</span
+      >
       <p class="uppercase text-gray-400">Id#:</p>
       <Badge>{metadata.id?.value}</Badge>
     </div>

--- a/packages/grid/frontend/src/routes/(auth)/login/+page.svelte
+++ b/packages/grid/frontend/src/routes/(auth)/login/+page.svelte
@@ -6,7 +6,8 @@
   import DomainOnlineIndicator from '$lib/components/DomainOnlineIndicator.svelte';
   import { getClient } from '$lib/store';
   import { goto } from '$app/navigation';
-
+  import type { DomainOnlineStatus } from '../../../types/domain/onlineIndicator';
+  let status: DomainOnlineStatus = 'online';
 
   async function login({ email, password }, client) {
     await client
@@ -35,7 +36,16 @@
             </span>
           </div>
           <div class="contents" slot="body">
-            <DomainOnlineIndicator />
+            <div class="flex justify-center items-center gap-2">
+              <DomainOnlineIndicator />
+              <p class="text-600">
+                {#if status === 'pending'}
+                  Checking connection
+                {:else}
+                  Domain {status}
+                {/if}
+              </p>
+            </div>
             <Input
               label="Email"
               type="email"
@@ -45,7 +55,10 @@
             />
             <Input label="Password" type="password" id="password" placeholder="******" required />
             <p class="text-center">
-              Don't have an account yet? Apply for an account <a href="/signup">here</a>.
+              Don't have an account yet? Apply for an account <a
+                href="/signup"
+                class="text-primary-600 underline hover:opacity-50">here</a
+              >.
             </p>
           </div>
           <Button variant="secondary" slot="button-group">Login</Button>

--- a/packages/grid/frontend/src/types/domain/onlineIndicator.ts
+++ b/packages/grid/frontend/src/types/domain/onlineIndicator.ts
@@ -1,0 +1,1 @@
+export type DomainOnlineStatus = 'online' | 'offline' | 'pending';


### PR DESCRIPTION
## Description
This fix created `DomainOnlineStatus` type and changes the text color for the anchor tag on the login page.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests

<img width="1128" alt="Login" src="https://user-images.githubusercontent.com/29546622/224308547-dcd3933a-c1f4-4e2f-ba2f-311d5dd507c8.PNG">

