### PR TITLE
Get metadata via connection instead of logging in as guest

### DIFF
--- a/packages/syft/src/syft/service/enclave/enclave.py
+++ b/packages/syft/src/syft/service/enclave/enclave.py
@@ -11,6 +11,7 @@ from ...client.client import login
 from ...client.client import login_as_guest
 from ...serde.serializable import serializable
 from ...service.metadata.node_metadata import NodeMetadataJSON
+from ...service.network.node_peer import route_to_connection
 from ...service.network.routes import NodeRouteType
 from ...service.response import SyftError
 from ...service.response import SyftException
@@ -48,8 +49,8 @@ class EnclaveInstance(SyftObject):
     # TODO replace the create method with pydantic field validators, or find a better alternative
     @classmethod
     def create(cls, route: NodeRouteType) -> Self:
-        # TODO: find the standard method to convert route to client object
-        metadata = login_as_guest(url=route.host_or_ip, port=route.port).metadata
+        connection = route_to_connection(route)
+        metadata = connection.get_node_metadata(credentials=None)
         if not metadata:
             raise SyftException("Failed to fetch metadata from the node")
         return cls(


### PR DESCRIPTION
## Description
Retrieves metadata via connection instead of logging in as guest when creating enclave instances.



## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Manually created enclave with `admin_client.enclaves.add(node_handle.client.connection.route)` and confirmed create successful

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [] My changes are covered by tests
