### PR TITLE
Execute usercode on mock data

### DIFF
--- a/packages/syft/src/syft/protocol/protocol_version.json
+++ b/packages/syft/src/syft/protocol/protocol_version.json
@@ -1117,7 +1117,7 @@
         },
         "2": {
           "version": 2,
-          "hash": "1a4e6fe11786c3243ba5429f836951b72274f0ff51c3d13c5f1d3494b9de1fd7",
+          "hash": "ded970c92f202716ed33a2117cf541789f35fad66bd4b1db39da5026b1d7d0e7",
           "action": "add"
         }
       },
@@ -1129,7 +1129,7 @@
         },
         "2": {
           "version": 2,
-          "hash": "59d3532893d09edc1aa86a68e4166e9720c4ef2bf33bdcc73800b4e0a094b697",
+          "hash": "32cba8fbd786c575f92e26c31384d282e68e3ebfe5c4b0a0e793820b1228d246",
           "action": "add"
         }
       },
@@ -1141,7 +1141,7 @@
         },
         "2": {
           "version": 2,
-          "hash": "d580e2a4ebb7787b326b6f6c34de27ddf30c6e8303f245c834d1c97fd42b9b42",
+          "hash": "2540188c5aaea866914dccff459df6e0f4727108a503414bb1567ff6297d4646",
           "action": "add"
         }
       },
@@ -1153,7 +1153,7 @@
         },
         "2": {
           "version": 2,
-          "hash": "41b3637c59c00bd121cd8034b3be7c055cd741ac61a5e982f818b85d5c3fe3d5",
+          "hash": "e410de583bb15bc5af57acef7be55ea5fc56b5b0fc169daa3869f4203c4d7473",
           "action": "add"
         }
       }

--- a/packages/syft/src/syft/protocol/protocol_version.json
+++ b/packages/syft/src/syft/protocol/protocol_version.json
@@ -1108,6 +1108,54 @@
           "hash": "cf26eeac3d9254dfa439917493b816341f8a379a77d182bbecba3b7ed2c1d00a",
           "action": "add"
         }
+      },
+      "User": {
+        "1": {
+          "version": 1,
+          "hash": "078636e64f737e60245b39cf348d30fb006531e80c12b70aa7cf98254e1bb37a",
+          "action": "remove"
+        },
+        "2": {
+          "version": 2,
+          "hash": "1a4e6fe11786c3243ba5429f836951b72274f0ff51c3d13c5f1d3494b9de1fd7",
+          "action": "add"
+        }
+      },
+      "UserUpdate": {
+        "1": {
+          "version": 1,
+          "hash": "839dd90aeb611e1dc471c8fd6daf230e913465c0625c6a297079cb7f0a271195",
+          "action": "remove"
+        },
+        "2": {
+          "version": 2,
+          "hash": "59d3532893d09edc1aa86a68e4166e9720c4ef2bf33bdcc73800b4e0a094b697",
+          "action": "add"
+        }
+      },
+      "UserCreate": {
+        "1": {
+          "version": 1,
+          "hash": "dab78b63544ae91c09f9843c323cb237c0a6fcfeb71c1acf5f738e2fcf5c277f",
+          "action": "remove"
+        },
+        "2": {
+          "version": 2,
+          "hash": "d580e2a4ebb7787b326b6f6c34de27ddf30c6e8303f245c834d1c97fd42b9b42",
+          "action": "add"
+        }
+      },
+      "UserView": {
+        "1": {
+          "version": 1,
+          "hash": "63289383fe7e7584652f242a4362ce6e2f0ade52f6416ab6149b326a506b0675",
+          "action": "remove"
+        },
+        "2": {
+          "version": 2,
+          "hash": "41b3637c59c00bd121cd8034b3be7c055cd741ac61a5e982f818b85d5c3fe3d5",
+          "action": "add"
+        }
       }
     }
   }

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -424,11 +424,14 @@ def convert_to_pointers(
     args: Optional[List] = None,
     kwargs: Optional[Dict] = None,
 ) -> Tuple[List, Dict]:
+    # relative
+    from ..dataset.dataset import Asset
+
     arg_list = []
     kwarg_dict = {}
     if args is not None:
         for arg in args:
-            if not isinstance(arg, SyftObject):
+            if not isinstance(arg, (ActionObject, Asset)):
                 arg = ActionObject.from_obj(
                     syft_action_data=arg,
                     syft_client_verify_key=api.signing_key.verify_key,
@@ -443,7 +446,7 @@ def convert_to_pointers(
 
     if kwargs is not None:
         for k, arg in kwargs.items():
-            if not isinstance(arg, SyftObject):
+            if not isinstance(arg, (ActionObject, Asset)):
                 arg = ActionObject.from_obj(
                     syft_action_data=arg,
                     syft_client_verify_key=api.signing_key.verify_key,

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -431,7 +431,7 @@ def convert_to_pointers(
     kwarg_dict = {}
     if args is not None:
         for arg in args:
-            if not isinstance(arg, (ActionObject, Asset)):
+            if not isinstance(arg, (ActionObject, Asset, UID)):
                 arg = ActionObject.from_obj(
                     syft_action_data=arg,
                     syft_client_verify_key=api.signing_key.verify_key,
@@ -446,7 +446,7 @@ def convert_to_pointers(
 
     if kwargs is not None:
         for k, arg in kwargs.items():
-            if not isinstance(arg, (ActionObject, Asset)):
+            if not isinstance(arg, (ActionObject, Asset, UID)):
                 arg = ActionObject.from_obj(
                     syft_action_data=arg,
                     syft_client_verify_key=api.signing_key.verify_key,

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -428,7 +428,7 @@ def convert_to_pointers(
     kwarg_dict = {}
     if args is not None:
         for arg in args:
-            if not isinstance(arg, ActionObject):
+            if not isinstance(arg, SyftObject):
                 arg = ActionObject.from_obj(
                     syft_action_data=arg,
                     syft_client_verify_key=api.signing_key.verify_key,
@@ -443,7 +443,7 @@ def convert_to_pointers(
 
     if kwargs is not None:
         for k, arg in kwargs.items():
-            if not isinstance(arg, ActionObject):
+            if not isinstance(arg, SyftObject):
                 arg = ActionObject.from_obj(
                     syft_action_data=arg,
                     syft_client_verify_key=api.signing_key.verify_key,

--- a/packages/syft/src/syft/service/code/user_code.py
+++ b/packages/syft/src/syft/service/code/user_code.py
@@ -1217,7 +1217,7 @@ class SecureContext:
             kw2id = {}
             for k, v in kwargs.items():
                 value = ActionObject.from_obj(v)
-                ptr = action_service.set(context, value)
+                ptr = action_service._set(context, value)
                 ptr = ptr.ok()
                 kw2id[k] = ptr.id
             try:

--- a/packages/syft/src/syft/service/code/user_code_service.py
+++ b/packages/syft/src/syft/service/code/user_code_service.py
@@ -308,6 +308,8 @@ class UserCodeService(AbstractService):
             return SyftError(message="Endpoint only supported for enclave code")
 
     def is_mock_execution_allowed(self, code: UserCode, context: AuthedServiceContext):
+        if context.role == ServiceRole.ADMIN:
+            return True
         user_service = context.node.get_service("userservice")
         current_user = user_service.get_current_user(context=context)
         return current_user.allow_mock_execution
@@ -379,12 +381,12 @@ class UserCodeService(AbstractService):
                 if self.is_mock_execution_allowed(code, context):
                     kwargs = self._wrap_as_action_object(kwargs, context)
                     if isinstance(kwargs, SyftError):
-                        return kwargs
+                        return Err(value=kwargs.message)
 
                     # Execution is allowed for mock objects
                     context.has_execute_permissions = True
                 else:
-                    return SyftError(message="Only Syft objects are allowed as inputs")
+                    return Err(value="Only Syft objects are allowed as inputs")
 
             kwarg2id = map_kwargs_to_id(kwargs)
 

--- a/packages/syft/src/syft/service/code/user_code_service.py
+++ b/packages/syft/src/syft/service/code/user_code_service.py
@@ -323,9 +323,6 @@ class UserCodeService(AbstractService):
             return True
         user_service = context.node.get_service("userservice")
         current_user = user_service.get_current_user(context=context)
-        if isinstance(current_user, SyftError):
-            # TODO with test guest_client we have no current user
-            return False
         return current_user.mock_execution_permission
 
     def get_mock_kwargs(

--- a/packages/syft/src/syft/service/code/user_code_service.py
+++ b/packages/syft/src/syft/service/code/user_code_service.py
@@ -324,6 +324,9 @@ class UserCodeService(AbstractService):
             return True
         user_service = context.node.get_service("userservice")
         current_user = user_service.get_current_user(context=context)
+        if isinstance(current_user, SyftError):
+            # TODO with test guest_client we have no current user
+            return False
         return current_user.mock_execution_permission
 
     def get_mock_kwargs(

--- a/packages/syft/src/syft/service/user/user.py
+++ b/packages/syft/src/syft/service/user/user.py
@@ -266,6 +266,11 @@ class UserView(SyftObject):
 
         return SyftSuccess(message="User details successfully updated.")
 
+    @property
+    def allow_mock_execution(self) -> bool:
+        # TODO
+        return self.role >= ServiceRole.DATA_SCIENTIST
+
 
 @serializable()
 class UserViewPage(SyftObject):

--- a/packages/syft/src/syft/service/user/user.py
+++ b/packages/syft/src/syft/service/user/user.py
@@ -80,7 +80,7 @@ class User(SyftObject):
     website: Optional[str] = None
     created_at: Optional[str] = None
     # TODO where do we put this flag?
-    allow_mock_execution: bool = False
+    mock_execution_permission: bool = False
 
     # serde / storage rules
     __attr_searchable__ = ["name", "email", "verify_key", "role"]
@@ -163,7 +163,7 @@ class UserUpdate(PartialSyftObject):
     verify_key: SyftVerifyKey
     institution: str
     website: str
-    allow_mock_execution: bool
+    mock_execution_permission: bool
 
 
 class UserCreateV1(UserUpdateV1):
@@ -195,7 +195,7 @@ class UserCreate(UserUpdate):
     institution: Optional[str]
     website: Optional[str]
     created_by: Optional[SyftSigningKey]
-    allow_mock_execution: bool = False
+    mock_execution_permission: bool = False
 
     __repr_attrs__ = ["name", "email"]
 
@@ -232,7 +232,7 @@ class UserView(SyftObject):
     role: ServiceRole  # make sure role cant be set without uid
     institution: Optional[str]
     website: Optional[str]
-    allow_mock_execution: bool
+    mock_execution_permission: bool
 
     __repr_attrs__ = ["name", "email", "institution", "website", "role"]
 
@@ -305,7 +305,7 @@ class UserView(SyftObject):
         institution: Union[Empty, str] = Empty,
         website: Union[str, Empty] = Empty,
         role: Union[str, Empty] = Empty,
-        allow_mock_execution: Union[bool, Empty] = Empty,
+        mock_execution_permission: Union[bool, Empty] = Empty,
     ) -> Union[SyftSuccess, SyftError]:
         """Used to update name, institution, website of a user."""
         api = APIRegistry.api_for(
@@ -319,7 +319,7 @@ class UserView(SyftObject):
             institution=institution,
             website=website,
             role=role,
-            allow_mock_execution=allow_mock_execution,
+            mock_execution_permission=mock_execution_permission,
         )
         result = api.services.user.update(uid=self.id, user_update=user_update)
 
@@ -330,6 +330,9 @@ class UserView(SyftObject):
             setattr(self, attr, val)
 
         return SyftSuccess(message="User details successfully updated.")
+
+    def allow_mock_execution(self, allow: bool = True) -> Union[SyftSuccess, SyftError]:
+        return self.update(mock_execution_permission=allow)
 
 
 @serializable()
@@ -374,7 +377,7 @@ def user_to_view_user() -> List[Callable]:
                 "role",
                 "institution",
                 "website",
-                "allow_mock_execution",
+                "mock_execution_permission",
             ]
         )
     ]
@@ -397,39 +400,39 @@ def user_to_user_verify() -> List[Callable]:
 
 @migrate(UserV1, User)
 def upgrade_user_v1_to_v2():
-    return [make_set_default(key="allow_mock_execution", value=False)]
+    return [make_set_default(key="mock_execution_permission", value=False)]
 
 
 @migrate(User, UserV1)
 def downgrade_user_v2_to_v1():
-    return [drop(["allow_mock_execution"])]
+    return [drop(["mock_execution_permission"])]
 
 
 @migrate(UserUpdateV1, UserUpdate)
 def upgrade_user_update_v1_to_v2():
-    return [make_set_default(key="allow_mock_execution", value=False)]
+    return [make_set_default(key="mock_execution_permission", value=False)]
 
 
 @migrate(UserUpdate, UserUpdateV1)
 def downgrade_user_update_v2_to_v1():
-    return [drop(["allow_mock_execution"])]
+    return [drop(["mock_execution_permission"])]
 
 
 @migrate(UserCreateV1, UserCreate)
 def upgrade_user_create_v1_to_v2():
-    return [make_set_default(key="allow_mock_execution", value=False)]
+    return [make_set_default(key="mock_execution_permission", value=False)]
 
 
 @migrate(UserCreate, UserCreateV1)
 def downgrade_user_create_v2_to_v1():
-    return [drop(["allow_mock_execution"])]
+    return [drop(["mock_execution_permission"])]
 
 
 @migrate(UserViewV1, UserView)
 def upgrade_user_view_v1_to_v2():
-    return [make_set_default(key="allow_mock_execution", value=False)]
+    return [make_set_default(key="mock_execution_permission", value=False)]
 
 
 @migrate(UserView, UserViewV1)
 def downgrade_user_view_v2_to_v1():
-    return [drop(["allow_mock_execution"])]
+    return [drop(["mock_execution_permission"])]

--- a/packages/syft/src/syft/service/user/user.py
+++ b/packages/syft/src/syft/service/user/user.py
@@ -22,8 +22,10 @@ from ...node.credentials import SyftSigningKey
 from ...node.credentials import SyftVerifyKey
 from ...serde.serializable import serializable
 from ...types.syft_metaclass import Empty
+from ...types.syft_migration import migrate
 from ...types.syft_object import PartialSyftObject
 from ...types.syft_object import SYFT_OBJECT_VERSION_1
+from ...types.syft_object import SYFT_OBJECT_VERSION_2
 from ...types.syft_object import SyftObject
 from ...types.transforms import TransformContext
 from ...types.transforms import drop
@@ -38,11 +40,27 @@ from ..response import SyftSuccess
 from .user_roles import ServiceRole
 
 
+class UserV1(SyftObject):
+    __canonical_name__ = "User"
+    __version__ = SYFT_OBJECT_VERSION_1
+
+    email: Optional[EmailStr]
+    name: Optional[str]
+    hashed_password: Optional[str]
+    salt: Optional[str]
+    signing_key: Optional[SyftSigningKey]
+    verify_key: Optional[SyftVerifyKey]
+    role: Optional[ServiceRole]
+    institution: Optional[str]
+    website: Optional[str] = None
+    created_at: Optional[str] = None
+
+
 @serializable()
 class User(SyftObject):
     # version
     __canonical_name__ = "User"
-    __version__ = SYFT_OBJECT_VERSION_1
+    __version__ = SYFT_OBJECT_VERSION_2
 
     id: Optional[UID]
 
@@ -61,6 +79,8 @@ class User(SyftObject):
     institution: Optional[str]
     website: Optional[str] = None
     created_at: Optional[str] = None
+    # TODO where do we put this flag?
+    allow_mock_execution: bool = False
 
     # serde / storage rules
     __attr_searchable__ = ["name", "email", "verify_key", "role"]
@@ -106,10 +126,24 @@ def check_pwd(password: str, hashed_password: str) -> bool:
     )
 
 
+class UserUpdateV1(PartialSyftObject):
+    __canonical_name__ = "UserUpdate"
+    __version__ = SYFT_OBJECT_VERSION_1
+
+    email: EmailStr
+    name: str
+    role: ServiceRole
+    password: str
+    password_verify: str
+    verify_key: SyftVerifyKey
+    institution: str
+    website: str
+
+
 @serializable()
 class UserUpdate(PartialSyftObject):
     __canonical_name__ = "UserUpdate"
-    __version__ = SYFT_OBJECT_VERSION_1
+    __version__ = SYFT_OBJECT_VERSION_2
 
     @pydantic.validator("email", pre=True)
     def make_email(cls, v: Any) -> Any:
@@ -129,12 +163,28 @@ class UserUpdate(PartialSyftObject):
     verify_key: SyftVerifyKey
     institution: str
     website: str
+    allow_mock_execution: bool
+
+
+class UserCreateV1(UserUpdateV1):
+    __canonical_name__ = "UserCreate"
+    __version__ = SYFT_OBJECT_VERSION_1
+
+    email: EmailStr
+    name: str
+    role: Optional[ServiceRole] = None
+    password: str
+    password_verify: Optional[str] = None
+    verify_key: Optional[SyftVerifyKey]
+    institution: Optional[str]
+    website: Optional[str]
+    created_by: Optional[SyftSigningKey]
 
 
 @serializable()
 class UserCreate(UserUpdate):
     __canonical_name__ = "UserCreate"
-    __version__ = SYFT_OBJECT_VERSION_1
+    __version__ = SYFT_OBJECT_VERSION_2
 
     email: EmailStr
     name: str
@@ -145,6 +195,7 @@ class UserCreate(UserUpdate):
     institution: Optional[str]
     website: Optional[str]
     created_by: Optional[SyftSigningKey]
+    allow_mock_execution: bool = False
 
     __repr_attrs__ = ["name", "email"]
 
@@ -160,8 +211,7 @@ class UserSearch(PartialSyftObject):
     name: str
 
 
-@serializable()
-class UserView(SyftObject):
+class UserViewV1(SyftObject):
     __canonical_name__ = "UserView"
     __version__ = SYFT_OBJECT_VERSION_1
 
@@ -170,6 +220,19 @@ class UserView(SyftObject):
     role: ServiceRole  # make sure role cant be set without uid
     institution: Optional[str]
     website: Optional[str]
+
+
+@serializable()
+class UserView(SyftObject):
+    __canonical_name__ = "UserView"
+    __version__ = SYFT_OBJECT_VERSION_2
+
+    email: EmailStr
+    name: str
+    role: ServiceRole  # make sure role cant be set without uid
+    institution: Optional[str]
+    website: Optional[str]
+    allow_mock_execution: bool
 
     __repr_attrs__ = ["name", "email", "institution", "website", "role"]
 
@@ -242,6 +305,7 @@ class UserView(SyftObject):
         institution: Union[Empty, str] = Empty,
         website: Union[str, Empty] = Empty,
         role: Union[str, Empty] = Empty,
+        allow_mock_execution: Union[bool, Empty] = Empty,
     ) -> Union[SyftSuccess, SyftError]:
         """Used to update name, institution, website of a user."""
         api = APIRegistry.api_for(
@@ -255,6 +319,7 @@ class UserView(SyftObject):
             institution=institution,
             website=website,
             role=role,
+            allow_mock_execution=allow_mock_execution,
         )
         result = api.services.user.update(uid=self.id, user_update=user_update)
 
@@ -265,11 +330,6 @@ class UserView(SyftObject):
             setattr(self, attr, val)
 
         return SyftSuccess(message="User details successfully updated.")
-
-    @property
-    def allow_mock_execution(self) -> bool:
-        # TODO
-        return self.role >= ServiceRole.DATA_SCIENTIST
 
 
 @serializable()
@@ -305,7 +365,19 @@ def user_create_to_user() -> List[Callable]:
 
 @transform(User, UserView)
 def user_to_view_user() -> List[Callable]:
-    return [keep(["id", "email", "name", "role", "institution", "website"])]
+    return [
+        keep(
+            [
+                "id",
+                "email",
+                "name",
+                "role",
+                "institution",
+                "website",
+                "allow_mock_execution",
+            ]
+        )
+    ]
 
 
 @serializable()
@@ -321,3 +393,43 @@ class UserPrivateKey(SyftObject):
 @transform(User, UserPrivateKey)
 def user_to_user_verify() -> List[Callable]:
     return [keep(["email", "signing_key", "id", "role"])]
+
+
+@migrate(UserV1, User)
+def upgrade_user_v1_to_v2():
+    return [make_set_default(key="allow_mock_execution", value=False)]
+
+
+@migrate(User, UserV1)
+def downgrade_user_v2_to_v1():
+    return [drop(["allow_mock_execution"])]
+
+
+@migrate(UserUpdateV1, UserUpdate)
+def upgrade_user_update_v1_to_v2():
+    return [make_set_default(key="allow_mock_execution", value=False)]
+
+
+@migrate(UserUpdate, UserUpdateV1)
+def downgrade_user_update_v2_to_v1():
+    return [drop(["allow_mock_execution"])]
+
+
+@migrate(UserCreateV1, UserCreate)
+def upgrade_user_create_v1_to_v2():
+    return [make_set_default(key="allow_mock_execution", value=False)]
+
+
+@migrate(UserCreate, UserCreateV1)
+def downgrade_user_create_v2_to_v1():
+    return [drop(["allow_mock_execution"])]
+
+
+@migrate(UserViewV1, UserView)
+def upgrade_user_view_v1_to_v2():
+    return [make_set_default(key="allow_mock_execution", value=False)]
+
+
+@migrate(UserView, UserViewV1)
+def downgrade_user_view_v2_to_v1():
+    return [drop(["allow_mock_execution"])]

--- a/packages/syft/src/syft/service/user/user_service.py
+++ b/packages/syft/src/syft/service/user/user_service.py
@@ -224,7 +224,7 @@ class UserService(AbstractService):
 
         if updates_role and not can_edit_roles:
             return SyftError(message=f"{context.role} is not allowed to edit roles")
-        if (user_update.allow_mock_execution is not Empty) and not can_edit_roles:
+        if (user_update.mock_execution_permission is not Empty) and not can_edit_roles:
             return SyftError(
                 message=f"{context.role} is not allowed to update permissions"
             )

--- a/packages/syft/src/syft/service/user/user_service.py
+++ b/packages/syft/src/syft/service/user/user_service.py
@@ -220,12 +220,14 @@ class UserService(AbstractService):
         self, context: AuthedServiceContext, uid: UID, user_update: UserUpdate
     ) -> Union[UserView, SyftError]:
         updates_role = user_update.role is not Empty
+        can_edit_roles = ServiceRoleCapability.CAN_EDIT_ROLES in context.capabilities()
 
-        if (
-            updates_role
-            and ServiceRoleCapability.CAN_EDIT_ROLES not in context.capabilities()
-        ):
+        if updates_role and not can_edit_roles:
             return SyftError(message=f"{context.role} is not allowed to edit roles")
+        if (user_update.allow_mock_execution is not Empty) and not can_edit_roles:
+            return SyftError(
+                message=f"{context.role} is not allowed to update permissions"
+            )
 
         # Get user to be updated by its UID
         result = self.stash.get_by_uid(credentials=context.credentials, uid=uid)

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -827,7 +827,7 @@ class PartialSyftObject(SyftObject, metaclass=PartialModelMetaclass):
 
         fields_with_default = set()
         for _field_name, _field in self.__fields__.items():
-            if _field.default or _field.allow_none:
+            if _field.default is not None or _field.allow_none:
                 fields_with_default.add(_field_name)
 
         # Fields whose values are set via a validator hook

--- a/packages/syft/tests/syft/syft_functions/syft_function_test.py
+++ b/packages/syft/tests/syft/syft_functions/syft_function_test.py
@@ -17,8 +17,10 @@ from syft.service.response import SyftSuccess
 
 @pytest.fixture
 def node():
+    random.seed()
+    name = f"nested_job_test_domain-{random.randint(0,1000)}"
     _node = sy.orchestra.launch(
-        name="nested_job_test_domain",
+        name=name,
         dev_mode=True,
         reset=True,
         n_consumers=3,

--- a/packages/syft/tests/syft/syft_functions/syft_function_test.py
+++ b/packages/syft/tests/syft/syft_functions/syft_function_test.py
@@ -21,7 +21,7 @@ def node():
         name="nested_job_test_domain",
         dev_mode=True,
         reset=True,
-        n_consumers=3,
+        n_consumers=4,
         create_producer=True,
         queue_port=random.randint(13000, 13300),
     )
@@ -31,7 +31,7 @@ def node():
     _node.land()
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=1)
+# @pytest.mark.flaky(reruns=5, reruns_delay=1)
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_nested_jobs(node):
     client = node.login(email="info@openmined.org", password="changethis")
@@ -42,7 +42,7 @@ def test_nested_jobs(node):
     ## Dataset
 
     x = ActionObject.from_obj([1, 2])
-    x_ptr = x.send(ds_client)
+    x_ptr = x.send(client)
 
     ## aggregate function
     @sy.syft_function()
@@ -89,7 +89,6 @@ def test_nested_jobs(node):
     job = ds_client.code.process_all(x=x_ptr, blocking=False)
 
     job.wait()
-    # stdlib
 
     assert len(job.subjobs) == 3
     # stdlib

--- a/packages/syft/tests/syft/syft_functions/syft_function_test.py
+++ b/packages/syft/tests/syft/syft_functions/syft_function_test.py
@@ -31,7 +31,7 @@ def node():
     _node.land()
 
 
-# @pytest.mark.flaky(reruns=5, reruns_delay=1)
+@pytest.mark.flaky(reruns=5, reruns_delay=1)
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_nested_jobs(node):
     client = node.login(email="info@openmined.org", password="changethis")

--- a/packages/syft/tests/syft/users/user_code_test.py
+++ b/packages/syft/tests/syft/users/user_code_test.py
@@ -29,8 +29,22 @@ def test_func_2():
     return 1
 
 
-def test_user_code(worker, guest_client: User) -> None:
-    # test_func()
+def test_user_code(worker) -> None:
+    root_domain_client = worker.root_client
+    root_domain_client.register(
+        name="data-scientist",
+        email="test_user@openmined.org",
+        password="0000",
+        password_verify="0000",
+    )
+    guest_client = root_domain_client.login(
+        email="test_user@openmined.org",
+        password="0000",
+    )
+
+    users = root_domain_client.users.get_all()
+    users[-1].allow_mock_execution()
+
     guest_client.api.services.code.request_code_execution(test_func)
 
     root_domain_client = worker.root_client

--- a/packages/syft/tests/syft/users/user_code_test.py
+++ b/packages/syft/tests/syft/users/user_code_test.py
@@ -87,8 +87,7 @@ def test_user_code_mock_execution(worker) -> None:
 
     # Guest attempts to set own permissions
     guest_user = ds_client.users.get_current_user()
-    print(guest_user)
-    res = guest_user.update(allow_mock_execution=True)
+    res = guest_user.allow_mock_execution()
     assert isinstance(res, SyftError)
 
     # Mock execution fails, no permissions
@@ -98,7 +97,7 @@ def test_user_code_mock_execution(worker) -> None:
     # DO grants permissions
     users = root_domain_client.users.get_all()
     guest_user = [u for u in users if u.id == guest_user.id][0]
-    guest_user.update(allow_mock_execution=True)
+    guest_user.allow_mock_execution()
 
     # Mock execution succeeds
     result = ds_client.api.services.code.compute_mean(data=data.mock).get()

--- a/packages/syft/tests/syft/users/user_code_test.py
+++ b/packages/syft/tests/syft/users/user_code_test.py
@@ -47,63 +47,6 @@ def test_user_code(worker, guest_client: User) -> None:
     assert isinstance(real_result, int)
 
 
-def test_user_code_mock_execution(worker) -> None:
-    # Setup
-    root_domain_client = worker.root_client
-
-    # TODO guest_client is not in root_domain_client.users
-    root_domain_client.register(
-        name="data-scientist",
-        email="test_user@openmined.org",
-        password="0000",
-        password_verify="0000",
-    )
-    ds_client = root_domain_client.login(
-        email="test_user@openmined.org",
-        password="0000",
-    )
-
-    dataset = sy.Dataset(
-        name="my-dataset",
-        asset_list=[
-            sy.Asset(
-                name="numpy-data",
-                data=np.array([0, 1, 2, 3, 4]),
-                mock=np.array([5, 6, 7, 8, 9]),
-            )
-        ],
-    )
-    root_domain_client.upload_dataset(dataset)
-
-    # DS requests code execution
-    data = ds_client.datasets[0].assets[0]
-
-    @sy.syft_function_single_use(data=data)
-    def compute_mean(data):
-        return data.mean()
-
-    compute_mean.code = dedent(compute_mean.code)
-    ds_client.api.services.code.request_code_execution(compute_mean)
-
-    # Guest attempts to set own permissions
-    guest_user = ds_client.users.get_current_user()
-    res = guest_user.allow_mock_execution()
-    assert isinstance(res, SyftError)
-
-    # Mock execution fails, no permissions
-    result = ds_client.api.services.code.compute_mean(data=data.mock)
-    assert isinstance(result, SyftError)
-
-    # DO grants permissions
-    users = root_domain_client.users.get_all()
-    guest_user = [u for u in users if u.id == guest_user.id][0]
-    guest_user.allow_mock_execution()
-
-    # Mock execution succeeds
-    result = ds_client.api.services.code.compute_mean(data=data.mock).get()
-    assert isinstance(result, float)
-
-
 def test_duplicated_user_code(worker, guest_client: User) -> None:
     # test_func()
     result = guest_client.api.services.code.request_code_execution(test_func)
@@ -202,3 +145,117 @@ def test_nested_requests(worker, guest_client: User):
     assert linked_obj.resolve.id == inner.id
     assert outer.status.approved
     assert not inner.status.approved
+
+
+def test_user_code_mock_execution(worker) -> None:
+    # Setup
+    root_domain_client = worker.root_client
+
+    # TODO guest_client fixture is not in root_domain_client.users
+    root_domain_client.register(
+        name="data-scientist",
+        email="test_user@openmined.org",
+        password="0000",
+        password_verify="0000",
+    )
+    ds_client = root_domain_client.login(
+        email="test_user@openmined.org",
+        password="0000",
+    )
+
+    dataset = sy.Dataset(
+        name="my-dataset",
+        asset_list=[
+            sy.Asset(
+                name="numpy-data",
+                data=np.array([0, 1, 2, 3, 4]),
+                mock=np.array([5, 6, 7, 8, 9]),
+            )
+        ],
+    )
+    root_domain_client.upload_dataset(dataset)
+
+    # DS requests code execution
+    data = ds_client.datasets[0].assets[0]
+
+    @sy.syft_function_single_use(data=data)
+    def compute_mean(data):
+        return data.mean()
+
+    compute_mean.code = dedent(compute_mean.code)
+    ds_client.api.services.code.request_code_execution(compute_mean)
+
+    # Guest attempts to set own permissions
+    guest_user = ds_client.users.get_current_user()
+    res = guest_user.allow_mock_execution()
+    assert isinstance(res, SyftError)
+
+    # Mock execution fails, no permissions
+    result = ds_client.api.services.code.compute_mean(data=data.mock)
+    assert isinstance(result, SyftError)
+
+    # DO grants permissions
+    users = root_domain_client.users.get_all()
+    guest_user = [u for u in users if u.id == guest_user.id][0]
+    guest_user.allow_mock_execution()
+
+    # Mock execution succeeds
+    result = ds_client.api.services.code.compute_mean(data=data.mock).get()
+    assert isinstance(result, float)
+
+
+def test_mock_multiple_arguments(worker) -> None:
+    # Setup
+    root_domain_client = worker.root_client
+
+    root_domain_client.register(
+        name="data-scientist",
+        email="test_user@openmined.org",
+        password="0000",
+        password_verify="0000",
+    )
+    ds_client = root_domain_client.login(
+        email="test_user@openmined.org",
+        password="0000",
+    )
+
+    dataset = sy.Dataset(
+        name="my-dataset",
+        asset_list=[
+            sy.Asset(
+                name="numpy-data",
+                data=np.array([0, 1, 2, 3, 4]),
+                mock=np.array([5, 6, 7, 8, 9]),
+            )
+        ],
+    )
+    root_domain_client.upload_dataset(dataset)
+    users = root_domain_client.users.get_all()
+    users[-1].allow_mock_execution()
+
+    # DS requests code execution
+    data = ds_client.datasets[0].assets[0]
+
+    @sy.syft_function_single_use(data1=data, data2=data)
+    def compute_sum(data1, data2):
+        return data1 + data2
+
+    compute_sum.code = dedent(compute_sum.code)
+    ds_client.api.services.code.request_code_execution(compute_sum)
+    root_domain_client.requests[-1].approve()
+
+    # Mock execution succeeds, result not cached
+    result = ds_client.api.services.code.compute_sum(data1=1, data2=1)
+    assert result.get() == 2
+
+    # Mixed execution fails on input policy
+    result = ds_client.api.services.code.compute_sum(data1=1, data2=data)
+    assert isinstance(result, SyftError)
+
+    # Real execution succeeds
+    result = ds_client.api.services.code.compute_sum(data1=data, data2=data)
+    assert np.equal(result.get(), np.array([0, 2, 4, 6, 8])).all()
+
+    # Mixed execution fails, no result from cache
+    result = ds_client.api.services.code.compute_sum(data1=1, data2=data)
+    assert isinstance(result, SyftError)


### PR DESCRIPTION
## Description
Implements executing usercode on mock data (=non-syft inputs)

includes 2 bugfixes:
- allows local execution on ephemeral nodes (is the same as mock execution)
- fix in PartialSyftObject for boolean default Field arguments, check for None explicitly when searching for None-valued defaults


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
