### PR TITLE
Fix 0.8.1 hagrid env variable bug

### DIFF
--- a/packages/hagrid/hagrid/cli.py
+++ b/packages/hagrid/hagrid/cli.py
@@ -2187,6 +2187,7 @@ def create_launch_docker_cmd(
         "DOCKER_BUILDKIT": 1,
         "HTTP_PORT": int(host_term.free_port),
         "HTTPS_PORT": int(host_term.free_port_tls),
+        "BACKEND_STORAGE_PATH": "credentials-data",
         "TRAEFIK_TAG": str(tag),
         "NODE_NAME": str(snake_name),
         "NODE_TYPE": str(node_type.input),


### PR DESCRIPTION
## Description
This PR aims to fix the issue related to hagrid launch execution when using local approach.

## Affected Dependencies
- Hagrid

## How has this been tested?
- Installed `hagrid==0.3.79`
- Executed `hagrid launch local_node --verbose`
