### PR TITLE
Fix for overloaded or comparison in syncing pandas object

### DIFF
--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -310,7 +310,10 @@ class ObjectDiff(SyftObject):  # StateTuple (compare 2 objects)
 
     @property
     def non_empty_object(self) -> SyftObject | None:
-        return self.low_obj or self.high_obj
+        if self.low_obj is not None:
+            return self.low_obj
+        else:
+            return self.high_obj
 
     @property
     def object_type(self) -> str:


### PR DESCRIPTION
## Description
Returning a non-empty Syft object fails when self.low_obj or self.high_obj are pandas series where `or` is overloaded. This is a fix to work in that case.

Resolves the following error:
```
ValueError                                Traceback (most recent call last)
/var/folders/mt/hh7shybx3xq2888mhg60t29h0000gn/T/ipykernel_76398/2216766038.py in ?()
----> 1 diff.resolve()

~/miniconda3/envs/hackathon_jun2024/lib/python3.12/site-packages/syft/service/sync/diff_state.py in ?(self)
   1150     def resolve(self) -> "PaginatedResolveWidget":
   1151         # relative
   1152         from .resolve_widget import PaginatedResolveWidget
   1153 
-> 1154         return PaginatedResolveWidget(batches=self.batches)

~/miniconda3/envs/hackathon_jun2024/lib/python3.12/site-packages/syft/service/sync/resolve_widget.py in ?(self, batches)
    718     def __init__(self, batches: list[ObjectDiffBatch]):
    719         self.batches = batches
--> 720         self.resolve_widgets: list[ResolveWidget] = [
    721             ResolveWidget(
    722                 batch,
    723                 on_sync_callback=partial(self.on_click_sync, i),

~/miniconda3/envs/hackathon_jun2024/lib/python3.12/site-packages/syft/service/sync/resolve_widget.py in ?(self, obj_diff_batch, on_sync_callback)
    420         self.id2widget: dict[
    421             UID, CollapsableObjectDiffWidget | MainObjectDiffWidget
    422         ] = {}
    423         self.on_sync_callback = on_sync_callback
...
   1578             f"The truth value of a {type(self).__name__} is ambiguous. "
   1579             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
   1580         )

ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Tested on low side / high side sync between deployed azure nodes.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [] My changes are covered by tests
