### PR TITLE
Fix indexing for search results

### DIFF
--- a/packages/syft/src/syft/util/notebook_ui/notebook_addons.py
+++ b/packages/syft/src/syft/util/notebook_ui/notebook_addons.py
@@ -556,6 +556,7 @@ custom_code = """
                         resetById${uid}('table${uid}');
                         resetById${uid}('pag${uid}');
                         result = paginate${uid}(result, page_size${uid})
+                        paginatedElements${uid} = result
                         buildGrid${uid}(result,pageIndex${uid});
                         buildPaginationContainer${uid}(result);
                     }


### PR DESCRIPTION
## Description
Previously, when conducting a search in our table, clicking on a page index would reset the view to display all elements, rather than maintaining the filtered search results. We have now implemented a fix to ensure that pagination is applied exclusively to the elements within our search results.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
