### PR TITLE
feat: add password check to SyftClient login with email

### DIFF
--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -604,6 +604,8 @@ class SyftClient:
             self.register(
                 email=email, password=password, password_verify=password, **kwargs
             )
+        if password is None:
+            password = getpass("Password: ")
         user_private_key = self.connection.login(email=email, password=password)
         if isinstance(user_private_key, SyftError):
             return user_private_key
@@ -819,7 +821,10 @@ def login(
     connection = _client.connection
 
     login_credentials = None
-    if email and password:
+
+    if email:
+        if not password:
+            password = getpass("Password: ")
         login_credentials = UserLoginCredentials(email=email, password=password)
 
     if login_credentials is None:


### PR DESCRIPTION
## Description
Adds a password prompt in case `sy.login(email="e@mail.com")` is called with an email.

## How has this been tested?
- Notebook check

<img width="466" alt="Screenshot 2023-09-20 at 19 01 17" src="https://github.com/OpenMined/PySyft/assets/802731/082047e1-0f2d-44f4-bb99-0c20277a0f19">

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests