### PR TITLE
Fixes to SeaweedFS PR

### DIFF
--- a/notebooks/api/0.8/05-custom-policy.ipynb
+++ b/notebooks/api/0.8/05-custom-policy.ipynb
@@ -185,7 +185,7 @@
    "source": [
     "x = np.array([1,2,3])\n",
     "x_pointer = sy.ActionObject.from_obj(x)\n",
-    "domain_client.api.services.action.save(x_pointer)"
+    "domain_client.api.services.action.set(x_pointer)"
    ]
   },
   {

--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -1317,11 +1317,11 @@ def create_launch_cmd(
     else:
         parsed_kwargs["image_name"] = "default"
 
-    if "tag" in kwargs and kwargs["tag"] is not None and kwargs["tag"] != "":
-        parsed_kwargs["tag"] = kwargs["tag"]
+    if parsed_kwargs["dev"] is True:
+        parsed_kwargs["tag"] = "local"
     else:
-        if parsed_kwargs["dev"] is True:
-            parsed_kwargs["tag"] = "local"
+        if "tag" in kwargs and kwargs["tag"] is not None and kwargs["tag"] != "":
+            parsed_kwargs["tag"] = kwargs["tag"]
         else:
             parsed_kwargs["tag"] = "latest"
 

--- a/packages/syft/src/syft/types/blob_storage.py
+++ b/packages/syft/src/syft/types/blob_storage.py
@@ -43,6 +43,9 @@ class SecureFilePathLocation(SyftObject):
     id: UID
     path: str
 
+    def __repr__(self) -> str:
+        return f"{self.path}"
+
 
 @serializable()
 class SeaweedSecureFilePathLocation(SecureFilePathLocation):

--- a/tox.ini
+++ b/tox.ini
@@ -202,8 +202,9 @@ commands =
     ; reset volumes and create nodes
     bash -c "echo Starting Nodes; date"
     bash -c "docker rm -f $(docker ps -a -q) || true"
-    bash -c "docker volume rm test_domain_1_mongo-data --force || true"
-    bash -c "docker volume rm test_domain_1_credentials-data --force || true"
+    bash -c "docker volume rm test-domain-1_mongo-data --force || true"
+    bash -c "docker volume rm test-domain-1_credentials-data --force || true"
+    bash -c "docker volume rm test-domain-1_seaweedfs-data --force || true"
 
     bash -c 'HAGRID_ART=$HAGRID_ART hagrid launch test_domain_1 domain to docker:9081 $HAGRID_FLAGS --enable-signup --no-health-checks --verbose --no-warnings'
 
@@ -262,21 +263,20 @@ commands =
     ; reset volumes and create nodes
     bash -c "echo Starting Nodes; date"
     bash -c "docker rm -f $(docker ps -a -q) || true"
-    bash -c "docker volume rm test_domain_1_mongo-data --force || true"
-    bash -c "docker volume rm test_domain_1_credentials-data --force || true"
-    bash -c "docker volume rm test_domain_2_mongo-data --force || true"
-    bash -c "docker volume rm test_domain_2_credentials-data --force || true"
-    bash -c "docker volume rm test_gateway_1_mongo-data --force || true"
-    bash -c "docker volume rm test_gateway_1_credentials-data --force || true"
-    bash -c "docker volume rm test_domain_1_seaweedfs-data --force || true"
-    bash -c "docker volume rm test_domain_2_seaweedfs-data --force || true"
-    bash -c "docker volume rm test_domain_1_app-redis-data --force || true"
-    bash -c "docker volume rm test_domain_2_app-redis-data --force || true"
-    bash -c "docker volume rm test_gateway_1_app-redis-data --force || true"
-    bash -c "docker volume rm test_domain_1_tailscale-data --force || true"
-    bash -c "docker volume rm test_domain_2_tailscale-data --force || true"
-    bash -c "docker volume rm test_gateway_1_tailscale-data --force || true"
-    bash -c "docker volume rm test_gateway_1_headscale-data --force || true"
+    bash -c "docker volume rm test-domain-1_mongo-data --force || true"
+    bash -c "docker volume rm test-domain-1_credentials-data --force || true"
+    bash -c "docker volume rm test-domain-1_seaweedfs-data --force || true"
+    bash -c "docker volume rm test-domain-2_mongo-data --force || true"
+    bash -c "docker volume rm test-domain-2_credentials-data --force || true"
+    bash -c "docker volume rm test-domain-2_seaweedfs-data --force || true"
+    bash -c "docker volume rm test-gateway-1_mongo-data --force || true"
+    bash -c "docker volume rm test-gateway-1_credentials-data --force || true"
+    bash -c "docker volume rm test-gateway-1_seaweedfs-data --force || true"
+
+    bash -c "docker volume rm test-domain-1_tailscale-data --force || true"
+    bash -c "docker volume rm test-domain-2_tailscale-data --force || true"
+    bash -c "docker volume rm test-gateway-1_tailscale-data --force || true"
+    bash -c "docker volume rm test-gateway-1_headscale-data --force || true"
 
     bash -c 'HAGRID_ART=$HAGRID_ART hagrid launch test_gateway_1 network to docker:9081 $HAGRID_FLAGS --no-health-checks --verbose --no-warnings'
     bash -c 'HAGRID_ART=$HAGRID_ART hagrid launch test_domain_1 domain to docker:9082 $HAGRID_FLAGS --no-health-checks --enable-signup --verbose --no-warnings'
@@ -465,6 +465,7 @@ commands =
     # Volume cleanup
     bash -c "docker volume rm test-domain-1_mongo-data --force || true"
     bash -c "docker volume rm test-domain-1_credentials-data --force || true"
+    bash -c "docker volume rm test-domain-1_seaweedfs-data --force || true"
 
     bash -c "echo Running with ORCHESTRA_DEPLOYMENT_TYPE=$ORCHESTRA_DEPLOYMENT_TYPE DEV_MODE=$DEV_MODE TEST_NOTEBOOK_PATHS=$TEST_NOTEBOOK_PATHS; date"
     bash -c "for subfolder in $(echo ${TEST_NOTEBOOK_PATHS} | tr ',' ' ');\


### PR DESCRIPTION
- dev mode True has to trigger local template
- if any environment variables of docker compose changes occur the template must be local to the source

- changed docker volume from _ to - naming
- fixed left over action.save command in notebook
- added blob storage path print for debugging in database

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
