### PR TITLE
[WIP] Add initial API bridge login and auth demo

### DIFF
--- a/.github/workflows/pr-tests-syft.yml
+++ b/.github/workflows/pr-tests-syft.yml
@@ -8,6 +8,7 @@ on:
       - dev
       - main
       - "0.8"
+      - "23_8_bridge"
 
   workflow_dispatch:
     inputs:

--- a/notebooks/api/0.8/08-api-bridge.ipynb
+++ b/notebooks/api/0.8/08-api-bridge.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "70877e23-bd5d-4d6d-bcdd-9dfa671ce12f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "SYFT_VERSION = \">=0.8.2.b0,<0.9\"\n",
@@ -16,7 +18,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5640eeca-9111-4f9e-b733-b4fa198c8b5d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import syft as sy\n",
@@ -27,7 +31,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65c5c3d8-bd19-49aa-a670-07c5d7f0c456",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "node = sy.orchestra.launch(name=\"blue-book\", port=\"auto\", dev_mode=True, reset=True)"
@@ -37,7 +43,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2c439c77-9eb5-42ef-8e3a-7ba34357609a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "domain_client = node.login(email=\"info@openmined.org\", password=\"changethis\")"
@@ -47,7 +55,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4d28cb80-58fa-40f1-990a-b50cdb950908",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# start the third party service with openapi.json endpoint"
@@ -57,7 +67,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d97566e0-2452-42a2-b955-5c86cb157251",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import gevent\n",
@@ -76,7 +88,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "078988b7-f6d1-4ed3-98ec-83222cccbbab",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "url = \"http://127.0.0.1:8000/openapi.json\""
@@ -86,7 +100,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8ef57b3d-0306-4c1a-948b-49d6b239122c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!curl $url"
@@ -96,7 +112,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8681c05e-5782-473d-afdf-8ee288dfe35e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "result = domain_client.api.services.bridge.add(url=url)\n",
@@ -106,8 +124,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ca00a39-dac2-42fb-a4dc-27d43bf6a5cc",
+   "id": "094c4dcc-c595-4af9-9884-2ae274272557",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# auth required, will fail without login\n",
+    "result = domain_client.api.services.blue_book.get_me()\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24b14c9e-f20d-48a8-844d-8a114b140a85",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "result = domain_client.api.services.bridge.authenticate(\"blue_book\", method_name=\"login\", username=\"johndoe\", password=\"secret\")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db13c3b4-a0da-4e27-9702-6c3b3d76dae0",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = domain_client.api.services.blue_book.get_me()\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ca00a39-dac2-42fb-a4dc-27d43bf6a5cc",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "result = domain_client.api.services.blue_book.get_all()\n",
@@ -178,13 +236,21 @@
     "# Cleanup local domain server\n",
     "node.land()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "695cd2f4-2870-4b3f-ba47-880622de1c4b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "api_bridge",
    "language": "python",
-   "name": "python3"
+   "name": "api_bridge"
   },
   "language_info": {
    "codemirror_mode": {
@@ -196,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/api/0.8/08-api-bridge.ipynb
+++ b/notebooks/api/0.8/08-api-bridge.ipynb
@@ -124,10 +124,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "094c4dcc-c595-4af9-9884-2ae274272557",
-   "metadata": {
-    "tags": []
-   },
+   "id": "93269736-76d4-49fb-a940-cd089d9f2efe",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# auth required, will fail without login\n",
@@ -138,20 +136,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24b14c9e-f20d-48a8-844d-8a114b140a85",
-   "metadata": {
-    "tags": []
-   },
+   "id": "789af516-c2b9-4394-bdca-076f0bdb88b3",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "result = domain_client.api.services.bridge.authenticate(\"blue_book\", method_name=\"login\", username=\"johndoe\", password=\"secret\")\n",
+    "result = domain_client.api.services.bridge.authenticate(token=\"letmein\")\n",
     "result"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db13c3b4-a0da-4e27-9702-6c3b3d76dae0",
+   "id": "0c5efac7-e9f1-4d0a-b64e-73d7d492d62f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,10 +158,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ca00a39-dac2-42fb-a4dc-27d43bf6a5cc",
-   "metadata": {
-    "tags": []
-   },
+   "id": "3d605f80-9333-4c82-8742-442b88def7ef",
+   "metadata": {},
    "outputs": [],
    "source": [
     "result = domain_client.api.services.blue_book.get_all()\n",
@@ -248,9 +242,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "api_bridge",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "api_bridge"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -262,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.1"
   }
  },
  "nbformat": 4,

--- a/packages/grid/openapi/fastapi/main.py
+++ b/packages/grid/openapi/fastapi/main.py
@@ -1,20 +1,78 @@
 # stdlib
+from typing import Annotated
 from typing import Dict
 from typing import List
 from typing import Optional
 
 # third party
+from fastapi import Depends
 from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi import status
+from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel
 
 app = FastAPI(title="Blue Book", version="0.2.0")
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+
+
+class UserOut(BaseModel):
+    username: str
+
+
+class User(UserOut):
+    password: str
+
+
+fake_user = User(username="johndoe", password="secret")
+
+
+async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> User:
+    if token != fake_user.username:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return fake_user
 
 
 class ResearchModel(BaseModel):
     name: str
 
 
+class LoginResponse(BaseModel):
+    access_token: str
+    token_type: str
+
+
 api_state: Dict[int, ResearchModel] = {7: ResearchModel(name="Ava")}
+
+
+@app.post("/login", operation_id="login", summary="Login to the Blue Book API")
+# application/x-www-form-urlencoded not supported by openapi3
+# => User used instead of OAuth2PasswordRequestForm as form_data
+# File "openapi3/paths.py", line 284, in _request_handle_body
+#    raise NotImplementedError()
+# async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+async def login(form_data: Annotated[User, Depends()]) -> LoginResponse:
+    if (
+        form_data.username != fake_user.username
+        or form_data.password != fake_user.password
+    ):
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+
+    response = {"access_token": fake_user.username, "token_type": "bearer"}
+    return LoginResponse(**response)
+
+
+@app.get("/users/me", operation_id="get_me", summary="Get the current user")
+async def read_users_me(
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> UserOut:
+    return current_user
 
 
 @app.get("/", operation_id="home", summary="Home Page")

--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -64,6 +64,7 @@ syft =
     recordlinkage==0.15
     openapi3==1.8.1
     docker==6.1.3
+    python-multipart==0.0.6
 
 install_requires =
     %(syft)s

--- a/packages/syft/src/syft/node/node.py
+++ b/packages/syft/src/syft/node/node.py
@@ -55,6 +55,7 @@ from ..service.context import AuthedServiceContext
 from ..service.context import NodeServiceContext
 from ..service.context import UnauthedServiceContext
 from ..service.context import UserLoginCredentials
+from ..service.context import UserSession
 from ..service.data_subject.data_subject_member_service import DataSubjectMemberService
 from ..service.data_subject.data_subject_service import DataSubjectService
 from ..service.dataset.dataset_service import DatasetService
@@ -685,6 +686,12 @@ class Node(AbstractNode):
         )
         return role
 
+    def get_user_session(self, credentials: SyftVerifyKey) -> Optional[UserSession]:
+        session = self.get_service("userservice").get_user_session(
+            credentials=credentials
+        )
+        return session
+
     def handle_api_call(
         self, api_call: Union[SyftAPICall, SignedSyftAPICall]
     ) -> Result[SignedSyftAPICall, Err]:
@@ -724,8 +731,9 @@ class Node(AbstractNode):
             api_call = api_call.message
 
             role = self.get_role_for_credentials(credentials=credentials)
+            session = self.get_user_session(credentials=credentials)
             context = AuthedServiceContext(
-                node=self, credentials=credentials, role=role
+                node=self, credentials=credentials, role=role, session=session
             )
 
             user_config_registry = UserServiceConfigRegistry.from_role(role)

--- a/packages/syft/src/syft/service/bridge/api_bridge.py
+++ b/packages/syft/src/syft/service/bridge/api_bridge.py
@@ -35,7 +35,7 @@ def consume_api(url: str, base_url: Optional[str] = None) -> OpenAPI:
     else:
         base_url = GridURL.from_url(url)
     x["servers"] = [{"url": str(base_url)}]
-    api = OpenAPI(x)
+    api = OpenAPI(x, use_session=True)
     return api, base_url
 
 

--- a/packages/syft/src/syft/service/container/container.py
+++ b/packages/syft/src/syft/service/container/container.py
@@ -6,12 +6,12 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Self
 from typing import Type
 from typing import Union
 
 # third party
 from docker.models.containers import ExecResult
+from typing_extensions import Self
 
 # relative
 from ...serde.serializable import serializable

--- a/packages/syft/src/syft/service/user/user.py
+++ b/packages/syft/src/syft/service/user/user.py
@@ -33,6 +33,7 @@ from ...types.transforms import make_set_default
 from ...types.transforms import transform
 from ...types.transforms import validate_email
 from ...types.uid import UID
+from ..context import UserSession
 from ..response import SyftError
 from ..response import SyftSuccess
 from .user_roles import ServiceRole
@@ -61,6 +62,7 @@ class User(SyftObject):
     institution: Optional[str]
     website: Optional[str] = None
     created_at: Optional[str] = None
+    session: Optional[UserSession] = None
 
     # serde / storage rules
     __attr_searchable__ = ["name", "email", "verify_key", "role"]


### PR DESCRIPTION
## Description

* NOTE: This implementation relies on manual fix in `openapi3` package
   * fixes applying session headers to the request
   * changed a line in `paths.py`, line 346
     * from: `result = session.send(self._request.prepare(), verify=verify)`
     * to: `result = session.send(session.prepare_request(self._request), verify=verify)`
* instead of setting the headers, an alternative solution could be to use `HTTPBearer`
  * and injecting `callable_op.security = { 'HTTPBearer': '<token>'  }`
  * didn't get it working yet, though
* content type `application/x-www-form-urlencoded` not supported by openapi3
* [aiopenapi3](https://github.com/commonism/aiopenapi3) could also be investigated 
     * fork of `openapi3`
     * e.g. has [manual access to request object](https://aiopenapi3.readthedocs.io/en/latest/advanced.html#manual-requests), [plugins](https://aiopenapi3.readthedocs.io/en/latest/plugin.html)

### TODO
 * Notify User if not logged in on Authed endpoints
 * Store information in a User Session in the Syft server
 * Customize login name method (either infer it from the API or allow AOs to provide it)
 

## Affected Dependencies
- manually modified openapi3 package to fix applying session headers

## How has this been tested?
- ran the `08-api-bridge.ipynb` notebook

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
