### PR TITLE
Disallow adding an asset with None mock to a dataset

### DIFF
--- a/notebooks/api/0.8/00-load-data.ipynb
+++ b/notebooks/api/0.8/00-load-data.ipynb
@@ -432,6 +432,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ctf.no_mock()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -572,13 +581,6 @@
     "if node.node_type.value == \"python\":\n",
     "    node.land()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -597,7 +599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -372,6 +372,8 @@ class SyftClient:
         # relative
         from ..types.twin_object import TwinObject
 
+        dataset._check_asset_must_contain_mock()
+
         for asset in tqdm(dataset.asset_list):
             print(f"Uploading: {asset.name}")
             try:

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -427,6 +427,21 @@ _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE: str = "".join(
 )
 
 
+def _check_asset_must_contain_mock(asset_list: List[CreateAsset]) -> None:
+    assets_without_mock = [asset.name for asset in asset_list if asset.mock is None]
+    if assets_without_mock:
+        raise ValueError(
+            "".join(
+                [
+                    "These assets do not contain a mock:\n",
+                    *[f"{asset}\n" for asset in assets_without_mock],
+                    "\n",
+                    _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE,
+                ]
+            )
+        )
+
+
 @serializable()
 class CreateDataset(Dataset):
     # version
@@ -440,22 +455,14 @@ class CreateDataset(Dataset):
     class Config:
         validate_assignment = True
 
+    def _check_asset_must_contain_mock(self) -> None:
+        _check_asset_must_contain_mock(self.asset_list)
+
     @validator("asset_list")
     def __assets_must_contain_mock(
         cls, asset_list: List[CreateAsset]
     ) -> List[CreateAsset]:
-        assets_without_mock = [asset.name for asset in asset_list if asset.mock is None]
-        if assets_without_mock:
-            raise ValueError(
-                "".join(
-                    [
-                        "These assets do not contain a mock:\n",
-                        *[f"{asset}\n" for asset in assets_without_mock],
-                        "\n",
-                        _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE,
-                    ]
-                )
-            )
+        _check_asset_must_contain_mock(asset_list)
         return asset_list
 
     def set_description(self, description: str) -> None:

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -416,6 +416,17 @@ class Dataset(SyftObject):
         return client
 
 
+_ASSET_WITH_NONE_MOCK_ERROR_MESSAGE: str = "".join(
+    [
+        "To be included in a Dataset, an asset must either contain a mock, ",
+        "or have it explicitly set to be empty.\n",
+        "You can create an asset without a mock with `sy.Asset(..., mock=sy.ActionObject.empty())` or\n"
+        "set the mock of an existing asset to be empty with `asset.no_mock()` or ",
+        "`asset.mock = sy.ActionObject.empty()`.",
+    ]
+)
+
+
 @serializable()
 class CreateDataset(Dataset):
     # version
@@ -441,11 +452,7 @@ class CreateDataset(Dataset):
                         "These assets do not contain a mock:\n",
                         *[f"{asset}\n" for asset in assets_without_mock],
                         "\n",
-                        "To be included in a Dataset, an asset must either contain a mock, ",
-                        "or have it explicitly set to be empty.\n",
-                        "You can create an asset without a mock with `sy.Asset(..., mock=sy.ActionObject.empty())` or "
-                        "set the mock of an existing asset to be empty with `asset.no_mock()` or ",
-                        "`asset.mock = sy.ActionObject.empty()`.",
+                        _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE,
                     ]
                 )
             )
@@ -475,6 +482,9 @@ class CreateDataset(Dataset):
         self.contributors.append(contributor)
 
     def add_asset(self, asset: CreateAsset) -> None:
+        if asset.mock is None:
+            raise ValueError(_ASSET_WITH_NONE_MOCK_ERROR_MESSAGE)
+
         self.asset_list.append(asset)
 
     def remove_asset(self, name: str) -> None:

--- a/packages/syft/tests/syft/service/dataset/dataset_service_test.py
+++ b/packages/syft/tests/syft/service/dataset/dataset_service_test.py
@@ -202,3 +202,17 @@ def test_guest_client_get_empty_mock_as_private_pointer(
     assert mock.is_real
     assert mock.is_pointer
     assert mock.syft_twin_type is TwinMode.PRIVATE
+
+
+def test_domain_client_cannot_upload_dataset_with_non_mock(worker: Worker) -> None:
+    assets = [Asset(**make_asset_with_mock()) for _ in range(10)]
+    dataset = Dataset(name=random_hash(), asset_list=assets)
+
+    dataset.asset_list[0].mock = None
+
+    root_domain_client = worker.root_client
+
+    with pytest.raises(ValueError) as excinfo:
+        root_domain_client.upload_dataset(dataset)
+
+    assert _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE in str(excinfo.value)

--- a/packages/syft/tests/syft/service/dataset/dataset_service_test.py
+++ b/packages/syft/tests/syft/service/dataset/dataset_service_test.py
@@ -13,6 +13,7 @@ from syft.node.worker import Worker
 from syft.service.action.action_object import ActionObject
 from syft.service.dataset.dataset import CreateAsset as Asset
 from syft.service.dataset.dataset import CreateDataset as Dataset
+from syft.service.dataset.dataset import _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE
 from syft.types.twin_object import TwinMode
 
 
@@ -138,11 +139,13 @@ def test_dataset_cannot_have_assets_with_none_mock() -> None:
     ]
     assets = assets_without_mock + assets_with_mock
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as excinfo:
         Dataset(
             name=random_hash(),
             asset_list=assets,
         )
+
+    assert _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE in str(excinfo.value)
 
     assert Dataset(name=random_hash(), asset_list=assets_with_mock)
 
@@ -162,6 +165,22 @@ def test_dataset_can_have_assets_with_empty_mock() -> None:
     assets = assets_without_mock + assets_with_mock
 
     assert Dataset(name=random_hash(), asset_list=assets)
+
+
+def test_cannot_add_assets_with_none_mock_to_dataset(
+    asset_with_mock: dict[str, Any], asset_without_mock: dict[str, Any]
+) -> None:
+    dataset = Dataset(name=random_hash())
+
+    with_mock = Asset(**asset_with_mock)
+    with_none_mock = Asset(**asset_without_mock)
+
+    dataset.add_asset(with_mock)
+
+    with pytest.raises(ValueError) as excinfo:
+        dataset.add_asset(with_none_mock)
+
+    assert _ASSET_WITH_NONE_MOCK_ERROR_MESSAGE in str(excinfo.value)
 
 
 def test_guest_client_get_empty_mock_as_private_pointer(


### PR DESCRIPTION
## Description
As a follow up of #7676, this PR
- adds a check to disallow `dataset.add_asset` an asset with `None` mock
- adds a check to disallow `client.upload_dataset` a dataset containing assets with `None` mock. Since users can still bypass all the `Dataset` validation checks with `dataset.asset_list[0].mock = None`

See https://github.com/OpenMined/Heartbeat/issues/245#issuecomment-1583925057 for context.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
