### PR TITLE
Enable notifications via settings api

### DIFF
--- a/packages/syft/src/syft/service/settings/settings_service.py
+++ b/packages/syft/src/syft/service/settings/settings_service.py
@@ -1,6 +1,7 @@
 # stdlib
 
 # stdlib
+from typing import Optional
 from typing import Union
 
 # third party
@@ -18,6 +19,7 @@ from ..response import SyftError
 from ..response import SyftSuccess
 from ..service import AbstractService
 from ..service import service_method
+from ..user.user_roles import ADMIN_ROLE_LEVEL
 from ..warnings import HighSideCRUDWarning
 from .settings import NodeSettingsUpdate
 from .settings import NodeSettingsV2
@@ -79,6 +81,29 @@ class SettingsService(AbstractService):
                 return SyftError(message="No settings found")
         else:
             return SyftError(message=result.err())
+
+    @service_method(
+        path="settings.enable_notifications",
+        name="enable_notifications",
+        roles=ADMIN_ROLE_LEVEL,
+    )
+    def enable_notifications(
+        self, context: AuthedServiceContext, token: Optional[str] = None
+    ) -> Union[SyftSuccess, SyftError]:
+        notifier_service = context.node.get_service("notifierservice")
+        return notifier_service.turn_on(context=context, email_token=token)
+
+    @service_method(
+        path="settings.disable_notifications",
+        name="disable_notifications",
+        roles=ADMIN_ROLE_LEVEL,
+    )
+    def disable_notifications(
+        self,
+        context: AuthedServiceContext,
+    ) -> Union[SyftSuccess, SyftError]:
+        notifier_service = context.node.get_service("notifierservice")
+        return notifier_service.turn_off(context=context)
 
     @service_method(
         path="settings.allow_guest_signup",


### PR DESCRIPTION
Using the new Notifier Service, the node admin must be able to enable/disable the node notifier.

But to achieve that, there are some edge cases to keep in mind.

- [X] By UX/UI reasons, the api used to enable / disable it will be set at client.settints.
  - To enable: `client.settings.enable_notifications(token=<TOKEN>)`
  - To disable: `client.settings.disable_notifications()`
- [X] If email token isn't provided, returns a `SyftError` informing that **email_token** parameter is mandatory. 
- [X] If a regular user tries to use this API, it must receive the regular PySyft non authorized error.
- [X] If admin provides all the informations properly, it will return a `SyftSuccess` message. 