### PR TITLE
[syft] fix: remove extra two div tags from custom_code

### DIFF
--- a/packages/syft/src/syft/util/notebook_ui/notebook_addons.py
+++ b/packages/syft/src/syft/util/notebook_ui/notebook_addons.py
@@ -690,8 +690,6 @@ custom_code = """
                 </script>
             </div>
         </div>
-    </div>
-    </div>
 """
 
 


### PR DESCRIPTION
## Description
Remove extra div closing tags that were breaking docs.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
