### PR TITLE
refactor: remove unneeded conditions in login/login_as_guest

### DIFF
--- a/packages/hagrid/hagrid/orchestra.py
+++ b/packages/hagrid/hagrid/orchestra.py
@@ -172,31 +172,18 @@ class NodeHandle:
             )
 
     def login_as_guest(self, **kwargs: Any) -> Optional[Any]:
-        client = self.client
-
-        session = client.login_as_guest(**kwargs)
-
-        if isinstance(session, SyftError):
-            return session
-
-        return session
+        return self.client.login_as_guest(**kwargs)
 
     def login(
         self, email: Optional[str] = None, password: Optional[str] = None, **kwargs: Any
     ) -> Optional[Any]:
-        client = self.client
-
         if not email:
             email = input("Email: ")
+
         if not password:
             password = getpass.getpass("Password: ")
 
-        session = client.login(email=email, password=password, **kwargs)
-
-        if isinstance(session, SyftError):
-            return session
-
-        return session
+        return self.client.login(email=email, password=password, **kwargs)
 
     def register(
         self,

--- a/packages/hagrid/hagrid/orchestra.py
+++ b/packages/hagrid/hagrid/orchestra.py
@@ -36,6 +36,8 @@ DEFAULT_PORT = 8080
 # Gevent used instead of threading module ,as we monkey patch gevent in syft
 # and this causes context switch error when we use normal threading in hagrid
 
+ClientAlias = Any  # we don't want to import Client in case it changes
+
 
 # Define a function to read and print a stream
 def read_stream(stream: subprocess.PIPE) -> None:
@@ -172,12 +174,12 @@ class NodeHandle:
                 f"client not implemented for the deployment type:{self.deployment_type}"
             )
 
-    def login_as_guest(self, **kwargs: Any) -> Optional[Any]:
+    def login_as_guest(self, **kwargs: Any) -> ClientAlias:
         return self.client.login_as_guest(**kwargs)
 
     def login(
         self, email: Optional[str] = None, password: Optional[str] = None, **kwargs: Any
-    ) -> Optional[Any]:
+    ) -> ClientAlias:
         if not email:
             email = input("Email: ")
 


### PR DESCRIPTION
## Description
Very small change to ditch unneeded conditions in `login` and `login_as_guest`.

```py
if isinstance(session, SyftError):
  return session
return session
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
