### PR TITLE
Distributed project result refactor (check all parties get result)

### DIFF
--- a/packages/syft/src/syft/service/enclave/enclave_service.py
+++ b/packages/syft/src/syft/service/enclave/enclave_service.py
@@ -310,6 +310,9 @@ class EnclaveService(AbstractService):
     ) -> Any:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
+        
+        # if context.node.name == "italy-domain":
+        #     return SyftError(message="For testing purposes, italy-domain execution is blocked")
 
         code_service = context.node.get_service("usercodeservice")
         code: UserCode = code_service.get_by_service_name(

--- a/packages/syft/src/syft/service/enclave/enclave_service.py
+++ b/packages/syft/src/syft/service/enclave/enclave_service.py
@@ -310,7 +310,7 @@ class EnclaveService(AbstractService):
     ) -> Any:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
-        
+
         # if context.node.name == "italy-domain":
         #     return SyftError(message="For testing purposes, italy-domain execution is blocked")
 

--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -166,24 +166,35 @@ class DistributedProject(BaseModel):
             print(assets_transferred.message)
 
         result_parts = []
-        errors = []
+        # errors = []
+        # for client in self.clients.values():
+        #     result = client.api.services.enclave.request_execution(
+        #         service_func_name=self.code.service_func_name
+        #     )
+        #     if isinstance(result, SyftError):
+        #         errors.append(result.message)
+        #     else:
+        #         result_parts.append(result)
+
+        # # TODO reconstruct the result from the parts and return
+        # # TODO Cleanup the Enclave in owner domain node
+        # if errors:
+        #     return SyftError(
+        #         message=f"One or more errors occurred: {', '.join(errors)}"
+        #     )
+        # else:
+        #     return result_parts[0]
+        
         for client in self.clients.values():
             result = client.api.services.enclave.request_execution(
                 service_func_name=self.code.service_func_name
             )
             if isinstance(result, SyftError):
-                errors.append(result.message)
+                return SyftError(message=f"Enclave execution failure: {result.message}")
             else:
                 result_parts.append(result)
 
-        # TODO reconstruct the result from the parts and return
-        # TODO Cleanup the Enclave in owner domain node
-        if errors:
-            return SyftError(
-                message=f"One or more errors occurred: {', '.join(errors)}"
-            )
-        else:
-            return result_parts[0]
+        return result_parts[0]
 
     def _get_clients_from_code(self) -> dict[UID, SyftClient]:
         if not self.code or not self.code.input_policy_init_kwargs:

--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -179,8 +179,10 @@ class DistributedProject(BaseModel):
         # TODO reconstruct the result from the parts and return
         # TODO Cleanup the Enclave in owner domain node
         if errors:
-            return SyftError(message=f"One or more errors occurred: {', '.join(errors)}")
-        else:        
+            return SyftError(
+                message=f"One or more errors occurred: {', '.join(errors)}"
+            )
+        else:
             return result_parts[0]
 
     def _get_clients_from_code(self) -> dict[UID, SyftClient]:

--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -184,7 +184,7 @@ class DistributedProject(BaseModel):
         #     )
         # else:
         #     return result_parts[0]
-        
+
         for client in self.clients.values():
             result = client.api.services.enclave.request_execution(
                 service_func_name=self.code.service_func_name

--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -166,17 +166,22 @@ class DistributedProject(BaseModel):
             print(assets_transferred.message)
 
         result_parts = []
+        errors = []
         for client in self.clients.values():
             result = client.api.services.enclave.request_execution(
                 service_func_name=self.code.service_func_name
             )
             if isinstance(result, SyftError):
-                raise SyftException(result.message)
-            result_parts.append(result)
+                errors.append(result.message)
+            else:
+                result_parts.append(result)
 
         # TODO reconstruct the result from the parts and return
         # TODO Cleanup the Enclave in owner domain node
-        return result_parts[0]
+        if errors:
+            return SyftError(message=f"One or more errors occurred: {', '.join(errors)}")
+        else:        
+            return result_parts[0]
 
     def _get_clients_from_code(self) -> dict[UID, SyftClient]:
         if not self.code or not self.code.input_policy_init_kwargs:


### PR DESCRIPTION
This adds a check to `DistributedProject.request_execution()` to return only when all domains get the result.