### PR TITLE
Use Annotated in FastAPI routes

### DIFF
--- a/packages/syft/src/syft/node/routes.py
+++ b/packages/syft/src/syft/node/routes.py
@@ -10,6 +10,7 @@ from fastapi import Response
 from fastapi.responses import JSONResponse
 from loguru import logger
 from pydantic import ValidationError
+from typing_extensions import Annotated
 
 # relative
 from ..abstract_node import AbstractNode
@@ -98,7 +99,7 @@ def make_routes(worker: Worker) -> APIRouter:
     # make a request to the SyftAPI
     @router.post("/api_call")
     def syft_new_api_call(
-        request: Request, data: bytes = Depends(get_body)  # noqa: B008
+        request: Request, data: Annotated[bytes, Depends(get_body)]
     ) -> Response:
         if TRACE_MODE:
             with trace.get_tracer(syft_new_api_call.__module__).start_as_current_span(
@@ -175,7 +176,7 @@ def make_routes(worker: Worker) -> APIRouter:
 
     @router.post("/register", name="register", status_code=200)
     def register(
-        request: Request, data: bytes = Depends(get_body)  # noqa: B008
+        request: Request, data: Annotated[bytes, Depends(get_body)]
     ) -> Response:
         if TRACE_MODE:
             with trace.get_tracer(register.__module__).start_as_current_span(

--- a/packages/syft/src/syft/node/routes.py
+++ b/packages/syft/src/syft/node/routes.py
@@ -1,5 +1,4 @@
 # stdlib
-from typing import Any
 from typing import Dict
 
 # third party
@@ -111,7 +110,7 @@ def make_routes(worker: Worker) -> APIRouter:
         else:
             return handle_new_api_call(data)
 
-    def handle_login(email: str, password: str, node: AbstractNode) -> Any:
+    def handle_login(email: str, password: str, node: AbstractNode) -> Response:
         try:
             login_credentials = UserLoginCredentials(email=email, password=password)
         except ValidationError as e:
@@ -135,7 +134,7 @@ def make_routes(worker: Worker) -> APIRouter:
             media_type="application/octet-stream",
         )
 
-    def handle_register(data: bytes, node: AbstractNode) -> Any:
+    def handle_register(data: bytes, node: AbstractNode) -> Response:
         user_create = deserialize(data, from_bytes=True)
 
         if not isinstance(user_create, UserCreate):
@@ -163,7 +162,7 @@ def make_routes(worker: Worker) -> APIRouter:
         request: Request,
         email: str = Body(..., example="info@openmined.org"),  # noqa: B008
         password: str = Body(..., example="changethis"),  # noqa: B008
-    ) -> Any:
+    ) -> Response:
         if TRACE_MODE:
             with trace.get_tracer(login.__module__).start_as_current_span(
                 login.__qualname__,
@@ -177,7 +176,7 @@ def make_routes(worker: Worker) -> APIRouter:
     @router.post("/register", name="register", status_code=200)
     def register(
         request: Request, data: bytes = Depends(get_body)  # noqa: B008
-    ) -> Any:
+    ) -> Response:
         if TRACE_MODE:
             with trace.get_tracer(register.__module__).start_as_current_span(
                 register.__qualname__,

--- a/packages/syft/src/syft/node/routes.py
+++ b/packages/syft/src/syft/node/routes.py
@@ -161,8 +161,8 @@ def make_routes(worker: Worker) -> APIRouter:
     @router.post("/login", name="login", status_code=200)
     def login(
         request: Request,
-        email: str = Body(..., example="info@openmined.org"),  # noqa: B008
-        password: str = Body(..., example="changethis"),  # noqa: B008
+        email: Annotated[str, Body(example="info@openmined.org")],
+        password: Annotated[str, Body(example="changethis")],
     ) -> Response:
         if TRACE_MODE:
             with trace.get_tracer(login.__module__).start_as_current_span(


### PR DESCRIPTION
## Description
to avoid B008 "Do not perform function calls in argument defaults."
https://fastapi.tiangolo.com/tutorial/dependencies/
originally part of #7677 but taken out since it fails the oblv tests. ~not sure why.~ Issue resolved. Was due to `syft-enclave` outdated test dependencies.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
