### PR TITLE
Make UserCode share UID in DistributedProject

### DIFF
--- a/packages/syft/src/syft/service/enclave/enclave_service.py
+++ b/packages/syft/src/syft/service/enclave/enclave_service.py
@@ -99,14 +99,14 @@ class EnclaveService(AbstractService):
         roles=DATA_SCIENTIST_ROLE_LEVEL,
     )
     def request_enclave_for_code_execution(
-        self, context: AuthedServiceContext, service_func_id: UID
+        self, context: AuthedServiceContext, user_code_id: UID
     ) -> SyftSuccess | SyftError:
         """Request an Enclave for running a project."""
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
+        code: UserCode = code_service.get_by_uid(context=context, uid=user_code_id)
         if not code.deployment_policy_init_kwargs:
             return SyftError(
                 message=f"Code '{code.service_func_name}' does not have a deployment policy."
@@ -166,14 +166,14 @@ class EnclaveService(AbstractService):
         roles=DATA_SCIENTIST_ROLE_LEVEL,  # TODO 🟣 update this
     )
     def request_assets_transfer_to_enclave(
-        self, context: AuthedServiceContext, service_func_id: UID
+        self, context: AuthedServiceContext, user_code_id: UID
     ) -> SyftSuccess | SyftError:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         # Get the code
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
+        code: UserCode = code_service.get_by_uid(context=context, uid=user_code_id)
         if code.input_policy_init_kwargs is None:
             return SyftSuccess(message="No assets to transfer")
 
@@ -211,7 +211,7 @@ class EnclaveService(AbstractService):
 
         # Upload the assets to the enclave
         result = enclave_client.api.services.enclave.upload_input_data_for_code(
-            service_func_id=service_func_id, action_objects=action_objects
+            user_code_id=user_code_id, action_objects=action_objects
         )
         if isinstance(result, SyftError):
             return result
@@ -228,7 +228,7 @@ class EnclaveService(AbstractService):
     def upload_input_data_for_code(
         self,
         context: AuthedServiceContext,
-        service_func_id: UID,
+        user_code_id: UID,
         action_objects: list[ActionObject] | list[TwinObject],
     ) -> SyftSuccess | SyftError:
         if not context.node or not context.node.signing_key:
@@ -238,7 +238,7 @@ class EnclaveService(AbstractService):
         action_service = context.node.get_service("actionservice")
 
         # Get the code
-        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
+        code: UserCode = code_service.get_by_uid(context=context, uid=user_code_id)
 
         init_kwargs = code.input_policy_init_kwargs
         if not code or not init_kwargs:
@@ -301,13 +301,13 @@ class EnclaveService(AbstractService):
         roles=DATA_SCIENTIST_ROLE_LEVEL,  # TODO 🟣 update this
     )
     def request_execution(
-        self, context: AuthedServiceContext, service_func_id: UID
+        self, context: AuthedServiceContext, user_code_id: UID
     ) -> Any:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
+        code: UserCode = code_service.get_by_uid(context=context, uid=user_code_id)
 
         if not code.deployment_policy_init_kwargs:
             return SyftError(
@@ -321,7 +321,7 @@ class EnclaveService(AbstractService):
 
         enclave_client = provider.get_client(verify_key=context.node.verify_key)
         result = enclave_client.api.services.enclave.execute_code(
-            service_func_id=service_func_id
+            user_code_id=user_code_id
         )
         return result
 
@@ -330,12 +330,12 @@ class EnclaveService(AbstractService):
         name="execute_code",
         roles=DATA_SCIENTIST_ROLE_LEVEL,  # TODO 🟣 update this
     )
-    def execute_code(self, context: AuthedServiceContext, service_func_id: UID) -> Any:
+    def execute_code(self, context: AuthedServiceContext, user_code_id: UID) -> Any:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
+        code: UserCode = code_service.get_by_uid(context=context, uid=user_code_id)
 
         init_kwargs = (
             code.input_policy_init_kwargs.values()

--- a/packages/syft/src/syft/service/enclave/enclave_service.py
+++ b/packages/syft/src/syft/service/enclave/enclave_service.py
@@ -143,6 +143,7 @@ class EnclaveService(AbstractService):
 
         if isinstance(code, UserCode):
             code = SubmitUserCode(
+                id=code.id,
                 code=code.raw_code,
                 func_name=code.service_func_name,
                 signature=code.signature,

--- a/packages/syft/src/syft/service/enclave/enclave_service.py
+++ b/packages/syft/src/syft/service/enclave/enclave_service.py
@@ -99,24 +99,22 @@ class EnclaveService(AbstractService):
         roles=DATA_SCIENTIST_ROLE_LEVEL,
     )
     def request_enclave_for_code_execution(
-        self, context: AuthedServiceContext, service_func_name: str
+        self, context: AuthedServiceContext, service_func_id: UID
     ) -> SyftSuccess | SyftError:
         """Request an Enclave for running a project."""
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_service_name(
-            context=context, service_func_name=service_func_name
-        )[-1]  # TODO also match code hash and check status to get the actual code
+        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
         if not code.deployment_policy_init_kwargs:
             return SyftError(
-                message=f"Code '{service_func_name}' does not have a deployment policy."
+                message=f"Code '{code.service_func_name}' does not have a deployment policy."
             )
         provider = code.deployment_policy_init_kwargs.get("provider")
         if not isinstance(provider, EnclaveInstance):
             return SyftError(
-                message=f"Code '{service_func_name}' does not have an Enclave deployment provider."
+                message=f"Code '{code.service_func_name}' does not have an Enclave deployment provider."
             )
         if context.node.id != provider.syft_node_location:
             return SyftError(
@@ -168,16 +166,14 @@ class EnclaveService(AbstractService):
         roles=DATA_SCIENTIST_ROLE_LEVEL,  # TODO 🟣 update this
     )
     def request_assets_transfer_to_enclave(
-        self, context: AuthedServiceContext, service_func_name: str
+        self, context: AuthedServiceContext, service_func_id: UID
     ) -> SyftSuccess | SyftError:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         # Get the code
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_service_name(
-            context=context, service_func_name=service_func_name
-        )[-1]  # TODO also match code hash and check status to get the actual code
+        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
         if code.input_policy_init_kwargs is None:
             return SyftSuccess(message="No assets to transfer")
 
@@ -204,18 +200,18 @@ class EnclaveService(AbstractService):
         # Get the enclave client
         if not code.deployment_policy_init_kwargs:
             return SyftError(
-                message=f"Code '{service_func_name}' does not have a deployment policy."
+                message=f"Code '{code.service_func_name}' does not have a deployment policy."
             )
         provider = code.deployment_policy_init_kwargs.get("provider")
         if not isinstance(provider, EnclaveInstance):
             return SyftError(
-                message=f"Code '{service_func_name}' does not have an Enclave deployment provider."
+                message=f"Code '{code.service_func_name}' does not have an Enclave deployment provider."
             )
         enclave_client = provider.get_client(verify_key=context.node.verify_key)
 
         # Upload the assets to the enclave
         result = enclave_client.api.services.enclave.upload_input_data_for_code(
-            service_func_name=service_func_name, action_objects=action_objects
+            service_func_id=service_func_id, action_objects=action_objects
         )
         if isinstance(result, SyftError):
             return result
@@ -232,7 +228,7 @@ class EnclaveService(AbstractService):
     def upload_input_data_for_code(
         self,
         context: AuthedServiceContext,
-        service_func_name: str,
+        service_func_id: UID,
         action_objects: list[ActionObject] | list[TwinObject],
     ) -> SyftSuccess | SyftError:
         if not context.node or not context.node.signing_key:
@@ -242,9 +238,7 @@ class EnclaveService(AbstractService):
         action_service = context.node.get_service("actionservice")
 
         # Get the code
-        code: UserCode = code_service.get_by_service_name(
-            context=context, service_func_name=service_func_name
-        )[-1]  # TODO also match code hash to get the actual code
+        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
 
         init_kwargs = code.input_policy_init_kwargs
         if not code or not init_kwargs:
@@ -291,7 +285,7 @@ class EnclaveService(AbstractService):
             status_link = code.status_link
             if not status_link:
                 return SyftError(
-                    message=f"Code '{service_func_name}' does not have a status link."
+                    message=f"Code '{code.service_func_name}' does not have a status link."
                 )
             res = status_link.update_with_context(root_context, status)
             if isinstance(res, SyftError):
@@ -307,29 +301,27 @@ class EnclaveService(AbstractService):
         roles=DATA_SCIENTIST_ROLE_LEVEL,  # TODO 🟣 update this
     )
     def request_execution(
-        self, context: AuthedServiceContext, service_func_name: str
+        self, context: AuthedServiceContext, service_func_id: UID
     ) -> Any:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_service_name(
-            context=context, service_func_name=service_func_name
-        )[-1]
+        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
 
         if not code.deployment_policy_init_kwargs:
             return SyftError(
-                message=f"Code '{service_func_name}' does not have a deployment policy."
+                message=f"Code '{code.service_func_name}' does not have a deployment policy."
             )
         provider = code.deployment_policy_init_kwargs.get("provider")
         if not isinstance(provider, EnclaveInstance):
             return SyftError(
-                message=f"Code '{service_func_name}' does not have an Enclave deployment provider."
+                message=f"Code '{code.service_func_name}' does not have an Enclave deployment provider."
             )
 
         enclave_client = provider.get_client(verify_key=context.node.verify_key)
         result = enclave_client.api.services.enclave.execute_code(
-            service_func_name=service_func_name
+            service_func_id=service_func_id
         )
         return result
 
@@ -338,16 +330,12 @@ class EnclaveService(AbstractService):
         name="execute_code",
         roles=DATA_SCIENTIST_ROLE_LEVEL,  # TODO 🟣 update this
     )
-    def execute_code(
-        self, context: AuthedServiceContext, service_func_name: str
-    ) -> Any:
+    def execute_code(self, context: AuthedServiceContext, service_func_id: UID) -> Any:
         if not context.node or not context.node.signing_key:
             return SyftError(message=f"{type(context)} has no node")
 
         code_service = context.node.get_service("usercodeservice")
-        code: UserCode = code_service.get_by_service_name(
-            context=context, service_func_name=service_func_name
-        )[-1]  # TODO also match code hash to get the actual code
+        code: UserCode = code_service.get_by_uid(context=context, uid=service_func_id)
 
         init_kwargs = (
             code.input_policy_init_kwargs.values()

--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -129,6 +129,11 @@ class DistributedProject(BaseModel):
         self.members = self._get_members_from_clients()
         return self
 
+    @model_validator(mode="after")
+    def _set_code_uid(self) -> Self:
+        self.code.id = UID()
+        return self
+
     def submit(self) -> Self:
         self._pre_submit_checks()
         self.all_projects = self._submit_project_to_all_clients()


### PR DESCRIPTION
## Description
Changes DistributedProject to set a consistent UserCode UID when created. Also updates Enclave Service to retrieve code by this UID instead of service_func_name. 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
