### PR TITLE
Fix guest login

### DIFF
--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -923,6 +923,13 @@ def login(
             )
             _client = _client_cache
 
+    if login_credentials is None:
+        print(
+            f"Logged into <{_client.name}: {_client.metadata.node_side_type.capitalize()}-side "
+            f"{_client.metadata.node_type.capitalize()}> as GUEST"
+        )
+        return _client.guest()
+
     if not _client.authed and login_credentials:
         _client.login(
             email=login_credentials.email,

--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -923,13 +923,6 @@ def login(
             )
             _client = _client_cache
 
-    if login_credentials is None:
-        print(
-            f"Logged into <{_client.name}: {_client.metadata.node_side_type.capitalize()}-side "
-            f"{_client.metadata.node_type.capitalize()}> as GUEST"
-        )
-        return _client.guest()
-
     if not _client.authed and login_credentials:
         _client.login(
             email=login_credentials.email,

--- a/packages/syft/src/syft/service/network/network_service.py
+++ b/packages/syft/src/syft/service/network/network_service.py
@@ -204,10 +204,9 @@ class NetworkService(AbstractService):
                 message="verify_key does not match the remote node's verify_key for add_peer"
             )
 
-        remote_client = peer.client_with_context(context=context)
-        random_challenge = secrets.token_bytes(16)
-
         try:
+            remote_client = peer.client_with_context(context=context)
+            random_challenge = secrets.token_bytes(16)
             remote_res = remote_client.api.services.network.ping(
                 challenge=random_challenge
             )

--- a/tests/integration/network/gateway_test.py
+++ b/tests/integration/network/gateway_test.py
@@ -9,9 +9,7 @@ from syft.service.user.user_roles import ServiceRole
 
 
 def test_domain_connect_to_gateway(domain_1_port, gateway_port):
-    gateway_client: GatewayClient = sy.login(
-        port=gateway_port, email="info@openmined.org", password="changethis"
-    )
+    gateway_client: GatewayClient = sy.login_as_guest(port=gateway_port)
 
     domain_client: DomainClient = sy.login(
         port=domain_1_port, email="info@openmined.org", password="changethis"


### PR DESCRIPTION
## Description
Currently, calling sy.login() does not provide a guest client, if the email and password are None.
The PR address the same.




## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
