### PR TITLE
Dataset without mock

### DIFF
--- a/notebooks/tutorials/data-owner/01-uploading-private-data.ipynb
+++ b/notebooks/tutorials/data-owner/01-uploading-private-data.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "99d92d96-a607-472e-983d-86958f7939e8",
    "metadata": {},
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "066d942e",
    "metadata": {},
@@ -50,6 +52,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5045b434",
    "metadata": {},
@@ -58,6 +61,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b7adb06e",
    "metadata": {},
@@ -77,6 +81,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "918ad9f3-4ced-47f2-98b3-496b83cc3f4f",
    "metadata": {},
@@ -96,6 +101,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b9072584",
    "metadata": {},
@@ -114,16 +120,18 @@
     "    name=\"my dataset\",\n",
     "    asset_list=[\n",
     "        sy.Asset(\n",
-    "        name=\"my asset\",\n",
-    "        data=np.array([1,2,3]),\n",
-    "        mock=np.array([1,1,1])\n",
-    "    )]\n",
+    "            name=\"my asset\",\n",
+    "            data=np.array([1, 2, 3]),\n",
+    "            mock=np.array([1, 1, 1])\n",
+    "        )\n",
+    "    ]\n",
     ")\n",
     "\n",
     "client.upload_dataset(dataset)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "08dd52fe",
    "metadata": {},
@@ -132,6 +140,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e0460b72",
    "metadata": {},
@@ -150,6 +159,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "23d82efb-2aa2-4293-9566-d2269c8de942",
    "metadata": {},
@@ -158,16 +168,17 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e580a65e",
    "metadata": {},
    "source": [
     "When we construct an Asset e.g.\n",
-    "```\n",
+    "```python\n",
     "sy.Asset(\n",
     "    name=\"my asset\",\n",
-    "    data=np.array([1,2,3]),\n",
-    "    mock=np.array([1,1,1])\n",
+    "    data=np.array([1, 2, 3]),\n",
+    "    mock=np.array([1, 1, 1])\n",
     ")\n",
     "```\n",
     "\n",
@@ -175,6 +186,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fb5757bf-e6e1-4b0b-b454-2f7c277721d3",
    "metadata": {},
@@ -183,6 +195,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "422fbe1e",
    "metadata": {},
@@ -207,6 +220,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d6d8002e-2369-4833-8002-048636833dda",
    "metadata": {},
@@ -225,10 +239,11 @@
     "    name=\"my dataset2\",\n",
     "    asset_list=[\n",
     "        sy.Asset(\n",
-    "        name=\"my asset2\",\n",
-    "        data=np.array([1,2,3]),\n",
-    "        mock=sy.ActionObject.empty()\n",
-    "    )]\n",
+    "            name=\"my asset2\",\n",
+    "            data=np.array([1, 2, 3]),\n",
+    "            mock=sy.ActionObject.empty()\n",
+    "        )\n",
+    "    ]\n",
     ")"
    ]
   },
@@ -243,6 +258,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6b639eae-4ed2-46aa-a2b2-afca6d08b338",
    "metadata": {},

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -1368,11 +1368,9 @@ def debug_original_func(name: str, func: Callable) -> None:
 
 
 def is_action_data_empty(obj: Any) -> bool:
-    if hasattr(obj, "syft_action_data"):
-        obj = obj.syft_action_data
-    if isinstance(obj, ActionDataEmpty):
-        return True
-    return False
+    return isinstance(obj, AnyActionObject) and isinstance(
+        obj.syft_action_data, ActionDataEmpty
+    )
 
 
 def has_action_data_empty(args: Any, kwargs: Any) -> bool:

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -232,7 +232,7 @@ class PreHookContext(SyftBaseObject):
 
 
 def make_action_side_effect(
-    context: PreHookContext, *args: List[Any, ...], **kwargs: Dict[str, Any]
+    context: PreHookContext, *args: Any, **kwargs: Any
 ) -> Result[Ok[Tuple[PreHookContext, Tuple[Any, ...], Dict[str, Any]]], Err[str]]:
     """Create a new action from context_op_name, and add it to the PreHookContext
 

--- a/packages/syft/src/syft/service/action/action_store.py
+++ b/packages/syft/src/syft/service/action/action_store.py
@@ -23,6 +23,7 @@ from ...types.uid import LineageID
 from ...types.uid import UID
 from ..response import SyftSuccess
 from .action_object import TwinMode
+from .action_object import is_action_data_empty
 from .action_permissions import ActionObjectEXECUTE
 from .action_permissions import ActionObjectOWNER
 from .action_permissions import ActionObjectPermission
@@ -91,8 +92,9 @@ class KeyValueActionStore(ActionStore):
             if uid in self.data:
                 obj = self.data[uid]
                 if isinstance(obj, TwinObject):
-                    obj = obj.mock
-                    obj.syft_twin_type = TwinMode.MOCK
+                    obj = (
+                        obj.mock if not is_action_data_empty(obj.mock) else obj.private
+                    )
                     # we patch the real id on it so we can keep using the twin
                     obj.id = uid
                 else:

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -12,6 +12,7 @@ from typing import Tuple
 from typing import Union
 
 # third party
+from pydantic import ValidationError
 from pydantic import root_validator
 from pydantic import validator
 from result import Err
@@ -210,8 +211,15 @@ class CreateAsset(SyftObject):
     def set_mock(self, mock_data: Any, mock_is_real: bool) -> None:
         if isinstance(mock_data, SyftError):
             raise SyftException(mock_data)
+
+        current_mock = self.mock
         self.mock = mock_data
-        self.mock_is_real = mock_is_real
+
+        try:
+            self.mock_is_real = mock_is_real
+        except ValidationError as e:
+            self.mock = current_mock
+            raise e
 
     def no_mock(self) -> None:
         # relative

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -132,9 +132,9 @@ def _is_action_data_empty(obj: Any) -> bool:
     # to work around circular import error
 
     # relative
-    from ...service.action.action_object import is_action_data_empty as f
+    from ...service.action.action_object import is_action_data_empty
 
-    return f(obj)
+    return is_action_data_empty(obj)
 
 
 def check_mock(data: Any, mock: Any) -> bool:

--- a/packages/syft/tests/syft/service/dataset/dataset_service_test.py
+++ b/packages/syft/tests/syft/service/dataset/dataset_service_test.py
@@ -97,6 +97,25 @@ def test_mock_always_not_real_after_set_to_empty(asset_with_mock: Asset) -> None
     assert asset.mock_is_real
 
 
+@pytest.mark.parametrize(
+    "empty_mock",
+    [
+        None,
+        ActionObject.empty(),
+    ],
+)
+def test_cannot_set_empty_mock_with_true_mock_is_real(
+    asset_with_mock: Asset, empty_mock: Any
+) -> None:
+    asset = Asset(**asset_with_mock, mock_is_real=True)
+    assert asset.mock_is_real
+
+    with pytest.raises(ValidationError):
+        asset.set_mock(empty_mock, mock_is_real=True)
+
+    assert asset.mock is asset_with_mock["mock"]
+
+
 def test_dataset_cannot_have_assets_with_none_mock() -> None:
     TOTAL_ASSETS = 10
     ASSETS_WITHOUT_MOCK = random.randint(2, 8)

--- a/packages/syft/tests/syft/service/dataset/dataset_service_test.py
+++ b/packages/syft/tests/syft/service/dataset/dataset_service_test.py
@@ -1,0 +1,136 @@
+# stdlib
+import random
+from typing import Any
+from uuid import uuid4
+
+# third party
+import numpy as np
+from pydantic import ValidationError
+import pytest
+
+# syft absolute
+from syft.service.action.action_object import ActionObject
+from syft.service.dataset.dataset import CreateAsset as Asset
+from syft.service.dataset.dataset import CreateDataset as Dataset
+
+
+def random_hash() -> str:
+    return uuid4().hex
+
+
+def data():
+    return np.array([1, 2, 3])
+
+
+def mock():
+    return np.array([1, 1, 1])
+
+
+def make_asset_without_mock() -> dict[str, Any]:
+    return {
+        "name": random_hash(),
+        "data": data(),
+    }
+
+
+def make_asset_with_mock() -> dict[str, Any]:
+    return {**make_asset_without_mock(), "mock": mock()}
+
+
+asset_without_mock = pytest.fixture(make_asset_without_mock)
+asset_with_mock = pytest.fixture(make_asset_with_mock)
+
+
+@pytest.mark.parametrize(
+    "asset_without_mock",
+    [
+        make_asset_without_mock(),
+        {**make_asset_without_mock(), "mock": ActionObject.empty()},
+    ],
+)
+def test_asset_without_mock_mock_is_real_must_be_false(
+    asset_without_mock: dict[str, Any]
+):
+    with pytest.raises(ValidationError):
+        Asset(**asset_without_mock, mock_is_real=True)
+
+
+def test_mock_always_not_real_after_calling_no_mock(
+    asset_with_mock: dict[str, Any]
+) -> None:
+    asset = Asset(**asset_with_mock, mock_is_real=True)
+    assert asset.mock_is_real
+
+    asset.no_mock()
+    assert not asset.mock_is_real
+
+
+def test_mock_always_not_real_after_set_mock_to_empty(
+    asset_with_mock: dict[str, Any]
+) -> None:
+    asset = Asset(**asset_with_mock, mock_is_real=True)
+    assert asset.mock_is_real
+
+    asset.no_mock()
+    assert not asset.mock_is_real
+
+    with pytest.raises(ValidationError):
+        asset.mock_is_real = True
+
+    asset.mock = mock()
+    asset.mock_is_real = True
+    assert asset.mock_is_real
+
+
+def test_mock_always_not_real_after_set_to_empty(asset_with_mock: Asset) -> None:
+    asset = Asset(**asset_with_mock, mock_is_real=True)
+    assert asset.mock_is_real
+
+    asset.mock = ActionObject.empty()
+    assert not asset.mock_is_real
+
+    with pytest.raises(ValidationError):
+        asset.mock_is_real = True
+
+    asset.mock = mock()
+    asset.mock_is_real = True
+    assert asset.mock_is_real
+
+
+def test_dataset_cannot_have_assets_with_none_mock() -> None:
+    TOTAL_ASSETS = 10
+    ASSETS_WITHOUT_MOCK = random.randint(2, 8)
+    ASSETS_WITH_MOCK = TOTAL_ASSETS - ASSETS_WITHOUT_MOCK
+
+    assets_without_mock = [
+        Asset(**make_asset_without_mock()) for _ in range(ASSETS_WITHOUT_MOCK)
+    ]
+    assets_with_mock = [
+        Asset(**make_asset_with_mock()) for _ in range(ASSETS_WITH_MOCK)
+    ]
+    assets = assets_without_mock + assets_with_mock
+
+    with pytest.raises(ValidationError):
+        Dataset(
+            name=random_hash(),
+            asset_list=assets,
+        )
+
+    assert Dataset(name=random_hash(), asset_list=assets_with_mock)
+
+
+def test_dataset_can_have_assets_with_empty_mock() -> None:
+    TOTAL_ASSETS = 10
+    ASSETS_WITH_EMPTY_MOCK = random.randint(2, 8)
+    ASSETS_WITH_MOCK = TOTAL_ASSETS - ASSETS_WITH_EMPTY_MOCK
+
+    assets_without_mock = [
+        Asset(**make_asset_without_mock(), mock=ActionObject.empty())
+        for _ in range(ASSETS_WITH_EMPTY_MOCK)
+    ]
+    assets_with_mock = [
+        Asset(**make_asset_with_mock()) for _ in range(ASSETS_WITH_MOCK)
+    ]
+    assets = assets_without_mock + assets_with_mock
+
+    assert Dataset(name=random_hash(), asset_list=assets)

--- a/packages/syft/tests/syft/service/dataset/dataset_service_test.py
+++ b/packages/syft/tests/syft/service/dataset/dataset_service_test.py
@@ -11,9 +11,9 @@ import pytest
 # syft absolute
 from syft.node.worker import Worker
 from syft.service.action.action_object import ActionObject
-from syft.service.action.action_object import is_action_data_empty
 from syft.service.dataset.dataset import CreateAsset as Asset
 from syft.service.dataset.dataset import CreateDataset as Dataset
+from syft.types.twin_object import TwinMode
 
 
 def random_hash() -> str:
@@ -164,7 +164,7 @@ def test_dataset_can_have_assets_with_empty_mock() -> None:
     assert Dataset(name=random_hash(), asset_list=assets)
 
 
-def test_guest_client_can_get_empty_mock(
+def test_guest_client_get_empty_mock_as_private_pointer(
     worker: Worker,
     asset_with_empty_mock: dict[str, Any],
 ) -> None:
@@ -178,4 +178,8 @@ def test_guest_client_can_get_empty_mock(
     guest_datasets = guest_domain_client.api.services.dataset.get_all()
     guest_dataset = guest_datasets[0]
 
-    assert is_action_data_empty(guest_dataset.assets[0].mock)
+    mock = guest_dataset.assets[0].mock
+
+    assert mock.is_real
+    assert mock.is_pointer
+    assert mock.syft_twin_type is TwinMode.PRIVATE

--- a/packages/syft/tests/syft/service/dataset/dataset_service_test.py
+++ b/packages/syft/tests/syft/service/dataset/dataset_service_test.py
@@ -82,7 +82,9 @@ def test_mock_always_not_real_after_set_mock_to_empty(
     assert asset.mock_is_real
 
 
-def test_mock_always_not_real_after_set_to_empty(asset_with_mock: Asset) -> None:
+def test_mock_always_not_real_after_set_to_empty(
+    asset_with_mock: dict[str, Any]
+) -> None:
     asset = Asset(**asset_with_mock, mock_is_real=True)
     assert asset.mock_is_real
 
@@ -105,7 +107,7 @@ def test_mock_always_not_real_after_set_to_empty(asset_with_mock: Asset) -> None
     ],
 )
 def test_cannot_set_empty_mock_with_true_mock_is_real(
-    asset_with_mock: Asset, empty_mock: Any
+    asset_with_mock: dict[str, Any], empty_mock: Any
 ) -> None:
     asset = Asset(**asset_with_mock, mock_is_real=True)
     assert asset.mock_is_real

--- a/packages/syft/tests/syft/service/dataset/dataset_service_test.py
+++ b/packages/syft/tests/syft/service/dataset/dataset_service_test.py
@@ -11,9 +11,9 @@ import pytest
 # syft absolute
 from syft.node.worker import Worker
 from syft.service.action.action_object import ActionObject
+from syft.service.action.action_object import is_action_data_empty
 from syft.service.dataset.dataset import CreateAsset as Asset
 from syft.service.dataset.dataset import CreateDataset as Dataset
-from syft.service.dataset.dataset import is_action_data_empty
 
 
 def random_hash() -> str:


### PR DESCRIPTION
## Description
When users try to create a `sy.Dataset` containing `sy.Asset`'s without mock, an error will be raised. The error message lists the assets without mock and also shows instructions on how to explicitly set empty mock on an asset.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
