### PR TITLE
Add Pending Requests Count to Project View

### DIFF
--- a/packages/syft/src/syft/service/project/project.py
+++ b/packages/syft/src/syft/service/project/project.py
@@ -52,6 +52,7 @@ from ..network.network_service import NodePeer
 from ..network.routes import NodeRoute
 from ..network.routes import connection_to_route
 from ..request.request import Request
+from ..request.request import RequestStatus
 from ..response import SyftError
 from ..response import SyftException
 from ..response import SyftNotReady
@@ -690,6 +691,7 @@ class Project(SyftObject):
             "Name": self.name,
             "description": self.description,
             "created by": self.created_by,
+            "pending requests": self.pending_requests,
         }
 
     def _repr_html_(self) -> Any:
@@ -1120,6 +1122,12 @@ class Project(SyftObject):
         return [
             event.request for event in self.events if isinstance(event, ProjectRequest)
         ]
+    
+    @property
+    def pending_requests(self) -> int:
+        return len([request.status == RequestStatus.PENDING for request in self.requests])
+    
+
 
 
 @serializable(without=["bootstrap_events", "clients"])

--- a/packages/syft/src/syft/service/project/project.py
+++ b/packages/syft/src/syft/service/project/project.py
@@ -1125,7 +1125,7 @@ class Project(SyftObject):
     
     @property
     def pending_requests(self) -> int:
-        return len([request.status == RequestStatus.PENDING for request in self.requests])
+        return sum([request.status == RequestStatus.PENDING for request in self.requests])
     
 
 

--- a/packages/syft/src/syft/service/project/project.py
+++ b/packages/syft/src/syft/service/project/project.py
@@ -1122,12 +1122,12 @@ class Project(SyftObject):
         return [
             event.request for event in self.events if isinstance(event, ProjectRequest)
         ]
-    
+
     @property
     def pending_requests(self) -> int:
-        return sum([request.status == RequestStatus.PENDING for request in self.requests])
-    
-
+        return sum(
+            [request.status == RequestStatus.PENDING for request in self.requests]
+        )
 
 
 @serializable(without=["bootstrap_events", "clients"])


### PR DESCRIPTION
This pull request PR aims to enhance the project view by adding an extra piece of information – the number of pending requests. 

Currently, when reviewing projects, the DO lacks the necessary data to determine if any action needs to be taken. By directly incorporating the count of pending requests into the project view, we can provide a clearer picture of the project's status and assist the DO in making informed decisions.

The PR introduces a new property called pending_requests within the project module. This property utilizes the existing requests list and calculates the count of requests in a "PENDING" status using the RequestStatus.PENDING enum.

By leveraging this property, the project view will now display the total number of pending requests alongside other relevant project details, making it easy for the DO to identify projects that require immediate attention.

<img width="1375" alt="Screenshot 2023-08-07 at 03 32 13" src="https://github.com/OpenMined/PySyft/assets/56586364/9a258b00-297e-42cc-86c5-17e7f502c94c">
