### PR TITLE
Misc fixes (`BaseStash` tests' flakiness, `@seriablizable` and `@instrument` typings)

### DIFF
--- a/packages/syft/src/syft/core/node/new/serializable.py
+++ b/packages/syft/src/syft/core/node/new/serializable.py
@@ -20,7 +20,6 @@ def serializable(
     without: Sequence[str] = [],
     inherit: Optional[bool] = True,
     inheritable: Optional[bool] = True,
-    **kwargs,
 ) -> T:
     """
     Recursively serialize attributes of the class.

--- a/packages/syft/src/syft/core/node/new/serializable.py
+++ b/packages/syft/src/syft/core/node/new/serializable.py
@@ -1,7 +1,7 @@
 # stdlib
-from typing import Any
 from typing import Optional
 from typing import Sequence
+from typing import TypeVar
 
 # syft absolute
 import syft
@@ -12,13 +12,16 @@ from .recursive import recursive_serde_register
 module_type = type(syft)
 
 
+T = TypeVar("T")
+
+
 def serializable(
     attrs: Sequence[str] = [],
     without: Sequence[str] = [],
     inherit: Optional[bool] = True,
     inheritable: Optional[bool] = True,
     **kwargs,
-) -> Any:
+) -> T:
     """
     Recursively serialize attributes of the class.
 
@@ -44,7 +47,7 @@ def serializable(
         Decorated class
     """
 
-    def rs_decorator(cls: Any) -> Any:
+    def rs_decorator(cls: T) -> T:
         recursive_serde_register(
             cls,
             serialize_attrs=attrs,

--- a/packages/syft/src/syft/telemetry.py
+++ b/packages/syft/src/syft/telemetry.py
@@ -1,6 +1,5 @@
 # stdlib
 import os
-from typing import Any
 from typing import Optional
 
 
@@ -15,10 +14,10 @@ def str_to_bool(bool_str: Optional[str]) -> bool:
 TRACE_MODE = str_to_bool(os.environ.get("TRACE", "False"))
 
 
-def setup_tracer() -> Any:
+def setup_tracer():
     if not TRACE_MODE:
 
-        def noop(func: Any) -> Any:
+        def noop(func):
             return func
 
         return noop

--- a/packages/syft/src/syft/trace_decorator.py
+++ b/packages/syft/src/syft/trace_decorator.py
@@ -7,6 +7,8 @@ from functools import wraps
 import inspect
 from typing import Callable
 from typing import Dict
+from typing import Optional
+from typing import TypeVar
 
 # third party
 from opentelemetry import trace
@@ -35,13 +37,16 @@ class TracingDecoratorOptions:
             TracingDecoratorOptions.default_attributes[att] = attributes[att]
 
 
+T = TypeVar("T")
+
+
 def instrument(
-    _func_or_class=None,
+    _func_or_class: Optional[T] = None,
     *,
     span_name: str = "",
     record_exception: bool = True,
-    attributes: Dict[str, str] = None,
-    existing_tracer: Tracer = None,
+    attributes: Optional[Dict[str, str]] = None,
+    existing_tracer: Optional[Tracer] = None,
     ignore=False
 ):
     """
@@ -59,7 +64,7 @@ def instrument(
     :return:The decorator function
     """
 
-    def decorate_class(cls):
+    def decorate_class(cls: T) -> T:
         for name, method in inspect.getmembers(cls, inspect.isfunction):
             # Ignore private functions, TODO: maybe make this a setting?
             if not name.startswith("_"):
@@ -92,7 +97,7 @@ def instrument(
     if inspect.isclass(_func_or_class):
         return decorate_class(_func_or_class)
 
-    def span_decorator(func_or_class):
+    def span_decorator(func_or_class: T) -> T:
         if inspect.isclass(func_or_class):
             return decorate_class(func_or_class)
 

--- a/packages/syft/tests/syft/messages/message_stash_test.py
+++ b/packages/syft/tests/syft/messages/message_stash_test.py
@@ -52,7 +52,7 @@ def add_mock_message(
 
     # print("*******", mock_message._repr_debug_())
 
-    result = message_stash.partition.set(mock_message)
+    result = message_stash.set(mock_message)
     assert result.is_ok()
 
     return mock_message
@@ -227,7 +227,7 @@ def test_messagestash_get_all_by_verify_key_for_status(document_store) -> None:
     mock_message = add_mock_message(test_stash, test_verify_key, random_verify_key)
 
     response2 = test_stash.get_all_by_verify_key_for_status(
-        mock_message.from_user_verify_key, messeage_status_undelivered
+        mock_message.to_user_verify_key, messeage_status_undelivered
     )
     assert response2.is_ok()
 

--- a/packages/syft/tests/syft/stores/base_stash_test.py
+++ b/packages/syft/tests/syft/stores/base_stash_test.py
@@ -1,9 +1,19 @@
 # stdlib
 import random
+import sys
 from typing import Any
+from typing import Callable
+from typing import Container
 from typing import Dict
 from typing import List
 from typing import Tuple
+from typing import TypeVar
+
+if sys.version_info >= (3, 10):
+    # stdlib
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 # third party
 from faker import Faker
@@ -57,6 +67,21 @@ def add_mock_object(stash: MockStash, obj: MockObject) -> MockObject:
     assert result.is_ok()
 
     return result.ok()
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def create_unique(
+    gen: Callable[P, T], xs: Container[T], *args: P.args, **kwargs: P.kwargs
+) -> T:
+    """Generate a value with `gen()` that does not collide with any element in xs"""
+    x = gen(*args, **kwargs)
+    while x in xs:
+        x = gen(*args, **kwargs)
+
+    return x
 
 
 @pytest.fixture
@@ -145,7 +170,7 @@ def test_basestash_cannot_delete_non_existent(
 ) -> None:
     add_mock_object(base_stash, mock_object)
 
-    random_uid = UID()
+    random_uid = create_unique(UID, [mock_object.id])
     for result in [
         base_stash.delete(UIDPartitionKey.with_obj(random_uid)),
         base_stash.delete_by_uid(random_uid),
@@ -177,7 +202,7 @@ def test_basestash_cannot_update_non_existent(
     add_mock_object(base_stash, mock_object)
 
     updated_obj = mock_object.copy()
-    updated_obj.id = UID()
+    updated_obj.id = create_unique(UID, [mock_object.id])
     updated_obj.name = faker.name()
 
     result = base_stash.update(updated_obj)
@@ -208,7 +233,7 @@ def test_basestash_get_by_uid(base_stash: MockStash, mock_object: MockObject) ->
     assert result.is_ok()
     assert result.ok() == mock_object
 
-    random_uid = UID()
+    random_uid = create_unique(UID, [mock_object.id])
     result = base_stash.get_by_uid(random_uid)
     assert result.is_ok()
     assert result.ok() is None
@@ -244,7 +269,9 @@ def test_basestash_query_one(
         assert result.is_ok()
         assert result.ok() == obj
 
-    random_name = faker.name()
+    existing_names = set(obj.name for obj in mock_objects)
+    random_name = create_unique(faker.name, existing_names)
+
     for result in (
         base_stash.query_one_kwargs(name=random_name),
         base_stash.query_one(QueryKey.from_obj(NamePartitionKey, random_name)),
@@ -260,7 +287,7 @@ def test_basestash_query_one(
         assert result.is_ok()
         assert result.ok() == obj
 
-    params = {"name": faker.name(), "desc": random_sentence(faker)}
+    params = {"name": random_name, "desc": random_sentence(faker)}
     for result in [
         base_stash.query_one_kwargs(**params),
         base_stash.query_one(QueryKeys.from_dict(params)),
@@ -276,8 +303,9 @@ def test_basestash_query_all(
     n_same = 3
     kwargs_list = multiple_object_kwargs(faker, n=n_same, desc=desc)
     similar_objects = [MockObject(**kwargs) for kwargs in kwargs_list]
+    all_objects = mock_objects + similar_objects
 
-    for obj in mock_objects + similar_objects:
+    for obj in all_objects:
         base_stash.set(obj)
 
     for result in [
@@ -292,7 +320,9 @@ def test_basestash_query_all(
         retrived_objects_values = set(get_object_values(obj) for obj in objects)
         assert original_object_values == retrived_objects_values
 
-    random_desc = random_sentence(faker)
+    random_desc = create_unique(
+        random_sentence, [obj.desc for obj in all_objects], faker
+    )
     for result in [
         base_stash.query_all_kwargs(desc=random_desc),
         base_stash.query_all(QueryKey.from_obj(DescPartitionKey, random_desc)),
@@ -310,7 +340,9 @@ def test_basestash_query_all(
     ]:
         assert result.is_ok()
         objects = result.ok()
-        assert len(objects) == 1
+        assert len(objects) == sum(
+            1 for obj_ in all_objects if (obj_.name, obj_.desc) == (obj.name, obj.desc)
+        )
         assert objects[0] == obj
 
 
@@ -324,8 +356,9 @@ def test_basestash_query_all_kwargs_multiple_params(
         faker, n=n_same, importance=importance, desc=desc
     )
     similar_objects = [MockObject(**kwargs) for kwargs in kwargs_list]
+    all_objects = mock_objects + similar_objects
 
-    for obj in mock_objects + similar_objects:
+    for obj in all_objects:
         base_stash.set(obj)
 
     params = {"importance": importance, "desc": desc}
@@ -341,7 +374,10 @@ def test_basestash_query_all_kwargs_multiple_params(
         retrived_objects_values = set(get_object_values(obj) for obj in objects)
         assert original_object_values == retrived_objects_values
 
-    params = {"name": faker.name(), "desc": random_sentence(faker)}
+    params = {
+        "name": create_unique(faker.name, [obj.name for obj in all_objects]),
+        "desc": random_sentence(faker),
+    }
     for result in [
         base_stash.query_all_kwargs(**params),
         base_stash.query_all(QueryKeys.from_dict(params)),

--- a/packages/syft/tests/syft/stores/base_stash_test.py
+++ b/packages/syft/tests/syft/stores/base_stash_test.py
@@ -23,7 +23,7 @@ from syft.core.node.new.syft_object import SyftObject
 from syft.core.node.new.uid import UID
 
 
-@serializable(recursive_serde=True)
+@serializable()
 class MockObject(SyftObject):
     __canonical_name__ = "base_stash_mock_object_type"
     id: UID

--- a/packages/syft/tests/syft/stores/base_stash_test.py
+++ b/packages/syft/tests/syft/stores/base_stash_test.py
@@ -79,7 +79,7 @@ def object_kwargs(faker: Faker, **kwargs: Any) -> Dict[str, Any]:
 
 
 def multiple_object_kwargs(
-    faker, n=10, same=False, **kwargs: Any
+    faker: Faker, n=10, same=False, **kwargs: Any
 ) -> List[Dict[str, Any]]:
     if same:
         kwargs_ = {"id": UID(), **object_kwargs(faker), **kwargs}


### PR DESCRIPTION
## Description
- Remove unused `**kwargs` from `@serializable` plus remove the now deprecated `recursive_serde` in tests for `BaseStash`.
- Fix `BaseStash` tests' flakiness by avoiding collision from random generators.
- Fix typing for `@serializable` and `@instrument` so that `@serializable`- and `@instrument`-ed classes and functions now offer correct typing and code completion (originally from #7475).

> Currently the `serializable` decorator has return type `Any` so when we apply it to any class the class will lose all typing. For example, currently with this
>
> ```py
> @serializable
> class PartitionKey(BaseModel):
>    ...
>
> PTKey = PartitionKey(...)
> ```
>
> we won't get any typing, completion, ... when using PTKey.
>
> This PR fixex that by using type parameter (`TypeVar`) to type `serializable`.

- Fix `test_messagestash_get_all_by_verify_key_for_status` added in #7462.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
