### PR TITLE
fix PandasDataFrameObject truthiness

### DIFF
--- a/packages/syft/src/syft/service/action/pandas.py
+++ b/packages/syft/src/syft/service/action/pandas.py
@@ -40,6 +40,8 @@ class PandasDataFrameObject(ActionObject):
         return super().syft_is_property(obj, method)
 
     def __bool__(self) -> bool:
+        if self.syft_action_data_cache is None:
+            return False
         return bool(self.syft_action_data_cache.empty)
 
 

--- a/packages/syft/src/syft/service/action/pandas.py
+++ b/packages/syft/src/syft/service/action/pandas.py
@@ -40,7 +40,7 @@ class PandasDataFrameObject(ActionObject):
         return super().syft_is_property(obj, method)
 
     def __bool__(self) -> bool:
-        return bool(self.empty)
+        return bool(self.syft_action_data_cache.empty)
 
 
 @serializable()

--- a/packages/syft/src/syft/service/action/pandas.py
+++ b/packages/syft/src/syft/service/action/pandas.py
@@ -39,6 +39,9 @@ class PandasDataFrameObject(ActionObject):
             return True
         return super().syft_is_property(obj, method)
 
+    def __bool__(self) -> bool:
+        return bool(self.empty)
+
 
 @serializable()
 class PandasSeriesObject(ActionObject):

--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from typing import Literal
 
 # third party
+import pandas as pd
 from pydantic import model_validator
 from rich import box
 from rich.console import Console
@@ -325,6 +326,14 @@ class ObjectDiff(SyftObject):  # StateTuple (compare 2 objects)
 
             if value_low is None or value_high is None:
                 res[attr] = DiffStatus.NEW
+            elif isinstance(value_low, pd.DataFrame) and isinstance(
+                value_high, pd.DataFrame
+            ):
+                res[attr] = (
+                    DiffStatus.MODIFIED
+                    if not value_low.equals(value_high)
+                    else DiffStatus.SAME
+                )
             elif value_low != value_high:
                 res[attr] = DiffStatus.MODIFIED
             else:


### PR DESCRIPTION
## Description
`ObjectDiff[PandasDataFrameObject].non_empty_object` property returns the following error without the fix: `Truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()`

```python
	@property
	def non_empty_object(self) -> SyftObject | None:
        return self.low_obj or self.high_obj
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
