### PR TITLE
Disabled some of the mongo thread tests on MacOS

### DIFF
--- a/packages/syft/tests/syft/stores/mongo_document_store_test.py
+++ b/packages/syft/tests/syft/stores/mongo_document_store_test.py
@@ -623,7 +623,7 @@ def test_mongo_store_partition_set_delete_joblib(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 def test_mongo_store_partition_permissions_collection(
     mongo_store_partition: MongoStorePartition,
@@ -638,7 +638,7 @@ def test_mongo_store_partition_permissions_collection(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 def test_mongo_store_partition_add_remove_permission(
     root_verify_key: SyftVerifyKey, mongo_store_partition: MongoStorePartition
@@ -729,7 +729,7 @@ def test_mongo_store_partition_add_remove_permission(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 def test_mongo_store_partition_add_permissions(
     root_verify_key: SyftVerifyKey,
@@ -781,7 +781,7 @@ def test_mongo_store_partition_add_permissions(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 @pytest.mark.parametrize("permission", PERMISSIONS)
 def test_mongo_store_partition_has_permission(
@@ -830,7 +830,7 @@ def test_mongo_store_partition_has_permission(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 @pytest.mark.parametrize("permission", PERMISSIONS)
 def test_mongo_store_partition_take_ownership(
@@ -885,7 +885,7 @@ def test_mongo_store_partition_take_ownership(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 def test_mongo_store_partition_permissions_set(
     root_verify_key: SyftVerifyKey,
@@ -931,7 +931,7 @@ def test_mongo_store_partition_permissions_set(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 def test_mongo_store_partition_permissions_get_all(
     root_verify_key: SyftVerifyKey,
@@ -964,7 +964,7 @@ def test_mongo_store_partition_permissions_get_all(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 def test_mongo_store_partition_permissions_delete(
     root_verify_key: SyftVerifyKey,
@@ -1018,7 +1018,7 @@ def test_mongo_store_partition_permissions_delete(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="pytest_mock_resources + docker issues on Windows"
+    sys.platform != "linux", reason="pytest_mock_resources + docker issues on Windows"
 )
 def test_mongo_store_partition_permissions_update(
     root_verify_key: SyftVerifyKey,


### PR DESCRIPTION
- These tests regularly flap, its likely this is related to the FileLock / Thread issues we have on MacOS

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
