### PR TITLE
fix: handle empty kwargs and high state update in high-to-low case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ nohup.out
 notebooks/helm/scenario_data.jsonl
 # tox syft.build.helm generated file
 out.txt
+
+# gitconfig
+.git-blame-ignore-revs

--- a/packages/syft/src/syft/client/api.py
+++ b/packages/syft/src/syft/client/api.py
@@ -573,7 +573,8 @@ class APIModule:
         except AttributeError:
             raise SyftAttributeError(
                 f"'APIModule' api{self.path} object has no submodule or method '{name}', "
-                "you may not have permission to access the module you are trying to access"
+                "you may not have permission to access the module you are trying to access."
+                "If you think this is an error, try calling `client.refresh()` to update the API."
             )
 
     def __getitem__(self, key: str | int) -> Any:

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -2078,6 +2078,11 @@ class AnyActionObject(ActionObject):
     def __int__(self) -> float:
         return int(self.syft_action_data)
 
+    def syft_eq(self, ext_obj: Self | None) -> bool:
+        if ext_obj is None:
+            return False
+        return self.id.id == ext_obj.id.id
+
 
 action_types[Any] = AnyActionObject
 

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -2078,11 +2078,6 @@ class AnyActionObject(ActionObject):
     def __int__(self) -> float:
         return int(self.syft_action_data)
 
-    def syft_eq(self, ext_obj: Self | None) -> bool:
-        if ext_obj is None:
-            return False
-        return self.id.id == ext_obj.id.id
-
 
 action_types[Any] = AnyActionObject
 

--- a/packages/syft/src/syft/service/action/action_object.py
+++ b/packages/syft/src/syft/service/action/action_object.py
@@ -2059,6 +2059,11 @@ class ActionObject(SyncableSyftObject):
 
 @serializable()
 class AnyActionObject(ActionObject):
+    """
+    This is a catch-all class for all objects that are not
+    defined in the `action_types` dictionary.
+    """
+
     __canonical_name__ = "AnyActionObject"
     __version__ = SYFT_OBJECT_VERSION_3
 

--- a/packages/syft/src/syft/service/action/action_types.py
+++ b/packages/syft/src/syft/service/action/action_types.py
@@ -15,17 +15,15 @@ def action_type_for_type(obj_or_type: Any) -> type:
         obj_or_type: Union[object, type]
             Can be an object or a class
     """
+    if isinstance(obj_or_type, ActionDataEmpty):
+        obj_or_type = obj_or_type.syft_internal_type
     if type(obj_or_type) != type:
-        if isinstance(obj_or_type, ActionDataEmpty):
-            obj_or_type = obj_or_type.syft_internal_type
-        else:
-            obj_or_type = type(obj_or_type)
+        obj_or_type = type(obj_or_type)
 
     if obj_or_type not in action_types:
         debug(f"WARNING: No Type for {obj_or_type}, returning {action_types[Any]}")
-        return action_types[Any]
 
-    return action_types[obj_or_type]
+    return action_types.get(obj_or_type, action_types[Any])
 
 
 def action_type_for_object(obj: Any) -> type:

--- a/packages/syft/src/syft/service/code/user_code_service.py
+++ b/packages/syft/src/syft/service/code/user_code_service.py
@@ -384,7 +384,9 @@ class UserCodeService(AbstractService):
     def is_execution_on_owned_args(
         self, kwargs: dict[str, Any], context: AuthedServiceContext
     ) -> bool:
-        return len(self.keep_owned_kwargs(kwargs, context)) == len(kwargs)
+        return bool(kwargs) and len(self.keep_owned_kwargs(kwargs, context)) == len(
+            kwargs
+        )
 
     @service_method(path="code.call", name="call", roles=GUEST_ROLE_LEVEL)
     def call(

--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -16,6 +16,7 @@ from rich.panel import Panel
 from typing_extensions import Self
 
 # relative
+from ...client.api import APIRegistry
 from ...client.client import SyftClient
 from ...client.sync_decision import SyncDecision
 from ...client.sync_decision import SyncDirection
@@ -577,6 +578,15 @@ class ObjectDiffBatch(SyftObject):
             return self.low_node_uid
 
     @property
+    def source_node_uid(self) -> UID:
+        if self.sync_direction is None:
+            raise ValueError("no direction specified")
+        if self.sync_direction == SyncDirection.LOW_TO_HIGH:
+            return self.low_node_uid
+        else:
+            return self.high_node_uid
+
+    @property
     def target_verify_key(self) -> SyftVerifyKey:
         if self.sync_direction is None:
             raise ValueError("no direction specified")
@@ -584,6 +594,35 @@ class ObjectDiffBatch(SyftObject):
             return self.user_verify_key_high
         else:
             return self.user_verify_key_low
+
+    @property
+    def source_verify_key(self) -> SyftVerifyKey:
+        if self.sync_direction is None:
+            raise ValueError("no direction specified")
+        if self.sync_direction == SyncDirection.LOW_TO_HIGH:
+            return self.user_verify_key_low
+        else:
+            return self.user_verify_key_high
+
+    @property
+    def source_client(self) -> SyftClient:
+        return self.build(self.source_node_uid, self.source_verify_key)
+
+    @property
+    def target_client(self) -> SyftClient:
+        return self.build(self.target_node_uid, self.target_verify_key)
+
+    def build(self, node_uid: UID, syft_client_verify_key: SyftVerifyKey):  # type: ignore
+        # relative
+        from ...client.domain_client import DomainClient
+
+        api = APIRegistry.api_for(node_uid, syft_client_verify_key)
+        client = DomainClient(
+            api=api,
+            connection=api.connection,  # type: ignore
+            credentials=api.signing_key,  # type: ignore
+        )
+        return client
 
     def get_dependencies(
         self,

--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -1233,6 +1233,8 @@ class SyncInstruction(SyftObject):
                     ]
 
         mockify = widget.mockify
+        if widget.has_unused_share_button:
+            print("Share button was not used, so we will mockify the object")
 
         # storage permissions
         new_storage_permissions = []

--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -1232,7 +1232,6 @@ class SyncInstruction(SyftObject):
                         )
                     ]
 
-        # mockify
         mockify = widget.mockify
 
         # storage permissions

--- a/packages/syft/src/syft/service/sync/resolve_widget.py
+++ b/packages/syft/src/syft/service/sync/resolve_widget.py
@@ -15,7 +15,6 @@ from ipywidgets import Layout
 from ipywidgets import VBox
 
 # relative
-from ...client.api import APIRegistry
 from ...client.sync_decision import SyncDecision
 from ...client.sync_decision import SyncDirection
 from ...node.credentials import SyftVerifyKey
@@ -426,8 +425,12 @@ class ResolveWidget:
         # Maybe default read permission for some objects (high -> low)
 
         # TODO: UID
-        resolved_state_low = ResolvedSyncState(node_uid=UID(), alias="low")
-        resolved_state_high = ResolvedSyncState(node_uid=UID(), alias="high")
+        resolved_state_low = ResolvedSyncState(
+            node_uid=self.obj_diff_batch.low_node_uid, alias="low"
+        )
+        resolved_state_high = ResolvedSyncState(
+            node_uid=self.obj_diff_batch.high_node_uid, alias="high"
+        )
 
         batch_diff = self.obj_diff_batch
         if batch_diff.is_unchanged:
@@ -495,25 +498,23 @@ class ResolveWidget:
             resolved_state_low.add_sync_instruction(sync_instruction)
             resolved_state_high.add_sync_instruction(sync_instruction)
 
-        # TODO: ONLY WORKS FOR LOW TO HIGH
-        # relative
-        from ...client.domain_client import DomainClient
-
-        api = APIRegistry.api_for(
-            self.obj_diff_batch.target_node_uid, self.obj_diff_batch.target_verify_key
-        )
-        client = DomainClient(
-            api=api,
-            connection=api.connection,  # type: ignore
-            credentials=api.signing_key,  # type: ignore
-        )
-
         if self.obj_diff_batch.sync_direction is None:
             raise ValueError("no direction specified")
-        if self.obj_diff_batch.sync_direction == SyncDirection.LOW_TO_HIGH:
-            res = client.apply_state(resolved_state_high)
-        else:
-            res = client.apply_state(resolved_state_low)
+        sync_direction = self.obj_diff_batch.sync_direction
+        resolved_state = (
+            resolved_state_high
+            if sync_direction == SyncDirection.LOW_TO_HIGH
+            else resolved_state_low
+        )
+        res = self.obj_diff_batch.target_client.apply_state(resolved_state)
+
+        if sync_direction == SyncDirection.HIGH_TO_LOW:
+            # apply empty state to generete a new state
+            resolved_state_high = ResolvedSyncState(
+                node_uid=self.obj_diff_batch.high_node_uid, alias="high"
+            )
+            high_client = self.obj_diff_batch.source_client
+            res = high_client.apply_state(resolved_state_high)
 
         self.is_synced = True
         self.set_result_state(res)

--- a/packages/syft/src/syft/service/sync/resolve_widget.py
+++ b/packages/syft/src/syft/service/sync/resolve_widget.py
@@ -121,6 +121,11 @@ class MainObjectDiffWidget:
         return not self.share_private_data
 
     @property
+    def has_unused_share_button(self) -> bool:
+        # does not have share button
+        return False
+
+    @property
     def share_private_data(self) -> bool:
         # there are TwinAPIEndpoint.__private_sync_attr_mocks__
         return not isinstance(self.diff.non_empty_object, TwinAPIEndpoint)
@@ -191,10 +196,14 @@ class CollapsableObjectDiffWidget:
     def mockify(self) -> bool:
         if isinstance(self.diff.non_empty_object, TwinAPIEndpoint):
             return True
-        if self.show_share_button and not self.share_private_data:
+        if self.has_unused_share_button:
             return True
         else:
             return False
+
+    @property
+    def has_unused_share_button(self) -> bool:
+        return self.show_share_button and not self.share_private_data
 
     @property
     def show_share_button(self) -> bool:

--- a/packages/syft/tests/syft/service/sync/sync_flow_test.py
+++ b/packages/syft/tests/syft/service/sync/sync_flow_test.py
@@ -7,8 +7,10 @@ import numpy as np
 import pytest
 
 # syft absolute
+import syft
 import syft as sy
 from syft.abstract_node import NodeSideType
+from syft.client.domain_client import DomainClient
 from syft.client.sync_decision import SyncDecision
 from syft.client.syncing import compare_clients
 from syft.client.syncing import compare_states
@@ -16,6 +18,41 @@ from syft.client.syncing import resolve
 from syft.client.syncing import resolve_single
 from syft.service.action.action_object import ActionObject
 from syft.service.response import SyftError
+from syft.service.response import SyftSuccess
+
+
+def compare_and_resolve(*, from_client: DomainClient, to_client: DomainClient):
+    diff_state_before = compare_clients(from_client, to_client)
+    for obj_diff_batch in diff_state_before.batches:
+        widget = resolve_single(obj_diff_batch)
+        widget.click_share_all_private_data()
+        res = widget.click_sync()
+        assert isinstance(res, SyftSuccess)
+    from_client.refresh()
+    to_client.refresh()
+    diff_state_after = compare_clients(from_client, to_client)
+    return diff_state_before, diff_state_after
+
+
+def run_and_accept_result(client):
+    job_high = client.code.compute(blocking=True)
+    client.requests[0].accept_by_depositing_result(job_high)
+    return job_high
+
+
+@syft.syft_function_single_use()
+def compute() -> int:
+    return 42
+
+
+def get_ds_client(client: DomainClient) -> DomainClient:
+    client.register(
+        name="a",
+        email="a@a.com",
+        password="asdf",
+        password_verify="asdf",
+    )
+    return client.login(email="a@a.com", password="asdf")
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
@@ -212,9 +249,9 @@ def test_sync_flow():
 
 
 def test_diff_state(low_worker, high_worker):
-    low_client = low_worker.root_client
-    client_low_ds = low_worker.guest_client
-    high_client = high_worker.root_client
+    low_client: DomainClient = low_worker.root_client
+    client_low_ds = get_ds_client(low_client)
+    high_client: DomainClient = high_worker.root_client
 
     @sy.syft_function_single_use()
     def compute() -> int:
@@ -224,26 +261,28 @@ def test_diff_state(low_worker, high_worker):
 
     _ = client_low_ds.code.request_code_execution(compute)
 
-    diff_state = compare_clients(low_client, high_client)
-    low_items_to_sync, high_items_to_sync = resolve(
-        diff_state, decision="low", share_private_objects=True
+    diff_state_before, diff_state_after = compare_and_resolve(
+        from_client=low_client, to_client=high_client
     )
 
-    assert not diff_state.is_same
-    assert not low_items_to_sync.is_empty
-    assert not high_items_to_sync.is_empty
+    assert not diff_state_before.is_same
 
-    low_client.apply_state(low_items_to_sync)
-    high_client.apply_state(high_items_to_sync)
+    assert diff_state_after.is_same
 
-    diff_state = compare_clients(low_client, high_client)
-    low_items_to_sync, high_items_to_sync = resolve(
-        diff_state, decision="low", share_private_objects=True
+    run_and_accept_result(high_client)
+    diff_state_before, diff_state_after = compare_and_resolve(
+        from_client=high_client, to_client=low_client
     )
 
-    assert diff_state.is_same
-    assert low_items_to_sync.is_empty
-    assert high_items_to_sync.is_empty
+    high_state = high_client.get_sync_state()
+    low_state = high_client.get_sync_state()
+    assert high_state.get_previous_state_diff().is_same
+    assert low_state.get_previous_state_diff().is_same
+    assert diff_state_after.is_same
+
+    client_low_ds.refresh()
+    res = client_low_ds.code.compute(blocking=True)
+    assert res == compute(blocking=True).get()
 
 
 def test_forget_usercode(low_worker, high_worker):
@@ -306,18 +345,7 @@ def private_function(context) -> str:
 def test_twin_api_integration(low_worker, high_worker):
     low_client = low_worker.root_client
     high_client = high_worker.root_client
-
-    low_client.register(
-        email="newuser@openmined.org",
-        name="John Doe",
-        password="pw",
-        password_verify="pw",
-    )
-
-    client_low_ds = low_client.login(
-        email="newuser@openmined.org",
-        password="pw",
-    )
+    client_low_ds = get_ds_client(low_client)
 
     new_endpoint = sy.TwinAPIEndpoint(
         path="testapi.query",
@@ -330,12 +358,9 @@ def test_twin_api_integration(low_worker, high_worker):
     high_private_res = high_client.api.services.testapi.query.private()
     assert high_private_res == 42
 
-    low_state = low_client.get_sync_state()
-    high_state = high_client.get_sync_state()
-    diff_state = compare_states(high_state, low_state)
-    obj_diff_batch = diff_state[0]
-    widget = resolve_single(obj_diff_batch)
-    widget.click_sync()
+    diff_before, diff_after = compare_and_resolve(
+        from_client=high_client, to_client=low_client
+    )
 
     client_low_ds.refresh()
     low_private_res = client_low_ds.api.services.testapi.query.private()
@@ -345,6 +370,29 @@ def test_twin_api_integration(low_worker, high_worker):
     low_mock_res = client_low_ds.api.services.testapi.query.mock()
     high_mock_res = high_client.api.services.testapi.query.mock()
     assert low_mock_res == high_mock_res == -42
+
+    @syft.syft_function_single_use(
+        query=client_low_ds.api.services.testapi.query,
+    )
+    def compute(query):
+        return query()
+
+    compute.code = dedent(compute.code)
+    _ = client_low_ds.code.request_code_execution(compute)
+
+    diff_before, diff_after = compare_and_resolve(
+        from_client=low_client, to_client=high_client
+    )
+
+    job_high = high_client.code.compute(query=high_client.api.services.testapi.query)
+    high_client.requests[0].accept_by_depositing_result(job_high)
+    diff_before, diff_after = compare_and_resolve(
+        from_client=high_client, to_client=low_client
+    )
+    client_low_ds.refresh()
+    res = client_low_ds.code.compute(query=client_low_ds.api.services.testapi.query)
+    assert res.syft_action_data == high_client.api.services.testapi.query.private()
+    assert diff_after.is_same
 
 
 def test_skip_user_code(low_worker, high_worker):

--- a/packages/syft/tests/syft/service/sync/sync_flow_test.py
+++ b/packages/syft/tests/syft/service/sync/sync_flow_test.py
@@ -248,43 +248,6 @@ def test_sync_flow():
     high_worker.cleanup()
 
 
-def test_diff_state(low_worker, high_worker):
-    low_client: DomainClient = low_worker.root_client
-    client_low_ds = get_ds_client(low_client)
-    high_client: DomainClient = high_worker.root_client
-
-    @sy.syft_function_single_use()
-    def compute() -> int:
-        return 42
-
-    compute.code = dedent(compute.code)
-
-    _ = client_low_ds.code.request_code_execution(compute)
-
-    diff_state_before, diff_state_after = compare_and_resolve(
-        from_client=low_client, to_client=high_client
-    )
-
-    assert not diff_state_before.is_same
-
-    assert diff_state_after.is_same
-
-    run_and_accept_result(high_client)
-    diff_state_before, diff_state_after = compare_and_resolve(
-        from_client=high_client, to_client=low_client
-    )
-
-    high_state = high_client.get_sync_state()
-    low_state = high_client.get_sync_state()
-    assert high_state.get_previous_state_diff().is_same
-    assert low_state.get_previous_state_diff().is_same
-    assert diff_state_after.is_same
-
-    client_low_ds.refresh()
-    res = client_low_ds.code.compute(blocking=True)
-    assert res == compute(blocking=True).get()
-
-
 def test_forget_usercode(low_worker, high_worker):
     low_client = low_worker.root_client
     client_low_ds = low_worker.guest_client
@@ -330,69 +293,6 @@ def test_forget_usercode(low_worker, high_worker):
         share_private_objects=True,
         decision_callback=skip_if_user_code,
     )
-
-
-@sy.mock_api_endpoint()
-def mock_function(context) -> str:
-    return -42
-
-
-@sy.private_api_endpoint()
-def private_function(context) -> str:
-    return 42
-
-
-def test_twin_api_integration(low_worker, high_worker):
-    low_client = low_worker.root_client
-    high_client = high_worker.root_client
-    client_low_ds = get_ds_client(low_client)
-
-    new_endpoint = sy.TwinAPIEndpoint(
-        path="testapi.query",
-        private_function=private_function,
-        mock_function=mock_function,
-        description="",
-    )
-    high_client.api.services.api.add(endpoint=new_endpoint)
-    high_client.refresh()
-    high_private_res = high_client.api.services.testapi.query.private()
-    assert high_private_res == 42
-
-    diff_before, diff_after = compare_and_resolve(
-        from_client=high_client, to_client=low_client
-    )
-
-    client_low_ds.refresh()
-    low_private_res = client_low_ds.api.services.testapi.query.private()
-    assert isinstance(
-        low_private_res, SyftError
-    ), "Should not have access to private on low side"
-    low_mock_res = client_low_ds.api.services.testapi.query.mock()
-    high_mock_res = high_client.api.services.testapi.query.mock()
-    assert low_mock_res == high_mock_res == -42
-
-    @syft.syft_function_single_use(
-        query=client_low_ds.api.services.testapi.query,
-    )
-    def compute(query):
-        return query()
-
-    compute.code = dedent(compute.code)
-    _ = client_low_ds.code.request_code_execution(compute)
-
-    diff_before, diff_after = compare_and_resolve(
-        from_client=low_client, to_client=high_client
-    )
-
-    job_high = high_client.code.compute(query=high_client.api.services.testapi.query)
-    high_client.requests[0].accept_by_depositing_result(job_high)
-    diff_before, diff_after = compare_and_resolve(
-        from_client=high_client, to_client=low_client
-    )
-    client_low_ds.refresh()
-    res = client_low_ds.code.compute(query=client_low_ds.api.services.testapi.query)
-    assert res.syft_action_data == high_client.api.services.testapi.query.private()
-    assert diff_after.is_same
 
 
 def test_skip_user_code(low_worker, high_worker):

--- a/packages/syft/tests/syft/service/sync/sync_widget_test.py
+++ b/packages/syft/tests/syft/service/sync/sync_widget_test.py
@@ -1,5 +1,3 @@
-# stdlib
-
 # syft absolute
 import syft
 from syft.client.domain_client import DomainClient
@@ -12,6 +10,7 @@ def compare_and_resolve(*, from_client: DomainClient, to_client: DomainClient):
     diff_state_before = compare_clients(from_client, to_client)
     for obj_diff_batch in diff_state_before.batches:
         widget = resolve_single(obj_diff_batch)
+        widget.click_share_all_private_data()
         widget.click_sync()
     from_client.refresh()
     to_client.refresh()

--- a/packages/syft/tests/syft/service/sync/sync_widget_test.py
+++ b/packages/syft/tests/syft/service/sync/sync_widget_test.py
@@ -1,0 +1,50 @@
+# stdlib
+
+# syft absolute
+import syft
+from syft.client.domain_client import DomainClient
+from syft.client.syncing import compare_clients
+from syft.client.syncing import resolve_single
+from syft.service.job.job_stash import Job
+
+
+def compare_and_resolve(*, from_client: DomainClient, to_client: DomainClient):
+    diff_state_before = compare_clients(from_client, to_client)
+    for obj_diff_batch in diff_state_before.batches:
+        widget = resolve_single(obj_diff_batch)
+        widget.click_sync()
+    from_client.refresh()
+    to_client.refresh()
+    diff_state_after = compare_clients(from_client, to_client)
+    return diff_state_before, diff_state_after
+
+
+def run_and_accept_result(client):
+    job_high = client.code.compute(blocking=True)
+    client.requests[0].accept_by_depositing_result(job_high)
+    return job_high
+
+
+@syft.syft_function_single_use()
+def compute() -> int:
+    return 42
+
+
+def test_diff_widget_merge_status(low_worker, high_worker):
+    low_client = low_worker.root_client
+    client_low_ds = low_worker.guest_client
+    high_client = high_worker.root_client
+
+    _ = client_low_ds.code.request_code_execution(compute)
+
+    diff_before, diff_after = compare_and_resolve(
+        from_client=low_client, to_client=high_client
+    )
+    run_and_accept_result(high_client)
+    diff_before, diff_after = compare_and_resolve(
+        from_client=high_client, to_client=low_client
+    )
+
+    # expect to have a job diff, might fail if the implementation changes
+    job_diff = [batch for batch in diff_after.batches if batch.root_type is Job][0]
+    assert job_diff.status == "SAME", "Job diff status should be SAME after syncing"

--- a/packages/syft/tests/syft/service/sync/sync_widget_test.py
+++ b/packages/syft/tests/syft/service/sync/sync_widget_test.py
@@ -1,9 +1,13 @@
+# stdlib
+from textwrap import dedent
+
 # syft absolute
 import syft
 from syft.client.domain_client import DomainClient
 from syft.client.syncing import compare_clients
 from syft.client.syncing import resolve_single
-from syft.service.job.job_stash import Job
+from syft.service.response import SyftError
+from syft.service.response import SyftSuccess
 
 
 def compare_and_resolve(*, from_client: DomainClient, to_client: DomainClient):
@@ -11,7 +15,8 @@ def compare_and_resolve(*, from_client: DomainClient, to_client: DomainClient):
     for obj_diff_batch in diff_state_before.batches:
         widget = resolve_single(obj_diff_batch)
         widget.click_share_all_private_data()
-        widget.click_sync()
+        res = widget.click_sync()
+        assert isinstance(res, SyftSuccess)
     from_client.refresh()
     to_client.refresh()
     diff_state_after = compare_clients(from_client, to_client)
@@ -29,9 +34,19 @@ def compute() -> int:
     return 42
 
 
+def get_ds_client(client: DomainClient) -> DomainClient:
+    client.register(
+        name="a",
+        email="a@a.com",
+        password="asdf",
+        password_verify="asdf",
+    )
+    return client.login(email="a@a.com", password="asdf")
+
+
 def test_diff_widget_merge_status(low_worker, high_worker):
     low_client = low_worker.root_client
-    client_low_ds = low_worker.guest_client
+    client_low_ds = get_ds_client(low_client)
     high_client = high_worker.root_client
 
     _ = client_low_ds.code.request_code_execution(compute)
@@ -44,6 +59,71 @@ def test_diff_widget_merge_status(low_worker, high_worker):
         from_client=high_client, to_client=low_client
     )
 
-    # expect to have a job diff, might fail if the implementation changes
-    job_diff = [batch for batch in diff_after.batches if batch.root_type is Job][0]
-    assert job_diff.status == "SAME", "Job diff status should be SAME after syncing"
+    assert diff_after.is_same
+
+    client_low_ds.refresh()
+    res = client_low_ds.code.compute(blocking=True)
+    assert res == 42
+
+
+@syft.mock_api_endpoint()
+def mock_function(context) -> str:
+    return -42
+
+
+@syft.private_api_endpoint()
+def private_function(context) -> str:
+    return 42
+
+
+def test_twin_api_integration2(low_worker, high_worker):
+    low_client = low_worker.root_client
+    high_client = high_worker.root_client
+    client_low_ds = get_ds_client(low_client)
+
+    new_endpoint = syft.TwinAPIEndpoint(
+        path="testapi.query",
+        private_function=private_function,
+        mock_function=mock_function,
+        description="",
+    )
+    high_client.api.services.api.add(endpoint=new_endpoint)
+    high_client.refresh()
+    high_private_res = high_client.api.services.testapi.query.private()
+    assert high_private_res == 42
+
+    diff_before, diff_after = compare_and_resolve(
+        from_client=high_client, to_client=low_client
+    )
+
+    client_low_ds.refresh()
+    low_private_res = client_low_ds.api.services.testapi.query.private()
+    assert isinstance(
+        low_private_res, SyftError
+    ), "Should not have access to private on low side"
+    low_mock_res = client_low_ds.api.services.testapi.query.mock()
+    high_mock_res = high_client.api.services.testapi.query.mock()
+    assert low_mock_res == high_mock_res == -42
+
+    @syft.syft_function_single_use(
+        query=client_low_ds.api.services.testapi.query,
+    )
+    def compute(query):
+        return query()
+
+    compute.code = dedent(compute.code)
+    _ = client_low_ds.code.request_code_execution(compute)
+
+    diff_before, diff_after = compare_and_resolve(
+        from_client=low_client, to_client=high_client
+    )
+
+    job_high = high_client.code.compute(query=high_client.api.services.testapi.query)
+    high_client.requests[0].accept_by_depositing_result(job_high)
+    diff_before, diff_after = compare_and_resolve(
+        from_client=high_client, to_client=low_client
+    )
+    client_low_ds.refresh()
+    res = client_low_ds.code.compute(query=client_low_ds.api.services.testapi.query)
+    assert res.syft_action_data == high_client.api.services.testapi.query.private()
+    assert diff_after.is_same


### PR DESCRIPTION
Bug fixes:
- Fixed `is_execution_on_owned_args` when `kwargs` is empty.
- Fixed ObjectDiff showing modified after syncing by applying empty state.
Thanks @eelcovdw for the help.

Test updates:
- Updated tests to check for the bugs above.
- Extended twin api integration test. I need to update it with the changes from https://github.com/OpenMined/PySyft/pull/8693
- Seperated sync tests into two files. New one is using the new flow with `resolve_single`, while the old one is still using `resolve`.

Some extra prints and docs:
- Added a reminder to `__getattribute__` error message to call `.refresh()`.
- Added a docstr to `AnyActionObject`.
- Added a warning print when a widget has an unused share button.