### PR TITLE
fix actiondatalink check

### DIFF
--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -1829,7 +1829,7 @@ class ActionObject(SyncableSyftObject):
 
     @property
     def is_link(self) -> bool:
-        return isinstance(self.syft_action_data, ActionDataLink)
+        return self.syft_action_data_type is ActionDataLink
 
     def __setattr__(self, name: str, value: Any) -> Any:
         defined_on_self = name in self.__dict__ or name in self.__private_attributes__

--- a/packages/syft/src/syft/service/action/action_service.py
+++ b/packages/syft/src/syft/service/action/action_service.py
@@ -140,12 +140,11 @@ class ActionService(AbstractService):
     ) -> Result[Ok[bool], Err[str]]:
         """Get an object from the action store"""
         # relative
-        from .action_data_empty import ActionDataLink
 
         result = self._get(context, uid)
         if result.is_ok():
             obj = result.ok()
-            if isinstance(obj.syft_action_data, ActionDataLink):
+            if obj.is_link:
                 result = self.resolve_links(
                     context, obj.syft_action_data.action_object_id.id
                 )
@@ -177,7 +176,6 @@ class ActionService(AbstractService):
     ) -> Result[Ok[ActionObject], Err[str]]:
         """Get an object from the action store"""
         # relative
-        from .action_data_empty import ActionDataLink
 
         result = self.store.get(uid=uid, credentials=context.credentials)
         # If user has permission to get the object / object exists
@@ -185,7 +183,7 @@ class ActionService(AbstractService):
             obj = result.ok()
 
             # If it's not a leaf
-            if isinstance(obj.syft_action_data, ActionDataLink):
+            if obj.is_link:
                 nested_result = self.resolve_links(
                     context, obj.syft_action_data.action_object_id.id, twin_mode
                 )
@@ -219,7 +217,6 @@ class ActionService(AbstractService):
         # stdlib
 
         # relative
-        from .action_data_empty import ActionDataLink
 
         result = self.store.get(
             uid=uid, credentials=context.credentials, has_permission=has_permission
@@ -234,7 +231,7 @@ class ActionService(AbstractService):
             if (
                 not isinstance(obj, TwinObject)  # type: ignore[unreachable]
                 and resolve_nested
-                and isinstance(obj.syft_action_data, ActionDataLink)
+                and obj.is_link
             ):
                 if not self.is_resolved(  # type: ignore[unreachable]
                     context, obj.syft_action_data.action_object_id.id

--- a/packages/syft/src/syft/service/job/job_stash.py
+++ b/packages/syft/src/syft/service/job/job_stash.py
@@ -37,7 +37,6 @@ from ...util.colors import SURFACE
 from ...util.markdown import as_markdown_code
 from ...util.telemetry import instrument
 from ...util.util import prompt_warning_message
-from ..action.action_data_empty import ActionDataLink
 from ..action.action_object import Action
 from ..action.action_object import ActionObject
 from ..action.action_permissions import ActionObjectPermission
@@ -487,7 +486,7 @@ class Job(SyncableSyftObject):
                 result_obj = api.services.action.get(
                     self.result.id, resolve_nested=False
                 )
-                if isinstance(result_obj.syft_action_data, ActionDataLink) and job_only:
+                if result_obj.is_link and job_only:
                     print(
                         "You're trying to wait on a job that has a link as a result."
                         "This means that the job may be ready but the linked result may not."


### PR DESCRIPTION
## Description
When checking if something a linked ActionObject, we were loading the action data from blob storage. PR fixes this in all places we check for `is_link`

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
