### PR TITLE
Add workflow for rendering tutorial notebooks

### DIFF
--- a/.github/workflows/render-tutorial-notebooks.yml
+++ b/.github/workflows/render-tutorial-notebooks.yml
@@ -1,0 +1,67 @@
+name: Render Tutorial Notebooks
+on:
+  workflow_dispatch:
+    inputs:
+      none:
+        description: "Render Notebooks Manually"
+        required: false
+
+jobs:
+  tutorial-notebooks:
+    strategy:
+      max-parallel: 99
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.11"]
+        node-type: ["python"]
+        notebook-paths: ["tutorials"]
+        rendered-notebooks-paths: ["tutorials-rendered"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade --user pip
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py${{ matrix.python-version }}-
+
+      - name: Install Dependencies
+        run: |
+          pip install --upgrade tox packaging wheel --default-timeout=60
+          python -c "import platform; import os; os.system('pip install jaxlib==0.4.10 -f https://whls.blob.core.windows.net/unstable/index.html') if platform.system().lower() == 'windows' else ''"
+
+      - name: Render notebooks
+        uses: nick-fields/retry@v2
+        env:
+          ORCHESTRA_NODE_TYPE: "${{ matrix.node-type }}"
+          NOTEBOOK_PATHS: "${{ matrix.notebook-paths }}"
+          RENDERED_NOTEBOOK_PATHS: "${{ matrix.rendered-notebooks-paths }}"
+        with:
+          timeout_seconds: 1800
+          max_attempts: 3
+          command: tox -e syft.render.notebook
+
+      - name: Commit Rendered Notebooks
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "Render notebooks"
+          push: true

--- a/tox.ini
+++ b/tox.ini
@@ -373,6 +373,34 @@ commands =
     ; pytest --nbmake tutorials -p no:randomly -vvvv
     ; pytest --nbmake tutorials/pandas-cookbook -p no:randomly -vvvv
 
+[testenv:syft.render.notebook]
+description = Syft Notebook Rendering
+deps =
+    {[testenv:syft]deps}
+    {[testenv:hagrid]deps}
+    nbmake
+changedir = {toxinidir}/notebooks
+allowlist_externals =
+    bash
+setenv =
+    ORCHESTRA_NODE_TYPE = {env:ORCHESTRA_NODE_TYPE:python}
+    DEV_MODE = {env:DEV_MODE:False}
+    NOTEBOOK_PATHS = {env:NOTEBOOK_PATHS:tutorials/data-scientist}
+    RENDERED_NOTEBOOK_PATHS = {env:RENDERED_NOTEBOOK_PATHS:tutorials-rendered/data-scientist}
+    ENABLE_SIGNUP=True
+commands =
+    bash -c "echo Running with ORCHESTRA_NODE_TYPE=$ORCHESTRA_NODE_TYPE DEV_MODE=$DEV_MODE TEST_NOTEBOOK_PATHS=$NOTEBOOK_PATHS; date"
+    bash -c "paths=$(echo "${NOTEBOOK_PATHS}" | tr ',' ' '); \
+    output_paths=$(echo "${RENDERED_NOTEBOOK_PATHS}" | tr ',' ' '); \
+    for i in ${!paths[@]}; do \
+    path=${paths[$i]}; \
+    output_path=${output_paths[$i]}; \
+    rm -rf "${output_path}" && \
+    mkdir -p "${output_path}" && \
+    cp -R ${path}/* ${output_path}; \
+    pytest --nbmake "${output_path}" -p no:randomly -vvvv --overwrite --exitfirst; \
+    done"
+
 [testenv:stack.test.notebook]
 description = Stack Notebook Tests
 deps =


### PR DESCRIPTION
## Description
- Added GitHub workflow and `tox.ini` section for rendering tutorial notebooks
   1. copies the notebooks to a separate folder 
   2. Renders the output notebooks by using `pytest --nbmake` with `--overwrite` flag 
- Manually triggered: `workflow-dispatch`
- `tutorials-rendered` folder is used for the rendered notebooks
   - Perhaps change the folder structure in a follow-up task
       - `tutorials-dev`: original notebooks
       - `tutorials`: rendered notebooks

## Affected Dependencies
N/A

## How has this been tested?
- Manually ran the workflow in my forked repo
   - https://github.com/akalliokoski/PySyft/actions/runs/5410740982/jobs/9832591739
   - needed to push the workflow first to default `dev` branch
   - enabled write permissions for actions in the repo settings  

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
