### PR TITLE
Rename args in some API endpoints to be more consistent

### DIFF
--- a/notebooks/admin/Custom API + Custom Worker.ipynb
+++ b/notebooks/admin/Custom API + Custom Worker.ipynb
@@ -235,7 +235,7 @@
    "source": [
     "worker_pool_name = \"bigquery-pool\"\n",
     "domain_client.api.services.worker_pool.launch(\n",
-    "    name=worker_pool_name,\n",
+    "    pool_name=worker_pool_name,\n",
     "    image_uid=workerimage.id,\n",
     "    num_workers=1,\n",
     ")"

--- a/notebooks/api/0.8/10-container-images.ipynb
+++ b/notebooks/api/0.8/10-container-images.ipynb
@@ -600,7 +600,7 @@
    "source": [
     "worker_pool_name = \"opendp-pool\"\n",
     "worker_pool_res = domain_client.api.services.worker_pool.launch(\n",
-    "    name=worker_pool_name,\n",
+    "    pool_name=worker_pool_name,\n",
     "    image_uid=workerimage.id,\n",
     "    num_workers=2,\n",
     ")"

--- a/notebooks/api/0.8/10-container-images.ipynb
+++ b/notebooks/api/0.8/10-container-images.ipynb
@@ -393,7 +393,7 @@
     "    image_uid=workerimage.id,\n",
     "    tag=docker_tag,\n",
     "    registry_uid=registry_uid,\n",
-    "    pull=pull,\n",
+    "    pull_image=pull,\n",
     ")\n",
     "docker_build_result"
    ]
@@ -1483,7 +1483,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/api/0.8/11-container-images-k8s.ipynb
+++ b/notebooks/api/0.8/11-container-images-k8s.ipynb
@@ -570,8 +570,8 @@
     "    pool_name=worker_pool_name,\n",
     "    image_uid=workerimage.id,\n",
     "    num_workers=3,\n",
-    "    reg_username=external_registry_username,\n",
-    "    reg_password=external_registry_password,\n",
+    "    registry_username=external_registry_username,\n",
+    "    registry_password=external_registry_password,\n",
     ")"
    ]
   },
@@ -1097,7 +1097,8 @@
    "source": [
     "# get the pending request and approve it\n",
     "req_result = pool_create_request.approve(\n",
-    "    reg_username=external_registry_username, reg_password=external_registry_password\n",
+    "    registry_username=external_registry_username,\n",
+    "    registry_password=external_registry_password,\n",
     ")\n",
     "req_result"
    ]
@@ -1243,7 +1244,8 @@
    "outputs": [],
    "source": [
     "req_result = pool_image_create_request.approve(\n",
-    "    reg_username=external_registry_username, reg_password=external_registry_password\n",
+    "    registry_username=external_registry_username,\n",
+    "    registry_password=external_registry_password,\n",
     ")\n",
     "req_result"
    ]

--- a/notebooks/api/0.8/11-container-images-k8s.ipynb
+++ b/notebooks/api/0.8/11-container-images-k8s.ipynb
@@ -567,7 +567,7 @@
    "source": [
     "worker_pool_name = \"custom-pool\"\n",
     "worker_pool_res = domain_client.api.services.worker_pool.launch(\n",
-    "    name=worker_pool_name,\n",
+    "    pool_name=worker_pool_name,\n",
     "    image_uid=workerimage.id,\n",
     "    num_workers=3,\n",
     "    reg_username=external_registry_username,\n",

--- a/packages/syft/src/syft/custom_worker/runner_k8s.py
+++ b/packages/syft/src/syft/custom_worker/runner_k8s.py
@@ -28,19 +28,19 @@ class KubernetesRunner:
         replicas: int = 1,
         env_vars: list[dict] | None = None,
         mount_secrets: dict | None = None,
-        reg_username: str | None = None,
-        reg_password: str | None = None,
+        registry_username: str | None = None,
+        registry_password: str | None = None,
         reg_url: str | None = None,
         **kwargs: Any,
     ) -> StatefulSet:
         try:
             # create pull secret if registry credentials are passed
             pull_secret = None
-            if reg_username and reg_password and reg_url:
+            if registry_username and registry_password and reg_url:
                 pull_secret = self._create_image_pull_secret(
                     pool_name,
-                    reg_username,
-                    reg_password,
+                    registry_username,
+                    registry_password,
                     reg_url,
                 )
 
@@ -126,8 +126,8 @@ class KubernetesRunner:
     def _create_image_pull_secret(
         self,
         pool_name: str,
-        reg_username: str,
-        reg_password: str,
+        registry_username: str,
+        registry_password: str,
         reg_url: str,
         **kwargs: Any,
     ) -> Secret:
@@ -135,7 +135,7 @@ class KubernetesRunner:
             secret_name=f"pull-secret-{pool_name}",
             component=pool_name,
             registries=[
-                (reg_url, reg_username, reg_password),
+                (reg_url, registry_username, registry_password),
             ],
         )
 

--- a/packages/syft/src/syft/node/node.py
+++ b/packages/syft/src/syft/node/node.py
@@ -1741,7 +1741,7 @@ def create_default_worker_pool(node: Node) -> SyftError | None:
             context,
             image_uid=default_image.id,
             tag=DEFAULT_WORKER_IMAGE_TAG,
-            pull=pull_image,
+            pull_image=pull_image,
         )
 
         if isinstance(result, SyftError):

--- a/packages/syft/src/syft/node/node.py
+++ b/packages/syft/src/syft/node/node.py
@@ -1761,7 +1761,7 @@ def create_default_worker_pool(node: Node) -> SyftError | None:
         create_pool_method = node.get_service_method(SyftWorkerPoolService.launch)
         result = create_pool_method(
             context,
-            name=default_pool_name,
+            pool_name=default_pool_name,
             image_uid=default_image.id,
             num_workers=worker_count,
         )

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -251,7 +251,7 @@ class CreateCustomImageChange(Change):
                     image_uid=worker_image.id,
                     tag=self.tag,
                     registry_uid=self.registry_uid,
-                    pull=self.pull_image,
+                    pull_image=self.pull_image,
                 )
 
                 if isinstance(build_result, SyftError):

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -332,7 +332,7 @@ class CreateCustomWorkerPoolChange(Change):
 
             result = worker_pool_service.launch(
                 context=service_context,
-                name=self.pool_name,
+                pool_name=self.pool_name,
                 image_uid=self.image_uid,
                 num_workers=self.num_workers,
                 reg_username=context.extra_kwargs.get("reg_username", None),

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -267,8 +267,8 @@ class CreateCustomImageChange(Change):
                 push_result = worker_image_service.push(
                     service_context,
                     image_uid=worker_image.id,
-                    username=context.extra_kwargs.get("reg_username", None),
-                    password=context.extra_kwargs.get("reg_password", None),
+                    username=context.extra_kwargs.get("registry_username", None),
+                    password=context.extra_kwargs.get("registry_password", None),
                 )
 
                 if isinstance(push_result, SyftError):
@@ -335,8 +335,8 @@ class CreateCustomWorkerPoolChange(Change):
                 pool_name=self.pool_name,
                 image_uid=self.image_uid,
                 num_workers=self.num_workers,
-                reg_username=context.extra_kwargs.get("reg_username", None),
-                reg_password=context.extra_kwargs.get("reg_password", None),
+                registry_username=context.extra_kwargs.get("registry_username", None),
+                registry_password=context.extra_kwargs.get("registry_password", None),
             )
             if isinstance(result, SyftError):
                 return Err(result)

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -266,7 +266,7 @@ class CreateCustomImageChange(Change):
             if IN_KUBERNETES and not worker_image.is_prebuilt:
                 push_result = worker_image_service.push(
                     service_context,
-                    image=worker_image.id,
+                    image_uid=worker_image.id,
                     username=context.extra_kwargs.get("reg_username", None),
                     password=context.extra_kwargs.get("reg_password", None),
                 )

--- a/packages/syft/src/syft/service/worker/utils.py
+++ b/packages/syft/src/syft/service/worker/utils.py
@@ -325,8 +325,8 @@ def create_kubernetes_pool(
     replicas: int,
     queue_port: int,
     debug: bool,
-    reg_username: str | None = None,
-    reg_password: str | None = None,
+    registry_username: str | None = None,
+    registry_password: str | None = None,
     reg_url: str | None = None,
     **kwargs: Any,
 ) -> list[Pod] | SyftError:
@@ -360,8 +360,8 @@ def create_kubernetes_pool(
             replicas=replicas,
             env_vars=env_vars,
             mount_secrets=mount_secrets,
-            reg_username=reg_username,
-            reg_password=reg_password,
+            registry_username=registry_username,
+            registry_password=registry_password,
             reg_url=reg_url,
         )
     except Exception as e:
@@ -402,8 +402,8 @@ def run_workers_in_kubernetes(
     queue_port: int,
     start_idx: int = 0,
     debug: bool = False,
-    reg_username: str | None = None,
-    reg_password: str | None = None,
+    registry_username: str | None = None,
+    registry_password: str | None = None,
     reg_url: str | None = None,
     **kwargs: Any,
 ) -> list[ContainerSpawnStatus] | SyftError:
@@ -419,8 +419,8 @@ def run_workers_in_kubernetes(
                 replicas=worker_count,
                 queue_port=queue_port,
                 debug=debug,
-                reg_username=reg_username,
-                reg_password=reg_password,
+                registry_username=registry_username,
+                registry_password=registry_password,
                 reg_url=reg_url,
             )
         else:
@@ -501,8 +501,8 @@ def run_containers(
     queue_port: int,
     dev_mode: bool = False,
     start_idx: int = 0,
-    reg_username: str | None = None,
-    reg_password: str | None = None,
+    registry_username: str | None = None,
+    registry_password: str | None = None,
     reg_url: str | None = None,
 ) -> list[ContainerSpawnStatus] | SyftError:
     results = []
@@ -524,8 +524,8 @@ def run_containers(
                     pool_name=pool_name,
                     queue_port=queue_port,
                     debug=dev_mode,
-                    username=reg_username,
-                    password=reg_password,
+                    username=registry_username,
+                    password=registry_password,
                     registry_url=reg_url,
                 )
                 results.append(spawn_result)
@@ -537,8 +537,8 @@ def run_containers(
             queue_port=queue_port,
             debug=dev_mode,
             start_idx=start_idx,
-            reg_username=reg_username,
-            reg_password=reg_password,
+            registry_username=registry_username,
+            registry_password=registry_password,
             reg_url=reg_url,
         )
 

--- a/packages/syft/src/syft/service/worker/worker_image_service.py
+++ b/packages/syft/src/syft/service/worker/worker_image_service.py
@@ -82,7 +82,7 @@ class SyftWorkerImageService(AbstractService):
         image_uid: UID,
         tag: str,
         registry_uid: UID | None = None,
-        pull: bool = True,
+        pull_image: bool = True,
     ) -> SyftSuccess | SyftError:
         registry: SyftImageRegistry | None = None
 
@@ -130,7 +130,7 @@ class SyftWorkerImageService(AbstractService):
         result = None
 
         if not context.node.in_memory_workers:
-            build_result = image_build(worker_image, pull=pull)
+            build_result = image_build(worker_image, pull=pull_image)
             if isinstance(build_result, SyftError):
                 return build_result
 

--- a/packages/syft/src/syft/service/worker/worker_image_service.py
+++ b/packages/syft/src/syft/service/worker/worker_image_service.py
@@ -162,14 +162,14 @@ class SyftWorkerImageService(AbstractService):
     def push(
         self,
         context: AuthedServiceContext,
-        image: UID,
+        image_uid: UID,
         username: str | None = None,
         password: str | None = None,
     ) -> SyftSuccess | SyftError:
-        result = self.stash.get_by_uid(credentials=context.credentials, uid=image)
+        result = self.stash.get_by_uid(credentials=context.credentials, uid=image_uid)
         if result.is_err():
             return SyftError(
-                message=f"Failed to get Image ID: {image}. Error: {result.err()}"
+                message=f"Failed to get Image ID: {image_uid}. Error: {result.err()}"
             )
         worker_image: SyftWorkerImage = result.ok()
 

--- a/packages/syft/src/syft/service/worker/worker_pool_service.py
+++ b/packages/syft/src/syft/service/worker/worker_pool_service.py
@@ -67,8 +67,8 @@ class SyftWorkerPoolService(AbstractService):
         pool_name: str,
         image_uid: UID | None,
         num_workers: int,
-        reg_username: str | None = None,
-        reg_password: str | None = None,
+        registry_username: str | None = None,
+        registry_password: str | None = None,
     ) -> list[ContainerSpawnStatus] | SyftError:
         """Creates a pool of workers from the given SyftWorkerImage.
 
@@ -126,8 +126,8 @@ class SyftWorkerPoolService(AbstractService):
             worker_cnt=num_workers,
             worker_image=worker_image,
             worker_stash=worker_stash,
-            reg_username=reg_username,
-            reg_password=reg_password,
+            registry_username=registry_username,
+            registry_password=registry_password,
         )
 
         if isinstance(result, SyftError):
@@ -366,8 +366,8 @@ class SyftWorkerPoolService(AbstractService):
         number: int,
         pool_id: UID | None = None,
         pool_name: str | None = None,
-        reg_username: str | None = None,
-        reg_password: str | None = None,
+        registry_username: str | None = None,
+        registry_password: str | None = None,
     ) -> list[ContainerSpawnStatus] | SyftError:
         """Add workers to existing worker pool.
 
@@ -425,8 +425,8 @@ class SyftWorkerPoolService(AbstractService):
             worker_cnt=number,
             worker_image=worker_image,
             worker_stash=worker_stash,
-            reg_username=reg_username,
-            reg_password=reg_password,
+            registry_username=registry_username,
+            registry_password=registry_password,
         )
 
         if isinstance(result, SyftError):
@@ -487,8 +487,8 @@ class SyftWorkerPoolService(AbstractService):
                 pool_id=pool_id,
                 pool_name=pool_name,
                 # kube scaling doesn't require password as it replicates an existing deployment
-                reg_username=None,
-                reg_password=None,
+                registry_username=None,
+                registry_password=None,
             )
             if isinstance(result, SyftError):
                 return result
@@ -656,8 +656,8 @@ def _create_workers_in_pool(
     worker_cnt: int,
     worker_image: SyftWorkerImage,
     worker_stash: WorkerStash,
-    reg_username: str | None = None,
-    reg_password: str | None = None,
+    registry_username: str | None = None,
+    registry_password: str | None = None,
 ) -> tuple[list[LinkedObject], list[ContainerSpawnStatus]] | SyftError:
     queue_port = context.node.queue_config.client_config.queue_port
 
@@ -686,8 +686,8 @@ def _create_workers_in_pool(
             orchestration=get_orchestration_type(),
             queue_port=queue_port,
             dev_mode=context.node.dev_mode,
-            reg_username=reg_username,
-            reg_password=reg_password,
+            registry_username=registry_username,
+            registry_password=registry_password,
             reg_url=registry_host,
         )
         if isinstance(result, SyftError):

--- a/packages/syft/src/syft/service/worker/worker_pool_service.py
+++ b/packages/syft/src/syft/service/worker/worker_pool_service.py
@@ -64,7 +64,7 @@ class SyftWorkerPoolService(AbstractService):
     def launch(
         self,
         context: AuthedServiceContext,
-        name: str,
+        pool_name: str,
         image_uid: UID | None,
         num_workers: int,
         reg_username: str | None = None,
@@ -84,13 +84,15 @@ class SyftWorkerPoolService(AbstractService):
             num_workers (int): the number of SyftWorker that needs to be created in the pool
         """
 
-        result = self.stash.get_by_name(context.credentials, pool_name=name)
+        result = self.stash.get_by_name(context.credentials, pool_name=pool_name)
 
         if result.is_err():
             return SyftError(message=f"{result.err()}")
 
         if result.ok() is not None:
-            return SyftError(message=f"Worker Pool with name: {name} already exists !!")
+            return SyftError(
+                message=f"Worker Pool with name: {pool_name} already exists !!"
+            )
 
         # If image uid is not passed, then use the default worker image
         # to create the worker pool
@@ -119,7 +121,7 @@ class SyftWorkerPoolService(AbstractService):
         # and with the desired number of workers
         result = _create_workers_in_pool(
             context=context,
-            pool_name=name,
+            pool_name=pool_name,
             existing_worker_cnt=0,
             worker_cnt=num_workers,
             worker_image=worker_image,
@@ -135,7 +137,7 @@ class SyftWorkerPoolService(AbstractService):
 
         # Update the Database with the pool information
         worker_pool = WorkerPool(
-            name=name,
+            name=pool_name,
             max_count=num_workers,
             image_id=worker_image.id,
             worker_list=worker_list,

--- a/packages/syft/tests/syft/worker_pool/worker_test.py
+++ b/packages/syft/tests/syft/worker_pool/worker_test.py
@@ -43,7 +43,7 @@ def test_syft_worker(worker: Worker):
     pool_name = "custom-worker-pool"
     num_workers = 3
     worker_pool_res = root_client.api.services.worker_pool.launch(
-        name=pool_name,
+        pool_name=pool_name,
         image_uid=worker_image.id,
         num_workers=num_workers,
     )

--- a/tests/integration/container_workload/pool_image_test.py
+++ b/tests/integration/container_workload/pool_image_test.py
@@ -150,7 +150,7 @@ def test_pool_launch(
     # Launch a worker pool
     worker_pool_name = f"custom-worker-pool-opendp{'-prebuilt' if prebuilt else ''}"
     worker_pool_res = domain_client.api.services.worker_pool.launch(
-        name=worker_pool_name,
+        pool_name=worker_pool_name,
         image_uid=worker_image.id,
         num_workers=3,
     )


### PR DESCRIPTION
See https://github.com/OpenMined/PySyft/pull/8802#issuecomment-2123880989

- [x] Rename arg `image` to `image_uid` in `worker_image_service.push` to be consistent with other endpoints.
- [x] Rename arg `pool` to `pool_name` in `worker_pool_service.launch` `to be consistent with other endpoints.
- [x] Rename arg `pull` in `worker_image_service.build` to be consistent with `worker_pool_service.create_image_and_pool_request(pull_image: bool)`
- [x] Rename `reg_username` and `reg_password` to `registry_username` and `registry_password`. The later are much clearer while not much longer. Plus we are using `registry_uid` anyway.