### PR TITLE
Safer execution

### DIFF
--- a/packages/syft/src/syft/service/code/user_code.py
+++ b/packages/syft/src/syft/service/code/user_code.py
@@ -1011,24 +1011,24 @@ class SecureContext:
             job.current_iter += current_iter
             job_service.update(context, job)
 
-        def set_api_registry():
-            user_signing_key = [
-                x.signing_key
-                for x in user_service.stash.partition.data.values()
-                if x.verify_key == context.credentials
-            ][0]
-            data_protcol = get_data_protocol()
-            user_api = node.get_api(context.credentials, data_protcol.latest_version)
-            user_api.signing_key = user_signing_key
-            # We hardcode a python connection here since we have access to the node
-            # TODO: this is not secure
-            user_api.connection = PythonConnection(node=node)
+        # def set_api_registry():
+        #     user_signing_key = [
+        #         x.signing_key
+        #         for x in user_service.stash.partition.data.values()
+        #         if x.verify_key == context.credentials
+        #     ][0]
+        #     data_protcol = get_data_protocol()
+        #     user_api = node.get_api(context.credentials, data_protcol.latest_version)
+        #     user_api.signing_key = user_signing_key
+        #     # We hardcode a python connection here since we have access to the node
+        #     # TODO: this is not secure
+        #     user_api.connection = PythonConnection(node=node)
 
-            APIRegistry.set_api_for(
-                node_uid=node.id,
-                user_verify_key=context.credentials,
-                api=user_api,
-            )
+        #     APIRegistry.set_api_for(
+        #         node_uid=node.id,
+        #         user_verify_key=context.credentials,
+        #         api=user_api,
+        #     )
 
         def launch_job(func: UserCode, **kwargs):
             # relative
@@ -1049,8 +1049,8 @@ class SecureContext:
                     parent_job_id=context.job_id,
                     has_execute_permissions=True,
                 )
-                # set api in global scope to enable using .get(), .wait())
-                set_api_registry()
+                # # set api in global scope to enable using .get(), .wait())
+                # set_api_registry()
 
                 return job
             except Exception as e:

--- a/packages/syft/src/syft/service/code/user_code.py
+++ b/packages/syft/src/syft/service/code/user_code.py
@@ -1151,8 +1151,6 @@ def execute_byte_code(
         _locals = {"kwargs": kwargs}
         _globals = {}
         
-        original_print("Test")
-
 
         for service_func_name, (linked_obj, _) in code_item.nested_codes.items():
             code_obj = linked_obj.resolve_with_context(context=context)
@@ -1163,7 +1161,6 @@ def execute_byte_code(
         exec(code_item.parsed_code, _globals, _locals)  # nosec
 
         evil_string = f"{code_item.unique_func_name}(**kwargs)"
-        original_print(kwargs)
         try:
             result = eval(evil_string, _globals, _locals)  # nosec
         except Exception as e:
@@ -1175,8 +1172,6 @@ def execute_byte_code(
                 )
                 log_service = context.node.get_service("LogService")
                 log_service.append(context=context, uid=log_id, new_err=error_msg)
-            original_print(e)
-
             result = Err(
                 f"Exception encountered while running {code_item.service_func_name}"
                 ", please contact the Node Admin for more info."

--- a/packages/syft/src/syft/service/code/user_code.py
+++ b/packages/syft/src/syft/service/code/user_code.py
@@ -29,12 +29,9 @@ from typing_extensions import Self
 
 # relative
 from ...abstract_node import NodeType
-from ...client.api import APIRegistry
 from ...client.api import NodeIdentity
-from ...client.client import PythonConnection
 from ...client.enclave_client import EnclaveMetadata
 from ...node.credentials import SyftVerifyKey
-from ...protocol.data_protocol import get_data_protocol
 from ...serde.deserialize import _deserialize
 from ...serde.serializable import serializable
 from ...serde.serialize import _serialize
@@ -994,7 +991,7 @@ class SecureContext:
         node = context.node
         job_service = node.get_service("jobservice")
         action_service = node.get_service("actionservice")
-        user_service = node.get_service("userservice")
+        # user_service = node.get_service("userservice")
 
         def job_set_n_iters(n_iters):
             job = context.job
@@ -1150,7 +1147,6 @@ def execute_byte_code(
         # We only need access to local kwargs
         _locals = {"kwargs": kwargs}
         _globals = {}
-        
 
         for service_func_name, (linked_obj, _) in code_item.nested_codes.items():
             code_obj = linked_obj.resolve_with_context(context=context)

--- a/packages/syft/src/syft/store/sqlite_document_store.py
+++ b/packages/syft/src/syft/store/sqlite_document_store.py
@@ -206,8 +206,8 @@ class SQLiteBackingStore(KeyValueBackingStore):
             self._update(key, value)
         else:
             insert_sql = (
-                f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)"  # nosec
-            )  # nosec
+                f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)"
+            )  # nosec  # nosec
             data = _serialize(value, to_bytes=True)
             res = self._execute(insert_sql, [str(key), _repr_debug_(value), data])
             if res.is_err():
@@ -215,8 +215,8 @@ class SQLiteBackingStore(KeyValueBackingStore):
 
     def _update(self, key: UID, value: Any) -> None:
         insert_sql = (
-            f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?"  # nosec
-        )  # nosec
+            f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?"
+        )  # nosec  # nosec
         data = _serialize(value, to_bytes=True)
         res = self._execute(insert_sql, [str(key), _repr_debug_(value), data, str(key)])
         if res.is_err():

--- a/packages/syft/src/syft/store/sqlite_document_store.py
+++ b/packages/syft/src/syft/store/sqlite_document_store.py
@@ -205,18 +205,14 @@ class SQLiteBackingStore(KeyValueBackingStore):
         if self._exists(key):
             self._update(key, value)
         else:
-            insert_sql = (
-                f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)"
-            )  # nosec
+            insert_sql = (f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)")  # nosec
             data = _serialize(value, to_bytes=True)
             res = self._execute(insert_sql, [str(key), _repr_debug_(value), data])
             if res.is_err():
                 raise ValueError(res.err())
 
     def _update(self, key: UID, value: Any) -> None:
-        insert_sql = (
-            f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?"
-        )  # nosec
+        insert_sql = (f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?")  # nosec
         data = _serialize(value, to_bytes=True)
         res = self._execute(insert_sql, [str(key), _repr_debug_(value), data, str(key)])
         if res.is_err():

--- a/packages/syft/src/syft/store/sqlite_document_store.py
+++ b/packages/syft/src/syft/store/sqlite_document_store.py
@@ -205,14 +205,18 @@ class SQLiteBackingStore(KeyValueBackingStore):
         if self._exists(key):
             self._update(key, value)
         else:
-            insert_sql = (f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)")  # nosec
+            insert_sql = (
+                f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)" # nosec
+            )
             data = _serialize(value, to_bytes=True)
             res = self._execute(insert_sql, [str(key), _repr_debug_(value), data])
             if res.is_err():
                 raise ValueError(res.err())
 
     def _update(self, key: UID, value: Any) -> None:
-        insert_sql = (f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?")  # nosec
+        insert_sql = (
+            f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?" # nosec
+        )
         data = _serialize(value, to_bytes=True)
         res = self._execute(insert_sql, [str(key), _repr_debug_(value), data, str(key)])
         if res.is_err():

--- a/packages/syft/src/syft/store/sqlite_document_store.py
+++ b/packages/syft/src/syft/store/sqlite_document_store.py
@@ -207,7 +207,7 @@ class SQLiteBackingStore(KeyValueBackingStore):
         else:
             insert_sql = (
                 f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)"
-            )  # nosec  # nosec
+            )  # nosec
             data = _serialize(value, to_bytes=True)
             res = self._execute(insert_sql, [str(key), _repr_debug_(value), data])
             if res.is_err():
@@ -216,7 +216,7 @@ class SQLiteBackingStore(KeyValueBackingStore):
     def _update(self, key: UID, value: Any) -> None:
         insert_sql = (
             f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?"
-        )  # nosec  # nosec
+        )  # nosec
         data = _serialize(value, to_bytes=True)
         res = self._execute(insert_sql, [str(key), _repr_debug_(value), data, str(key)])
         if res.is_err():

--- a/packages/syft/src/syft/store/sqlite_document_store.py
+++ b/packages/syft/src/syft/store/sqlite_document_store.py
@@ -206,7 +206,7 @@ class SQLiteBackingStore(KeyValueBackingStore):
             self._update(key, value)
         else:
             insert_sql = (
-                f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)" # nosec
+                f"insert into {self.table_name} (uid, repr, value) VALUES (?, ?, ?)"  # nosec
             )
             data = _serialize(value, to_bytes=True)
             res = self._execute(insert_sql, [str(key), _repr_debug_(value), data])
@@ -215,7 +215,7 @@ class SQLiteBackingStore(KeyValueBackingStore):
 
     def _update(self, key: UID, value: Any) -> None:
         insert_sql = (
-            f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?" # nosec
+            f"update {self.table_name} set uid = ?, repr = ?, value = ? where uid = ?"  # nosec
         )
         data = _serialize(value, to_bytes=True)
         res = self._execute(insert_sql, [str(key), _repr_debug_(value), data, str(key)])


### PR DESCRIPTION
## Description
Some small changes for the execution context:
* allowed only kwargs in locals for function execution
* disabled access to the API for the SecureContext (breaking .get and .wait inside the syft function, but we have different approaches to allow result chaining for jobs)

## How has this been tested?
- running CI without breaking

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
