### PR TITLE
Use pytest<8 to maintain compatibility with pytest-lazy-fixure

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -107,8 +107,11 @@ telemetry =
     opentelemetry-instrumentation-requests==0.35b0
     ; opentelemetry-instrumentation-digma==0.9.0
 
+# pytest>=8.0 broke pytest-lazy-fixture which doesn't seem to be actively maintained
+# temporarily pin to pytest<8
+# see https://github.com/pytest-dev/pytest/issues/11890
 test_plugins =
-    pytest
+    pytest<8
     pytest-cov
     pytest-xdist[psutil]
     pytest-parallel


### PR DESCRIPTION
pytest>=8.0 broke pytest-lazy-fixture which doesn't seem to be actively maintained
temporarily pin to pytest<8
see pytest-dev/pytest#11890