### PR TITLE
Include Hagrid in Manifests of beta releases.

### DIFF
--- a/.github/workflows/cd-syft.yml
+++ b/.github/workflows/cd-syft.yml
@@ -176,6 +176,7 @@ jobs:
           files: |
             ./packages/syftcli/manifest.yml
             ./build/syftcli-config/*
+            ./packages/hagrid/hagrid/manifest_template.yml
           tag_name: v${{ steps.release_checks.outputs.github_release_version }}
 
       - name: Set up QEMU


### PR DESCRIPTION
## Description
Currently, we do not have a way to reference template of beta releases.

The PR add templates of hagrid to each beta releases.



## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
