### PR TITLE
feat: widget grid spacing, add dejavu-sans

### DIFF
--- a/packages/syft/src/syft/service/sync/sync_state.py
+++ b/packages/syft/src/syft/service/sync/sync_state.py
@@ -10,12 +10,13 @@ from syft.service.request.request import Request
 from syft.util.colors import SURFACE
 from syft.util.fonts import ITABLES_CSS, FONT_CSS
 from ...util import options
+from ...util.notebook_ui.notebook_addons import create_table_template
 
 # relative
 from ...serde.serializable import serializable
 from ...store.linked_obj import LinkedObject
 from ...types.datetime import DateTime
-from ...types.syft_object import SYFT_OBJECT_VERSION_1
+from ...types.syft_object import SYFT_OBJECT_VERSION_1, get_repr_values_table
 from ...types.syft_object import SyftObject
 from ...types.syncable_object import SyncableSyftObject
 from ...types.uid import LineageID
@@ -294,4 +295,7 @@ class SyncState(SyftObject):
             {date_html}
         </div>
 """
-        return repr + self.rows._repr_html_()
+
+        rews = get_repr_values_table(self.rows, True)
+        return repr + create_table_template(rews, "SyncStateRow", grid_template_columns="auto auto 1fr auto", grid_template_cell_columns="unset", table_icon=None)
+

--- a/packages/syft/src/syft/util/notebook_ui/notebook_addons.py
+++ b/packages/syft/src/syft/util/notebook_ui/notebook_addons.py
@@ -212,16 +212,16 @@ CSS_CODE = """
 
     .grid-table${uid} {
         display:grid;
-        grid-template-columns: 1fr repeat(${cols}, 1fr);
-        grid-template-rows: repeat(2, 1fr);
+        grid-template-columns: ${grid_template_columns};
+        /*grid-template-rows: repeat(2, 1fr);*/
         overflow-x: auto;
         position: relative;
     }
 
-    .grid-std-cells {
-        grid-column: span 4;
-
+    .grid-std-cells${uid} {
+        grid-column: ${grid_template_cell_columns};
     }
+
     .grid-index-cells {
         grid-column: span 1;
         /* tmp fix to make left col stand out (fix with font-family) */
@@ -629,14 +629,14 @@ custom_code = """
                                 grid.appendChild(div);
                                 headers.forEach((title) =>{
                                     let div = document.createElement("div");
-                                    div.classList.add('grid-header', 'grid-std-cells');
+                                    div.classList.add('grid-header', 'grid-std-cells${uid}');
                                     div.innerText = title;
 
                                     grid.appendChild(div);
                                 });
 
                                 let page = items[pageIndex -1]
-                                if (page !== 'undefine'){
+                                if (page !== 'undefined'){
                                     let table_index${uid} = ((pageIndex - 1) * page_size${uid})
                                     page.forEach((item) => {
                                         let grid = document.getElementById("table${uid}");
@@ -657,15 +657,15 @@ custom_code = """
                                                     badge_div.classList.add('badge',item[attr].type)
                                                     badge_div.innerText = String(item[attr].value).toUpperCase();
                                                     div.appendChild(badge_div);
-                                                    div.classList.add('grid-row','grid-std-cells');
+                                                    div.classList.add('grid-row','grid-std-cells${uid}');
                                                 } else if (item[attr].type.includes('label')){
                                                     let label_div = document.createElement("div");
                                                     label_div.classList.add('label',item[attr].type)
                                                     label_div.innerText = String(item[attr].value).toUpperCase();
                                                     div.appendChild(label_div);
-                                                    div.classList.add('grid-row','grid-std-cells');
+                                                    div.classList.add('grid-row','grid-std-cells${uid}');
                                                 } else if (item[attr].type === "clipboard") {
-                                                    div.classList.add('grid-row','grid-std-cells');
+                                                    div.classList.add('grid-row','grid-std-cells${uid}');
 
                                                     // Create clipboard div
                                                     let clipboard_div = document.createElement('div');
@@ -693,7 +693,7 @@ custom_code = """
                                                     div.appendChild(clipboard_div);
                                                 }
                                             } else{
-                                                div.classList.add('grid-row','grid-std-cells');
+                                                div.classList.add('grid-row','grid-std-cells${uid}');
                                                 if (item[attr] == null) {
                                                     text = ' '
                                                 } else {
@@ -740,10 +740,9 @@ custom_code = """
                         buildGrid${uid}(paginatedElements${uid}, pageIndex)
                     }
                     (async function() {
-                        const myFont = new FontFace('DejaVu Sans', 'url(https://cdn.jsdelivr.net/npm/dejavu-sans@1.0.0/css/dejavu-sans.min.css)');
+                        const myFont = new FontFace('DejaVu Sans', 'url(https://cdn.jsdelivr.net/npm/dejavu-sans@1.0.0/fonts/dejavu-sans-webfont.woff2?display=swap');
                         await myFont.load();
                         document.fonts.add(myFont);
-                        document.getElementsByTagName('h1')[0].style.fontFamily = "DejaVu Sans";
                     })();
 
                     buildPaginationContainer${uid}(paginatedElements${uid})
@@ -754,7 +753,7 @@ custom_code = """
 
 
 def create_table_template(
-    items: Sequence, list_name: Any, rows: int = 5, table_icon: Any = None
+    items: Sequence, list_name: Any, rows: int = 5, table_icon: Any = None, grid_template_columns: str = "1fr repeat({cols}, 1fr)", grid_template_cell_columns: str = "span 4"
 ) -> str:
     if not table_icon:
         table_icon = TABLE_ICON
@@ -767,6 +766,8 @@ def create_table_template(
         cols = 0
     else:
         cols = (len(items[0].keys())) * 4
+    if '{cols}' in grid_template_columns:
+        grid_template_columns = grid_template_columns.format(cols=cols)
     return template.substitute(
         uid=str(UID()),
         element=items_dict,
@@ -776,4 +777,6 @@ def create_table_template(
         icon=table_icon,
         searchIcon=SEARCH_ICON,
         clipboardIcon=CLIPBOARD_ICON,
+        grid_template_columns=grid_template_columns,
+        grid_template_cell_columns=grid_template_cell_columns
     )


### PR DESCRIPTION
## Description
- Add ability to set grid-template-columns and cell's grid-column via create_table_template
- Load font dejavu-sans (but did not set any classes)

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
