### PR TITLE
remove adding read permissions on deposit_result

### DIFF
--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -793,7 +793,6 @@ class Request(SyncableSyftObject):
         self,
         result: Any,
         logs: str = "",
-        add_code_owner_read_permissions: bool = True,
     ) -> Job | SyftError:
         """
         Adds a result to this Request:
@@ -825,12 +824,13 @@ class Request(SyncableSyftObject):
             return action_object
 
         # Create Job
+        # NOTE code owner read permissions are added when syncing this Job
         job = api.services.job.create_job_for_user_code_id(
             code.id,
             result=action_object,
             log_stdout=logs,
             status=JobStatus.COMPLETED,
-            add_code_owner_read_permissions=add_code_owner_read_permissions,
+            add_code_owner_read_permissions=False,
         )
         if isinstance(job, SyftError):
             return job


### PR DESCRIPTION
## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
