### PR TITLE
Remove autouse from fixtures

### DIFF
--- a/packages/syft/tests/conftest.py
+++ b/packages/syft/tests/conftest.py
@@ -68,43 +68,43 @@ def stage_protocol(protocol_file: Path):
         dp.save_history(dp.protocol_history)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def worker(faker, stage_protocol):
     return sy.Worker.named(name=faker.name())
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def root_domain_client(worker):
     return worker.root_client
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def root_verify_key(worker):
     return worker.root_client.credentials.verify_key
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def guest_client(worker):
     return worker.guest_client
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def guest_verify_key(worker):
     return worker.guest_client.credentials.verify_key
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def guest_domain_client(root_domain_client):
     return root_domain_client.guest()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def document_store(worker):
     yield worker.document_store
     worker.document_store.reset()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def action_store(worker):
     return worker.action_store
 

--- a/packages/syft/tests/syft/notifications/fixtures.py
+++ b/packages/syft/tests/syft/notifications/fixtures.py
@@ -22,22 +22,22 @@ test_verify_key_string = (
 test_verify_key = SyftVerifyKey.from_string(test_verify_key_string)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def notification_stash(document_store):
     return NotificationStash(store=document_store)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def notification_service(document_store):
     return NotificationService(store=document_store)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def authed_context(admin_user: User, worker: Worker) -> AuthedServiceContext:
     return AuthedServiceContext(credentials=test_verify_key, node=worker)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def linked_object():
     return LinkedObject(
         node_uid=UID(),
@@ -47,7 +47,7 @@ def linked_object():
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def mock_create_notification(faker) -> CreateNotification:
     test_signing_key1 = SyftSigningKey.generate()
     test_verify_key1 = test_signing_key1.verify_key
@@ -66,7 +66,7 @@ def mock_create_notification(faker) -> CreateNotification:
     return mock_notification
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def mock_notification(
     root_verify_key,
     notification_stash: NotificationStash,

--- a/packages/syft/tests/syft/users/fixtures.py
+++ b/packages/syft/tests/syft/users/fixtures.py
@@ -19,7 +19,7 @@ from syft.service.user.user_stash import UserStash
 from syft.store.document_store import DocumentStore
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def admin_create_user(faker) -> UserCreate:
     password = faker.password()
     user_create = UserCreate(
@@ -34,7 +34,7 @@ def admin_create_user(faker) -> UserCreate:
     return user_create
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def guest_create_user(faker) -> UserCreate:
     password = faker.password()
     user_create = UserCreate(
@@ -49,25 +49,25 @@ def guest_create_user(faker) -> UserCreate:
     return user_create
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def admin_user(admin_create_user) -> User:
     user = admin_create_user.to(User)
     return user
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def guest_user(guest_create_user) -> User:
     user = guest_create_user.to(User)
     return user
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def admin_view_user(admin_user) -> UserView:
     user_view = admin_user.to(UserView)
     return user_view
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def guest_view_user(guest_user) -> UserView:
     user_view = guest_user.to(UserView)
     return user_view
@@ -90,7 +90,7 @@ def guest_user_private_key(guest_user) -> UserPrivateKey:
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def update_user(faker) -> UserSearch:
     return UserUpdate(
         name=faker.name(),
@@ -98,14 +98,14 @@ def update_user(faker) -> UserSearch:
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def guest_user_search(guest_user) -> UserSearch:
     return UserSearch(
         name=guest_user.name, email=guest_user.email, verify_key=guest_user.verify_key
     )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def user_stash(document_store: DocumentStore) -> UserStash:
     return UserStash(store=document_store)
 


### PR DESCRIPTION
## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
Remove `autouse=True` from fixtures. Looks like none of the fixtures we have actually benefit from `autouse` and it only slows down the tests. `autouse=True` is usually only used for side effects, not fixtures that return a value. Also putting `autouse=True` on fixtures with no dependencies (fixtures that take no arguments) applies that fixtures to every single test in the test suite, a lot of which do not require the fixture at all, slowing down these tests tremendously.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
