### PR TITLE
SQLiteStore fixes

### DIFF
--- a/packages/syft/src/syft/core/node/new/sqlite_document_store.py
+++ b/packages/syft/src/syft/core/node/new/sqlite_document_store.py
@@ -13,10 +13,8 @@ from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
-from uuid import uuid4
 
 # third party
-from pydantic import Field
 from typing_extensions import Self
 
 # relative
@@ -314,14 +312,24 @@ class SQLiteStoreClientConfig(StoreClientConfig):
             database, it will be locked until that transaction is committed. Default five seconds.
     """
 
-    filename: str = Field(default_factory=lambda: f"{uuid4().hex}.sqlite")
-    path: Union[str, Path] = Field(default_factory=tempfile.gettempdir)
+    filename: Optional[str] = None
+    path: Union[str, Path]
     check_same_thread: bool = True
     timeout: int = 5
 
+    def __init__(
+        self,
+        filename: Optional[str] = None,
+        path: Optional[Union[str, Path]] = None,
+        *args,
+        **kwargs,
+    ):
+        path_ = tempfile.gettempdir() if path is None else path
+        super().__init__(filename=filename, path=path_, *args, **kwargs)
+
     @property
-    def file_path(self) -> Path:
-        return Path(self.path) / self.filename
+    def file_path(self) -> Optional[Path]:
+        return Path(self.path) / self.filename if self.filename is not None else None
 
 
 @serializable()

--- a/packages/syft/src/syft/core/node/new/sqlite_document_store.py
+++ b/packages/syft/src/syft/core/node/new/sqlite_document_store.py
@@ -13,8 +13,10 @@ from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
+from uuid import uuid4
 
 # third party
+from pydantic import Field
 from typing_extensions import Self
 
 # relative
@@ -312,20 +314,14 @@ class SQLiteStoreClientConfig(StoreClientConfig):
             database, it will be locked until that transaction is committed. Default five seconds.
     """
 
-    filename: Optional[str]
-    path: Optional[Union[str, Path]] = None
+    filename: str = Field(default_factory=lambda: f"{uuid4().hex}.sqlite")
+    path: Union[str, Path] = Field(default_factory=tempfile.gettempdir)
     check_same_thread: bool = True
     timeout: int = 5
 
     @property
-    def temp_path(self) -> str:
-        return tempfile.gettempdir()
-
-    @property
-    def file_path(self) -> str:
-        path = self.path if self.path else self.temp_path
-        path = Path(path)
-        return path / self.filename
+    def file_path(self) -> Path:
+        return Path(self.path) / self.filename
 
 
 @serializable()

--- a/packages/syft/src/syft/core/node/new/sqlite_document_store.py
+++ b/packages/syft/src/syft/core/node/new/sqlite_document_store.py
@@ -69,7 +69,7 @@ class SQLiteBackingStore(KeyValueBackingStore):
         self.store_config = store_config
         self._ddtype = ddtype
         self._db: Dict[int, sqlite3.Connection] = {}
-        self._cur: Dict[int, sqlite3.Connection] = {}
+        self._cur: Dict[int, sqlite3.Cursor] = {}
         self.create_table()
 
     @property


### PR DESCRIPTION
## Description
Fix `SQLiteStoreClientConfig`
- Correct typing
- Fix the issue where if you initializa a `SQLiteStoreClientConfig` `x = SQLiteStoreClientConfig()` its `file_path` value will change everytime you call it.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
