### PR TITLE
feat(page): switch the 'loading' string for a skeleton loading card

### DIFF
--- a/packages/grid/frontend/src/lib/components/LoadingDatasets.svelte
+++ b/packages/grid/frontend/src/lib/components/LoadingDatasets.svelte
@@ -1,0 +1,26 @@
+<script>
+    let table = [1,2,3,4,5]
+</script>
+
+{#each table as element}
+    <div class="p-4 pb-6 flex gap-4 hover:bg-primary-50">
+    <div class="animate-pulse flex flex-grow space-x-4">
+        <div class='flex flex-col space-y-2 w-full'>
+            <div class="flex gap-1 w-full">
+                <div class='h-2 basis-1/2 bg-gray-400 rounded'></div>
+            </div>
+            <div class="flex gap-1 w-full space-x-2 items-center">
+                <div class='h-2 basis-1/4 bg-gray-400 rounded'></div>
+                <span class="dot">●</span>
+                <div class='h-2 basis-1/4 bg-gray-400 rounded'></div>
+            </div>
+            <div class="flex gap-1 w-full space-x-2 items-center">
+                <div class='h-2 basis-1/12 bg-gray-400 rounded'></div>
+                <span class="dot">●</span>
+                <div class='h-2 basis-3/12 bg-gray-400 rounded'></div>
+            </div>
+        </div>
+    </div>
+</div>
+{/each}
+

--- a/packages/grid/frontend/src/routes/(app)/datasets/+page.svelte
+++ b/packages/grid/frontend/src/routes/(app)/datasets/+page.svelte
@@ -4,6 +4,7 @@
   import Filter from '$lib/components/Filter.svelte';
   import Search from '$lib/components/Search.svelte';
   import Button from '$lib/components/Button.svelte';
+  import LoadingDatasets from '$lib/components/LoadingDatasets.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import DatasetListItem from '$lib/components/Datasets/DatasetListItem.svelte';
   import NoDatasetFound from '$lib/components/Datasets/DatasetNoneFound.svelte';
@@ -89,7 +90,7 @@
       </div>
 
       {#if datasets === null}
-        <h2>Loading</h2>
+        <LoadingDatasets />
       {:else if datasets.length === 0}
         <NoDatasetFound />
       {:else if datasets.length > 0}


### PR DESCRIPTION
## Description
On the loading page of datasets, was a static string 'Loading'. I've replaced it with a skeleton loading card.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
