### PR TITLE
diffstate repr fix

### DIFF
--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -801,7 +801,14 @@ class ObjectDiffBatch(SyftObject):
         return flatten_dict(self.get_visual_hierarchy())
 
     def _repr_html_(self) -> str:
-        diffs = self.flatten_visual_hierarchy()
+        try:
+            diffs = self.flatten_visual_hierarchy()
+        except Exception as _:
+            return SyftError(
+                message=html.escape(
+                    "Could not render batch, please use resolve_single(<batch>) instead."
+                )
+            )._repr_html_()
 
         return f"""
 <h2> ObjectBatchDiff </h2>
@@ -876,11 +883,18 @@ class ObjectDiffBatch(SyftObject):
     def root(self) -> ObjectDiff:
         return self.root_diff
 
-    def __repr__(self) -> str:
-        return f"""{self.hierarchy_str('low')}
+    def __repr__(self) -> Any:
+        try:
+            return f"""{self.hierarchy_str('low')}
 
-{self.hierarchy_str('high')}
-"""
+    {self.hierarchy_str('high')}
+    """
+        except Exception as _:
+            return SyftError(
+                message=html.escape(
+                    "Could not render batch, please use resolve_single(<batch>) instead."
+                )
+            )._repr_html_()
 
     def _repr_markdown_(self, wrap_as_python: bool = True, indent: int = 0) -> str:
         return ""  # Turns off the _repr_markdown_ of SyftObject


### PR DESCRIPTION
## Description

clean up error message when diff repr fails. This is a quickfix, new repr is a larger ticket: https://github.com/orgs/OpenMined/projects/79/views/2?pane=issue&itemId=58556385

![image](https://github.com/OpenMined/PySyft/assets/7243409/3b4e64eb-a569-4a71-821c-c018104795a9)


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
