### PR TITLE
Minor improvements related to package manager caches in Dockerfile

### DIFF
--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -18,7 +18,8 @@ ARG USER
 ARG UID
 
 # Setup Python DEV
-RUN apk update && \
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk update && \
     apk add build-base gcc tzdata python-$PYTHON_VERSION-dev py$PYTHON_VERSION-pip && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # uncomment for creating rootless user
@@ -65,10 +66,10 @@ ARG USER
 ARG USER_GRP
 
 # Setup Python
-RUN apk update && \
-    apk add --no-cache tzdata bash python-$PYTHON_VERSION py$PYTHON_VERSION-pip && \
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk update && \
+    apk add tzdata bash python-$PYTHON_VERSION py$PYTHON_VERSION-pip && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    rm -rf /var/cache/apk/* && \
     # Uncomment for rootless user
     # adduser -D -u 1000 $USER && \
     mkdir -p /var/log/pygrid $HOME/data/creds $HOME/data/db $HOME/.cache $HOME/.local

--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -48,7 +48,7 @@ COPY --chown=$USER_GRP syft/src/syft/VERSION ./syft/src/syft/VERSION
 COPY --chown=$USER_GRP syft/src/syft/capnp ./syft/src/syft/capnp
 
 # Install all dependencies together here to avoid any version conflicts across pkgs
-RUN --mount=type=cache,target=$HOME/.cache/,rw,uid=$UID \
+RUN --mount=type=cache,target=$HOME/.cache/pip,uid=$UID \
     pip install --user torch==2.1.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html && \
     pip install --user pip-autoremove jupyterlab==4.0.7 -e ./syft[data_science] && \
     pip-autoremove ansible ansible-core -y

--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -18,7 +18,7 @@ ARG USER
 ARG UID
 
 # Setup Python DEV
-RUN --mount=type=cache,target=/var/cache/apk \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk update && \
     apk add build-base gcc tzdata python-$PYTHON_VERSION-dev py$PYTHON_VERSION-pip && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -71,7 +71,7 @@ ARG USER
 ARG USER_GRP
 
 # Setup Python
-RUN --mount=type=cache,target=/var/cache/apk \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk update && \
     apk add tzdata bash python-$PYTHON_VERSION py$PYTHON_VERSION-pip && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \

--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -40,12 +40,17 @@ WORKDIR $APPDIR
 ENV PATH=$PATH:$HOME/.local/bin
 
 # copy skeleton to do package install
-COPY --chown=$USER_GRP syft/setup.py ./syft/setup.py
-COPY --chown=$USER_GRP syft/setup.cfg ./syft/setup.cfg
-COPY --chown=$USER_GRP syft/pyproject.toml ./syft/pyproject.toml
-COPY --chown=$USER_GRP syft/MANIFEST.in ./syft/MANIFEST.in
-COPY --chown=$USER_GRP syft/src/syft/VERSION ./syft/src/syft/VERSION
-COPY --chown=$USER_GRP syft/src/syft/capnp ./syft/src/syft/capnp
+COPY --chown=$USER_GRP \
+    syft/setup.py \
+    syft/setup.cfg \
+    syft/pyproject.toml \
+    syft/MANIFEST.in \
+    syft/
+
+COPY --chown=$USER_GRP \
+    syft/src/syft/VERSION \
+    syft/src/syft/capnp \
+    syft/src/syft/
 
 # Install all dependencies together here to avoid any version conflicts across pkgs
 RUN --mount=type=cache,id=pip-$UID,target=$HOME/.cache/pip,uid=$UID,gid=$UID \

--- a/packages/grid/backend/backend.dockerfile
+++ b/packages/grid/backend/backend.dockerfile
@@ -48,7 +48,7 @@ COPY --chown=$USER_GRP syft/src/syft/VERSION ./syft/src/syft/VERSION
 COPY --chown=$USER_GRP syft/src/syft/capnp ./syft/src/syft/capnp
 
 # Install all dependencies together here to avoid any version conflicts across pkgs
-RUN --mount=type=cache,target=$HOME/.cache/pip,uid=$UID \
+RUN --mount=type=cache,id=pip-$UID,target=$HOME/.cache/pip,uid=$UID,gid=$UID \
     pip install --user torch==2.1.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html && \
     pip install --user pip-autoremove jupyterlab==4.0.7 -e ./syft[data_science] && \
     pip-autoremove ansible ansible-core -y

--- a/packages/grid/backend/syft_base_cpu.dockerfile
+++ b/packages/grid/backend/syft_base_cpu.dockerfile
@@ -23,7 +23,7 @@ ARG USER
 ARG UID
 
 # Setup Python DEV
-RUN --mount=type=cache,target=/var/cache/apk \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk update && \
     apk add build-base gcc tzdata python-$PYTHON_VERSION-dev py$PYTHON_VERSION-pip && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -81,7 +81,7 @@ ARG USER
 ARG USER_GRP
 
 # Setup Python
-RUN --mount=type=cache,target=/var/cache/apk \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk update && \
     apk add tzdata bash python-$PYTHON_VERSION py$PYTHON_VERSION-pip $SYSTEM_PACKAGES && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \

--- a/packages/grid/backend/syft_base_cpu.dockerfile
+++ b/packages/grid/backend/syft_base_cpu.dockerfile
@@ -23,7 +23,8 @@ ARG USER
 ARG UID
 
 # Setup Python DEV
-RUN apk update && \
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk update && \
     apk add build-base gcc tzdata python-$PYTHON_VERSION-dev py$PYTHON_VERSION-pip && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # uncomment for creating rootless user
@@ -75,10 +76,10 @@ ARG USER
 ARG USER_GRP
 
 # Setup Python
-RUN apk update && \
-    apk add --no-cache tzdata bash python-$PYTHON_VERSION py$PYTHON_VERSION-pip $SYSTEM_PACKAGES && \
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk update && \
+    apk add tzdata bash python-$PYTHON_VERSION py$PYTHON_VERSION-pip $SYSTEM_PACKAGES && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    rm -rf /var/cache/apk/* && \
     # Uncomment for rootless user
     # adduser -D -u 1000 $USER && \
     mkdir -p /var/log/pygrid $HOME/data/creds $HOME/data/db $HOME/.cache $HOME/.local

--- a/packages/grid/backend/syft_base_cpu.dockerfile
+++ b/packages/grid/backend/syft_base_cpu.dockerfile
@@ -46,12 +46,17 @@ WORKDIR $APPDIR
 ENV PATH=$PATH:$HOME/.local/bin
 
 # copy skeleton to do package install
-COPY --chown=$USER_GRP syft/setup.py ./syft/setup.py
-COPY --chown=$USER_GRP syft/setup.cfg ./syft/setup.cfg
-COPY --chown=$USER_GRP syft/pyproject.toml ./syft/pyproject.toml
-COPY --chown=$USER_GRP syft/MANIFEST.in ./syft/MANIFEST.in
-COPY --chown=$USER_GRP syft/src/syft/VERSION ./syft/src/syft/VERSION
-COPY --chown=$USER_GRP syft/src/syft/capnp ./syft/src/syft/capnp
+COPY --chown=$USER_GRP \
+    syft/setup.py \
+    syft/setup.cfg \
+    syft/pyproject.toml \
+    syft/MANIFEST.in \
+    syft/
+
+COPY --chown=$USER_GRP \
+    syft/src/syft/VERSION \
+    syft/src/syft/capnp \
+    syft/src/syft/
 
 # Install all dependencies together here to avoid any version conflicts across pkgs
 RUN --mount=type=cache,id=pip-$UID,target=$HOME/.cache/pip,uid=$UID,gid=$UID \

--- a/packages/grid/backend/syft_base_cpu.dockerfile
+++ b/packages/grid/backend/syft_base_cpu.dockerfile
@@ -54,13 +54,13 @@ COPY --chown=$USER_GRP syft/src/syft/VERSION ./syft/src/syft/VERSION
 COPY --chown=$USER_GRP syft/src/syft/capnp ./syft/src/syft/capnp
 
 # Install all dependencies together here to avoid any version conflicts across pkgs
-RUN --mount=type=cache,target=$HOME/.cache/pip,uid=$UID \
+RUN --mount=type=cache,id=pip-$UID,target=$HOME/.cache/pip,uid=$UID,gid=$UID \
     pip install --user pip-autoremove ./syft && \
     pip-autoremove ansible ansible-core -y
 
 # cache PIP_PACKAGES as a separate layer so installation will be faster when a new
 # package is provided
-RUN --mount=type=cache,target=$HOME/.cache/,rw \
+RUN --mount=type=cache,id=pip-$UID,target=$HOME/.cache/pip,uid=$UID,gid=$UID \
     pip install --user $PIP_PACKAGES
 
 # ==================== [Final] Setup Syft Server ==================== #

--- a/packages/grid/backend/syft_base_cpu.dockerfile
+++ b/packages/grid/backend/syft_base_cpu.dockerfile
@@ -54,7 +54,7 @@ COPY --chown=$USER_GRP syft/src/syft/VERSION ./syft/src/syft/VERSION
 COPY --chown=$USER_GRP syft/src/syft/capnp ./syft/src/syft/capnp
 
 # Install all dependencies together here to avoid any version conflicts across pkgs
-RUN --mount=type=cache,target=$HOME/.cache/,rw,uid=$UID \
+RUN --mount=type=cache,target=$HOME/.cache/pip,uid=$UID \
     pip install --user pip-autoremove ./syft && \
     pip-autoremove ansible ansible-core -y
 


### PR DESCRIPTION
## Description
Couple of improvements related to `--mount=type=cache`.
Most importantly is adding `id=pip-$UID` to pip cache to use different caches for different users. Since we now support both root and rootless, not separating the caches could lead to a permission error.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
