### PR TITLE
Fix random name generation while launching nodes by Hagrid

### DIFF
--- a/packages/grid/backend/grid/core/node.py
+++ b/packages/grid/backend/grid/core/node.py
@@ -1,6 +1,7 @@
 # syft absolute
 from syft.node.domain import Domain
 from syft.node.gateway import Gateway
+from syft.node.node import get_node_name
 from syft.node.node import get_node_type
 from syft.store.mongo_client import MongoStoreClientConfig
 from syft.store.mongo_document_store import MongoStoreConfig
@@ -24,12 +25,17 @@ client_config = SQLiteStoreClientConfig(path="/storage/")
 sql_store_config = SQLiteStoreConfig(client_config=client_config)
 
 node_type = get_node_type()
+node_name = get_node_name()
 
 if node_type == "gateway" or node_type == "network":
     worker = Gateway(
-        action_store_config=sql_store_config, document_store_config=mongo_store_config
+        name=node_name,
+        action_store_config=sql_store_config,
+        document_store_config=mongo_store_config,
     )
 else:
     worker = Domain(
-        action_store_config=sql_store_config, document_store_config=mongo_store_config
+        name=node_name,
+        action_store_config=sql_store_config,
+        document_store_config=mongo_store_config,
     )

--- a/packages/grid/worker/worker.py
+++ b/packages/grid/worker/worker.py
@@ -1,5 +1,4 @@
 # stdlib
-import os
 
 # third party
 from fastapi import FastAPI
@@ -10,6 +9,8 @@ from syft.client.client import API_PATH
 from syft.node.domain import Domain
 from syft.node.enclave import Enclave
 from syft.node.gateway import Gateway
+from syft.node.node import get_node_name
+from syft.node.node import get_node_type
 from syft.node.routes import make_routes
 
 worker_classes = {
@@ -18,8 +19,8 @@ worker_classes = {
     NodeType.ENCLAVE: Enclave,
 }
 
-node_name = os.environ.get("NODE_NAME", "default_node_name")
-node_type = NodeType(os.environ.get("NODE_TYPE", "domain"))
+node_name = get_node_name()
+node_type = NodeType(get_node_type())
 if node_type not in worker_classes:
     raise NotImplementedError(f"node_type: {node_type} is not supported")
 worker_class = worker_classes[node_type]

--- a/packages/syft/src/syft/node/node.py
+++ b/packages/syft/src/syft/node/node.py
@@ -109,6 +109,7 @@ def gipc_decoder(obj_bytes):
 NODE_PRIVATE_KEY = "NODE_PRIVATE_KEY"
 NODE_UID = "NODE_UID"
 NODE_TYPE = "NODE_TYPE"
+NODE_NAME = "NODE_NAME"
 
 DEFAULT_ROOT_EMAIL = "DEFAULT_ROOT_EMAIL"
 DEFAULT_ROOT_PASSWORD = "DEFAULT_ROOT_PASSWORD"  # nosec
@@ -124,6 +125,10 @@ def get_private_key_env() -> Optional[str]:
 
 def get_node_type() -> Optional[str]:
     return get_env(NODE_TYPE, "domain")
+
+
+def get_node_name() -> Optional[str]:
+    return get_env(NODE_NAME, None)
 
 
 def get_node_uid_env() -> Optional[str]:
@@ -196,7 +201,7 @@ class Node(AbstractNode):
 
         self.processes = processes
         self.is_subprocess = is_subprocess
-        self.name = name
+        self.name = random_name() if name is None else name
         services = (
             [
                 UserService,

--- a/tests/integration/network/client_test.py
+++ b/tests/integration/network/client_test.py
@@ -19,3 +19,14 @@ def test_client_type(node_metadata):
     client = sy.login(port=port, email="info@openmined.org", password="changethis")
 
     assert isinstance(client, client_type)
+
+
+@pytest.mark.parametrize(
+    "node_metadata", [(NETWORK_PORT, "test_gateway_1"), (DOMAIN_PORT, "test_domain_1")]
+)
+@pytest.mark.network
+def test_client_name(node_metadata):
+    port, node_name = node_metadata
+    client = sy.login(port=port, email="info@openmined.org", password="changethis")
+
+    assert client.name == node_name


### PR DESCRIPTION
## Description
When we launch a node in hagrid by a given name
like
```python3
hagrid launch emerald domain to docker:8081
```

Even though the domain name in emerald, it takes a random name after launching , as we did not set the environment variable, 

The PR fixes the same.



## How has this been tested?
- Added unit tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
