### PR TITLE
Optimize attaching attributes to `SyftBaseObject`s

### DIFF
--- a/packages/syft/src/syft/service/service.py
+++ b/packages/syft/src/syft/service/service.py
@@ -372,9 +372,8 @@ def service_method(
                 "syft_node_location": context.node.id,
                 "syft_client_verify_key": context.credentials,
             }
-            return attach_attribute_to_syft_object(
-                result=result, attr_dict=attrs_to_attach
-            )
+            attach_attribute_to_syft_object(result=result, attr_dict=attrs_to_attach)
+            return result
 
         if autosplat is not None and len(autosplat) > 0:
             signature = expand_signature(signature=input_signature, autosplat=autosplat)

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -5,8 +5,6 @@ from collections.abc import Generator
 from collections.abc import Iterable
 from collections.abc import KeysView
 from collections.abc import Mapping
-from collections.abc import MutableMapping
-from collections.abc import MutableSequence
 from collections.abc import Sequence
 from collections.abc import Set
 from hashlib import sha256
@@ -45,7 +43,6 @@ from ..util.table import list_dict_repr_html
 from ..util.util import aggressive_set_attr
 from ..util.util import full_name_with_qualname
 from ..util.util import get_qualname_for
-from .dicttuple import DictTuple
 from .syft_metaclass import Empty
 from .syft_metaclass import PartialModelMetaclass
 from .uid import UID
@@ -796,21 +793,17 @@ recursive_serde_register_type(PartialSyftObject)
 
 
 def attach_attribute_to_syft_object(result: Any, attr_dict: dict[str, Any]) -> None:
+    iterator: Iterable
     if isinstance(result, OkErr):
-
-        def iterator():  # type: ignore
-            yield result._value
-
+        iterator = (result._value,)
     elif isinstance(result, Mapping):
-        iterator = result.values
+        iterator = result.values()
     elif isinstance(result, Sequence):
-        iterator = lambda: result
+        iterator = result
     else:
+        iterator = (result,)
 
-        def iterator():  # type: ignore
-            yield result
-
-    for _object in iterator():
+    for _object in iterator:
         # if object is SyftBaseObject,
         # then attach the value to the attribute
         # on the object

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -818,5 +818,5 @@ def attach_attribute_to_syft_object(result: Any, attr_dict: dict[str, Any]) -> N
             for attr_name, attr_value in attr_dict.items():
                 setattr(_object, attr_name, attr_value)
 
-            for obj in _object.__dict__.values():
-                attach_attribute_to_syft_object(obj, attr_dict)
+            for field in _object.model_fields.keys():
+                attach_attribute_to_syft_object(getattr(_object, field), attr_dict)

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -797,18 +797,20 @@ recursive_serde_register_type(PartialSyftObject)
 
 def attach_attribute_to_syft_object(result: Any, attr_dict: dict[str, Any]) -> None:
     if isinstance(result, OkErr):
-        result = result._value
 
-    if isinstance(result, Mapping):
-        iterable_keys: Iterable = result.keys()
+        def iterator():  # type: ignore
+            yield result._value
+
+    elif isinstance(result, Mapping):
+        iterator = result.values
     elif isinstance(result, Sequence):
-        iterable_keys = range(len(result))
+        iterator = lambda: result
     else:
-        result = [result]
-        iterable_keys = [0]
 
-    for key in iterable_keys:
-        _object = result[key]
+        def iterator():  # type: ignore
+            yield result
+
+    for _object in iterator():
         # if object is SyftBaseObject,
         # then attach the value to the attribute
         # on the object


### PR DESCRIPTION
## Description
Optimize the `attach_attribute_to_syft_object` function used to attach attributes (`syft_node_location` and `syft_client_verify_key`) to `SyftBaseObject`s by avoiding creating new/reconstructing objects.

The function also now works out of the box for data structures *eg* `tuple` and `DictTuple` which we currently have to special case.

Does seem to shave seconds off running the whole unit test suit, but nothing dramatic.