### PR TITLE
Added message_serde tests, cleaned up fixtures

### DIFF
--- a/packages/syft/tests/conftest.py
+++ b/packages/syft/tests/conftest.py
@@ -72,4 +72,5 @@ pytest_plugins = [
     "tests.syft.users.fixtures",
     "tests.syft.metadata.fixtures",
     "tests.syft.dataset.fixtures",
+    "tests.syft.messages.fixtures",
 ]

--- a/packages/syft/tests/syft/messages/fixtures.py
+++ b/packages/syft/tests/syft/messages/fixtures.py
@@ -1,0 +1,84 @@
+# third party
+import pytest
+
+# syft absolute
+from syft.core.node.new.context import AuthedServiceContext
+from syft.core.node.new.credentials import SyftSigningKey
+from syft.core.node.new.credentials import SyftVerifyKey
+from syft.core.node.new.datetime import DateTime
+from syft.core.node.new.linked_obj import LinkedObject
+from syft.core.node.new.message_service import MessageService
+from syft.core.node.new.message_stash import MessageStash
+from syft.core.node.new.messages import CreateMessage
+from syft.core.node.new.messages import Message
+from syft.core.node.new.uid import UID
+from syft.core.node.new.user import User
+from syft.core.node.worker import Worker
+
+test_verify_key_string = (
+    "e143d6cec3c7701e6ca9c6fb83d09e06fdad947742126831a684a111aba41a8c"
+)
+
+test_verify_key = SyftVerifyKey.from_string(test_verify_key_string)
+
+
+@pytest.fixture(autouse=True)
+def message_stash(document_store):
+    return MessageStash(store=document_store)
+
+
+@pytest.fixture(autouse=True)
+def message_service(document_store):
+    return MessageService(store=document_store)
+
+
+@pytest.fixture(autouse=True)
+def authed_context(admin_user: User, worker: Worker) -> AuthedServiceContext:
+    return AuthedServiceContext(credentials=test_verify_key, node=worker)
+
+
+@pytest.fixture(autouse=True)
+def linked_object():
+    return LinkedObject(
+        node_uid=UID(),
+        service_type=MessageService,
+        object_type=Message,
+        object_uid=UID(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_create_message(faker) -> CreateMessage:
+    test_signing_key1 = SyftSigningKey.generate()
+    test_verify_key1 = test_signing_key1.verify_key
+    test_signing_key2 = SyftSigningKey.generate()
+    test_verify_key2 = test_signing_key2.verify_key
+
+    mock_message = CreateMessage(
+        subject="mock_created_message",
+        id=UID(),
+        node_uid=UID(),
+        from_user_verify_key=test_verify_key1,
+        to_user_verify_key=test_verify_key2,
+        created_at=DateTime.now(),
+    )
+
+    return mock_message
+
+
+@pytest.fixture(autouse=True)
+def mock_message(
+    message_stash: MessageStash,
+) -> Message:
+    mock_message = Message(
+        subject="mock_message",
+        node_uid=UID(),
+        from_user_verify_key=SyftSigningKey.generate().verify_key,
+        to_user_verify_key=SyftSigningKey.generate().verify_key,
+        created_at=DateTime.now(),
+    )
+
+    result = message_stash.set(mock_message)
+    assert result.is_ok()
+
+    return mock_message

--- a/packages/syft/tests/syft/messages/message_serde_test.py
+++ b/packages/syft/tests/syft/messages/message_serde_test.py
@@ -1,0 +1,27 @@
+# stdlib
+
+# third party
+import pytest
+from pytest import FixtureRequest
+
+# syft absolute
+import syft as sy
+
+
+@pytest.mark.parametrize(
+    "obj_name",
+    [
+        "mock_message",
+        "mock_create_message",
+        # "message_stash", # 🟡 TODO: Fix serde for KVDocumentPartition
+        # "message_service",
+    ],
+)
+def test_message_serde(obj_name: str, request: FixtureRequest) -> None:
+    obj = request.getfixturevalue(obj_name)
+    ser_data = sy.serialize(obj, to_bytes=True)
+    assert isinstance(ser_data, bytes)
+    deser_data = sy.deserialize(ser_data, from_bytes=True)
+
+    assert isinstance(deser_data, type(obj))
+    assert deser_data == obj

--- a/packages/syft/tests/syft/messages/message_service_test.py
+++ b/packages/syft/tests/syft/messages/message_service_test.py
@@ -1,5 +1,4 @@
 # third party
-import pytest
 from pytest import MonkeyPatch
 from result import Err
 from result import Ok
@@ -19,58 +18,12 @@ from syft.core.node.new.messages import MessageStatus
 from syft.core.node.new.response import SyftError
 from syft.core.node.new.response import SyftSuccess
 from syft.core.node.new.uid import UID
-from syft.core.node.new.user import User
-from syft.core.node.worker import Worker
 
 test_verify_key_string = (
     "e143d6cec3c7701e6ca9c6fb83d09e06fdad947742126831a684a111aba41a8c"
 )
 
 test_verify_key = SyftVerifyKey.from_string(test_verify_key_string)
-
-
-@pytest.fixture(autouse=True)
-def message_stash(document_store):
-    return MessageStash(store=document_store)
-
-
-@pytest.fixture(autouse=True)
-def message_service(document_store):
-    return MessageService(store=document_store)
-
-
-@pytest.fixture(autouse=True)
-def authed_context(admin_user: User, worker: Worker) -> AuthedServiceContext:
-    return AuthedServiceContext(credentials=test_verify_key, node=worker)
-
-
-@pytest.fixture(autouse=True)
-def linked_object():
-    return LinkedObject(
-        node_uid=UID(),
-        service_type=MessageService,
-        object_type=Message,
-        object_uid=UID(),
-    )
-
-
-@pytest.fixture(autouse=True)
-def mock_create_message(faker) -> CreateMessage:
-    test_signing_key1 = SyftSigningKey.generate()
-    test_verify_key1 = test_signing_key1.verify_key
-    test_signing_key2 = SyftSigningKey.generate()
-    test_verify_key2 = test_signing_key2.verify_key
-
-    mock_message = CreateMessage(
-        subject="mock_created_message",
-        id=UID(),
-        node_uid=UID(),
-        from_user_verify_key=test_verify_key1,
-        to_user_verify_key=test_verify_key2,
-        created_at=DateTime.now(),
-    )
-
-    return mock_message
 
 
 def add_mock_message(
@@ -91,7 +44,7 @@ def add_mock_message(
         status=message_status_undelivered,
     )
 
-    result = message_stash.partition.set(mock_message)
+    result = message_stash.set(mock_message)
     assert result.is_ok()
 
     return mock_message

--- a/packages/syft/tests/syft/messages/message_stash_test.py
+++ b/packages/syft/tests/syft/messages/message_stash_test.py
@@ -27,11 +27,6 @@ test_verify_key_string = (
 test_verify_key = SyftVerifyKey.from_string(test_verify_key_string)
 
 
-@pytest.fixture(autouse=True)
-def message_stash(document_store):
-    return MessageStash(store=document_store)
-
-
 def add_mock_message(
     message_stash: MessageStash,
     from_user_verify_key: SyftVerifyKey,


### PR DESCRIPTION
## Description

Added the message serde test I could.
Added /test/messages/fixtures.py  and added to path in packages/syft/tests/conftest.py 

## Affected Dependencies

N/A

## How has this been tested?

Locally

## Checklist
- [X ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X ] My changes are covered by tests
