### PR TITLE
Fixed hackathon issues

### DIFF
--- a/packages/syft/src/syft/service/queue/zmq_queue.py
+++ b/packages/syft/src/syft/service/queue/zmq_queue.py
@@ -261,12 +261,17 @@ class ZMQProducer(QueueProducer):
         if res.is_err():
             return arg
         action_object = res.ok()
-        data = action_object.syft_action_data
-        new_data = self.unwrap_nested_actionobjects(data)
-        new_action_object = ActionObject.from_obj(new_data, id=action_object.id)
-        res = self.action_service.set(
-            context=self.auth_context, action_object=new_action_object
-        )
+
+        # TODO: do this elsewhere, because here it breaks mongo by setting data back
+        # really we shouldnt have nested issues requiring this in the first place
+
+        # data = action_object.syft_action_data
+        # new_data = self.unwrap_nested_actionobjects(data)
+        # new_action_object = ActionObject.from_obj(new_data, id=action_object.id)
+        # res = self.action_service.set(
+        #     context=self.auth_context, action_object=new_action_object
+        # )
+        return action_object
 
     def read_items(self) -> None:
         while True:

--- a/packages/syft/src/syft/service/settings/settings_stash.py
+++ b/packages/syft/src/syft/service/settings/settings_stash.py
@@ -34,7 +34,7 @@ class SettingsStash(BaseUIDStoreStash):
         self,
         credentials: SyftVerifyKey,
         settings: NodeSettings,
-        add_permission: list[ActionObjectPermission] | None = None,
+        add_permissions: list[ActionObjectPermission] | None = None,
         add_storage_permission: bool = True,
         ignore_duplicates: bool = False,
     ) -> Result[NodeSettings, str]:
@@ -42,7 +42,13 @@ class SettingsStash(BaseUIDStoreStash):
         # we dont use and_then logic here as it is hard because of the order of the arguments
         if res.is_err():
             return res
-        return super().set(credentials=credentials, obj=res.ok())
+        return super().set(
+            credentials=credentials,
+            obj=res.ok(),
+            add_permissions=add_permissions,
+            add_storage_permission=add_storage_permission,
+            ignore_duplicates=ignore_duplicates,
+        )
 
     def update(
         self,

--- a/packages/syft/src/syft/store/mongo_document_store.py
+++ b/packages/syft/src/syft/store/mongo_document_store.py
@@ -291,14 +291,25 @@ class MongoStorePartition(StorePartition):
                 f"The fields that should be unique are {keys}."
             )
         else:
+            # TODO: h4x fix ?????? how is this supposed to work? This returns if
+            # ignore_duplicates is set to True.....????!?!?
+
             # we are not throwing an error, because we are ignoring duplicates
             # we are also not writing though
-            return Ok(obj)
+            # return Ok(obj)
+            pass
 
         if can_write:
             storage_obj = obj.to(self.storage_type)
 
-            collection.insert_one(storage_obj)
+            # update if it exists
+            if store_key_exists:
+                collection.update_one(
+                    filter=store_query_key.as_dict_mongo,
+                    update={"$set": storage_obj},
+                )
+            else:
+                collection.insert_one(storage_obj)
 
             # adding permissions
             read_permission = ActionObjectPermission(
@@ -864,7 +875,7 @@ class MongoBackingStore(KeyValueBackingStore):
             )
         except Exception as e:
             raise RuntimeError(
-                f"Failed to update obj: {key} with value: {value}. Error: {e}"
+                f"Failed to update obj: {key} with value: {type(value)}. Error: {e}"
             )
 
     def __setitem__(self, key: Any, value: Any) -> None:


### PR DESCRIPTION
- Unable to set Settings due to no interface that allows it
- No ability for Mongo to do ignore_duplicates and updates
- No passing of kwargs between set methods in the Settings service
- Fixed issue with Jobs not working with data > 16MB in mongo because data was fetched from blob storage and then re-saved

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
