### PR TITLE
update mongomock installation path to use the forked version by OpenMined

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -102,7 +102,7 @@ dev =
     pre-commit==3.6.2
     safety>=2.4.0b2
     # our version of mongomock that has a fix for CodecOptions and custom TypeRegistry Support
-    mongomock @ git+https://github.com/OpenMined/PySyft.git@c823af4#egg=mongomock\&subdirectory=third_party/mongomock
+    mongomock @ git+https://github.com/OpenMined/mongomock.git@6398887#egg=mongomock
 
 telemetry =
     opentelemetry-api==1.14.0


### PR DESCRIPTION
Otherwise we have to clone the whole PySyft repo to install the forked version of mongomock. That takes a lot of time and space.
