### PR TITLE
Fixing issue where windows paths used in github url for hagrid templates

### DIFF
--- a/packages/hagrid/hagrid/parse_template.py
+++ b/packages/hagrid/hagrid/parse_template.py
@@ -65,7 +65,8 @@ def read_yml_url(yml_url: str) -> Tuple[Optional[Dict], str]:
 
 
 def git_url_for_file(file_path: str, base_url: str, hash: str) -> str:
-    return os.path.join(base_url, hash, file_path)
+    # url must have unix style slashes
+    return os.path.join(base_url, hash, file_path).replace(os.sep, "/")
 
 
 def get_local_abs_path(target_dir: str, file_path: str) -> str:


### PR DESCRIPTION
## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
