### PR TITLE
Refactor attr list/state

### DIFF
--- a/packages/syft/src/syft/core/node/new/action_data_empty.py
+++ b/packages/syft/src/syft/core/node/new/action_data_empty.py
@@ -12,7 +12,7 @@ from .syft_object import SYFT_OBJECT_VERSION_1
 from .syft_object import SyftObject
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ActionDataEmpty(SyftObject):
     __canonical_name__ = "ActionDataEmpty"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/action_object.py
+++ b/packages/syft/src/syft/core/node/new/action_object.py
@@ -34,7 +34,7 @@ from .uid import LineageID
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Action(SyftObject):
     __canonical_name__ = "Action"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -732,7 +732,7 @@ class ActionObject(SyftObject):
         return self.__rmatmul__(other)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class AnyActionObject(ActionObject):
     __canonical_name__ = "AnyActionObject"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/action_service.py
+++ b/packages/syft/src/syft/core/node/new/action_service.py
@@ -36,14 +36,14 @@ from .user_code import execute_byte_code
 from .user_roles import GUEST_ROLE_LEVEL
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class TwinMode(Enum):
     NONE = 0
     PRIVATE = 1
     MOCK = 2
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ActionService(AbstractService):
     def __init__(self, store: ActionStore) -> None:
         self.store = store

--- a/packages/syft/src/syft/core/node/new/action_store.py
+++ b/packages/syft/src/syft/core/node/new/action_store.py
@@ -24,7 +24,7 @@ from .twin_object import TwinObject
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ActionPermission(Enum):
     OWNER = 1
     READ = 2
@@ -32,7 +32,7 @@ class ActionPermission(Enum):
     EXECUTE = 8
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ActionObjectPermission:
     def __init__(
         self, uid: UID, credentials: SyftVerifyKey, permission: ActionPermission
@@ -81,7 +81,7 @@ class ActionStore:
     pass
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class KeyValueActionStore(ActionStore):
     """Generic Key-Value Action store.
 
@@ -232,7 +232,7 @@ class KeyValueActionStore(ActionStore):
             results.append(self.add_permission(permission))
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DictActionStore(KeyValueActionStore):
     """Dictionary-Based Key-Value Action store.
 
@@ -252,7 +252,7 @@ class DictActionStore(KeyValueActionStore):
         super().__init__(store_config=store_config, root_verify_key=root_verify_key)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SQLiteActionStore(KeyValueActionStore):
     """SQLite-Based Key-Value Action store.
 

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -109,7 +109,7 @@ class SignedSyftAPICall(SyftObject):
 
 
 @instrument
-@serializable(attrs=["path", "args", "kwargs"])
+@serializable(attrs=["path", "args", "kwargs", "node_uid"])
 class SyftAPICall(SyftObject):
     # version
     __canonical_name__ = "SyftAPICall"

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -62,7 +62,7 @@ class APIRegistry:
         return list(cls.__api_registry__.values())
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class APIEndpoint(SyftBaseObject):
     path: str
     name: str
@@ -73,12 +73,11 @@ class APIEndpoint(SyftBaseObject):
     pre_kwargs: Optional[Dict[str, Any]]
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["signature", "credentials", "serialized_message"])
 class SignedSyftAPICall(SyftObject):
     __canonical_name__ = "SignedSyftAPICall"
     __version__ = SYFT_OBJECT_VERSION_1
 
-    __attr_allowlist__ = ["signature", "credentials", "serialized_message"]
     credentials: SyftVerifyKey
     signature: bytes
     serialized_message: bytes
@@ -110,7 +109,7 @@ class SignedSyftAPICall(SyftObject):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable(attrs=["path", "args", "kwargs"])
 class SyftAPICall(SyftObject):
     # version
     __canonical_name__ = "SyftAPICall"
@@ -134,7 +133,7 @@ class SyftAPICall(SyftObject):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class SyftAPIData(SyftBaseObject):
     # version
     __canonical_name__ = "SyftAPIData"
@@ -253,7 +252,7 @@ def generate_remote_function(
     return wrapper
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class APIModule:
     _modules: List[APIModule]
     path: str
@@ -290,7 +289,7 @@ class APIModule:
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable(attrs=["endpoints", "node_uid", "node_name"])
 class SyftAPI(SyftObject):
     # version
     __canonical_name__ = "SyftAPI"
@@ -304,7 +303,6 @@ class SyftAPI(SyftObject):
     api_module: Optional[APIModule] = None
     signing_key: Optional[SyftSigningKey] = None
     # serde / storage rules
-    __attr_state__ = ["endpoints", "node_uid", "node_name"]
     refresh_api_callback: Optional[Callable] = None
 
     # def __post_init__(self) -> None:
@@ -528,7 +526,7 @@ except Exception:
     pass  # nosec
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NodeView(BaseModel):
     class Config:
         arbitrary_types_allowed = True

--- a/packages/syft/src/syft/core/node/new/api.py
+++ b/packages/syft/src/syft/core/node/new/api.py
@@ -109,7 +109,7 @@ class SignedSyftAPICall(SyftObject):
 
 
 @instrument
-@serializable(attrs=["path", "args", "kwargs", "node_uid"])
+@serializable()
 class SyftAPICall(SyftObject):
     # version
     __canonical_name__ = "SyftAPICall"

--- a/packages/syft/src/syft/core/node/new/client.py
+++ b/packages/syft/src/syft/core/node/new/client.py
@@ -80,12 +80,10 @@ DEFAULT_PYGRID_PORT = 80
 DEFAULT_PYGRID_ADDRESS = f"http://localhost:{DEFAULT_PYGRID_PORT}"
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["proxy_target_uid", "url"])
 class HTTPConnection(NodeConnection):
     __canonical_name__ = "HTTPConnection"
     __version__ = SYFT_OBJECT_VERSION_1
-
-    __attr_state__ = ["proxy_target_uid", "url"]
 
     proxy_target_uid: Optional[UID]
     url: GridURL
@@ -223,7 +221,7 @@ class HTTPConnection(NodeConnection):
         return hash(self.proxy_target_uid) + hash(self.url)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class PythonConnection(NodeConnection):
     __canonical_name__ = "PythonConnection"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -298,7 +296,7 @@ class PythonConnection(NodeConnection):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class SyftClient:
     connection: NodeConnection
     metadata: Optional[NodeMetadataJSON]

--- a/packages/syft/src/syft/core/node/new/credentials.py
+++ b/packages/syft/src/syft/core/node/new/credentials.py
@@ -17,7 +17,7 @@ from .serializable import serializable
 SIGNING_KEY_FOR = "SigningKey for"
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SyftVerifyKey(SyftBaseModel):
     verify_key: VerifyKey
 
@@ -49,7 +49,7 @@ class SyftVerifyKey(SyftBaseModel):
         return self.verify_key.__hash__()
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SyftSigningKey(SyftBaseModel):
     signing_key: SigningKey
 
@@ -92,7 +92,7 @@ class SyftSigningKey(SyftBaseModel):
 SyftCredentials = Union[SyftVerifyKey, SyftSigningKey]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserLoginCredentials(SyftBaseModel):
     email: str
     password: str

--- a/packages/syft/src/syft/core/node/new/data_subject.py
+++ b/packages/syft/src/syft/core/node/new/data_subject.py
@@ -23,7 +23,7 @@ from .uid import UID
 NamePartitionKey = PartitionKey(key="name", type_=str)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DataSubject(SyftObject):
     # version
     __canonical_name__ = "DataSubject"
@@ -65,7 +65,7 @@ class DataSubject(SyftObject):
         return "```python\n" + _repr_str + "\n```"
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DataSubjectCreate(SyftObject):
     # version
     __canonical_name__ = "DataSubjectCreate"

--- a/packages/syft/src/syft/core/node/new/data_subject_member.py
+++ b/packages/syft/src/syft/core/node/new/data_subject_member.py
@@ -8,7 +8,7 @@ ParentPartitionKey = PartitionKey(key="parent", type_=str)
 ChildPartitionKey = PartitionKey(key="child", type_=str)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DataSubjectMemberRelationship(SyftObject):
     __canonical_name__ = "DataSubjectMemberRelationship"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/data_subject_member_service.py
+++ b/packages/syft/src/syft/core/node/new/data_subject_member_service.py
@@ -25,7 +25,7 @@ from .service import TYPE_TO_SERVICE
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class DataSubjectMemberStash(BaseUIDStoreStash):
     object_type = DataSubjectMemberRelationship
     settings: PartitionSettings = PartitionSettings(
@@ -50,7 +50,7 @@ class DataSubjectMemberStash(BaseUIDStoreStash):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class DataSubjectMemberService(AbstractService):
     store: DocumentStore
     stash: DataSubjectMemberStash

--- a/packages/syft/src/syft/core/node/new/data_subject_service.py
+++ b/packages/syft/src/syft/core/node/new/data_subject_service.py
@@ -27,7 +27,7 @@ from .service import service_method
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class DataSubjectStash(BaseUIDStoreStash):
     object_type = DataSubject
     settings: PartitionSettings = PartitionSettings(
@@ -46,7 +46,7 @@ class DataSubjectStash(BaseUIDStoreStash):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class DataSubjectService(AbstractService):
     store: DocumentStore
     stash: DataSubjectStash

--- a/packages/syft/src/syft/core/node/new/dataset.py
+++ b/packages/syft/src/syft/core/node/new/dataset.py
@@ -34,7 +34,7 @@ from .transforms import validate_url
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class TupleDict(OrderedDict):
     def __getitem__(self, key: Union[str, int]) -> Any:
         if isinstance(key, int):
@@ -45,7 +45,7 @@ class TupleDict(OrderedDict):
 NamePartitionKey = PartitionKey(key="name", type_=str)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Contributor(SyftObject):
     __canonical_name__ = "Contributor"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -59,7 +59,7 @@ class Contributor(SyftObject):
     __attr_repr_cols__ = ["name", "role", "email"]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Asset(SyftObject):
     # version
     __canonical_name__ = "Asset"
@@ -108,7 +108,7 @@ class Asset(SyftObject):
         return api.services.action.get(self.action_id)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class CreateAsset(SyftObject):
     # version
     __canonical_name__ = "CreateAsset"
@@ -186,7 +186,7 @@ def get_shape_or_len(obj: Any) -> Optional[Union[Tuple[int, ...], int]]:
     return None
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Dataset(SyftObject):
     # version
     __canonical_name__ = "Dataset"
@@ -248,7 +248,7 @@ class Dataset(SyftObject):
         return client
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class CreateDataset(Dataset):
     # version
     __canonical_name__ = "CreateDataset"

--- a/packages/syft/src/syft/core/node/new/dataset_service.py
+++ b/packages/syft/src/syft/core/node/new/dataset_service.py
@@ -23,7 +23,7 @@ from .user_roles import GUEST_ROLE_LEVEL
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class DatasetService(AbstractService):
     store: DocumentStore
     stash: DatasetStash

--- a/packages/syft/src/syft/core/node/new/dataset_stash.py
+++ b/packages/syft/src/syft/core/node/new/dataset_stash.py
@@ -22,7 +22,7 @@ ActionIDsPartitionKey = PartitionKey(key="action_ids", type_=List[UID])
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class DatasetStash(BaseUIDStoreStash):
     object_type = Dataset
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/datetime.py
+++ b/packages/syft/src/syft/core/node/new/datetime.py
@@ -10,7 +10,7 @@ from .syft_object import SYFT_OBJECT_VERSION_1
 from .syft_object import SyftObject
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DateTime(SyftObject):
     __canonical_name__ = "DateTime"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/dict_document_store.py
+++ b/packages/syft/src/syft/core/node/new/dict_document_store.py
@@ -14,7 +14,7 @@ from .kv_document_store import KeyValueStorePartition
 from .serializable import serializable
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DictBackingStore(dict, KeyValueBackingStore):
     """Dictionary-based Store core logic"""
 
@@ -32,7 +32,7 @@ class DictBackingStore(dict, KeyValueBackingStore):
             raise e
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DictStorePartition(KeyValueStorePartition):
     """Dictionary-based StorePartition
 
@@ -48,7 +48,7 @@ class DictStorePartition(KeyValueStorePartition):
 
 
 # the base document store is already a dict but we can change it later
-@serializable(recursive_serde=True)
+@serializable()
 class DictDocumentStore(DocumentStore):
     """Dictionary-based Document Store
 
@@ -69,7 +69,7 @@ class DictDocumentStore(DocumentStore):
             partition.prune()
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class DictStoreConfig(StoreConfig):
     """Dictionary-based configuration
 

--- a/packages/syft/src/syft/core/node/new/document_store.py
+++ b/packages/syft/src/syft/core/node/new/document_store.py
@@ -292,10 +292,7 @@ class PartitionSettings(BasePartitionSettings):
 
 
 @instrument
-@serializable(
-    attrs=["settings", "store_config", "unique_cks", "searchable_cks"],
-    was_empty=True,
-)
+@serializable(attrs=["settings", "store_config", "unique_cks", "searchable_cks"])
 class StorePartition:
     """Base StorePartition
 

--- a/packages/syft/src/syft/core/node/new/document_store.py
+++ b/packages/syft/src/syft/core/node/new/document_store.py
@@ -292,7 +292,10 @@ class PartitionSettings(BasePartitionSettings):
 
 
 @instrument
-@serializable(attrs=["settings", "store_config", "unique_cks", "searchable_cks"], was_empty=True,)
+@serializable(
+    attrs=["settings", "store_config", "unique_cks", "searchable_cks"],
+    was_empty=True,
+)
 class StorePartition:
     """Base StorePartition
 

--- a/packages/syft/src/syft/core/node/new/document_store.py
+++ b/packages/syft/src/syft/core/node/new/document_store.py
@@ -32,7 +32,7 @@ from .syft_object import SyftObject
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class BasePartitionSettings(SyftBaseModel):
     """Basic Partition Settings
 
@@ -56,7 +56,7 @@ class StoreClientConfig(BaseModel):
     pass
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class PartitionKey(BaseModel):
     key: str
     type_: Union[type, object]
@@ -92,7 +92,7 @@ class PartitionKey(BaseModel):
         return False
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class PartitionKeys(BaseModel):
     pks: Union[PartitionKey, Tuple[PartitionKey, ...]]
 
@@ -125,7 +125,7 @@ class PartitionKeys(BaseModel):
             return self.with_tuple(*obj_arg)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class QueryKey(PartitionKey):
     value: Any
 
@@ -182,7 +182,7 @@ class QueryKey(PartitionKey):
         return {key: self.value}
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class PartitionKeysWithUID(PartitionKeys):
     uid_pk: PartitionKey
 
@@ -194,7 +194,7 @@ class PartitionKeysWithUID(PartitionKeys):
         return all_keys
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class QueryKeys(SyftBaseModel):
     qks: Union[QueryKey, Tuple[QueryKey, ...]]
 
@@ -276,7 +276,7 @@ class QueryKeys(SyftBaseModel):
 UIDPartitionKey = PartitionKey(key="id", type_=UID)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class PartitionSettings(BasePartitionSettings):
     object_type: type
     store_key: PartitionKey = UIDPartitionKey
@@ -292,7 +292,7 @@ class PartitionSettings(BasePartitionSettings):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable(attrs=["settings", "store_config", "unique_cks", "searchable_cks"], was_empty=True,)
 class StorePartition:
     """Base StorePartition
 
@@ -364,7 +364,7 @@ class StorePartition:
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class DocumentStore:
     """Base Document Store
 
@@ -519,7 +519,7 @@ class BaseUIDStoreStash(BaseStash):
         return self.check_type(obj, self.object_type).and_then(set_method)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class StoreConfig(SyftBaseObject):
     """Base Store configuration
 

--- a/packages/syft/src/syft/core/node/new/grid_url.py
+++ b/packages/syft/src/syft/core/node/new/grid_url.py
@@ -6,7 +6,6 @@ import copy
 import os
 import re
 from typing import Optional
-from typing import Sequence
 from typing import Union
 from urllib.parse import urlparse
 
@@ -18,16 +17,8 @@ from .serializable import serializable
 from .util import verify_tls
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["protocol", "host_or_ip", "port", "path", "query"])
 class GridURL:
-    __attr_allowlist__: Sequence[str] = [
-        "protocol",
-        "host_or_ip",
-        "port",
-        "path",
-        "query",
-    ]
-
     @staticmethod
     def from_url(url: Union[str, GridURL]) -> GridURL:
         if isinstance(url, GridURL):

--- a/packages/syft/src/syft/core/node/new/kv_document_store.py
+++ b/packages/syft/src/syft/core/node/new/kv_document_store.py
@@ -25,7 +25,7 @@ from .serializable import serializable
 from .syft_object import SyftObject
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UniqueKeyCheck(Enum):
     EMPTY = 0
     MATCHES = 1

--- a/packages/syft/src/syft/core/node/new/linked_obj.py
+++ b/packages/syft/src/syft/core/node/new/linked_obj.py
@@ -17,7 +17,7 @@ from .syft_object import SyftObject
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class LinkedObject(SyftObject):
     __canonical_name__ = "LinkedObject"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/message_service.py
+++ b/packages/syft/src/syft/core/node/new/message_service.py
@@ -22,7 +22,7 @@ from .uid import UID
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class MessageService(AbstractService):
     store: DocumentStore
     stash: MessageStash

--- a/packages/syft/src/syft/core/node/new/message_stash.py
+++ b/packages/syft/src/syft/core/node/new/message_stash.py
@@ -28,7 +28,7 @@ StatusPartitionKey = PartitionKey(key="status", type_=MessageStatus)
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class MessageStash(BaseUIDStoreStash):
     object_type = Message
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/messages.py
+++ b/packages/syft/src/syft/core/node/new/messages.py
@@ -17,7 +17,7 @@ from .transforms import transform
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MessageStatus(Enum):
     UNDELIVERED = 0
     DELIVERED = 1
@@ -28,7 +28,7 @@ class MessageExpiryStatus(Enum):
     NEVER = 1
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Message(SyftObject):
     __canonical_name__ = "Message"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -55,7 +55,7 @@ class Message(SyftObject):
         return None
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class CreateMessage(Message):
     __canonical_name__ = "CreateMessage"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/metadata_service.py
+++ b/packages/syft/src/syft/core/node/new/metadata_service.py
@@ -17,7 +17,7 @@ from .service import AbstractService
 from .service import service_method
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MetadataService(AbstractService):
     store: DocumentStore
     stash: MetadataStash

--- a/packages/syft/src/syft/core/node/new/metadata_stash.py
+++ b/packages/syft/src/syft/core/node/new/metadata_stash.py
@@ -19,7 +19,7 @@ ActionIDsPartitionKey = PartitionKey(key="action_ids", type_=List[UID])
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class MetadataStash(BaseUIDStoreStash):
     object_type = NodeMetadata
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/mongo_client.py
+++ b/packages/syft/src/syft/core/node/new/mongo_client.py
@@ -22,7 +22,7 @@ from .mongo_codecs import SYFT_CODEC_OPTIONS
 from .serializable import serializable
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MongoStoreClientConfig(StoreClientConfig):
     """
     Paramaters:

--- a/packages/syft/src/syft/core/node/new/mongo_document_store.py
+++ b/packages/syft/src/syft/core/node/new/mongo_document_store.py
@@ -89,16 +89,7 @@ def from_mongo(
     return constructor(**output)
 
 
-@serializable(
-    attrs=[
-        "storage_type",
-        "settings",
-        "store_config",
-        "unique_cks",
-        "searchable_cks",
-    ],
-    has_inherited_attrs=True,
-)
+@serializable(attrs=["storage_type"])
 class MongoStorePartition(StorePartition):
     """Mongo StorePartition
 

--- a/packages/syft/src/syft/core/node/new/mongo_document_store.py
+++ b/packages/syft/src/syft/core/node/new/mongo_document_store.py
@@ -89,7 +89,13 @@ def from_mongo(
     return constructor(**output)
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=[
+    "storage_type",
+    "settings",
+    "store_config",
+    "unique_cks",
+    "searchable_cks",
+], has_inherited_attrs=True,)
 class MongoStorePartition(StorePartition):
     """Mongo StorePartition
 
@@ -100,13 +106,6 @@ class MongoStorePartition(StorePartition):
             Mongo specific configuration
     """
 
-    __attr_allowlist__ = [
-        "storage_type",
-        "settings",
-        "store_config",
-        "unique_cks",
-        "searchable_cks",
-    ]
     storage_type: StorableObjectType = MongoBsonObject
 
     def init_store(self) -> Result[Ok, Err]:
@@ -291,7 +290,7 @@ class MongoStorePartition(StorePartition):
         return collection.count_documents(filter={})
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MongoDocumentStore(DocumentStore):
     """Mongo Document Store
 
@@ -303,7 +302,7 @@ class MongoDocumentStore(DocumentStore):
     partition_type = MongoStorePartition
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MongoStoreConfig(StoreConfig):
     """Mongo Store configuration
 

--- a/packages/syft/src/syft/core/node/new/mongo_document_store.py
+++ b/packages/syft/src/syft/core/node/new/mongo_document_store.py
@@ -89,13 +89,16 @@ def from_mongo(
     return constructor(**output)
 
 
-@serializable(attrs=[
-    "storage_type",
-    "settings",
-    "store_config",
-    "unique_cks",
-    "searchable_cks",
-], has_inherited_attrs=True,)
+@serializable(
+    attrs=[
+        "storage_type",
+        "settings",
+        "store_config",
+        "unique_cks",
+        "searchable_cks",
+    ],
+    has_inherited_attrs=True,
+)
 class MongoStorePartition(StorePartition):
     """Mongo StorePartition
 

--- a/packages/syft/src/syft/core/node/new/network_service.py
+++ b/packages/syft/src/syft/core/node/new/network_service.py
@@ -77,7 +77,7 @@ class HTTPNodeRoute(SyftObject, NodeRoute):
         return self == other
 
 
-@serializable(attrs=["worker_settings"], needs_debug=True)
+@serializable()
 class PythonNodeRoute(SyftObject, NodeRoute):
     __canonical_name__ = "PythonNodeRoute"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/network_service.py
+++ b/packages/syft/src/syft/core/node/new/network_service.py
@@ -53,7 +53,7 @@ class NodeRoute:
         return SyftClient(connection=connection, credentials=context.node.signing_key)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class HTTPNodeRoute(SyftObject, NodeRoute):
     __canonical_name__ = "HTTPNodeRoute"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -77,13 +77,12 @@ class HTTPNodeRoute(SyftObject, NodeRoute):
         return self == other
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["worker_settings"], needs_debug=True)
 class PythonNodeRoute(SyftObject, NodeRoute):
     __canonical_name__ = "PythonNodeRoute"
     __version__ = SYFT_OBJECT_VERSION_1
 
     worker_settings: WorkerSettings
-    __attr_state__ = ["id", "worker_settings"]
 
     @property
     def node(self) -> Optional[NewNode]:
@@ -134,7 +133,7 @@ def connection_to_route(connection: NodeConnection) -> NodeRoute:
         return connection.to(PythonNodeRoute)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NodePeer(SyftObject):
     # version
     __canonical_name__ = "NodePeer"
@@ -240,7 +239,7 @@ def metadata_to_peer() -> List[Callable]:
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class NetworkStash(BaseUIDStoreStash):
     object_type = NodePeer
     settings: PartitionSettings = PartitionSettings(
@@ -279,7 +278,7 @@ class NetworkStash(BaseUIDStoreStash):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class NetworkService(AbstractService):
     store: DocumentStore
     stash: NetworkStash

--- a/packages/syft/src/syft/core/node/new/node.py
+++ b/packages/syft/src/syft/core/node/new/node.py
@@ -10,7 +10,7 @@ from .serializable import serializable
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NodeType(Enum):
     DOMAIN = "domain"
     NETWORK = "network"

--- a/packages/syft/src/syft/core/node/new/node_metadata.py
+++ b/packages/syft/src/syft/core/node/new/node_metadata.py
@@ -41,7 +41,7 @@ def check_version(
     return True
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NodeMetadataUpdate(SyftObject):
     __canonical_name__ = "NodeMetadataUpdate"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -57,7 +57,7 @@ class NodeMetadataUpdate(SyftObject):
     syft_version: Optional[str]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NodeMetadata(SyftObject):
     __canonical_name__ = "NodeMetadata"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -82,7 +82,7 @@ class NodeMetadata(SyftObject):
         )
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NodeMetadataJSON(BaseModel, StorableObjectType):
     metadata_version: int
     name: str

--- a/packages/syft/src/syft/core/node/new/numpy.py
+++ b/packages/syft/src/syft/core/node/new/numpy.py
@@ -12,18 +12,11 @@ from .action_types import action_types
 from .serializable import serializable
 from .syft_object import SYFT_OBJECT_VERSION_1
 
-# @serializable(recursive_serde=True)
+# @serializable(attrs=["id", "node_uid", "parent_id"])
 # class NumpyArrayObjectPointer(ActionObjectPointer):
 #     _inflix_operations = ["__add__", "__sub__", "__eq__", "__mul__"]
 #     __canonical_name__ = "NumpyArrayObjectPointer"
 #     __version__ = SYFT_OBJECT_VERSION_1
-
-#     # 🟡 TODO 17: add state / allowlist inheritance to SyftObject and ignore methods by default
-#     __attr_state__ = [
-#         "id",
-#         "node_uid",
-#         "parent_id",
-#     ]
 
 #     def get_from(self, domain_client) -> Any:
 #         return domain_client.api.services.action.get(self.id).syft_action_data
@@ -45,7 +38,7 @@ def numpy_like_eq(left: Any, right: Any) -> bool:
 
 # 🔵 TODO 7: Map TPActionObjects and their 3rd Party types like numpy type to these
 # classes for bi-directional lookup.
-@serializable(recursive_serde=True)
+@serializable()
 class NumpyArrayObject(ActionObject, np.lib.mixins.NDArrayOperatorsMixin):
     __canonical_name__ = "NumpyArrayObject"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -87,7 +80,7 @@ class NumpyArrayObject(ActionObject, np.lib.mixins.NDArrayOperatorsMixin):
             )
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NumpyScalarObject(ActionObject, np.lib.mixins.NDArrayOperatorsMixin):
     __canonical_name__ = "NumpyScalarObject"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -100,7 +93,7 @@ class NumpyScalarObject(ActionObject, np.lib.mixins.NDArrayOperatorsMixin):
         return float(self.syft_action_data)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class NumpyBoolObject(ActionObject, np.lib.mixins.NDArrayOperatorsMixin):
     __canonical_name__ = "NumpyBoolObject"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/pandas.py
+++ b/packages/syft/src/syft/core/node/new/pandas.py
@@ -14,7 +14,7 @@ from .serializable import serializable
 from .syft_object import SYFT_OBJECT_VERSION_1
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class PandasDataFrameObject(ActionObject):
     __canonical_name__ = "PandasDataframeObject"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -39,7 +39,7 @@ class PandasDataFrameObject(ActionObject):
         return super().syft_is_property(obj, method)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class PandasSeriesObject(ActionObject):
     __canonical_name__ = "PandasSeriesObject"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/project.py
+++ b/packages/syft/src/syft/core/node/new/project.py
@@ -28,7 +28,7 @@ from .uid import UID
 from .user_code import UserCode
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Project(SyftObject):
     __canonical_name__ = "Project"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -47,7 +47,7 @@ class Project(SyftObject):
     __attr_repr_cols__ = ["requests"]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ObjectPermissionChange(SyftObject):
     __canonical_name__ = "PermissionChange"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -57,7 +57,7 @@ class ObjectPermissionChange(SyftObject):
     object_type: Type[SyftObject]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ProjectSubmit(SyftObject):
     __canonical_name__ = "ProjectSubmit"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/project_service.py
+++ b/packages/syft/src/syft/core/node/new/project_service.py
@@ -29,7 +29,7 @@ from .user_service import UserService
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class ProjectService(AbstractService):
     store: DocumentStore
     stash: ProjectStash

--- a/packages/syft/src/syft/core/node/new/project_stash.py
+++ b/packages/syft/src/syft/core/node/new/project_stash.py
@@ -22,7 +22,7 @@ ProjectUserVerifyKeyPartitionKey = PartitionKey(
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class ProjectStash(BaseUIDStoreStash):
     object_type = Project
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/queue_stash.py
+++ b/packages/syft/src/syft/core/node/new/queue_stash.py
@@ -24,14 +24,12 @@ from .syft_object import SyftObject
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["id", "node_uid", "result", "resolved"], has_explicit_id=True)
 class QueueItem(SyftObject):
     __canonical_name__ = "QueueItem"
     __version__ = SYFT_OBJECT_VERSION_1
 
-    __attr_state__ = ["id", "node_uid", "result", "resolved"]
-
-    id: UID
+    # id: UID
     node_uid: UID
     result: Optional[Any]
     resolved: bool = False
@@ -61,7 +59,7 @@ class QueueItem(SyftObject):
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class QueueStash(BaseStash):
     object_type = QueueItem
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/queue_stash.py
+++ b/packages/syft/src/syft/core/node/new/queue_stash.py
@@ -24,12 +24,12 @@ from .syft_object import SyftObject
 from .uid import UID
 
 
-@serializable(attrs=["id", "node_uid", "result", "resolved"], has_explicit_id=True)
+@serializable()
 class QueueItem(SyftObject):
     __canonical_name__ = "QueueItem"
     __version__ = SYFT_OBJECT_VERSION_1
 
-    # id: UID
+    id: UID
     node_uid: UID
     result: Optional[Any]
     resolved: bool = False

--- a/packages/syft/src/syft/core/node/new/recursive.py
+++ b/packages/syft/src/syft/core/node/new/recursive.py
@@ -53,7 +53,7 @@ def recursive_serde_register(
     if attribute_list:
         # Set __syft_state for making attributes inheritable
         # TODO: Discuss if this needs to be enabled by default
-        setattr(cls, '__syft_state__', attribute_list)
+        setattr(cls, "__syft_state__", attribute_list)
 
     serde_overrides = getattr(cls, "__serde_overrides__", {})
 

--- a/packages/syft/src/syft/core/node/new/recursive_primitives.py
+++ b/packages/syft/src/syft/core/node/new/recursive_primitives.py
@@ -306,7 +306,9 @@ def deserialize_generic_alias(type_blob: bytes) -> type:
 
 
 # 🟡 TODO 5: add tests and all typing options for signatures
-def recursive_serde_register_type(t: type, state_attrs: Optional[List] = None) -> None:
+def recursive_serde_register_type(
+    t: type, serialize_attrs: Optional[List] = None
+) -> None:
     if (isinstance(t, type) and issubclass(t, _GenericAlias)) or issubclass(
         type(t), _GenericAlias
     ):
@@ -314,14 +316,14 @@ def recursive_serde_register_type(t: type, state_attrs: Optional[List] = None) -
             t,
             serialize=serialize_generic_alias,
             deserialize=deserialize_generic_alias,
-            state_attrs=state_attrs,
+            serialize_attrs=serialize_attrs,
         )
     else:
         recursive_serde_register(
             t,
             serialize=serialize_type,
             deserialize=deserialize_type,
-            state_attrs=state_attrs,
+            serialize_attrs=serialize_attrs,
         )
 
 

--- a/packages/syft/src/syft/core/node/new/recursive_primitives.py
+++ b/packages/syft/src/syft/core/node/new/recursive_primitives.py
@@ -306,9 +306,7 @@ def deserialize_generic_alias(type_blob: bytes) -> type:
 
 
 # 🟡 TODO 5: add tests and all typing options for signatures
-def recursive_serde_register_type(
-    t: type, state_attrs: Optional[List] = None
-) -> None:
+def recursive_serde_register_type(t: type, state_attrs: Optional[List] = None) -> None:
     if (isinstance(t, type) and issubclass(t, _GenericAlias)) or issubclass(
         type(t), _GenericAlias
     ):

--- a/packages/syft/src/syft/core/node/new/recursive_primitives.py
+++ b/packages/syft/src/syft/core/node/new/recursive_primitives.py
@@ -307,7 +307,7 @@ def deserialize_generic_alias(type_blob: bytes) -> type:
 
 # 🟡 TODO 5: add tests and all typing options for signatures
 def recursive_serde_register_type(
-    t: type, attr_allowlist: Optional[List] = None
+    t: type, state_attrs: Optional[List] = None
 ) -> None:
     if (isinstance(t, type) and issubclass(t, _GenericAlias)) or issubclass(
         type(t), _GenericAlias
@@ -316,14 +316,14 @@ def recursive_serde_register_type(
             t,
             serialize=serialize_generic_alias,
             deserialize=deserialize_generic_alias,
-            attr_allowlist=attr_allowlist,
+            state_attrs=state_attrs,
         )
     else:
         recursive_serde_register(
             t,
             serialize=serialize_type,
             deserialize=deserialize_type,
-            attr_allowlist=attr_allowlist,
+            state_attrs=state_attrs,
         )
 
 

--- a/packages/syft/src/syft/core/node/new/request.py
+++ b/packages/syft/src/syft/core/node/new/request.py
@@ -41,14 +41,14 @@ from .user_code import UserCode
 from .user_code import UserCodeStatus
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class RequestStatus(Enum):
     PENDING = 0
     REJECTED = 1
     APPROVED = 2
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Change(SyftObject):
     __canonical_name__ = "Change"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -59,7 +59,7 @@ class Change(SyftObject):
         return self.linked_obj and type_ == self.linked_obj.object_type
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ActionStoreChange(Change):
     __canonical_name__ = "ActionStoreChange"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -108,7 +108,7 @@ class ActionStoreChange(Change):
         return self._run(context=context, apply=False)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class Request(SyftObject):
     __canonical_name__ = "Request"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -213,7 +213,7 @@ class Request(SyftObject):
         return result
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SubmitRequest(SyftObject):
     __canonical_name__ = "SubmitRequest"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -266,7 +266,7 @@ def submit_request_to_request() -> List[Callable]:
     ]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ObjectMutation(Change):
     __canonical_name__ = "ObjectMutation"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -316,7 +316,7 @@ def type_for_field(object_type: type, attr_name: str) -> Optional[type]:
     return field_type
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class EnumMutation(ObjectMutation):
     __canonical_name__ = "EnumMutation"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -403,7 +403,7 @@ class EnumMutation(ObjectMutation):
         return None
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserCodeStatusChange(Change):
     __canonical_name__ = "UserCodeStatusChange"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/request_service.py
+++ b/packages/syft/src/syft/core/node/new/request_service.py
@@ -30,7 +30,7 @@ from .user_service import UserService
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class RequestService(AbstractService):
     store: DocumentStore
     stash: RequestStash

--- a/packages/syft/src/syft/core/node/new/request_stash.py
+++ b/packages/syft/src/syft/core/node/new/request_stash.py
@@ -23,7 +23,7 @@ StatusPartitionKey = PartitionKey(key="status", type_=RequestStatus)
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class RequestStash(BaseUIDStoreStash):
     object_type = Request
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/response.py
+++ b/packages/syft/src/syft/core/node/new/response.py
@@ -34,7 +34,7 @@ class SyftResponseMessage(SyftBaseModel):
         )
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SyftError(SyftResponseMessage):
     _bool: bool = False
 
@@ -43,21 +43,21 @@ class SyftError(SyftResponseMessage):
         return "alert-danger"
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SyftSuccess(SyftResponseMessage):
     @property
     def _repr_html_class_(self) -> str:
         return "alert-success"
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SyftNotReady(SyftResponseMessage):
     @property
     def _repr_html_class_(self) -> str:
         return "alert-info"
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SyftException(Exception):
     traceback: bool = False
     traceback_limit: int = 10

--- a/packages/syft/src/syft/core/node/new/response.py
+++ b/packages/syft/src/syft/core/node/new/response.py
@@ -106,6 +106,6 @@ except Exception:
     pass  # nosec
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SyftAttributeError(AttributeError, SyftException):
     pass

--- a/packages/syft/src/syft/core/node/new/serializable.py
+++ b/packages/syft/src/syft/core/node/new/serializable.py
@@ -1,5 +1,6 @@
 # stdlib
 from typing import Any
+from typing import Sequence
 
 # syft absolute
 import syft
@@ -11,11 +12,18 @@ module_type = type(syft)
 
 
 def serializable(
-    recursive_serde: bool = False,
+    recursive_serde: bool = True,
+    attrs: Sequence[str] = [],
+    inherit_attrs: bool = True,
+    **kwargs,
 ) -> Any:
+    """ """
+
     def rs_decorator(cls: Any) -> Any:
-        recursive_serde_register(cls)
+        if recursive_serde:
+            recursive_serde_register(
+                cls, state_attrs=attrs, inherit_attrs=inherit_attrs
+            )
         return cls
 
-    if recursive_serde:
-        return rs_decorator
+    return rs_decorator

--- a/packages/syft/src/syft/core/node/new/serializable.py
+++ b/packages/syft/src/syft/core/node/new/serializable.py
@@ -1,5 +1,6 @@
 # stdlib
 from typing import Any
+from typing import Optional
 from typing import Sequence
 
 # syft absolute
@@ -12,18 +13,46 @@ module_type = type(syft)
 
 
 def serializable(
-    recursive_serde: bool = True,
     attrs: Sequence[str] = [],
-    inherit_attrs: bool = True,
+    without: Sequence[str] = [],
+    inherit: Optional[bool] = True,
+    inheritable: Optional[bool] = True,
+    pydantic: Optional[bool] = False,
     **kwargs,
 ) -> Any:
-    """ """
+    """
+    Recursively serialize attributes of the class.
+
+    Args:
+        `attrs`       : List of attributes to serialize
+        `without`     : List of attributes to exlucde from serialization
+        `inherit`     : Whether to inherit serializable attribute list from base class
+        `inheritable` : Whether the serializable attribute list can be inherited by derived class
+
+    For non-pydantic classes,
+        - `inheritable=True`  => Derived classes will include base class `attrs`
+        - `inheritable=False` => Derived classes will not include base class `attrs`
+        - `inherit=True`      => Base class `attrs` + `attrs` - `without`
+        - `inherit=False`     => `attrs` - `without`
+
+    For pydantic classes,
+        - No need to provide `attrs`. They will be automatically inferred.
+        - Providing `attrs` will override the inferred attributes.
+        - `without` will work only on attributes of `Optional` type
+        - `inherit`, `inheritable` will not work as pydantic inherits by default
+
+    Returns:
+        Decorated class
+    """
 
     def rs_decorator(cls: Any) -> Any:
-        if recursive_serde:
-            recursive_serde_register(
-                cls, state_attrs=attrs, inherit_attrs=inherit_attrs
-            )
+        recursive_serde_register(
+            cls,
+            serialize_attrs=attrs,
+            exclude_attrs=without,
+            inherit_attrs=inherit,
+            inheritable_attrs=inheritable,
+        )
         return cls
 
     return rs_decorator

--- a/packages/syft/src/syft/core/node/new/serializable.py
+++ b/packages/syft/src/syft/core/node/new/serializable.py
@@ -17,7 +17,6 @@ def serializable(
     without: Sequence[str] = [],
     inherit: Optional[bool] = True,
     inheritable: Optional[bool] = True,
-    pydantic: Optional[bool] = False,
     **kwargs,
 ) -> Any:
     """
@@ -25,7 +24,7 @@ def serializable(
 
     Args:
         `attrs`       : List of attributes to serialize
-        `without`     : List of attributes to exlucde from serialization
+        `without`     : List of attributes to exclude from serialization
         `inherit`     : Whether to inherit serializable attribute list from base class
         `inheritable` : Whether the serializable attribute list can be inherited by derived class
 

--- a/packages/syft/src/syft/core/node/new/service.py
+++ b/packages/syft/src/syft/core/node/new/service.py
@@ -44,7 +44,7 @@ class AbstractService:
         return self.stash.get_by_uid(uid=linked_obj.object_uid)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ServiceConfig(SyftBaseObject):
     public_path: str
     private_path: str

--- a/packages/syft/src/syft/core/node/new/signature.py
+++ b/packages/syft/src/syft/core/node/new/signature.py
@@ -12,7 +12,7 @@ recursive_serde_register(_ParameterKind)
 
 
 recursive_serde_register(
-    Parameter, state_attrs=["_annotation", "_name", "_kind", "_default"]
+    Parameter, serialize_attrs=["_annotation", "_name", "_kind", "_default"]
 )
 
 

--- a/packages/syft/src/syft/core/node/new/signature.py
+++ b/packages/syft/src/syft/core/node/new/signature.py
@@ -12,7 +12,7 @@ recursive_serde_register(_ParameterKind)
 
 
 recursive_serde_register(
-    Parameter, attr_allowlist=["_annotation", "_name", "_kind", "_default"]
+    Parameter, state_attrs=["_annotation", "_name", "_kind", "_default"]
 )
 
 

--- a/packages/syft/src/syft/core/node/new/sqlite_document_store.py
+++ b/packages/syft/src/syft/core/node/new/sqlite_document_store.py
@@ -40,7 +40,7 @@ def thread_ident() -> int:
     return threading.current_thread().ident
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["index_name", "settings", "store_config"])
 class SQLiteBackingStore(KeyValueBackingStore):
     """Core Store logic for the SQLite stores.
 
@@ -54,8 +54,6 @@ class SQLiteBackingStore(KeyValueBackingStore):
         `ddtype`: Type
             Class used as fallback on `get` errors
     """
-
-    __attr_state__ = ["index_name", "settings", "store_config"]
 
     def __init__(
         self,
@@ -265,7 +263,7 @@ class SQLiteBackingStore(KeyValueBackingStore):
             pass
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SQLiteStorePartition(KeyValueStorePartition):
     """SQLite StorePartition
 
@@ -288,7 +286,7 @@ class SQLiteStorePartition(KeyValueStorePartition):
 
 
 # the base document store is already a dict but we can change it later
-@serializable(recursive_serde=True)
+@serializable()
 class SQLiteDocumentStore(DocumentStore):
     """SQLite Document Store
 
@@ -300,7 +298,7 @@ class SQLiteDocumentStore(DocumentStore):
     partition_type = SQLiteStorePartition
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SQLiteStoreClientConfig(StoreClientConfig):
     """SQLite connection config
 
@@ -336,7 +334,7 @@ class SQLiteStoreClientConfig(StoreClientConfig):
         return path / self.filename
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SQLiteStoreConfig(StoreConfig):
     """SQLite Store config, used by SQLiteStorePartition
 

--- a/packages/syft/src/syft/core/node/new/test_service.py
+++ b/packages/syft/src/syft/core/node/new/test_service.py
@@ -12,7 +12,7 @@ from .service import service_method
 from .user_roles import GUEST_ROLE_LEVEL
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class TestService(AbstractService):
     def __init__(self) -> None:
         pass

--- a/packages/syft/src/syft/core/node/new/third_party.py
+++ b/packages/syft/src/syft/core/node/new/third_party.py
@@ -46,11 +46,11 @@ recursive_serde_register(
 
 
 # result Ok and Err
-recursive_serde_register(Ok, state_attrs=["_value"])
-recursive_serde_register(Err, state_attrs=["_value"])
+recursive_serde_register(Ok, serialize_attrs=["_value"])
+recursive_serde_register(Err, serialize_attrs=["_value"])
 
 recursive_serde_register_type(pydantic.main.ModelMetaclass)
-recursive_serde_register_type(Result, state_attrs=["_value"])
+recursive_serde_register_type(Result, serialize_attrs=["_value"])
 
 # exceptions
 recursive_serde_register(cls=TypeError)

--- a/packages/syft/src/syft/core/node/new/third_party.py
+++ b/packages/syft/src/syft/core/node/new/third_party.py
@@ -46,11 +46,11 @@ recursive_serde_register(
 
 
 # result Ok and Err
-recursive_serde_register(Ok, attr_allowlist=["_value"])
-recursive_serde_register(Err, attr_allowlist=["_value"])
+recursive_serde_register(Ok, state_attrs=["_value"])
+recursive_serde_register(Err, state_attrs=["_value"])
 
 recursive_serde_register_type(pydantic.main.ModelMetaclass)
-recursive_serde_register_type(Result, attr_allowlist=["_value"])
+recursive_serde_register_type(Result, state_attrs=["_value"])
 
 # exceptions
 recursive_serde_register(cls=TypeError)

--- a/packages/syft/src/syft/core/node/new/twin_object.py
+++ b/packages/syft/src/syft/core/node/new/twin_object.py
@@ -22,7 +22,10 @@ def to_action_object(obj: Any) -> ActionObject:
     raise Exception(f"{type(obj)} not in action_types")
 
 
-@serializable(attrs=["id", "private_obj", "private_obj_id", "mock_obj", "mock_obj_id"], has_explicit_id=True)
+@serializable(
+    attrs=["id", "private_obj", "private_obj_id", "mock_obj", "mock_obj_id"],
+    has_explicit_id=True,
+)
 class TwinObject(SyftObject):
     __canonical_name__ = "TwinObject"
     __version__ = 1

--- a/packages/syft/src/syft/core/node/new/twin_object.py
+++ b/packages/syft/src/syft/core/node/new/twin_object.py
@@ -22,13 +22,12 @@ def to_action_object(obj: Any) -> ActionObject:
     raise Exception(f"{type(obj)} not in action_types")
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["id", "private_obj", "private_obj_id", "mock_obj", "mock_obj_id"], has_explicit_id=True)
 class TwinObject(SyftObject):
     __canonical_name__ = "TwinObject"
     __version__ = 1
 
     __attr_searchable__ = []
-    __attr_state__ = ["id", "private_obj", "private_obj_id", "mock_obj", "mock_obj_id"]
 
     private_obj: ActionObject
     private_obj_id: UID

--- a/packages/syft/src/syft/core/node/new/twin_object.py
+++ b/packages/syft/src/syft/core/node/new/twin_object.py
@@ -22,10 +22,7 @@ def to_action_object(obj: Any) -> ActionObject:
     raise Exception(f"{type(obj)} not in action_types")
 
 
-@serializable(
-    attrs=["id", "private_obj", "private_obj_id", "mock_obj", "mock_obj_id"],
-    has_explicit_id=True,
-)
+@serializable()
 class TwinObject(SyftObject):
     __canonical_name__ = "TwinObject"
     __version__ = 1

--- a/packages/syft/src/syft/core/node/new/uid.py
+++ b/packages/syft/src/syft/core/node/new/uid.py
@@ -14,7 +14,7 @@ from ....logger import traceback_and_raise
 from .serializable import serializable
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["value"])
 class UID:
     """A unique ID for every Syft object.
 
@@ -32,7 +32,6 @@ class UID:
 
     """
 
-    __attr_allowlist__ = ["value"]
     __serde_overrides__: Dict[str, Sequence[Callable]] = {
         "value": (lambda x: x.bytes, lambda x: uuid.UUID(bytes=bytes(x)))
     }
@@ -200,11 +199,9 @@ class UID:
             )
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["value", "syft_history_hash"])
 class LineageID(UID):
     syft_history_hash: int
-
-    __attr_allowlist__ = ["value", "syft_history_hash"]
 
     def __init__(
         self,

--- a/packages/syft/src/syft/core/node/new/uid.py
+++ b/packages/syft/src/syft/core/node/new/uid.py
@@ -199,7 +199,7 @@ class UID:
             )
 
 
-@serializable(attrs=["value", "syft_history_hash"])
+@serializable(attrs=["syft_history_hash"])
 class LineageID(UID):
     syft_history_hash: int
 

--- a/packages/syft/src/syft/core/node/new/user.py
+++ b/packages/syft/src/syft/core/node/new/user.py
@@ -28,21 +28,7 @@ from .uid import UID
 from .user_roles import ServiceRole
 
 
-@serializable(
-    attrs=[
-        "id",
-        "email",
-        "name",
-        "hashed_password",
-        "salt",
-        "signing_key",
-        "verify_key",
-        "role",
-        "institution",
-        "website",
-        "created_at",
-    ]
-)
+@serializable()
 class User(SyftObject):
     # version
     __canonical_name__ = "User"

--- a/packages/syft/src/syft/core/node/new/user.py
+++ b/packages/syft/src/syft/core/node/new/user.py
@@ -28,7 +28,21 @@ from .uid import UID
 from .user_roles import ServiceRole
 
 
-@serializable(recursive_serde=True)
+@serializable(
+    attrs=[
+        "id",
+        "email",
+        "name",
+        "hashed_password",
+        "salt",
+        "signing_key",
+        "verify_key",
+        "role",
+        "institution",
+        "website",
+        "created_at",
+    ]
+)
 class User(SyftObject):
     # version
     __canonical_name__ = "User"
@@ -53,19 +67,6 @@ class User(SyftObject):
     created_at: Optional[str]
 
     # serde / storage rules
-    __attr_state__ = [
-        "id",
-        "email",
-        "name",
-        "hashed_password",
-        "salt",
-        "signing_key",
-        "verify_key",
-        "role",
-        "institution",
-        "website",
-        "created_at",
-    ]
     __attr_searchable__ = ["name", "email", "verify_key", "role"]
     __attr_unique__ = ["email", "signing_key", "verify_key"]
     __attr_repr_cols__ = ["name", "email"]
@@ -108,7 +109,7 @@ def check_pwd(password: str, hashed_password: str) -> bool:
     )
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserUpdate(SyftObject):
     __canonical_name__ = "UserUpdate"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -129,7 +130,7 @@ class UserUpdate(SyftObject):
     website: Optional[str] = None
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserCreate(UserUpdate):
     __canonical_name__ = "UserCreate"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -146,7 +147,7 @@ class UserCreate(UserUpdate):
     __attr_repr_cols__ = ["name", "email"]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserSearch(SyftObject):
     __canonical_name__ = "UserSearch"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -157,7 +158,7 @@ class UserSearch(SyftObject):
     name: Optional[str]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserView(UserUpdate):
     __canonical_name__ = "UserView"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -191,7 +192,7 @@ def user_to_view_user() -> List[Callable]:
     return [keep(["id", "email", "name", "role", "institution", "website"])]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserPrivateKey(SyftObject):
     __canonical_name__ = "UserPrivateKey"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -185,7 +185,7 @@ def allowed_ids_only(
     return filtered_kwargs
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ExactMatch(InputPolicy):
     # version
     __canonical_name__ = "ExactMatch"
@@ -202,7 +202,7 @@ class ExactMatch(InputPolicy):
         )
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class OutputHistory(SyftObject):
     # version
     __canonical_name__ = "OutputHistory"
@@ -228,7 +228,7 @@ class OutputPolicyState(SyftObject):
         raise NotImplementedError
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class OutputPolicyStateExecuteCount(OutputPolicyState):
     # version
     __canonical_name__ = "OutputPolicyStateExecuteCount"
@@ -269,7 +269,7 @@ class OutputPolicyStateExecuteCount(OutputPolicyState):
         self.count += 1
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class OutputPolicyStateExecuteOnce(OutputPolicyStateExecuteCount):
     __canonical_name__ = "OutputPolicyStateExecuteOnce"
     __version__ = SYFT_OBJECT_VERSION_1
@@ -299,7 +299,7 @@ class OutputPolicy(SyftObject):
         return op_code
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class SingleExecutionExactOutput(OutputPolicy):
     # version
     __canonical_name__ = "SingleExecutionExactOutput"
@@ -308,7 +308,7 @@ class SingleExecutionExactOutput(OutputPolicy):
     state_type: Type[OutputPolicyState] = OutputPolicyStateExecuteOnce
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserCodeStatus(Enum):
     SUBMITTED = "submitted"
     DENIED = "denied"
@@ -321,11 +321,8 @@ class UserCodeStatus(Enum):
 # User Code status context for multiple approvals
 # To make nested dicts hashable for mongodb
 # as status is in attr_searchable
-@serializable(recursive_serde=True)
+@serializable(attrs=["base_dict"])
 class UserCodeStatusContext:
-    __attr_allowlist__ = [
-        "base_dict",
-    ]
 
     base_dict: Dict = {}
 
@@ -384,7 +381,7 @@ class UserCodeStatusContext:
             )
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserCode(SyftObject):
     # version
     __canonical_name__ = "UserCode"
@@ -479,7 +476,15 @@ def partition_by_node(kwargs: Dict[str, Any]) -> Dict[str, UID]:
     return output_kwargs
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=[
+    "id",
+    "code",
+    "func_name",
+    "signature",
+    "input_policy",
+    "output_policy",
+    "enclave_metadata",
+], has_explicit_id=True)
 class SubmitUserCode(SyftObject):
     # version
     __canonical_name__ = "SubmitUserCode"
@@ -493,16 +498,6 @@ class SubmitUserCode(SyftObject):
     output_policy: OutputPolicy
     local_function: Optional[Callable]
     enclave_metadata: Optional[EnclaveMetadata] = None
-
-    __attr_state__ = [
-        "id",
-        "code",
-        "func_name",
-        "signature",
-        "input_policy",
-        "output_policy",
-        "enclave_metadata",
-    ]
 
     @property
     def kwargs(self) -> List[str]:
@@ -750,7 +745,7 @@ def submit_user_code_to_user_code() -> List[Callable]:
     ]
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class UserCodeExecutionResult(SyftObject):
     # version
     __canonical_name__ = "UserCodeExecutionResult"

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -323,7 +323,6 @@ class UserCodeStatus(Enum):
 # as status is in attr_searchable
 @serializable(attrs=["base_dict"])
 class UserCodeStatusContext:
-
     base_dict: Dict = {}
 
     def __init__(self, base_dict: Dict):
@@ -476,15 +475,18 @@ def partition_by_node(kwargs: Dict[str, Any]) -> Dict[str, UID]:
     return output_kwargs
 
 
-@serializable(attrs=[
-    "id",
-    "code",
-    "func_name",
-    "signature",
-    "input_policy",
-    "output_policy",
-    "enclave_metadata",
-], has_explicit_id=True)
+@serializable(
+    attrs=[
+        "id",
+        "code",
+        "func_name",
+        "signature",
+        "input_policy",
+        "output_policy",
+        "enclave_metadata",
+    ],
+    has_explicit_id=True,
+)
 class SubmitUserCode(SyftObject):
     # version
     __canonical_name__ = "SubmitUserCode"

--- a/packages/syft/src/syft/core/node/new/user_code.py
+++ b/packages/syft/src/syft/core/node/new/user_code.py
@@ -475,18 +475,7 @@ def partition_by_node(kwargs: Dict[str, Any]) -> Dict[str, UID]:
     return output_kwargs
 
 
-@serializable(
-    attrs=[
-        "id",
-        "code",
-        "func_name",
-        "signature",
-        "input_policy",
-        "output_policy",
-        "enclave_metadata",
-    ],
-    has_explicit_id=True,
-)
+@serializable()
 class SubmitUserCode(SyftObject):
     # version
     __canonical_name__ = "SubmitUserCode"

--- a/packages/syft/src/syft/core/node/new/user_code_service.py
+++ b/packages/syft/src/syft/core/node/new/user_code_service.py
@@ -31,7 +31,7 @@ from .user_roles import GUEST_ROLE_LEVEL
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class UserCodeService(AbstractService):
     store: DocumentStore
     stash: UserCodeStash

--- a/packages/syft/src/syft/core/node/new/user_code_stash.py
+++ b/packages/syft/src/syft/core/node/new/user_code_stash.py
@@ -19,7 +19,7 @@ from .user_code import UserVerifyKeyPartitionKey
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class UserCodeStash(BaseUIDStoreStash):
     object_type = UserCode
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/user_roles.py
+++ b/packages/syft/src/syft/core/node/new/user_roles.py
@@ -25,7 +25,7 @@ class ServiceRoleCapability(Enum):
     CAN_EDIT_DOMAIN_SETTINGS = 512
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class ServiceRole(Enum):
     NONE = 0
     GUEST = 1

--- a/packages/syft/src/syft/core/node/new/user_service.py
+++ b/packages/syft/src/syft/core/node/new/user_service.py
@@ -34,7 +34,7 @@ from .user_stash import UserStash
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class UserService(AbstractService):
     store: DocumentStore
     stash: UserStash

--- a/packages/syft/src/syft/core/node/new/user_stash.py
+++ b/packages/syft/src/syft/core/node/new/user_stash.py
@@ -29,7 +29,7 @@ VerifyKeyPartitionKey = PartitionKey(key="verify_key", type_=SyftVerifyKey)
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class UserStash(BaseStash):
     object_type = User
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/core/node/new/worker_settings.py
+++ b/packages/syft/src/syft/core/node/new/worker_settings.py
@@ -14,7 +14,7 @@ from .syft_object import SyftObject
 from .uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class WorkerSettings(SyftObject):
     __canonical_name__ = "WorkerSettings"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/core/node/worker.py
+++ b/packages/syft/src/syft/core/node/worker.py
@@ -108,7 +108,7 @@ node_uid_env = get_node_uid_env()
 
 
 @instrument
-@serializable(recursive_serde=True)
+@serializable()
 class Worker(NewNode):
     signing_key: Optional[SyftSigningKey]
     required_signed_calls: bool = True

--- a/packages/syft/src/syft/external/oblv/deployment_client.py
+++ b/packages/syft/src/syft/external/oblv/deployment_client.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from ...core.node.new.user_code import SubmitUserCode
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class OblvMetadata(EnclaveMetadata, BaseModel):
     """Contains Metadata to connect to Oblivious Enclave"""
 

--- a/packages/syft/src/syft/external/oblv/oblv_keys.py
+++ b/packages/syft/src/syft/external/oblv/oblv_keys.py
@@ -4,7 +4,7 @@ from ...core.node.new.syft_object import SYFT_OBJECT_VERSION_1
 from ...core.node.new.syft_object import SyftObject
 
 
-@serializable(attrs=["private_key", "public_key"])
+@serializable()
 class OblvKeys(SyftObject):
     # version
     __canonical_name__ = "OblvKeys"

--- a/packages/syft/src/syft/external/oblv/oblv_keys.py
+++ b/packages/syft/src/syft/external/oblv/oblv_keys.py
@@ -4,7 +4,7 @@ from ...core.node.new.syft_object import SYFT_OBJECT_VERSION_1
 from ...core.node.new.syft_object import SyftObject
 
 
-@serializable(recursive_serde=True)
+@serializable(attrs=["private_key", "public_key"])
 class OblvKeys(SyftObject):
     # version
     __canonical_name__ = "OblvKeys"
@@ -15,6 +15,5 @@ class OblvKeys(SyftObject):
     private_key: bytes
 
     # serde / storage rules
-    __attr_state__ = ["private_key", "public_key"]
     __attr_searchable__ = ["private_key", "public_key"]
     __attr_unique__ = ["private_key", "public_key"]

--- a/packages/syft/src/syft/external/oblv/oblv_keys_stash.py
+++ b/packages/syft/src/syft/external/oblv/oblv_keys_stash.py
@@ -18,7 +18,7 @@ from ...core.node.new.uid import UID
 from .oblv_keys import OblvKeys
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class OblvKeysStash(BaseStash):
     object_type = OblvKeys
     settings: PartitionSettings = PartitionSettings(

--- a/packages/syft/src/syft/external/oblv/oblv_service.py
+++ b/packages/syft/src/syft/external/oblv/oblv_service.py
@@ -53,7 +53,7 @@ OBLV_PROCESS_CACHE: Dict[str, List] = {}
 
 # TODO: 🟡 Duplication of PyPrimitive Dict
 # This is emulated since the action store curently accepts  only SyftObject types
-@serializable(attrs=["id", "base_dict"], has_explicit_id=True)
+@serializable()
 class DictObject(SyftObject):
     # version
     __canonical_name__ = "Dict"

--- a/packages/syft/src/syft/external/oblv/oblv_service.py
+++ b/packages/syft/src/syft/external/oblv/oblv_service.py
@@ -53,7 +53,7 @@ OBLV_PROCESS_CACHE: Dict[str, List] = {}
 
 # TODO: 🟡 Duplication of PyPrimitive Dict
 # This is emulated since the action store curently accepts  only SyftObject types
-@serializable(recursive_serde=True)
+@serializable(attrs=["id", "base_dict"], has_explicit_id=True)
 class DictObject(SyftObject):
     # version
     __canonical_name__ = "Dict"
@@ -62,8 +62,6 @@ class DictObject(SyftObject):
     base_dict: Dict[Any, Any] = {}
 
     # serde / storage rules
-    __attr_state__ = ["id", "base_dict"]
-
     __attr_searchable__ = []
     __attr_unique__ = ["id"]
 
@@ -254,7 +252,7 @@ def generate_oblv_key() -> Tuple[bytes, bytes]:
     return (public_key, private_key)
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class OblvService(AbstractService):
     store: DocumentStore
     oblv_keys_stash: OblvKeysStash

--- a/packages/syft/tests/syft/serializable_test.py
+++ b/packages/syft/tests/syft/serializable_test.py
@@ -1,0 +1,309 @@
+# stdlib
+from time import time
+from typing import Optional
+
+# third party
+from pydantic import BaseModel
+
+# syft absolute
+import syft as sy
+from syft.core.node.new.serializable import serializable
+
+
+def get_fqn_for_class(cls):
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+# ------------------------------ Simple classes ------------------------------
+
+
+class AbstractBase:
+    uid: str
+
+
+@serializable(attrs=["uid", "value"])
+class Base(AbstractBase):
+    """Serialize: uid, value"""
+
+    value: int
+
+    def __init__(self, uid: str, value: int):
+        self.uid = uid
+        self.value = value
+
+
+@serializable(attrs=["status"])
+class Derived(Base):
+    """Serialize: uid, value, status"""
+
+    status: int
+
+    def __init__(self, uid: str, value: int, status: int) -> None:
+        super().__init__(uid, value)
+        self.status = status
+
+
+@serializable(attrs=["status"], without=["uid"])
+class DerivedWithoutAttrs(Base):
+    """Serialize: value, status"""
+
+    status: int
+
+    def __init__(self, uid: str, value: int, status: int) -> None:
+        super().__init__(uid, value)
+        self.status = status
+
+
+@serializable(attrs=["status"], inherit=False)
+class DerivedNoInherit(Base):
+    """Serialize: status"""
+
+    status: int
+
+    def __init__(self, uid: str, value: int, status: int) -> None:
+        super().__init__(uid, value)
+        self.status = status
+
+
+@serializable(attrs=["uid", "value"], inheritable=False)
+class BaseAttrsNonInheritable(AbstractBase):
+    """Serialize: uid, value (Derived cannot inherit base attrs)"""
+
+    value: Optional[int]
+
+    def __init__(self, uid: str = None, value: int = None):
+        self.uid = uid
+        self.value = value
+
+
+@serializable(attrs=["status"])
+class DerivedWithoutBaseAttrs(BaseAttrsNonInheritable):
+    """Serialize: status (Dervied cannot inherit base attrs)"""
+
+    status: int
+
+    def __init__(self, uid: str, value: int, status: int):
+        super().__init__(uid, value)
+
+        self.uid = uid
+        self.value = value
+        self.status = status
+
+
+def test_base_attrs():
+    data = Base(uid=str(time()), value=2)
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert "uid" in data.__syft_serializable__
+    assert "value" in data.__syft_serializable__
+
+    assert (data.uid, data.value) == (
+        de.uid,
+        de.value,
+    ), "Deserialized values do not match"
+
+
+def test_base_non_inheritable_attrs():
+    data = BaseAttrsNonInheritable(uid=str(time()), value=2)
+
+    ser = sy.serialize(data, to_bytes=True)
+    sy.deserialize(ser, from_bytes=True)
+
+    assert "__syft_serializable__" not in data.__dict__
+
+
+def test_derived():
+    data = Derived(uid=str(time()), value=2, status=1)
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert "uid" in data.__syft_serializable__
+    assert "value" in data.__syft_serializable__
+
+    assert (data.uid, data.value, data.status) == (
+        de.uid,
+        de.value,
+        de.status,
+    ), "Deserialized values do not match"
+
+
+def test_derived_without_attrs():
+    data = DerivedWithoutAttrs(uid=str(time()), value=2, status=1)
+
+    ser = sy.serialize(data, to_bytes=True)
+    sy.deserialize(ser, from_bytes=True)
+
+    assert "uid" not in data.__syft_serializable__
+    assert "value" in data.__syft_serializable__
+    assert "status" in data.__syft_serializable__
+
+
+def test_derived_without_inherit():
+    data = DerivedNoInherit(uid=str(time()), value=2, status=1)
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert "uid" not in data.__syft_serializable__
+    assert "value" not in data.__syft_serializable__
+    assert de.status == data.status
+
+
+def test_derived_without_base_attrs():
+    data = DerivedWithoutBaseAttrs(uid=str(time()), value=2, status=1)
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert "uid" not in data.__syft_serializable__
+    assert "value" not in data.__syft_serializable__
+    assert "status" in data.__syft_serializable__
+
+    assert de.status == data.status
+
+
+# ------------------------------ Pydantic classes ------------------------------
+
+
+@serializable()
+class PydBase(BaseModel):
+    """Serialize: uid, value, flag"""
+
+    uid: Optional[str] = None
+    value: Optional[int] = None
+    flag: Optional[bool] = None
+
+
+@serializable()
+class PydDerived(PydBase):
+    """Serialize: uid, value, flag, source, target"""
+
+    source: str
+    target: str
+
+
+@serializable(without=["uid"])
+class PydDerivedWithoutAttr(PydBase):
+    """
+    Serialize: value, flag, source, target
+    `without=` will only work with Optional attributes due to pydantic's validation
+    """
+
+    source: str
+    target: str
+
+
+@serializable(without=["uid", "flag", "config"])
+class PydDerivedWithoutAttrs(PydBase):
+    """
+    Serialize: value, source, target
+    `without=` will only work with Optional attributes due to pydantic's validation
+    """
+
+    source: str
+    target: str
+    config: Optional[dict] = None
+
+
+@serializable(attrs=["source_path", "target"])
+class PydDerivedOnly(PydBase):
+    """
+    Serialize: source, target
+    """
+
+    source: str
+    target: str
+
+    def callback(x):
+        return x + 1
+
+
+def test_pydantic():
+    data = PydBase(uid=str(time()), value=2, flag=True)
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert (data.uid, data.value, data.flag) == (de.uid, de.value, de.flag)
+
+
+def test_pydantic_derived():
+    data = PydDerived(
+        uid=str(time()),
+        value=2,
+        source="source_path",
+        target="target_path",
+    )
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert (data.uid, data.value, data.flag, data.source, data.target) == (
+        de.uid,
+        de.value,
+        de.flag,
+        de.source,
+        de.target,
+    )
+
+
+def test_pydantic_derived_without_attr():
+    data = PydDerivedWithoutAttr(
+        uid=str(time()),
+        value=2,
+        source="source_path",
+        target="target_path",
+    )
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert data.uid is not None
+    assert de.uid is None
+    assert (data.value, data.flag, data.source, data.target) == (
+        de.value,
+        de.flag,
+        de.source,
+        de.target,
+    )
+
+
+def test_pydantic_derived_without_attrs():
+    data = PydDerivedWithoutAttrs(
+        uid=str(time()),
+        value=2,
+        source="source_path",
+        target="target_path",
+    )
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert (data.uid, data.flag, data.config) != (None, None, None)
+    assert (de.uid, de.flag, de.config) == (None, None, None)
+    assert (data.value, data.flag, data.source, data.target) == (
+        de.value,
+        de.flag,
+        de.source,
+        de.target,
+    )
+
+
+def test_pydantic_derived_only():
+    data = PydDerivedOnly(
+        uid=str(time()),
+        value=2,
+        flag=True,
+        source="source_path",
+        target="target_path",
+    )
+
+    ser = sy.serialize(data, to_bytes=True)
+    de = sy.deserialize(ser, from_bytes=True)
+
+    assert (data.uid, data.value, data.flag) != (de.uid, de.value, de.flag)
+    assert (de.uid, de.value, de.flag) == (None, None, None)
+    assert (data.source, data.target) == (de.source, de.target)

--- a/packages/syft/tests/syft/serializable_test.py
+++ b/packages/syft/tests/syft/serializable_test.py
@@ -1,5 +1,6 @@
 # stdlib
 from time import time
+from typing import Callable
 from typing import Optional
 
 # third party
@@ -208,7 +209,7 @@ class PydDerivedWithoutAttrs(PydBase):
     config: Optional[dict] = None
 
 
-@serializable(attrs=["source_path", "target"])
+@serializable(attrs=["source", "target"])
 class PydDerivedOnly(PydBase):
     """
     Serialize: source, target
@@ -216,9 +217,7 @@ class PydDerivedOnly(PydBase):
 
     source: str
     target: str
-
-    def callback(x):
-        return x + 1
+    callback: Optional[Callable] = lambda: None  # noqa: E731
 
 
 def test_pydantic():

--- a/packages/syft/tests/syft/stores/store_mocks_test.py
+++ b/packages/syft/tests/syft/stores/store_mocks_test.py
@@ -12,7 +12,7 @@ from syft.core.node.new.syft_object import SyftObject
 from syft.core.node.new.uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MockKeyValueBackingStore(dict, KeyValueBackingStore):
     def __init__(
         self,
@@ -40,23 +40,23 @@ class MockKeyValueBackingStore(dict, KeyValueBackingStore):
         return value
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MockObjectType(SyftObject):
     __canonical_name__ = "mock_type"
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MockStore(DocumentStore):
     pass
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MockSyftObject(SyftObject):
     __canonical_name__ = UID()
     data: Any
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MockStoreConfig(StoreConfig):
     store_type: Type[DocumentStore] = MockStore
     db_name: str = "testing"

--- a/test.py
+++ b/test.py
@@ -1,4 +1,0 @@
-# syft absolute
-import syft as sy
-
-worker = sy.Worker.named("test-worker", processes=1)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,4 @@
+# syft absolute
+import syft as sy
+
+worker = sy.Worker.named("test-worker", processes=1)


### PR DESCRIPTION
## Description

This change gets rid of all the `__attr_allowlist__` and `__attr_state__`, and unifies them through the `@serializable` decorator. The latter has been cleaned up and updated to provide more flexibility for controlling which attrs will be serialized.

Closes https://github.com/OpenMined/Heartbeat/issues/13

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Unit tests
- Created and reviewed list of all serializable classes and any changes in between dev & this PR - https://docs.google.com/spreadsheets/d/1gwq3dgN8T3lUR8TL4EVBbLP3c27sBvMAvM5tz53tXF8/edit?usp=sharing

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
