### PR TITLE
fix serde for _UnionGenericAlias for backward python compatibility

### DIFF
--- a/packages/syft/src/syft/serde/recursive_primitives.py
+++ b/packages/syft/src/syft/serde/recursive_primitives.py
@@ -340,7 +340,18 @@ recursive_serde_register_type(Union)
 recursive_serde_register_type(TypeVar)
 
 if sys.version_info >= (3, 9):
-    recursive_serde_register_type(_UnionGenericAlias)
+    recursive_serde_register_type(
+        _UnionGenericAlias,
+        serialize_attrs=[
+            "__parameters__",
+            "__slots__",
+            "_inst",
+            "_name",
+            "__args__",
+            "__module__",
+            "__origin__",
+        ],
+    )
     recursive_serde_register_type(_SpecialGenericAlias)
 
 recursive_serde_register_type(EnumMeta)


### PR DESCRIPTION
## Description
explicitly define serde attributes for _UnionGenericAlias which are common across versions

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
