### PR TITLE
Re-enable flake8-bugbear checks in Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,9 +72,9 @@ repos:
         # exclude: ^(packages/syft/src/syft/proto)
         files: "^packages/syft(?!(.*_pb2\\.py$)).*\\.py"
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.0.246"
+    rev: "v0.0.247"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -3370,14 +3370,13 @@ def get_docker_status(
         # If there are worker containers with an internal port
         # fetch the worker container with the launched worker name
         worker_containers = worker_containers_output.split("\n")
-        for idx, worker_container in enumerate(worker_containers):
+        for worker_container in worker_containers:
             container_name = worker_container.split(" ")[0]
             if node_name in container_name:
                 network_container = container_name
                 break
-
-        # If the worker container is not created yet
-        if idx == len(worker_containers):
+        else:
+            # If the worker container is not created yet
             return False, ("", "")
 
     if "proxy" in network_container:

--- a/packages/hagrid/hagrid/deps.py
+++ b/packages/hagrid/hagrid/deps.py
@@ -606,7 +606,7 @@ def check_deps(
         of = f" {of}"
     # output += f"Checking{of} Dependencies:\n"
     issues = []
-    for name, dep in deps.items():
+    for dep in deps.values():
         dep.check()
         output += (dep.display + "\n") if display else ""
         issues += dep.issues

--- a/packages/hagrid/hagrid/parse_template.py
+++ b/packages/hagrid/hagrid/parse_template.py
@@ -157,16 +157,17 @@ def setup_from_manifest_template(
         # Get all files w.r.t that package e.g. grid, syft, hagrid
         template_files = all_template_files[package_name]
         package_path = template_files["path"]
-        to_absolute_file_path = lambda x: os.path.join(package_path, x)  # noqa: E731
 
         # common files
-        files_to_download += list(map(to_absolute_file_path, template_files["common"]))
+        files_to_download += [
+            os.path.join(package_path, f) for f in template_files["common"]
+        ]
 
         # docker related files
         if host_type in ["docker"]:
-            files_to_download += list(
-                map(to_absolute_file_path, template_files["docker"])
-            )
+            files_to_download += [
+                os.path.join(package_path, f) for f in template_files["docker"]
+            ]
 
         # add k8s related files
         # elif host_type in ["k8s"]:

--- a/packages/hagrid/hagrid/util.py
+++ b/packages/hagrid/hagrid/util.py
@@ -43,7 +43,7 @@ def fix_windows_virtualenv_api(cls: type) -> None:
             return os.path.join(self.path, "Scripts", "python.exe")
         return os.path.join("bin", "python")
 
-    setattr(cls, "_python_rpath", property(_python_rpath))
+    cls._python_rpath = property(_python_rpath)
 
 
 def shell(command: str) -> str:

--- a/packages/syft/src/syft/client/api.py
+++ b/packages/syft/src/syft/client/api.py
@@ -598,7 +598,7 @@ def monkey_patch_getdef(self, obj, oname="") -> Union[str, None]:
     try:
         if hasattr(obj, "__ipython_inspector_signature_override__"):
             return _render_signature(
-                getattr(obj, "__ipython_inspector_signature_override__"), oname
+                obj.__ipython_inspector_signature_override__, oname
             )
         return _getdef(self, obj, oname)
     except Exception:

--- a/packages/syft/src/syft/external/oblv/deployment_client.py
+++ b/packages/syft/src/syft/external/oblv/deployment_client.py
@@ -73,7 +73,7 @@ class OblvMetadata(EnclaveMetadata, BaseModel):
 class DeploymentClient:
     deployment_id: str
     key_name: str
-    domain_clients: List[SyftClient] = []  # List of domain client objects
+    domain_clients: List[SyftClient]  # List of domain client objects
     oblv_client: OblvClient = None
     __conn_string: str
     __logs: Any
@@ -82,7 +82,7 @@ class DeploymentClient:
 
     def __init__(
         self,
-        domain_clients: List[Any],
+        domain_clients: List[SyftClient],
         deployment_id: str,
         oblv_client: Optional[OblvClient] = None,
         key_name: Optional[str] = None,

--- a/packages/syft/src/syft/node/routes.py
+++ b/packages/syft/src/syft/node/routes.py
@@ -1,4 +1,5 @@
 # stdlib
+from typing import Annotated
 from typing import Any
 from typing import Dict
 
@@ -99,7 +100,7 @@ def make_routes(worker: Worker) -> APIRouter:
     # make a request to the SyftAPI
     @router.post("/api_call")
     def syft_new_api_call(
-        request: Request, data: bytes = Depends(get_body)
+        request: Request, data: Annotated[bytes, Depends(get_body)]
     ) -> Response:
         if TRACE_MODE:
             with trace.get_tracer(syft_new_api_call.__module__).start_as_current_span(
@@ -175,7 +176,7 @@ def make_routes(worker: Worker) -> APIRouter:
             return handle_login(email, password, worker)
 
     @router.post("/register", name="register", status_code=200)
-    def register(request: Request, data: bytes = Depends(get_body)) -> Any:
+    def register(request: Request, data: Annotated[bytes, Depends(get_body)]) -> Any:
         if TRACE_MODE:
             with trace.get_tracer(register.__module__).start_as_current_span(
                 register.__qualname__,

--- a/packages/syft/src/syft/node/routes.py
+++ b/packages/syft/src/syft/node/routes.py
@@ -162,8 +162,8 @@ def make_routes(worker: Worker) -> APIRouter:
     @router.post("/login", name="login", status_code=200)
     def login(
         request: Request,
-        email: str = Body(..., example="info@openmined.org"),
-        password: str = Body(..., example="changethis"),
+        email: Annotated[str, Body(example="info@openmined.org")],
+        password: Annotated[str, Body(example="changethis")],
     ) -> Any:
         if TRACE_MODE:
             with trace.get_tracer(login.__module__).start_as_current_span(

--- a/packages/syft/src/syft/node/routes.py
+++ b/packages/syft/src/syft/node/routes.py
@@ -1,5 +1,4 @@
 # stdlib
-from typing import Annotated
 from typing import Any
 from typing import Dict
 
@@ -100,7 +99,7 @@ def make_routes(worker: Worker) -> APIRouter:
     # make a request to the SyftAPI
     @router.post("/api_call")
     def syft_new_api_call(
-        request: Request, data: Annotated[bytes, Depends(get_body)]
+        request: Request, data: bytes = Depends(get_body)  # noqa: B008
     ) -> Response:
         if TRACE_MODE:
             with trace.get_tracer(syft_new_api_call.__module__).start_as_current_span(
@@ -162,8 +161,8 @@ def make_routes(worker: Worker) -> APIRouter:
     @router.post("/login", name="login", status_code=200)
     def login(
         request: Request,
-        email: Annotated[str, Body(example="info@openmined.org")],
-        password: Annotated[str, Body(example="changethis")],
+        email: str = Body(..., example="info@openmined.org"),  # noqa: B008
+        password: str = Body(..., example="changethis"),  # noqa: B008
     ) -> Any:
         if TRACE_MODE:
             with trace.get_tracer(login.__module__).start_as_current_span(
@@ -176,7 +175,9 @@ def make_routes(worker: Worker) -> APIRouter:
             return handle_login(email, password, worker)
 
     @router.post("/register", name="register", status_code=200)
-    def register(request: Request, data: Annotated[bytes, Depends(get_body)]) -> Any:
+    def register(
+        request: Request, data: bytes = Depends(get_body)  # noqa: B008
+    ) -> Any:
         if TRACE_MODE:
             with trace.get_tracer(register.__module__).start_as_current_span(
                 register.__qualname__,

--- a/packages/syft/src/syft/serde/recursive.py
+++ b/packages/syft/src/syft/serde/recursive.py
@@ -97,7 +97,7 @@ def recursive_serde_register(
     if inheritable_attrs and attribute_list and not is_pydantic:
         # only set __syft_serializable__ for non-pydantic classes because
         # pydantic objects inherit by default
-        setattr(cls, "__syft_serializable__", attribute_list)
+        cls.__syft_serializable__ = attribute_list
 
     attributes = set(list(attribute_list)) if attribute_list else None
     attribute_types = get_types(cls, attributes)
@@ -279,7 +279,7 @@ def rs_proto2object(proto: _DynamicStructBuilder) -> Any:
             kwargs[attr_name] = attr_value
 
     if hasattr(class_type, "serde_constructor"):
-        return getattr(class_type, "serde_constructor")(kwargs)
+        return class_type.serde_constructor(kwargs)
 
     if issubclass(class_type, Enum) and "value" in kwargs:
         obj = class_type.__new__(class_type, kwargs["value"])  # type: ignore

--- a/packages/syft/src/syft/service/action/action_graph.py
+++ b/packages/syft/src/syft/service/action/action_graph.py
@@ -16,6 +16,8 @@ from typing import Union
 import matplotlib.pyplot as plt
 import networkx as nx
 import pydantic
+from pydantic import Field
+from pydantic import validator
 from result import Err
 from result import Ok
 from result import Result
@@ -188,23 +190,20 @@ class BaseGraphStore:
 
 @serializable()
 class InMemoryStoreClientConfig(StoreClientConfig):
-    filename: Optional[str] = None
-    path: Union[str, Path]
+    filename: str = "action_graph.bytes"
+    path: Union[str, Path] = Field(default_factory=tempfile.gettempdir)
 
-    def __init__(
-        self,
-        filename: Optional[str] = None,
-        path: Optional[Union[str, Path]] = None,
-        *args,
-        **kwargs,
-    ):
-        path_ = tempfile.gettempdir() if path is None else path
-        filename_ = "action_graph.bytes" if filename is None else filename
-        super().__init__(filename=filename_, path=path_, *args, **kwargs)
+    # We need this in addition to Field(default_factory=...)
+    # so users can still do InMemoryStoreClientConfig(path=None)
+    @validator("path", pre=True)
+    def __default_path(cls, path: Optional[Union[str, Path]]) -> Union[str, Path]:
+        if path is None:
+            return tempfile.gettempdir()
+        return path
 
     @property
-    def file_path(self) -> Optional[Path]:
-        return Path(self.path) / self.filename if self.filename is not None else None
+    def file_path(self) -> Path:
+        return Path(self.path) / self.filename
 
 
 @serializable(without=["_lock"])

--- a/packages/syft/src/syft/service/action/action_graph.py
+++ b/packages/syft/src/syft/service/action/action_graph.py
@@ -367,12 +367,16 @@ class InMemoryActionGraphStore(ActionGraphStore):
         self,
         node: NodeActionData,
         credentials: SyftVerifyKey,
-        parent_uids: List[UID] = [],
+        parent_uids: Optional[List[UID]] = None,
     ) -> Result[NodeActionData, str]:
         if self.graph.exists(uid=node.id):
             return Err(f"Node already exists in the graph: {node}")
 
         self.graph.set(uid=node.id, data=node)
+
+        if parent_uids is None:
+            parent_uids = []
+
         for parent_uid in parent_uids:
             result = self.add_edge(
                 parent=parent_uid,

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -598,10 +598,10 @@ class ActionObject(SyftObject):
         remote_self: Optional[Union[UID, LineageID]] = None,
         args: Optional[
             List[Union[UID, LineageID, ActionObjectPointer, ActionObject, Any]]
-        ] = [],
+        ] = None,
         kwargs: Optional[
             Dict[str, Union[UID, LineageID, ActionObjectPointer, ActionObject, Any]]
-        ] = {},
+        ] = None,
         action_type: Optional[ActionType] = None,
     ) -> Action:
         """Generate new action from the information
@@ -624,6 +624,11 @@ class ActionObject(SyftObject):
             ValueError: For invalid args or kwargs
             PydanticValidationError: For args and kwargs
         """
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
+
         arg_ids = []
         kwarg_ids = {}
 

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -368,7 +368,7 @@ def propagate_node_uid(
 
         if op not in context.obj._syft_dont_wrap_attrs():
             if hasattr(result, "syft_node_uid"):
-                setattr(result, "syft_node_uid", syft_node_uid)
+                result.syft_node_uid = syft_node_uid
         else:
             raise RuntimeError("dont propogate node_uid because output isnt wrapped")
     except Exception:

--- a/packages/syft/src/syft/service/code/unparse.py
+++ b/packages/syft/src/syft/service/code/unparse.py
@@ -17,7 +17,7 @@ from six.moves import cStringIO
 class FixUnparser(astunparse.Unparser):
     def _Constant(self, t: _ast.expr) -> None:
         if not hasattr(t, "kind"):
-            setattr(t, "kind", None)
+            t.kind = None
 
         super()._Constant(t)
 

--- a/packages/syft/src/syft/service/code/user_code.py
+++ b/packages/syft/src/syft/service/code/user_code.py
@@ -151,7 +151,7 @@ class UserCodeStatusContext:
         base_dict = self.base_dict
         if node_view in base_dict:
             base_dict[node_view] = value
-            setattr(self, "base_dict", base_dict)
+            self.base_dict = base_dict
             return Ok(self)
         else:
             return Err(
@@ -310,7 +310,7 @@ class UserCode(SyftObject):
         )
         inputs = self.input_policy_init_kwargs[node_view]
         all_assets = []
-        for k, uid in inputs.items():
+        for uid in inputs.values():
             if isinstance(uid, UID):
                 assets = api.services.dataset.get_assets_by_action_id(uid)
                 if not isinstance(assets, list):
@@ -482,7 +482,7 @@ def new_check_code(context: TransformContext) -> TransformContext:
     # TODO remove this tech debt hack
     input_kwargs = context.output["input_policy_init_kwargs"]
     node_view_workaround = False
-    for k, v in input_kwargs.items():
+    for k in input_kwargs.keys():
         if isinstance(k, NodeView):
             node_view_workaround = True
 

--- a/packages/syft/src/syft/service/policy/policy.py
+++ b/packages/syft/src/syft/service/policy/policy.py
@@ -366,7 +366,7 @@ class CustomPolicy(type):
     # capture the init_kwargs transparently
     def __call__(cls, *args: Any, **kwargs: Any) -> None:
         obj = super().__call__(*args, **kwargs)
-        setattr(obj, "init_kwargs", kwargs)
+        obj.init_kwargs = kwargs
         return obj
 
 
@@ -664,10 +664,10 @@ def add_class_to_user_module(klass: type, unique_name: str) -> type:
 
     if not hasattr(sy, "user"):
         user_module = types.ModuleType("user")
-        setattr(sys.modules["syft"], "user", user_module)
+        sys.modules["syft"].user = user_module
     user_module = sy.user
     setattr(user_module, unique_name, klass)
-    setattr(sys.modules["syft"], "user", user_module)
+    sys.modules["syft"].user = user_module
     return klass
 
 

--- a/packages/syft/src/syft/service/policy/policy.py
+++ b/packages/syft/src/syft/service/policy/policy.py
@@ -99,7 +99,7 @@ class Policy(SyftObject):
             init_kwargs = deepcopy(kwargs)
             if "id" in init_kwargs:
                 del init_kwargs["id"]
-        super().__init__(init_kwargs=init_kwargs, *args, **kwargs)
+        super().__init__(init_kwargs=init_kwargs, *args, **kwargs)  # noqa: B026
 
     @classmethod
     @property

--- a/packages/syft/src/syft/service/vpn/vpn.py
+++ b/packages/syft/src/syft/service/vpn/vpn.py
@@ -156,9 +156,11 @@ class VPNClientConnection(NodeConnection):
         self,
         path: str,
         api_key: str,
-        command_args: dict = {},
+        command_args: Optional[dict] = None,
         timeout: int = DEFAULT_TIMEOUT,
     ) -> Result[CommandReport, str]:
+        if command_args is None:
+            command_args = {}
         command_args.update({"timeout": timeout, "force_unique_key": True})
         headers = {"X-STACK-API-KEY": api_key}
         result = self._make_post(

--- a/packages/syft/src/syft/service/vpn/vpn.py
+++ b/packages/syft/src/syft/service/vpn/vpn.py
@@ -87,9 +87,9 @@ class VPNClientConnection(NodeConnection):
     session_cache: Optional[Session]
     routes: Type[VPNRoutes]
 
-    def __init__(self, url: Union[GridURL, str], *args, **kwargs) -> None:
-        url = GridURL.from_url(url)
-        super().__init__(url=url, *args, **kwargs)
+    @validator("url", pre=True)
+    def __make_grid_url(cls, url: Union[GridURL, str]) -> GridURL:
+        return GridURL.from_url(url)
 
     @property
     def session(self) -> Session:

--- a/packages/syft/src/syft/store/locks.py
+++ b/packages/syft/src/syft/store/locks.py
@@ -211,7 +211,7 @@ class PatchedFileLock(FileLock):
         # Acquire lock at OS level
         with self._lock_file:
             if self._data_file.exists():
-                for retry in range(10):
+                for _retry in range(10):
                     try:
                         data = json.loads(self._data_file.read_text())
                         break
@@ -256,7 +256,7 @@ class PatchedFileLock(FileLock):
 
         with self._lock_file:
             data = None
-            for retry in range(10):
+            for _retry in range(10):
                 try:
                     data = json.loads(self._data_file.read_text())
                     break
@@ -285,7 +285,7 @@ class PatchedFileLock(FileLock):
 
         with self._lock_file:
             data = None
-            for retry in range(10):
+            for _retry in range(10):
                 try:
                     data = json.loads(self._data_file.read_text())
                     break

--- a/packages/syft/src/syft/store/mongo_document_store.py
+++ b/packages/syft/src/syft/store/mongo_document_store.py
@@ -275,13 +275,13 @@ class MongoStorePartition(StorePartition):
             obj_id = obj["id"]
 
             # Set ID to the updated object value
-            setattr(obj, "id", prev_obj["id"])
+            obj.id = prev_obj["id"]
 
             # Create the Mongo object
             storage_obj = obj.to(self.storage_type)
 
             # revert the ID
-            setattr(obj, "id", obj_id)
+            obj.id = obj_id
 
             try:
                 collection.update_one(

--- a/packages/syft/src/syft/types/syft_metaclass.py
+++ b/packages/syft/src/syft/types/syft_metaclass.py
@@ -103,7 +103,7 @@ class PartialModelMetaclass(ModelMetaclass):
                 # Restore requiredness
                 optionalize(fields, restore=True)
 
-        setattr(cls, "__init__", __init__)
+        cls.__init__ = __init__
 
         def iter_exclude_empty(self) -> TupleGenerator:
             for key, value in self.__dict__.items():

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -5,6 +5,7 @@ from inspect import Signature
 import types
 from typing import Any
 from typing import Callable
+from typing import ClassVar
 from typing import Dict
 from typing import KeysView
 from typing import List
@@ -157,15 +158,17 @@ class SyftObject(SyftBaseObject, SyftObjectRegistry):
             values["id"] = id_field.type_()
         return values
 
-    __attr_searchable__: List[str] = []  # keys which can be searched in the ORM
-    __attr_unique__: List[str] = []
+    __attr_searchable__: ClassVar[
+        List[str]
+    ] = []  # keys which can be searched in the ORM
+    __attr_unique__: ClassVar[List[str]] = []
     # the unique keys for the particular Collection the objects will be stored in
     __serde_overrides__: Dict[
         str, Sequence[Callable]
     ] = {}  # List of attributes names which require a serde override.
     __owner__: str
 
-    __attr_repr_cols__: List[str] = []  # show these in html repr collections
+    __attr_repr_cols__: ClassVar[List[str]] = []  # show these in html repr collections
 
     def to_mongo(self) -> Dict[str, Any]:
         warnings.warn(

--- a/packages/syft/src/syft/util/trace_decorator.py
+++ b/packages/syft/src/syft/util/trace_decorator.py
@@ -119,7 +119,7 @@ def instrument(
             # We have already decorated this function, override
             return func_or_class
 
-        setattr(func_or_class, "__tracing_unwrapped__", func_or_class)
+        func_or_class.__tracing_unwrapped__ = func_or_class
 
         tracer = existing_tracer or trace.get_tracer(func_or_class.__module__)
 

--- a/packages/syft/tests/syft/action_graph/action_graph_test.py
+++ b/packages/syft/tests/syft/action_graph/action_graph_test.py
@@ -464,7 +464,7 @@ def test_multithreaded_graph_store_set_and_add_edge(verify_key: SyftVerifyKey) -
 
     def _cbk(tid: int) -> None:
         nonlocal execution_err
-        for idx in range(repeats):
+        for _idx in range(repeats):
             action_obj_a = ActionObject.from_obj([2, 4, 6])
             node_data_a = NodeActionData.from_action_obj(
                 action_obj_a, credentials=verify_key
@@ -516,7 +516,7 @@ def test_multithreaded_graph_store_delete_node(verify_key: SyftVerifyKey) -> Non
     thread_id_node_map = {}
     for tid in range(thread_cnt):
         thread_id_node_map[tid] = []
-        for rp in range(repeats):
+        for _rp in range(repeats):
             action_obj = ActionObject.from_obj([2, 4, 6])
             node_data = NodeActionData.from_action_obj(
                 action_obj, credentials=verify_key

--- a/packages/syft/tests/syft/eager_test.py
+++ b/packages/syft/tests/syft/eager_test.py
@@ -35,7 +35,9 @@ def test_plan(worker, guest_client):
     guest_client = worker.guest_client
 
     @planify
-    def my_plan(x=np.array([[2, 2, 2], [2, 2, 2]])):
+    def my_plan(x=None):
+        if x is None:
+            x = np.array([[2, 2, 2], [2, 2, 2]])
         y = x.flatten()
         z = y.prod()
         return z
@@ -75,7 +77,9 @@ def test_plan_with_function_call(worker, guest_client):
     guest_client = worker.guest_client
 
     @planify
-    def my_plan(x=np.array([[2, 2, 2], [2, 2, 2]])):
+    def my_plan(x=None):
+        if x is None:
+            x = np.array([[2, 2, 2], [2, 2, 2]])
         y = x.flatten()
         w = guest_client.api.lib.numpy.sum(y)
         return w
@@ -95,7 +99,9 @@ def test_plan_with_function_call(worker, guest_client):
 
 def test_plan_with_object_instantiation(worker, guest_client):
     @planify
-    def my_plan(x=np.array([1, 2, 3, 4, 5, 6])):
+    def my_plan(x=None):
+        if x is None:
+            x = np.array([1, 2, 3, 4, 5, 6])
         return x + 1
 
     root_domain_client = worker.root_client

--- a/packages/syft/tests/syft/eager_test.py
+++ b/packages/syft/tests/syft/eager_test.py
@@ -35,9 +35,7 @@ def test_plan(worker, guest_client):
     guest_client = worker.guest_client
 
     @planify
-    def my_plan(x=None):
-        if x is None:
-            x = np.array([[2, 2, 2], [2, 2, 2]])
+    def my_plan(x=np.array([[2, 2, 2], [2, 2, 2]])):  # noqa: B008
         y = x.flatten()
         z = y.prod()
         return z
@@ -77,9 +75,7 @@ def test_plan_with_function_call(worker, guest_client):
     guest_client = worker.guest_client
 
     @planify
-    def my_plan(x=None):
-        if x is None:
-            x = np.array([[2, 2, 2], [2, 2, 2]])
+    def my_plan(x=np.array([[2, 2, 2], [2, 2, 2]])):  # noqa: B008
         y = x.flatten()
         w = guest_client.api.lib.numpy.sum(y)
         return w
@@ -99,9 +95,7 @@ def test_plan_with_function_call(worker, guest_client):
 
 def test_plan_with_object_instantiation(worker, guest_client):
     @planify
-    def my_plan(x=None):
-        if x is None:
-            x = np.array([1, 2, 3, 4, 5, 6])
+    def my_plan(x=np.array([1, 2, 3, 4, 5, 6])):  # noqa: B008
         return x + 1
 
     root_domain_client = worker.root_client

--- a/packages/syft/tests/syft/locks_test.py
+++ b/packages/syft/tests/syft/locks_test.py
@@ -374,12 +374,12 @@ def test_locks_parallel_multithreading(config: LockingConfig) -> None:
     lock = SyftLock(config)
 
     def _kv_cbk(tid: int) -> None:
-        for idx in range(repeats):
+        for _idx in range(repeats):
             locked = lock.acquire()
             if not locked:
                 continue
 
-            for retry in range(10):
+            for _retry in range(10):
                 try:
                     with open(temp_file, "r") as f:
                         prev = f.read()
@@ -436,7 +436,7 @@ def test_parallel_joblib(
         f.write("0")
 
     def _kv_cbk(tid: int) -> None:
-        for idx in range(repeats):
+        for _idx in range(repeats):
             with SyftLock(config):
                 with open(temp_file, "r") as f:
                     prev = int(f.read())

--- a/packages/syft/tests/syft/messages/message_stash_test.py
+++ b/packages/syft/tests/syft/messages/message_stash_test.py
@@ -140,7 +140,7 @@ def test_messagestash_get_all_inbox_for_verify_key(
     # list of mock messages
     message_list = []
 
-    for i in range(5):
+    for _ in range(5):
         mock_message = add_mock_message(
             root_verify_key, test_stash, test_verify_key, random_verify_key
         )

--- a/packages/syft/tests/syft/users/user_test.py
+++ b/packages/syft/tests/syft/users/user_test.py
@@ -89,7 +89,7 @@ def test_read_returns_view(root_domain_client):
     # Test reading returns userview (and not real user), this wasnt the case, adding this as a sanity check
     users = root_domain_client.api.services.user
     assert len(list(users))
-    for user in users:
+    for _ in users:
         # check that result has no sensitive information
         assert isinstance(root_domain_client.api.services.user[0], UserView)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,3 +3,5 @@ line-length = 120
 # Enable flake8-bugbear (`B`) rules.
 # https://beta.ruff.rs/docs/configuration/#using-rufftoml
 select = ["E", "F", "B"]
+
+ignore = ["B904", "B905"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,5 @@
 line-length = 120
 
+# Enable flake8-bugbear (`B`) rules.
+# https://beta.ruff.rs/docs/configuration/#using-rufftoml
+select = ["E", "F", "B"]


### PR DESCRIPTION
## Description
Re-enable flake8-bugbear checks in Ruff to catch potential buggy code.

One of those is B006 `Do not use mutable data structures for argument defaults.`

for functions, instead of

```python
def f(ls=[]):
   ...
```

do

```python
def f(ls=None):
    if ls is None:
        ls = []
    ...
```

This is an [anti-pattern](https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html) and might lead to subtle bugs.
## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
