### PR TITLE
Fix user search

### DIFF
--- a/packages/syft/src/syft/client/api.py
+++ b/packages/syft/src/syft/client/api.py
@@ -90,8 +90,10 @@ IPYNB_BACKGROUND_PREFIXES = ["_ipy", "_repr", "__ipython", "__pydantic"]
 
 def _has_config_dict(t: Any) -> bool:
     return (
-        isinstance(t, type)
-        and issubclass(t, BaseModel)
+        # Use this instead of `issubclass`` to be compatible with python 3.10
+        # `inspect.isclass(t) and issubclass(t, BaseModel)`` wouldn't work with
+        # generics, e.g. `set[sy.UID]`, in python 3.10
+        (hasattr(t, "__mro__") and BaseModel in t.__mro__)
         or hasattr(t, "__pydantic_config__")
     )
 

--- a/packages/syft/src/syft/client/api.py
+++ b/packages/syft/src/syft/client/api.py
@@ -17,7 +17,10 @@ from typing import get_origin
 
 # third party
 from nacl.exceptions import BadSignatureError
+from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import EmailStr
+from pydantic import TypeAdapter
 from result import OkErr
 from result import Result
 from typeguard import check_type
@@ -83,6 +86,14 @@ IPYNB_BACKGROUND_METHODS = {
 }
 
 IPYNB_BACKGROUND_PREFIXES = ["_ipy", "_repr", "__ipython", "__pydantic"]
+
+
+def _has_config_dict(t: Any) -> bool:
+    return (
+        isinstance(t, type)
+        and issubclass(t, BaseModel)
+        or hasattr(t, "__pydantic_config__")
+    )
 
 
 class APIRegistry:
@@ -1321,30 +1332,25 @@ def validate_callable_args_and_kwargs(
                 t = index_syft_by_module_name(param.annotation)
             else:
                 t = param.annotation
-            msg = None
-            try:
-                if t is not inspect.Parameter.empty:
-                    if isinstance(t, _GenericAlias) and type(None) in t.__args__:
-                        success = False
-                        for v in t.__args__:
-                            if issubclass(v, EmailStr):
-                                v = str
-                            try:
-                                check_type(value, v)  # raises Exception
-                                success = True
-                                break  # only need one to match
-                            except Exception:  # nosec
-                                pass
-                        if not success:
-                            raise TypeError()
-                    else:
-                        check_type(value, t)  # raises Exception
-            except TypeError:
-                _type_str = getattr(t, "__name__", str(t))
-                msg = f"`{key}` must be of type `{_type_str}` not `{type(value).__name__}`"
 
-            if msg:
-                return SyftError(message=msg)
+            if t is not inspect.Parameter.empty:
+                try:
+                    config_kw = (
+                        {"config": ConfigDict(arbitrary_types_allowed=True)}
+                        if not _has_config_dict(t)
+                        else {}
+                    )
+
+                    # TypeAdapter only accepts `config` arg if `t` does not
+                    # already contain a ConfigDict
+                    # i.e model_config in BaseModel and __pydantic_config__ in
+                    # other types.
+                    TypeAdapter(t, **config_kw).validate_python(value)
+                except Exception:
+                    _type_str = getattr(t, "__name__", str(t))
+                    return SyftError(
+                        message=f"`{key}` must be of type `{_type_str}` not `{type(value).__name__}`"
+                    )
 
             _valid_kwargs[key] = value
 

--- a/packages/syft/tests/syft/users/user_test.py
+++ b/packages/syft/tests/syft/users/user_test.py
@@ -423,3 +423,21 @@ def test_user_view_set_role_admin(faker: Faker) -> None:
 
     node.python_node.cleanup()
     node.land()
+
+
+@pytest.mark.parametrize(
+    "search_param",
+    [
+        ("email", "logged_in_user"),
+        ("name", "logged_in_username"),
+    ],
+)
+def test_user_search(
+    root_client: DomainClient, ds_client: DomainClient, search_param: tuple[str, str]
+) -> None:
+    k, attr = search_param
+    v = getattr(ds_client, attr)
+    users = root_client.api.services.user.search(**{k: v})
+
+    for user in users:
+        assert getattr(user, k) == v


### PR DESCRIPTION
```py
import syft as sy

node = sy.orchestra.launch(name="test-domain-1", port="auto", dev_mode=True, reset=True)

domain_client = node.login(email="info@openmined.org", password="changethis")

domain_client.register(
    name="Jane Doe",
    email="jane@caltech.edu",
    password="abc123",
    password_verify="abc123",
    institution="Caltech",
    website="https://www.caltech.edu/",
)

domain_client.api.services.user.search(email="jane@caltech.edu")

TypeCheckError: str did not match any element in the union:
  pydantic.networks.EmailStr: is not an instance of pydantic.networks.EmailStr
  syft.types.syft_metaclass.EmptyType: is not an instance of syft.types.syft_metaclass.EmptyType
```

The error was due to `typeguard.check_type` does not take into consideration Pydantic type conversion.

```py
class UserSearch(PartialSyftObject):
    email: EmailStr
```

Here `email` would accept a `str`, not just `EmailStr` due to Pydantic type conversion, but `typeguard.check_type(v: str, EmailStr | EmptyType)` would fail.

Replacing `typeguard.check_type` with `pydantic.TypeAdapter.validate_python` works.