### PR TITLE
Always close DockerClient after use

### DIFF
--- a/notebooks/api/0.8/10-container-images.ipynb
+++ b/notebooks/api/0.8/10-container-images.ipynb
@@ -237,7 +237,9 @@
     "        image = client.images.get(tag)\n",
     "        return image.id\n",
     "    except docker.errors.ImageNotFound:\n",
-    "        return None"
+    "        return None\n",
+    "    finally:\n",
+    "        client.close()"
    ]
   },
   {
@@ -263,7 +265,9 @@
     "        container = client.containers.get(container_name)\n",
     "        return container.id\n",
     "    except docker.errors.NotFound:\n",
-    "        return None"
+    "        return None\n",
+    "    finally:\n",
+    "        client.close()"
    ]
   },
   {

--- a/notebooks/api/0.8/10-container-images.ipynb
+++ b/notebooks/api/0.8/10-container-images.ipynb
@@ -320,10 +320,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert len(worker_pool_list)==1\n",
+    "assert len(worker_pool_list) == 1\n",
     "worker_pool = worker_pool_list[0]\n",
-    "assert worker_pool.name==worker_pool_name\n",
-    "assert len(worker_pool.workers)==3"
+    "assert worker_pool.name == worker_pool_name\n",
+    "assert len(worker_pool.workers) == 3"
    ]
   },
   {
@@ -356,7 +356,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "worker_status = domain_client.api.services.worker_pool.get_worker_status(worker_pool_id=worker_pool.id, worker_id=get_worker.id)\n",
+    "worker_status = domain_client.api.services.worker_pool.get_worker_status(\n",
+    "    worker_pool_id=worker_pool.id, worker_id=get_worker.id\n",
+    ")\n",
     "worker_status"
    ]
   },

--- a/packages/syft/src/syft/custom_worker/builder.py
+++ b/packages/syft/src/syft/custom_worker/builder.py
@@ -1,4 +1,5 @@
 # stdlib
+import contextlib
 import os.path
 from pathlib import Path
 from typing import Tuple
@@ -54,17 +55,16 @@ class CustomWorkerBuilder:
         )
 
         try:
-            client = docker.from_env()
-
             # TODO: Push logs to mongo/seaweed?
-            client.images.build(
-                path=str(contextdir),
-                dockerfile=dockerfile,
-                pull=True,
-                tag=f"{self.CUSTOM_IMAGE_PREFIX}-{type}:{imgtag}",
-                timeout=self.BUILD_MAX_WAIT,
-                buildargs=build_args,
-            )
+            with contextlib.closing(docker.from_env()) as client:
+                client.images.build(
+                    path=str(contextdir),
+                    dockerfile=dockerfile,
+                    pull=True,
+                    tag=f"{self.CUSTOM_IMAGE_PREFIX}-{type}:{imgtag}",
+                    timeout=self.BUILD_MAX_WAIT,
+                    buildargs=build_args,
+                )
 
             return
         except docker.errors.BuildError as e:

--- a/packages/syft/src/syft/service/worker/worker_image.py
+++ b/packages/syft/src/syft/service/worker/worker_image.py
@@ -93,13 +93,14 @@ class SyftWorkerImage(SyftObject):
     created_by: SyftVerifyKey
 
 
-def build_using_docker(worker_image: SyftWorkerImage, push: bool = True):
+def build_using_docker(
+    client: docker.DockerClient, worker_image: SyftWorkerImage, push: bool = True
+):
     if not isinstance(worker_image.config, DockerWorkerConfig):
         # Handle this to worker with CustomWorkerConfig later
         return SyftError("We only support DockerWorkerConfig")
 
     try:
-        client = docker.from_env()
         file_obj = io.BytesIO(worker_image.config.dockerfile.encode("utf-8"))
 
         # docker build -f <dockerfile> <buildargs> <path>

--- a/packages/syft/src/syft/service/worker/worker_service.py
+++ b/packages/syft/src/syft/service/worker/worker_service.py
@@ -1,4 +1,5 @@
 # stdlib
+import contextlib
 import socket
 from typing import List
 from typing import Union
@@ -260,19 +261,19 @@ class WorkerService(AbstractService):
         if isinstance(workers, SyftWorker):
             workers = [workers]
 
-        client = docker.from_env()
-        for w in workers:
-            result = self.stash.delete_by_uid(context.credentials, uid=w.id)
+        with contextlib.closing(docker.from_env()) as client:
+            for w in workers:
+                result = self.stash.delete_by_uid(context.credentials, uid=w.id)
 
-            if result.is_err():
-                return SyftError(message=f"Failed to stop workers {result.err()}")
+                if result.is_err():
+                    return SyftError(message=f"Failed to stop workers {result.err()}")
 
-            # stop container
-            try:
-                client.containers.list(filters={"id": w.container_id})[0].stop()
-                # also prune here?
-            except Exception as e:
-                # we dont throw an error here because apparently the container was already killed
-                print(f"Failed to kill container {e}")
+                # stop container
+                try:
+                    client.containers.list(filters={"id": w.container_id})[0].stop()
+                    # also prune here?
+                except Exception as e:
+                    # we dont throw an error here because apparently the container was already killed
+                    print(f"Failed to kill container {e}")
 
         return SyftSuccess(message=f"{len(workers)} workers stopped")

--- a/packages/syft/src/syft/service/worker/worker_service.py
+++ b/packages/syft/src/syft/service/worker/worker_service.py
@@ -1,5 +1,4 @@
 # stdlib
-import contextlib
 import socket
 from typing import List
 from typing import Union
@@ -261,19 +260,19 @@ class WorkerService(AbstractService):
         if isinstance(workers, SyftWorker):
             workers = [workers]
 
-        with contextlib.closing(docker.from_env()) as client:
-            for w in workers:
-                result = self.stash.delete_by_uid(context.credentials, uid=w.id)
+        client = docker.from_env()
+        for w in workers:
+            result = self.stash.delete_by_uid(context.credentials, uid=w.id)
 
-                if result.is_err():
-                    return SyftError(message=f"Failed to stop workers {result.err()}")
+            if result.is_err():
+                return SyftError(message=f"Failed to stop workers {result.err()}")
 
-                # stop container
-                try:
-                    client.containers.list(filters={"id": w.container_id})[0].stop()
-                    # also prune here?
-                except Exception as e:
-                    # we dont throw an error here because apparently the container was already killed
-                    print(f"Failed to kill container {e}")
+            # stop container
+            try:
+                client.containers.list(filters={"id": w.container_id})[0].stop()
+                # also prune here?
+            except Exception as e:
+                # we dont throw an error here because apparently the container was already killed
+                print(f"Failed to kill container {e}")
 
         return SyftSuccess(message=f"{len(workers)} workers stopped")


### PR DESCRIPTION
Always close `DockerClient` after use, with `contextlib.closing` or `finally` to ensure resource safety.

```py
with contextlib.closing(docker.from_env) as client:
    ...
```

Also pass a `client: DockerClient` as argument to functions that need it instead of creating a new one inside the function body.

For example, from this

```py
def start_worker_container(worker_num: int):
    client = docker.from_env()
    ...

start_worker_container(1)
```

to this

```py
def start_worker_container(client: DockerClient, worker_num: int):
    ...

with contextlib.closing(docker.from_env()) as client:
    start_worker_container(client, 1)
```

This also make some parts of the code more efficient as well since we avoid creating multiple `DockerClient`s. 
For example currently

```py
for worker_num in range(n_workers):
    start_worker_container(worker_num)
```

will create `n_workers` `DockerClient`s

After refactoring,

```py
with contextlib.closing(docker.from_env()) as client:
    for worker_num in range(n_workers):
        start_worker_container(client, worker_num)
```

only uses 1 client.