### PR TITLE
Fix Helm Upgrade

### DIFF
--- a/packages/grid/helm/syft/templates/_labels.tpl
+++ b/packages/grid/helm/syft/templates/_labels.tpl
@@ -20,6 +20,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "common.chartname" . }}
 {{- end -}}
 
+{{- define "common.volumeLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
 {{/*
 Common labels for all resources
 Usage:

--- a/packages/grid/helm/syft/templates/backend/backend-statefulset.yaml
+++ b/packages/grid/helm/syft/templates/backend/backend-statefulset.yaml
@@ -157,7 +157,7 @@ spec:
   - metadata:
       name: credentials-data
       labels:
-        {{- include "common.labels" . | nindent 8 }}
+        {{- include "common.volumeLabels" . | nindent 8 }}
         app.kubernetes.io/component: backend
     spec:
       accessModes:

--- a/packages/grid/helm/syft/templates/mongo/mongo-statefulset.yaml
+++ b/packages/grid/helm/syft/templates/mongo/mongo-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
   - metadata:
       name: mongo-data
       labels:
-        {{- include "common.labels" . | nindent 8 }}
+        {{- include "common.volumeLabels" . | nindent 8 }}
         app.kubernetes.io/component: mongo
     spec:
       accessModes:

--- a/packages/grid/helm/syft/templates/registry/registry-statefulset.yaml
+++ b/packages/grid/helm/syft/templates/registry/registry-statefulset.yaml
@@ -56,7 +56,7 @@ spec:
   - metadata:
       name: registry-data
       labels:
-        {{- include "common.labels" . | nindent 8 }}
+        {{- include "common.volumeLabels" . | nindent 8 }}
         app.kubernetes.io/component: registry
     spec:
       accessModes:

--- a/packages/grid/helm/syft/templates/seaweedfs/seaweedfs-statefulset.yaml
+++ b/packages/grid/helm/syft/templates/seaweedfs/seaweedfs-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
   - metadata:
       name: seaweedfs-data
       labels:
-        {{- include "common.labels" . | nindent 8 }}
+        {{- include "common.volumeLabels" . | nindent 8 }}
         app.kubernetes.io/component: seaweedfs
     spec:
       accessModes:


### PR DESCRIPTION
## Description
During Helm Upgrade, we change elements of our statefulset, but kubernetes allow only particular values to be changeable.

In our case, the volumeclaimtemplates values change on each different version, which prevents upgrade of the cluster.

![Screenshot 2024-03-15 at 12 23 07 PM](https://github.com/OpenMined/PySyft/assets/43314053/a9357c00-a5af-470d-93b4-3e35917ecf80)

and this blocks our staging pipeline.
The PR address the same.



## Affected Dependencies
Helm Upgrade Functionality

## How has this been tested?
Locally

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
