### PR TITLE
refreshing ApiModule if submodule is not found

### DIFF
--- a/packages/syft/src/syft/client/api.py
+++ b/packages/syft/src/syft/client/api.py
@@ -589,10 +589,20 @@ def generate_remote_lib_function(
 class APIModule:
     _modules: list[str]
     path: str
+    refresh_callback: Callable | None
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, refresh_callback: Callable | None) -> None:
         self._modules = []
         self.path = path
+        self.refresh_callback = refresh_callback
+
+    def has_submodule(self, name: str) -> bool:
+        """We use this as hasattr() triggers __getattribute__ which triggers recursion"""
+        try:
+            _ = object.__getattribute__(self, name)
+            return True
+        except AttributeError:
+            return False
 
     def _add_submodule(
         self, attr_name: str, module_or_func: Callable | APIModule
@@ -604,6 +614,17 @@ class APIModule:
         try:
             return object.__getattribute__(self, name)
         except AttributeError:
+            # if we fail, we refresh the api and try again
+            if self.refresh_callback is not None:
+                api = self.refresh_callback()
+                try:
+                    new_current_module = api.services
+                    for submodule in self.path.split("."):
+                        if submodule != "":
+                            new_current_module = getattr(new_current_module, submodule)
+                    return object.__getattribute__(new_current_module, name)
+                except AttributeError:
+                    pass
             raise SyftAttributeError(
                 f"'APIModule' api{self.path} object has no submodule or method '{name}', "
                 "you may not have permission to access the module you are trying to access."
@@ -919,9 +940,8 @@ class SyftAPI(SyftObject):
             if self.refresh_api_callback is not None:
                 self.refresh_api_callback()
 
-    @staticmethod
     def _add_route(
-        api_module: APIModule, endpoint: APIEndpoint, endpoint_method: Callable
+        self, api_module: APIModule, endpoint: APIEndpoint, endpoint_method: Callable
     ) -> None:
         """Recursively create a module path to the route endpoint."""
 
@@ -931,9 +951,16 @@ class SyftAPI(SyftObject):
         _last_module = _modules.pop()
         while _modules:
             module = _modules.pop(0)
-            if not hasattr(_self, module):
-                submodule_path = f"{_self.path}.{module}"
-                _self._add_submodule(module, APIModule(path=submodule_path))
+            if not _self.has_submodule(module):
+                submodule_path = (
+                    f"{_self.path}.{module}" if _self.path != "" else module
+                )
+                _self._add_submodule(
+                    module,
+                    APIModule(
+                        path=submodule_path, refresh_callback=self.refresh_api_callback
+                    ),
+                )
             _self = getattr(_self, module)
         _self._add_submodule(_last_module, endpoint_method)
 
@@ -941,7 +968,7 @@ class SyftAPI(SyftObject):
         def build_endpoint_tree(
             endpoints: dict[str, LibEndpoint], communication_protocol: PROTOCOL_TYPE
         ) -> APIModule:
-            api_module = APIModule(path="")
+            api_module = APIModule(path="", refresh_callback=self.refresh_api_callback)
             for _, v in endpoints.items():
                 signature = v.signature
                 if not v.has_self:

--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -938,13 +938,13 @@ class SyftClient:
             metadata.check_version(__version__)
             self.metadata = metadata
 
-    def _fetch_api(self, credentials: SyftSigningKey) -> None:
+    def _fetch_api(self, credentials: SyftSigningKey) -> SyftAPI:
         _api: SyftAPI = self.connection.get_api(
             credentials=credentials,
             communication_protocol=self.communication_protocol,
         )
 
-        def refresh_callback() -> None:
+        def refresh_callback() -> SyftAPI:
             return self._fetch_api(self.credentials)
 
         _api.refresh_api_callback = refresh_callback
@@ -958,6 +958,7 @@ class SyftClient:
             api=_api,
         )
         self._api = _api
+        return _api
 
 
 @instrument

--- a/packages/syft/src/syft/client/domain_client.py
+++ b/packages/syft/src/syft/client/domain_client.py
@@ -312,49 +312,38 @@ class DomainClient(SyftClient):
                 return SyftSuccess(message=f"Connected to '{client.name}' gateway")
         return res
 
+    def _get_service_by_name_if_exists(self, name: str) -> APIModule | None:
+        if self.api.has_service(name):
+            return getattr(self.api.services, name)
+        return None
+
     @property
     def data_subject_registry(self) -> APIModule | None:
-        if self.api.has_service("data_subject"):
-            return self.api.services.data_subject
-        return None
+        return self._get_service_by_name_if_exists("data_subject")
 
     @property
     def code(self) -> APIModule | None:
-        # if self.api.refresh_api_callback is not None:
-        #     self.api.refresh_api_callback()
-        if self.api.has_service("code"):
-            return self.api.services.code
-        return None
+        return self._get_service_by_name_if_exists("code")
 
     @property
     def worker(self) -> APIModule | None:
-        if self.api.has_service("worker"):
-            return self.api.services.worker
-        return None
+        return self._get_service_by_name_if_exists("worker")
 
     @property
     def requests(self) -> APIModule | None:
-        if self.api.has_service("request"):
-            return self.api.services.request
-        return None
+        return self._get_service_by_name_if_exists("request")
 
     @property
     def datasets(self) -> APIModule | None:
-        if self.api.has_service("dataset"):
-            return self.api.services.dataset
-        return None
+        return self._get_service_by_name_if_exists("dataset")
 
     @property
     def projects(self) -> APIModule | None:
-        if self.api.has_service("project"):
-            return self.api.services.project
-        return None
+        return self._get_service_by_name_if_exists("project")
 
     @property
     def code_history_service(self) -> APIModule | None:
-        if self.api is not None and self.api.has_service("code_history"):
-            return self.api.services.code_history
-        return None
+        return self._get_service_by_name_if_exists("code_history")
 
     @property
     def code_history(self) -> CodeHistoriesDict:
@@ -366,39 +355,27 @@ class DomainClient(SyftClient):
 
     @property
     def images(self) -> APIModule | None:
-        if self.api.has_service("worker_image"):
-            return self.api.services.worker_image
-        return None
+        return self._get_service_by_name_if_exists("worker_image")
 
     @property
     def worker_pools(self) -> APIModule | None:
-        if self.api.has_service("worker_pool"):
-            return self.api.services.worker_pool
-        return None
+        return self._get_service_by_name_if_exists("worker_pool")
 
     @property
     def worker_images(self) -> APIModule | None:
-        if self.api.has_service("worker_image"):
-            return self.api.services.worker_image
-        return None
+        return self._get_service_by_name_if_exists("worker_images")
 
     @property
     def sync(self) -> APIModule | None:
-        if self.api.has_service("sync"):
-            return self.api.services.sync
-        return None
+        return self._get_service_by_name_if_exists("sync")
 
     @property
     def code_status(self) -> APIModule | None:
-        if self.api.has_service("code_status"):
-            return self.api.services.code_status
-        return None
+        return self._get_service_by_name_if_exists("code_status")
 
     @property
     def output(self) -> APIModule | None:
-        if self.api.has_service("output"):
-            return self.api.services.output
-        return None
+        return self._get_service_by_name_if_exists("output")
 
     def get_project(
         self,


### PR DESCRIPTION
When we try to get a apimodule like `client.code.x`, but we dont find `x`, we want to refresh the api and retry before returning an error. The tricky part is that when we refresh the api, a new api object is built and patched on the client. 

The solution is to get a pointer to this new api object via the refresh_api_callback, get the right parent `ApiModule` (`client.code`), and retry the getattr.

Apart from this this PR removes some duplication in getting services