### PR TITLE
fix check for mock if its a DataFrame in _repr_html_

### DIFF
--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -176,7 +176,7 @@ class Asset(SyftObject):
             mock_table_line = itables.to_html_datatable(
                 df=self.mock.syft_action_data, css=itables_css
             )
-        elif isinstance(self.data, pd.DataFrame):
+        elif isinstance(self.mock, pd.DataFrame):
             mock_table_line = itables.to_html_datatable(df=self.mock, css=itables_css)
         else:
             mock_table_line = self.mock


### PR DESCRIPTION
## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

- Fix check when converting mock to html if mock is a pandas DataFrame

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
