### PR TITLE
Improve repr for Dataset and Asset

### DIFF
--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -84,6 +84,19 @@ class Asset(SyftObject):
     #     obj_ptr = api.services.action.get_pointer(uid=self.action_id)
     #     return obj_ptr
 
+    def _repr_html_(self) -> Any:
+        return (
+            f'<div class="syft-asset">'
+            + f'<h3>{self.name}</h3>'
+            + f'<p>{self.description}</p>'
+            + f'<p><strong>Asset ID: </strong>{self.id}</p>'
+            + f'<p><strong>Action Object ID: </strong>{self.action_id}</p>'
+            + f'<p><strong>Uploaded by: </strong>{self.contributors[0].name}</p>'
+            + f'<p><strong>Created on: </strong>TODO</p>'
+            + self.data._repr_html_()
+            + f'</div>'
+        )
+
     def _repr_markdown_(self) -> str:
         _repr_str = f"Asset: {self.name}\n"
         _repr_str += f"Pointer Id: {self.action_id}\n"


### PR DESCRIPTION
## Description
Based on Kyoko designs, a quick and dirty solution to having some HTML repr for Dataset and Asset, might require some special care on the next sprint/release.

## How has this been tested?
- notebook

## UX pics

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
