### PR TITLE
Revert "ci: fix setup-python action by pinning python to 3.12.3"

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -16,7 +16,7 @@ jobs:
   cd-docs:
     strategy:
       matrix:
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cd-post-release-tests.yml
+++ b/.github/workflows/cd-post-release-tests.yml
@@ -35,7 +35,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
-        python-version: ["3.12.3", "3.11", "3.10"]
+        python-version: ["3.12", "3.11", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: System Architecture
@@ -89,7 +89,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -146,7 +146,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12.3", "3.11", "3.10"]
+        python-version: ["3.12", "3.11", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: System Architecture

--- a/.github/workflows/cd-syft-dev.yml
+++ b/.github/workflows/cd-syft-dev.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/cd-syft.yml
+++ b/.github/workflows/cd-syft.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
 
       # The steps ensure that the cron job is able to run only for
       # for beta releases and not for stable releases
@@ -100,7 +100,7 @@ jobs:
         if: ${{ !endsWith(matrix.runner, '-arm64') }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
 
       # Currently psutil package requires gcc to be installed on arm
       # for building psutil from source
@@ -118,7 +118,7 @@ jobs:
         if: ${{ endsWith(matrix.runner, '-arm64') }}
         uses: deadsnakes/action@v3.1.0
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
 
       - name: Install Git
         run: |
@@ -382,7 +382,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           pip install --upgrade pip uv==0.1.35 tox tox-uv==1.5.1 setuptools wheel twine bump2version PyYAML

--- a/.github/workflows/cd-syftcli.yml
+++ b/.github/workflows/cd-syftcli.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
 
       - name: Install dependencies
         if: ${{steps.get-hashes.outputs.current_hash != steps.get-hashes.outputs.previous_hash }}
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
 
       - name: Install build dependencies for syftcli
         run: |

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12.3"
+          python-version: "3.12"
 
       #Generate SBOM
       - name: Generate SBOM

--- a/.github/workflows/e2e-tests-notebook.yml
+++ b/.github/workflows/e2e-tests-notebook.yml
@@ -45,7 +45,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/post-merge-tasks.yml
+++ b/.github/workflows/post-merge-tasks.yml
@@ -12,7 +12,7 @@ jobs:
   post-merge-cleanup-notebooks:
     strategy:
       matrix:
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-tests-frontend.yml
+++ b/.github/workflows/pr-tests-frontend.yml
@@ -23,7 +23,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
 
     runs-on: ubuntu-20.04 # ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr-tests-linting.yml
+++ b/.github/workflows/pr-tests-linting.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-tests-stack.yml
+++ b/.github/workflows/pr-tests-stack.yml
@@ -27,7 +27,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
       fail-fast: false
 
     runs-on: ${{matrix.os}}
@@ -87,7 +87,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
         pytest-modules: ["local_node"]
       fail-fast: false
 
@@ -152,7 +152,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
         pytest-modules: ["frontend network container_workload"]
       fail-fast: false
 
@@ -306,7 +306,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
       fail-fast: false
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/pr-tests-syft.yml
+++ b/.github/workflows/pr-tests-syft.yml
@@ -25,7 +25,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
         include:
           - python-version: "3.11"
             os: "ubuntu-latest"
@@ -108,7 +108,7 @@ jobs:
         # Disable on windows until its flakyness is reduced.
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
         deployment-type: ["python"]
         notebook-paths: ["tutorials"]
         bump-version: ["False"]
@@ -121,7 +121,7 @@ jobs:
             os: "ubuntu-latest"
             deployment-type: "python"
             notebook-paths: "tutorials"
-          - python-version: "3.12.3"
+          - python-version: "3.12"
             os: "ubuntu-latest"
             deployment-type: "python"
             notebook-paths: "tutorials"
@@ -201,7 +201,7 @@ jobs:
       max-parallel: 99
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12.3"]
+        python-version: ["3.10", "3.11", "3.12"]
         deployment-type: ["remote"]
         notebook-paths: ["api/0.8"]
       fail-fast: false
@@ -317,7 +317,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12.3"]
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Reverts OpenMined/PySyft#8895

Looks like `3.12.4` has been removed from `actions/setup-python` https://github.com/actions/setup-python/issues/886#issuecomment-2158933749 so using `3.12` works again. A fix has been submitted too so `3.12` won't break again. Currently setting `3.12.3` blocks CI because of the Github `Required` setting.