### PR TITLE
Fix adding asset uploader when uploading a dataset

### DIFF
--- a/packages/syft/src/syft/client/domain_client.py
+++ b/packages/syft/src/syft/client/domain_client.py
@@ -66,9 +66,9 @@ class DomainClient(SyftClient):
 
         user = self.users.get_current_user()
         dataset = add_default_uploader(user, dataset)
-        for i in range(len(dataset.assets)):
-            asset = dataset.assets[i]
-            dataset.assets[i] = add_default_uploader(user, asset)
+        for i in range(len(dataset.asset_list)):
+            asset = dataset.asset_list[i]
+            dataset.asset_list[i] = add_default_uploader(user, asset)
 
         dataset._check_asset_must_contain_mock()
         dataset_size = 0


### PR DESCRIPTION
Should update `Dataset.asset_list` instead of `Dataset.assets` which is just a view. The current code only works by accident.

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
