### PR TITLE
Add antti to the skill_test

### DIFF
--- a/packages/syft/tests/trials/skill_test.py
+++ b/packages/syft/tests/trials/skill_test.py
@@ -41,10 +41,7 @@ def get_padawans(cohort: str) -> Dict[str, str]:
             "Vani": "PASSED",
             "Hithem": "PASSED",
         },
-        "R4Q2": {
-            "skywalker": "PASSED",
-            "alejandrosame": "PASSED",
-        },
+        "R4Q2": {"skywalker": "PASSED", "alejandrosame": "PASSED", "antti": "PASSED"},
     }
     return data[cohort]
 
@@ -89,5 +86,6 @@ def test_trial_of_skill() -> None:
 
     assert get_padawans("R4Q2")["skywalker"] == "PASSED"
     assert get_padawans("R4Q2")["alejandrosame"] == "PASSED"
+    assert get_padawans("R4Q2")["antti"] == "PASSED"
 
     assert len(get_padawans("R4Q2")) > 1


### PR DESCRIPTION
## Description
Added antti to the list of R4Q2 Padawans

## Affected Dependencies
N/A

## How has this been tested?
run `tox -e padawan.trials`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
