### PR TITLE
bugfix: base image build test failed due to conflicting system packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -987,7 +987,7 @@ allowlist_externals =
     bash
 setenv =
     PIP_PACKAGES = {env:PIP_PACKAGES:llama-index opendp}
-    SYSTEM_PACKAGES = {env:SYSTEM_PACKAGES:curl wget htop}
+    SYSTEM_PACKAGES = {env:SYSTEM_PACKAGES:curl wget}
 commands =
     bash -c 'docker buildx use default || true'
     ; Build the base image


### PR DESCRIPTION
Seems like there is a conflict in system packages when installing `htop` in `SYSTEM_PACKAGES` of `tox.ini`'s `backend.test.basecpu`, making the `pr-syft-image-test` failed.