### PR TITLE
[WIP] Local Execution using Custom Worker Containers 

### DIFF
--- a/packages/syft/src/syft/service/worker/worker_image_service.py
+++ b/packages/syft/src/syft/service/worker/worker_image_service.py
@@ -117,7 +117,7 @@ class SyftWorkerImageService(AbstractService):
         worker_image.image_identifier = image_identifier
         result = None
 
-        if not context.node.in_memory_workers:
+        if True or not context.node.in_memory_workers:
             build_result = docker_build(worker_image, pull=pull)
             if isinstance(build_result, SyftError):
                 return build_result

--- a/packages/syft/src/syft/service/worker/worker_pool_service.py
+++ b/packages/syft/src/syft/service/worker/worker_pool_service.py
@@ -496,8 +496,10 @@ def _create_workers_in_pool(
 
     # Check if workers needs to be run in memory or as containers
     start_workers_in_memory = context.node.in_memory_workers
+    import sys
+    print("FOUND:", start_workers_in_memory, file=sys.stderr)
 
-    if start_workers_in_memory:
+    if False and start_workers_in_memory:
         # Run in-memory workers in threads
         container_statuses: List[ContainerSpawnStatus] = run_workers_in_threads(
             node=context.node,


### PR DESCRIPTION
## Description
We have implemented local execution but it only works for in-memory nodes with in-memory workers. This limits the DS to test their codes with custom worker images, which we expect to be heavily used when users need some custom libraries that are not included with PySyft.

## Affected Dependencies

## How has this been tested?

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
