### PR TITLE
Remove extra prompts on .accept_by_depositing_result

### DIFF
--- a/packages/syft/src/syft/client/domain_client.py
+++ b/packages/syft/src/syft/client/domain_client.py
@@ -25,6 +25,7 @@ from ..service.user.user_roles import ServiceRole
 from ..types.uid import UID
 from ..util.fonts import fonts_css
 from ..util.util import get_mb_size
+from ..util.util import prompt_warning_message
 from .api import APIModule
 from .client import SyftClient
 from .client import login
@@ -71,6 +72,20 @@ class DomainClient(SyftClient):
 
         dataset._check_asset_must_contain_mock()
         dataset_size = 0
+
+        # TODO: Refactor so that object can also be passed to generate warnings
+        metadata = self.api.connection.get_node_metadata(self.api.signing_key)
+
+        if (
+            metadata.show_warnings
+            and metadata.node_side_type == NodeSideType.HIGH_SIDE.value
+        ):
+            message = (
+                "You're approving a request on "
+                f"{metadata.node_side_type} side {metadata.node_type} "
+                "which may host datasets with private information."
+            )
+            prompt_warning_message(message=message, confirm=True)
 
         for asset in tqdm(dataset.asset_list):
             print(f"Uploading: {asset.name}")

--- a/packages/syft/src/syft/service/action/action_service.py
+++ b/packages/syft/src/syft/service/action/action_service.py
@@ -29,7 +29,6 @@ from ..service import TYPE_TO_SERVICE
 from ..service import UserLibConfigRegistry
 from ..service import service_method
 from ..user.user_roles import GUEST_ROLE_LEVEL
-from ..warnings import HighSideCRUDWarning
 from .action_object import Action
 from .action_object import ActionObject
 from .action_object import ActionObjectPointer
@@ -73,7 +72,6 @@ class ActionService(AbstractService):
         path="action.set",
         name="set",
         roles=GUEST_ROLE_LEVEL,
-        warning=HighSideCRUDWarning(confirmation=True),
     )
     def set(
         self,

--- a/packages/syft/src/syft/service/dataset/dataset_service.py
+++ b/packages/syft/src/syft/service/dataset/dataset_service.py
@@ -39,7 +39,12 @@ class DatasetService(AbstractService):
         self.store = store
         self.stash = DatasetStash(store=store)
 
-    @service_method(path="dataset.add", name="add", roles=DATA_OWNER_ROLE_LEVEL)
+    @service_method(
+        path="dataset.add",
+        name="add",
+        roles=DATA_OWNER_ROLE_LEVEL,
+        warning=HighSideCRUDWarning(confirmation=True),
+    )
     def add(
         self, context: AuthedServiceContext, dataset: CreateDataset
     ) -> Union[SyftSuccess, SyftError]:

--- a/packages/syft/src/syft/service/dataset/dataset_service.py
+++ b/packages/syft/src/syft/service/dataset/dataset_service.py
@@ -43,7 +43,6 @@ class DatasetService(AbstractService):
         path="dataset.add",
         name="add",
         roles=DATA_OWNER_ROLE_LEVEL,
-        warning=HighSideCRUDWarning(confirmation=True),
     )
     def add(
         self, context: AuthedServiceContext, dataset: CreateDataset

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -335,7 +335,7 @@ class Request(SyftObject):
 
         return request_status
 
-    def approve(self):
+    def approve(self, disable_warnings: bool = False):
         api = APIRegistry.api_for(
             self.node_uid,
             self.syft_client_verify_key,
@@ -356,7 +356,7 @@ class Request(SyftObject):
                 f"{metadata.node_side_type} side {metadata.node_type} "
                 "which may host datasets with private information."
             )
-        if message and metadata.show_warnings:
+        if message and metadata.show_warnings and not disable_warnings:
             prompt_warning_message(message=message, confirm=True)
 
         print(f"Request approved for domain {api.node_name}")
@@ -525,7 +525,7 @@ class Request(SyftObject):
                 return result
             self = result
 
-            return self.approve()
+            return self.approve(disable_warnings=True)
 
 
 @serializable()


### PR DESCRIPTION
Since, we have .set function at various stages of our code, the PR moves prompts to high level functions to prevent repetitive prompts at request level.


Resolves: https://github.com/OpenMined/Heartbeat/issues/737

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
