### PR TITLE
Comment out pip install to speed up CI

### DIFF
--- a/notebooks/api/0.8/00-load-data.ipynb
+++ b/notebooks/api/0.8/00-load-data.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {
@@ -680,7 +680,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/api/0.8/01-submit-code.ipynb
+++ b/notebooks/api/0.8/01-submit-code.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {
@@ -550,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/api/0.8/02-review-code-and-approve.ipynb
+++ b/notebooks/api/0.8/02-review-code-and-approve.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {
@@ -517,7 +517,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/api/0.8/03-data-scientist-download-result.ipynb
+++ b/notebooks/api/0.8/03-data-scientist-download-result.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {
@@ -229,7 +229,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/api/0.8/04-jax-example.ipynb
+++ b/notebooks/api/0.8/04-jax-example.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {

--- a/notebooks/api/0.8/05-custom-policy.ipynb
+++ b/notebooks/api/0.8/05-custom-policy.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {
@@ -420,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.3"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/api/0.8/06-multiple-code-requests.ipynb
+++ b/notebooks/api/0.8/06-multiple-code-requests.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {

--- a/notebooks/api/0.8/07-domain-register-control-flow.ipynb
+++ b/notebooks/api/0.8/07-domain-register-control-flow.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
     "package_string = f'\"syft{SYFT_VERSION}\"'\n",
-    "%pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
+    "# %pip install {package_string} -f https://whls.blob.core.windows.net/unstable/index.html -q"
    ]
   },
   {


### PR DESCRIPTION
## Description
Comment out all the `%pip install` in notebooks to speed up CI since each of these takes seconds (up to 5 or 6s on my local machine) even when `syft` is already installed.

All the notebooks under `notebooks/tutorials/pandas-cookbook` are alr doing this.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
