### PR TITLE
Fix widget repr for ActionObject

### DIFF
--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -302,6 +302,7 @@ passthrough_attrs = [
     "__exclude_sync_diff_attrs__",  # syft
     "__repr_attrs__",  # syft
     "get_sync_dependencies",
+    "_data_repr",
 ]
 dont_wrap_output_attrs = [
     "__repr__",
@@ -623,6 +624,7 @@ BASE_PASSTHROUGH_ATTRS: list[str] = [
     "__exclude_sync_diff_attrs__",
     "__repr_attrs__",
     "get_sync_dependencies",
+    "_data_repr",
 ]
 
 
@@ -1858,6 +1860,16 @@ class ActionObject(SyncableSyftObject):
 
         return f"```python\n{res}\n```\n{data_repr_}"
 
+    def _data_repr(self) -> str | None:
+        if isinstance(self.syft_action_data_cache, ActionDataEmpty):
+            data_repr = self.syft_action_data_repr_
+        elif inspect.isclass(self.syft_action_data_cache):
+            data_repr = repr_cls(self.syft_action_data_cache)
+        else:
+            data_repr = self.syft_action_data_cache.__repr__()
+
+        return data_repr
+
     def __repr__(self) -> str:
         if self.is_mock:
             res = "TwinPointer(Mock)"
@@ -1865,14 +1877,8 @@ class ActionObject(SyncableSyftObject):
             res = "TwinPointer(Real)"
         if not self.is_twin:
             res = "Pointer"
-        if isinstance(self.syft_action_data_cache, ActionDataEmpty):
-            data_repr_ = self.syft_action_data_repr_
-        else:
-            if inspect.isclass(self.syft_action_data_cache):
-                data_repr_ = repr_cls(self.syft_action_data_cache)
-            else:
-                data_repr_ = self.syft_action_data_cache.__repr__()
-        return f"{res}:\n{data_repr_}"
+        data_repr = self._data_repr()
+        return f"{res}:\n{data_repr}"
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         return self.__call__(*args, **kwds)

--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -312,16 +312,14 @@ class ObjectDiff(SyftObject):  # StateTuple (compare 2 objects)
         # relative
         from .resolve_widget import DiffStatus
 
-        obj_low = self.low_obj
-        obj_high = self.high_obj
-        if obj_low is not None:
-            repr_attrs = getattr(obj_low, "__repr_attrs__", [])
-        else:
-            repr_attrs = getattr(obj_high, "__repr_attrs__", [])
+        low_attrs = self.repr_attr_dict("low")
+        high_attrs = self.repr_attr_dict("high")
+        all_attrs = set(low_attrs.keys()) | set(high_attrs.keys())
+
         res = {}
-        for attr in repr_attrs:
-            value_low = getattr(obj_low, attr, None)
-            value_high = getattr(obj_high, attr, None)
+        for attr in all_attrs:
+            value_low = low_attrs.get(attr, None)
+            value_high = high_attrs.get(attr, None)
 
             if value_low is None or value_high is None:
                 res[attr] = DiffStatus.NEW
@@ -333,6 +331,8 @@ class ObjectDiff(SyftObject):  # StateTuple (compare 2 objects)
 
     def repr_attr_dict(self, side: str) -> dict[str, Any]:
         obj = self.low_obj if side == "low" else self.high_obj
+        if isinstance(obj, ActionObject):
+            return {"value": obj.syft_action_data_cache}
         repr_attrs = getattr(obj, "__repr_attrs__", [])
         res = {}
         for attr in repr_attrs:


### PR DESCRIPTION
## Description

- split `ActionObject.__repr__()` in two methods. Thought I needed it for PR, ended up not using it but it looks better
- add separate widget repr handling for ActionObject

example with larger action object:
![image](https://github.com/OpenMined/PySyft/assets/7243409/331d6a61-96f4-4ece-aea1-3665a7704df0)

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
