### PR TITLE
Fix Node ID not found issue when logout

### DIFF
--- a/packages/grid/frontend/src/routes/(app)/logout/+page.svelte
+++ b/packages/grid/frontend/src/routes/(app)/logout/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { logout } from '$lib/utils';
+  import { getMetadata } from '$lib/api/metadata';
   import { onMount } from 'svelte';
 
   onMount(() => {
     logout();
+    getMetadata();
     goto('/login');
   });
 </script>


### PR DESCRIPTION
## Description
Small issue that happens when we logout and try to perform login again. This happens because during logout we delete the nodeID value from our storage. So to fix that, we call another request for metadata to update this variable in our storage.