### PR TITLE
Syft Workers & Registry Tests

### DIFF
--- a/notebooks/api/0.8/10-container-images.ipynb
+++ b/notebooks/api/0.8/10-container-images.ipynb
@@ -34,7 +34,8 @@
    "outputs": [],
    "source": [
     "# Disable inmemory worker for container stack\n",
-    "in_memory_workers = not os.environ.get(\"ORCHESTRA_DEPLOYMENT_TYPE\") == \"container_stack\""
+    "running_as_container = os.environ.get(\"ORCHESTRA_DEPLOYMENT_TYPE\") in (\"container_stack\", \"single_container\")\n",
+    "in_memory_workers = not running_as_container"
    ]
   },
   {
@@ -72,9 +73,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nginx_dockerfile_str = \"\"\"\n",
-    "# Use the official Nginx image as the base\n",
-    "FROM openmined/grid-backend:0.8.4-beta.10\n",
+    "custom_dockerfile_str = \"\"\"\n",
+    "FROM openmined/grid-backend:0.8.4-beta.12\n",
     "\n",
     "RUN pip install pydicom\n",
     "\n",
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docker_config = DockerWorkerConfig(dockerfile=nginx_dockerfile_str)"
+    "docker_config = DockerWorkerConfig(dockerfile=custom_dockerfile_str)"
    ]
   },
   {
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert docker_config.dockerfile == nginx_dockerfile_str"
+    "assert docker_config.dockerfile == custom_dockerfile_str"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res = domain_client.api.services.worker_image.submit_dockerfile(docker_config=docker_config)"
+    "submit_result = domain_client.api.services.worker_image.submit_dockerfile(docker_config=docker_config)"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res"
+    "submit_result"
    ]
   },
   {
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert isinstance( res, sy.SyftSuccess)"
+    "assert isinstance(submit_result, sy.SyftSuccess), str(submit_result)"
    ]
   },
   {
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dockerfile_list = domain_client.images\n",
+    "dockerfile_list = domain_client.images.get_all()\n",
     "dockerfile_list"
    ]
   },
@@ -159,13 +159,76 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workerimage = None\n",
+    "workerimage: SyftWorkerImage = None\n",
     "for image in dockerfile_list:\n",
-    "    if image.config.dockerfile == nginx_dockerfile_str:\n",
+    "    if image.config.dockerfile == custom_dockerfile_str:\n",
     "        workerimage = image\n",
     "        break\n",
     "\n",
-    "assert isinstance(workerimage, SyftWorkerImage)"
+    "assert isinstance(workerimage, SyftWorkerImage), str(workerimage)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8cf1efb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workerimage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35190951",
+   "metadata": {},
+   "source": [
+    "#### Setup Local Registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48bdd908",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import docker \n",
+    "\n",
+    "class LocalRegistryContainer:\n",
+    "    def __init__(self):\n",
+    "        self.name = 'local_registry'\n",
+    "        self.client = docker.from_env()\n",
+    "    \n",
+    "    def start(self, host_port=5678):\n",
+    "        existing = self.get()\n",
+    "        if existing:\n",
+    "            return existing\n",
+    "\n",
+    "        result = self.client.containers.run(\"registry:2\",\n",
+    "                                    name=self.name,\n",
+    "                                    detach=True,\n",
+    "                                    ports={'5000/tcp': host_port},\n",
+    "                                    labels={'orgs.openmined.syft': 'local-registry'},\n",
+    "                                    )\n",
+    "        \n",
+    "        return result\n",
+    "\n",
+    "    def teardown(self):\n",
+    "        existing = self.get()\n",
+    "        if existing:\n",
+    "            existing.stop()\n",
+    "            existing.remove()\n",
+    "\n",
+    "    def get(self):\n",
+    "        try:\n",
+    "            result = self.client.containers.get(self.name)\n",
+    "            if result.status == 'running':\n",
+    "                return result\n",
+    "        except docker.errors.NotFound:\n",
+    "            return None\n",
+    "\n",
+    "local_registry_container = LocalRegistryContainer()"
    ]
   },
   {
@@ -173,7 +236,7 @@
    "id": "91a66871",
    "metadata": {},
    "source": [
-    "#### Create Registry"
+    "#### Add Local Registry in Syft"
    ]
   },
   {
@@ -183,8 +246,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_add_res = domain_client.api.services.image_registry.add(\"localhost:5678\")\n",
-    "image_add_res"
+    "registry_add_result = domain_client.api.services.image_registry.add(\"localhost:5678\")\n",
+    "registry_add_result"
    ]
   },
   {
@@ -194,7 +257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert isinstance(image_add_res, sy.SyftSuccess), str(image_add_res)"
+    "assert isinstance(registry_add_result, sy.SyftSuccess), str(registry_add_result)"
    ]
   },
   {
@@ -227,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert isinstance(local_registry, SyftImageRegistry)"
+    "assert isinstance(local_registry, SyftImageRegistry), str(local_registry)"
    ]
   },
   {
@@ -245,18 +308,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docker_tag = \"openmined/test-nginx:0.7.8\"\n",
-    "docker_build_res = domain_client.api.services.worker_image.build(image_uid=workerimage.id, tag=docker_tag)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "573869c9-2bf9-4110-892b-edc75f0cd48d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "docker_build_res"
+    "docker_tag = \"openmined/custom-worker:0.7.8\"\n",
+    "registry_uid = local_registry.id if running_as_container else local_registry.id\n",
+    "\n",
+    "docker_build_result = domain_client.api.services.worker_image.build(image_uid=workerimage.id, tag=docker_tag, registry_uid=registry_uid)\n",
+    "docker_build_result\n"
    ]
   },
   {
@@ -266,34 +322,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert isinstance(docker_build_res, sy.SyftSuccess), str(docker_build_res)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15a74d29-25c7-4da7-b43b-a0b2a3ab7349",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "docker_tag"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c7ccfd18-2bae-4879-b6c2-27b6bcccf8f5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import subprocess\n",
-    "\n",
-    "def check_image_exists(tag) -> bool:\n",
-    "    result = subprocess.run(['docker', 'images', '-q', tag], stdout=subprocess.PIPE)\n",
-    "    return result.stdout.strip() != b''\n",
-    "\n",
-    "if domain.deployment_type.value == \"container_stack\":\n",
-    "    assert check_image_exists(docker_tag)"
+    "assert isinstance(docker_build_result, sy.SyftSuccess), str(docker_build_result)"
    ]
   },
   {
@@ -303,7 +332,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_list = domain_client.images\n",
+    "image_list = domain_client.images.get_all()\n",
     "image_list"
    ]
   },
@@ -318,9 +347,9 @@
     "    if image.id == workerimage.id:\n",
     "        workerimage = image  # we can also index with string using the repo_with_tag format\n",
     "\n",
-    "if domain.deployment_type.value == \"container_stack\":\n",
-    "    image_list[docker_tag]\n",
-    "    assert image_list[docker_tag] == workerimage\n",
+    "if running_as_container:\n",
+    "    image_list[workerimage.built_image_tag]\n",
+    "    assert image_list[workerimage.built_image_tag] == workerimage\n",
     "\n",
     "workerimage"
    ]
@@ -350,24 +379,97 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if domain.deployment_type.value == \"container_stack\":\n",
-    "    assert workerimage.image_hash == get_image_hash(docker_tag)"
+    "if running_as_container:\n",
+    "    assert workerimage.image_hash == get_image_hash(workerimage.built_image_tag), 'Worker Image image_hash does not match with built image hash'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e726428e",
+   "metadata": {},
+   "source": [
+    "#### Push Image to Local Registry"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5692f3a9-f493-467a-a394-7d8e62b970e5",
+   "id": "8468ce02",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_container_id(container_name: str) -> str:\n",
+    "push_result = None\n",
+    "if running_as_container:\n",
+    "    from time import sleep\n",
+    "    local_registry_container.start()\n",
+    "    sleep(5)\n",
+    "\n",
+    "    push_result = domain_client.api.services.worker_image.push(workerimage.id)\n",
+    "    assert isinstance(push_result, sy.SyftSuccess), str(push_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5ca573b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "push_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18941fce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if running_as_container:\n",
+    "    import requests\n",
+    "\n",
+    "    repos = requests.get(\"http://localhost:5678/v2/_catalog\").json()[\"repositories\"]\n",
+    "    tags = requests.get(\"http://localhost:5678/v2/openmined/custom-worker/tags/list\").json()[\"tags\"]\n",
+    "\n",
+    "    assert \"openmined/custom-worker\" in repos, f\"'openmined/custom-worker' not uploaded to local registry | {repos}\"\n",
+    "    assert \"0.7.8\" in tags, f\"'openmined/custom-worker' with tag '0.7.8' not available | {tags}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08ff08c5",
+   "metadata": {},
+   "source": [
+    "#### Delete locally built image to force pull from local registry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddd04da3",
+   "metadata": {},
+   "source": [
+    "This should make the subsequent `worker_pool.create` pull from registry at 'localhost:5678`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edbc0907",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import sleep\n",
+    "\n",
+    "def remove_local_image(tag):\n",
     "    client = docker.from_env()\n",
     "    try:\n",
-    "        container = client.containers.get(container_name)\n",
-    "        return container.id\n",
-    "    except docker.errors.NotFound:\n",
-    "        return None"
+    "        client.images.remove(tag)\n",
+    "    except docker.errors.ImageNotFound:\n",
+    "        pass\n",
+    "\n",
+    "if running_as_container:\n",
+    "    remove_local_image(workerimage.built_image_tag)\n",
+    "    sleep(5)"
    ]
   },
   {
@@ -408,8 +510,8 @@
    "source": [
     "for status in worker_pool_res:\n",
     "    assert status.error == None\n",
-    "    if domain.deployment_type.value == \"container_stack\":\n",
-    "        assert status.worker.image.image_hash == get_image_hash(docker_tag)"
+    "    if running_as_container:\n",
+    "        assert status.worker.image.image_hash == get_image_hash(workerimage.built_image_tag), 'Worker Pool Image image_hash does not match with built image hash'"
    ]
   },
   {
@@ -462,6 +564,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1c3166b0",
+   "metadata": {},
+   "source": [
+    "#### Get Worker Logs"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "fda29eca",
@@ -505,6 +615,14 @@
    "outputs": [],
    "source": [
     "assert isinstance(worker_logs, str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d339fd7f",
+   "metadata": {},
+   "source": [
+    "#### Delete Worker from Pool"
    ]
   },
   {
@@ -567,6 +685,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2db7ea37",
+   "metadata": {},
+   "source": [
+    "#### Worker Image"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "56fb74bb-a409-481a-93de-3a52d049c41a",
@@ -609,7 +735,10 @@
    "id": "94e16583-87ca-4c81-ade0-52bfbf4a5ec0",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "if running_as_container:\n",
+    "    local_registry_container.teardown()"
+   ]
   }
  ],
  "metadata": {

--- a/packages/grid/docker-compose.yml
+++ b/packages/grid/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       - DEV_MODE=${DEV_MODE}
       - NODE_SIDE_TYPE=${NODE_SIDE_TYPE}
       - ENABLE_WARNINGS=${ENABLE_WARNINGS}
-      - INMEMORY_WORKERS=true
+      - INMEMORY_WORKERS=${INMEMORY_WORKERS}
     ports:
       - "${HTTP_PORT}:${HTTP_PORT}"
     volumes:

--- a/packages/syft/src/syft/custom_worker/builder.py
+++ b/packages/syft/src/syft/custom_worker/builder.py
@@ -60,16 +60,12 @@ class CustomWorkerBuilder:
         return self._push_image(tag, **kwargs)
 
     def _build_dockerfile(self, config: DockerWorkerConfig, tag: str, **kwargs):
-        print("Building with provided dockerfile")
-
         # convert string to file-like object
         file_obj = io.BytesIO(config.dockerfile.encode("utf-8"))
         return self._build_image(fileobj=file_obj, tag=tag, **kwargs)
 
     def _build_template(self, config: CustomWorkerConfig, **kwargs: Any):
         # Builds a Docker pre-made CPU/GPU image template using a CustomWorkerConfig
-        print("Building with dockerfule template")
-
         # remove once GPU is supported
         if config.build.gpu:
             raise Exception("GPU custom worker is not supported yet")
@@ -86,12 +82,6 @@ class CustomWorkerBuilder:
             "PIP_PACKAGES": config.build.merged_python_pkgs(),
             "CUSTOM_CMD": config.build.merged_custom_cmds(),
         }
-
-        print(
-            f"Building dockerfile={dockerfile} "
-            f"in context={contextdir} "
-            f"with args={build_args}"
-        )
 
         return self._build_image(
             tag=f"{self.CUSTOM_IMAGE_PREFIX}-{type}:{imgtag}",

--- a/packages/syft/src/syft/service/worker/image_identifier.py
+++ b/packages/syft/src/syft/service/worker/image_identifier.py
@@ -1,6 +1,7 @@
 # stdlib
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 # third party
 from typing_extensions import Self
@@ -28,7 +29,7 @@ class SyftWorkerImageIdentifier(SyftBaseModel):
         https://docs.docker.com/engine/reference/commandline/tag/#tag-an-image-referenced-by-name-and-tag
     """
 
-    registry: Optional[SyftImageRegistry]
+    registry: Optional[Union[SyftImageRegistry, str]]
     repo: str
     tag: str
 
@@ -73,11 +74,12 @@ class SyftWorkerImageIdentifier(SyftBaseModel):
 
     @property
     def full_name_with_tag(self) -> str:
-        if self.registry:
-            return f"{self.registry.url}/{self.repo}:{self.tag}"
-        else:
-            # default registry is always docker.io
+        if self.registry is None:
             return f"docker.io/{self.repo}:{self.tag}"
+        elif isinstance(self.registry, str):
+            return f"{self.registry}/{self.repo}:{self.tag}"
+        else:
+            return f"{self.registry.url}/{self.repo}:{self.tag}"
 
     @property
     def registry_host(self) -> str:
@@ -90,6 +92,3 @@ class SyftWorkerImageIdentifier(SyftBaseModel):
 
     def __hash__(self) -> int:
         return hash(self.repo + self.tag + str(hash(self.registry)))
-
-    def __str__(self) -> str:
-        return f"registry: {str(self.registry)}, repo: {self.repo}, tag: {self.tag}"

--- a/packages/syft/src/syft/service/worker/image_identifier.py
+++ b/packages/syft/src/syft/service/worker/image_identifier.py
@@ -92,3 +92,6 @@ class SyftWorkerImageIdentifier(SyftBaseModel):
 
     def __hash__(self) -> int:
         return hash(self.repo + self.tag + str(hash(self.registry)))
+
+    def __repr__(self) -> str:
+        return f"SyftWorkerImageIdentifier(repo={self.repo}, tag={self.tag}, registry={self.registry})"

--- a/packages/syft/src/syft/service/worker/image_registry.py
+++ b/packages/syft/src/syft/service/worker/image_registry.py
@@ -29,5 +29,8 @@ class SyftImageRegistry(SyftObject):
     def __hash__(self) -> int:
         return hash(self.url + str(self.tls_enabled))
 
+    def __repr__(self) -> str:
+        return f"SyftImageRegistry(url={self.url})"
+
     def __str__(self) -> str:
         return self.url

--- a/packages/syft/src/syft/service/worker/image_registry_service.py
+++ b/packages/syft/src/syft/service/worker/image_registry_service.py
@@ -46,7 +46,7 @@ class SyftImageRegistryService(AbstractService):
             return SyftError(message=res.err())
 
         return SyftSuccess(
-            message=f"Image registry <id: {registry.id}> created successfully"
+            message=f"Image Registry ID: {registry.id} created successfully"
         )
 
     @service_method(
@@ -68,7 +68,7 @@ class SyftImageRegistryService(AbstractService):
             if res.is_err():
                 return SyftError(message=res.err())
             return SyftSuccess(
-                message=f"Image registry <url: {url}> successfully deleted."
+                message=f"Image Registry URL: {url} successfully deleted."
             )
 
         # if uid is provided, delete by uid
@@ -77,7 +77,7 @@ class SyftImageRegistryService(AbstractService):
             if res.is_err():
                 return SyftError(message=res.err())
             return SyftSuccess(
-                message=f"Image registry <id: {uid}> successfully deleted."
+                message=f"Image Registry ID: {uid} successfully deleted."
             )
         else:
             return SyftError(message="Either UID or URL must be provided.")

--- a/packages/syft/src/syft/service/worker/utils.py
+++ b/packages/syft/src/syft/service/worker/utils.py
@@ -160,7 +160,7 @@ def run_container_using_docker(
         environment["CONTAINER_HOST"] = "docker"
 
         container = docker_client.containers.run(
-            worker_image.image_identifier.repo_with_tag,
+            worker_image.image_identifier.full_name_with_tag,
             name=f"{hostname}-{worker_name}",
             detach=True,
             auto_remove=True,

--- a/packages/syft/src/syft/service/worker/utils.py
+++ b/packages/syft/src/syft/service/worker/utils.py
@@ -109,6 +109,9 @@ def run_container_using_docker(
     password: Optional[str] = None,
     registry_url: Optional[str] = None,
 ) -> ContainerSpawnStatus:
+    if not worker_image.is_built:
+        raise Exception("Image must be built before running it.")
+
     # Get hostname
     hostname = socket.gethostname()
 
@@ -266,6 +269,9 @@ def run_containers(
 
     if orchestration not in [WorkerOrchestrationType.DOCKER]:
         return SyftError(message="Only Orchestration via Docker is supported.")
+
+    if not worker_image.is_built:
+        return SyftError(message="Image must be built before running it.")
 
     with contextlib.closing(docker.from_env()) as client:
         for worker_count in range(start_idx + 1, number + 1):

--- a/packages/syft/src/syft/service/worker/utils.py
+++ b/packages/syft/src/syft/service/worker/utils.py
@@ -359,15 +359,15 @@ def docker_build(
         return ImageBuildResult(image_hash=built_image.id, logs=parse_output(logs))
     except docker.errors.APIError as e:
         return SyftError(
-            message=f"Docker API error when building {image.image_tag}. Reason - {e}"
+            message=f"Docker API error when building {image.image_identifier}. Reason - {e}"
         )
     except docker.errors.DockerException as e:
         return SyftError(
-            message=f"Docker exception when building {image.image_tag}. Reason - {e}"
+            message=f"Docker exception when building {image.image_identifier}. Reason - {e}"
         )
     except Exception as e:
         return SyftError(
-            message=f"Unknown exception when building {image.image_tag}. Reason - {e}"
+            message=f"Unknown exception when building {image.image_identifier}. Reason - {e}"
         )
 
 

--- a/packages/syft/src/syft/service/worker/worker_image.py
+++ b/packages/syft/src/syft/service/worker/worker_image.py
@@ -23,8 +23,22 @@ class SyftWorkerImage(SyftObject):
 
     id: UID
     config: WorkerConfig
-    image_identifier: Optional[SyftWorkerImageIdentifier]
-    image_hash: Optional[str]
-    created_at: DateTime = DateTime.now()
     created_by: SyftVerifyKey
-    built_at: Optional[DateTime]
+    created_at: DateTime = DateTime.now()
+    image_identifier: Optional[SyftWorkerImageIdentifier] = None
+    image_hash: Optional[str] = None
+    built_at: Optional[DateTime] = None
+
+    @property
+    def is_built(self) -> bool:
+        """Returns True if the image has been built."""
+
+        return self.built_at is not None
+
+    @property
+    def built_image_tag(self) -> Optional[str]:
+        """Returns the full name of the image if it has been built."""
+
+        if self.is_built and self.image_identifier:
+            return self.image_identifier.full_name_with_tag
+        return None

--- a/packages/syft/src/syft/service/worker/worker_image_service.py
+++ b/packages/syft/src/syft/service/worker/worker_image_service.py
@@ -48,11 +48,9 @@ class SyftWorkerImageService(AbstractService):
     def submit_dockerfile(
         self, context: AuthedServiceContext, docker_config: DockerWorkerConfig
     ) -> Union[SyftSuccess, SyftError]:
-        image_identifier = SyftWorkerImageIdentifier(repo="", tag="")
         worker_image = SyftWorkerImage(
             config=docker_config,
             created_by=context.credentials,
-            image_identifier=image_identifier,
         )
         res = self.stash.set(context.credentials, worker_image)
 

--- a/packages/syft/src/syft/service/worker/worker_image_service.py
+++ b/packages/syft/src/syft/service/worker/worker_image_service.py
@@ -207,7 +207,7 @@ class SyftWorkerImageService(AbstractService):
         res: List[Tuple] = []
         for im in images:
             if im.image_identifier is not None:
-                res.append((im.image_identifier.repo_with_tag, im))
+                res.append((im.image_identifier.full_name_with_tag, im))
             else:
                 res.append(("default-worker-image", im))
 
@@ -229,7 +229,7 @@ class SyftWorkerImageService(AbstractService):
 
         if not context.node.in_memory_workers and image and image.image_identifier:
             try:
-                full_tag: str = image.image_identifier.repo_with_tag
+                full_tag: str = image.image_identifier.full_name_with_tag
                 with contextlib.closing(docker.from_env()) as client:
                     client.images.remove(image=full_tag)
             except docker.errors.ImageNotFound:

--- a/packages/syft/src/syft/service/worker/worker_pool_service.py
+++ b/packages/syft/src/syft/service/worker/worker_pool_service.py
@@ -148,7 +148,7 @@ class SyftWorkerPoolService(AbstractService):
         res: List[Tuple] = []
         for pool in worker_pools:
             if pool.image.image_identifier is not None:
-                res.append((pool.image.image_identifier.repo_with_tag, pool))
+                res.append((pool.image.image_identifier.full_name_with_tag, pool))
             else:
                 res.append(("in-memory-pool", pool))
         return DictTuple(res)

--- a/packages/syft/src/syft/service/worker/worker_pool_service.py
+++ b/packages/syft/src/syft/service/worker/worker_pool_service.py
@@ -104,7 +104,7 @@ class SyftWorkerPoolService(AbstractService):
                 message=f"Failed to retrieve Worker Image with id: {image_uid}. Error: {result.err()}"
             )
 
-        worker_image = result.ok()
+        worker_image: SyftWorkerImage = result.ok()
 
         worker_list, container_statuses = _create_workers_in_pool(
             context=context,
@@ -114,7 +114,7 @@ class SyftWorkerPoolService(AbstractService):
             worker_image=worker_image,
             worker_stash=self.worker_stash,
             reg_username=reg_username,
-            reg_password=reg_username,
+            reg_password=reg_password,
         )
 
         worker_pool = WorkerPool(
@@ -193,7 +193,7 @@ class SyftWorkerPoolService(AbstractService):
                 message=f"Failed to retrieve image for worker pool: {worker_pool.name}"
             )
 
-        worker_image = result.ok()
+        worker_image: SyftWorkerImage = result.ok()
 
         worker_list, container_statuses = _create_workers_in_pool(
             context=context,

--- a/packages/syft/tests/syft/worker_image/image_identifier_test.py
+++ b/packages/syft/tests/syft/worker_image/image_identifier_test.py
@@ -1,0 +1,41 @@
+# third party
+import pytest
+
+# syft absolute
+from syft.service.worker.image_identifier import SyftWorkerImageIdentifier
+from syft.service.worker.image_registry import SyftImageRegistry
+
+
+def test_image_id_str_no_host():
+    tag = "openmined/test-nginx:0.7.8"
+    image_id = SyftWorkerImageIdentifier.from_str(tag)
+    assert image_id.registry_host == ""
+
+
+def test_image_id_str_with_host():
+    tag = "localhost:5678/openmined/test-nginx:0.7.8"
+    image_id = SyftWorkerImageIdentifier.from_str(tag)
+    assert image_id.registry_host == "localhost:5678"
+    assert image_id.tag == "0.7.8"
+    assert image_id.repo == "openmined/test-nginx"
+    assert image_id.repo_with_tag == "openmined/test-nginx:0.7.8"
+    assert image_id.full_name_with_tag == tag
+
+
+def test_image_id_with_registry():
+    tag = "docker.io/openmined/test-nginx:0.7.8"
+    registry = SyftImageRegistry.from_url("docker.io")
+    image_id = SyftWorkerImageIdentifier.with_registry(tag, registry)
+
+    assert image_id.registry_host == "docker.io"
+    assert image_id.repo == "openmined/test-nginx"
+    assert image_id.tag == "0.7.8"
+    assert image_id.repo_with_tag == "openmined/test-nginx:0.7.8"
+    assert image_id.full_name_with_tag == tag
+
+
+def test_image_id_with_incorrect_registry():
+    with pytest.raises(ValueError):
+        tag = "docker.io/openmined/test-nginx:0.7.8"
+        registry = SyftImageRegistry.from_url("localhost:5678")
+        _ = SyftWorkerImageIdentifier.with_registry(tag, registry)

--- a/tox.ini
+++ b/tox.ini
@@ -506,6 +506,7 @@ setenv =
 commands =
 
     # Volume cleanup
+    bash -c 'hagrid land all --force || true'
     bash -c "docker volume rm test-domain-1_mongo-data --force || true"
     bash -c "docker volume rm test-domain-1_credentials-data --force || true"
     bash -c "docker volume rm test-domain-1_seaweedfs-data --force || true"
@@ -520,6 +521,8 @@ commands =
     ; pytest --nbmake api/0.9 -p no:randomly -vvvv
     ; pytest --nbmake tutorials -p no:randomly -vvvv
     ; pytest --nbmake tutorials/pandas-cookbook -p no:randomly -vvvv
+
+    bash -c 'hagrid land all --force'
 
 [testenv:stack.test.vm]
 description = Stack VM Tests


### PR DESCRIPTION
## Description

Closes https://github.com/OpenMined/Heartbeat/issues/912

- Made sure that we can create a worker pool only on built images
- Use correct tag for starting worker pool when when image is built with custom registry
- Expose some props to know if image is built and with what tag
- Fix exceptions with `SyftWorkerImageIdentifier` registry being a union of url or SyftImageRegistry
- Cleaner jupyter SyftSuccess/SyftError messages
- Fix `INMEMORY_WORKERS` not being passed to `worker` in docker-compose
- Fix exceptions when using properties that were refactored

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
