### PR TITLE
Re-add explicit typing for decorators (`@instrument`, `@serializable`)

### DIFF
--- a/packages/syft/src/syft/core/node/new/serializable.py
+++ b/packages/syft/src/syft/core/node/new/serializable.py
@@ -1,6 +1,6 @@
 # stdlib
+from typing import List
 from typing import Optional
-from typing import Sequence
 from typing import TypeVar
 
 # syft absolute
@@ -12,12 +12,12 @@ from .recursive import recursive_serde_register
 module_type = type(syft)
 
 
-T = TypeVar("T")
+T = TypeVar("T", bound=type)
 
 
 def serializable(
-    attrs: Sequence[str] = [],
-    without: Sequence[str] = [],
+    attrs: Optional[List[str]] = None,
+    without: Optional[List[str]] = None,
     inherit: Optional[bool] = True,
     inheritable: Optional[bool] = True,
 ) -> T:

--- a/packages/syft/src/syft/telemetry.py
+++ b/packages/syft/src/syft/telemetry.py
@@ -1,6 +1,19 @@
 # stdlib
 import os
+import sys
+from typing import Callable
 from typing import Optional
+from typing import TypeVar
+from typing import Union
+
+if sys.version_info >= (3, 10):
+    # stdlib
+    from typing import Concatenate
+    from typing import ParamSpec
+else:
+    # third party
+    from typing_extensions import Concatenate
+    from typing_extensions import ParamSpec
 
 
 def str_to_bool(bool_str: Optional[str]) -> bool:
@@ -14,10 +27,14 @@ def str_to_bool(bool_str: Optional[str]) -> bool:
 TRACE_MODE = str_to_bool(os.environ.get("TRACE", "False"))
 
 
-def setup_tracer():
+T = TypeVar("T", bound=Union[Callable, type])
+P = ParamSpec("P")
+
+
+def setup_tracer() -> Callable[Concatenate[T, P], T]:
     if not TRACE_MODE:
 
-        def noop(func):
+        def noop(func: T) -> T:
             return func
 
         return noop

--- a/packages/syft/src/syft/telemetry.py
+++ b/packages/syft/src/syft/telemetry.py
@@ -1,19 +1,13 @@
 # stdlib
 import os
-import sys
 from typing import Callable
 from typing import Optional
 from typing import TypeVar
 from typing import Union
 
-if sys.version_info >= (3, 10):
-    # stdlib
-    from typing import Concatenate
-    from typing import ParamSpec
-else:
-    # third party
-    from typing_extensions import Concatenate
-    from typing_extensions import ParamSpec
+# third party
+from typing_extensions import Concatenate
+from typing_extensions import ParamSpec
 
 
 def str_to_bool(bool_str: Optional[str]) -> bool:

--- a/packages/syft/src/syft/trace_decorator.py
+++ b/packages/syft/src/syft/trace_decorator.py
@@ -9,6 +9,7 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import TypeVar
+from typing import Union
 
 # third party
 from opentelemetry import trace
@@ -37,7 +38,7 @@ class TracingDecoratorOptions:
             TracingDecoratorOptions.default_attributes[att] = attributes[att]
 
 
-T = TypeVar("T")
+T = TypeVar("T", bound=Union[Callable, type])
 
 
 def instrument(

--- a/packages/syft/src/syft/trace_decorator.py
+++ b/packages/syft/src/syft/trace_decorator.py
@@ -41,13 +41,13 @@ T = TypeVar("T")
 
 
 def instrument(
-    _func_or_class: Optional[T] = None,
+    _func_or_class: T,
     *,
     span_name: str = "",
     record_exception: bool = True,
     attributes: Optional[Dict[str, str]] = None,
     existing_tracer: Optional[Tracer] = None,
-    ignore=False
+    ignore=False,
 ):
     """
     A decorator to instrument a class or function with an OTEL tracing span.
@@ -159,7 +159,4 @@ def instrument(
 
         return wrapper
 
-    if _func_or_class is None:
-        return span_decorator
-    else:
-        return span_decorator(_func_or_class)
+    return span_decorator(_func_or_class)


### PR DESCRIPTION
## Description
See https://github.com/OpenMined/PySyft/pull/7476#discussion_r1154245386 for context.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
