### PR TITLE
Reloadable uvicorn app

### DIFF
--- a/packages/syft/src/syft/node/server.py
+++ b/packages/syft/src/syft/node/server.py
@@ -63,6 +63,48 @@ worker_classes = {
     NodeType.ENCLAVE: Enclave,
 }
 
+def run_reloadable_app():
+    # Read environment variables
+    name = os.getenv("NODE_NAME", "testing-node")
+    processes = int(os.getenv("PROCESSES", "1"))
+    reset = os.getenv("RESET", "False").lower() in ("true")
+    local_db = os.getenv("LOCAL_DB", "True").lower() in ("true")
+    node_type = os.getenv("NODE_TYPE", NodeType.DOMAIN)
+    node_side_type = os.getenv("NODE_SIDE_TYPE", NodeSideType.HIGH_SIDE)
+    
+    # Print variables for debugging
+    print("*" * 50)
+    print("Starting uvicorn app with the following settings:")
+    print(f"NODE_NAME: {name}")
+    print(f"PROCESSES: {processes}")
+    print(f"RESET: {reset}")
+    print(f"LOCAL_DB: {local_db}")
+    print(f"NODE_TYPE: {node_type}")
+    print(f"NODE_SIDE_TYPE: {node_side_type}")
+    print("*" * 50)
+
+    # Assuming worker_classes, make_routes, and make_app are defined elsewhere
+    worker_type = worker_classes[node_type]
+    worker = worker_type.named(
+        name=name,
+        processes=processes,
+        reset=reset,
+        local_db=local_db,
+        node_type=node_type,
+        node_side_type=node_side_type,
+        enable_warnings=False,
+        migrate=True,
+        in_memory_workers=True,
+        queue_port=None,
+        create_producer=False,
+        n_consumers=0,
+        association_request_auto_approval=False,
+        background_tasks=False,
+    )
+
+    router = make_routes(worker=worker)
+    app = make_app(worker.name, router=router)
+    return app
 
 def run_uvicorn(
     name: str,

--- a/scripts/reloadable_run.sh
+++ b/scripts/reloadable_run.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Run the different enclave servers as follows:
+# bash scripts/reloadable_run.sh --port 9081 --name "canada-domain"
+# bash scripts/reloadable_run.sh --port 9082 --name "italy-domain" 
+# bash scripts/reloadable_run.sh --port 9083 --name "canada-enclave" --node_type "enclave"
+
+# And get the NodeHandlers as follows (note that the handlers point to the correct objects but are buggy in their attributes)
+# canada_domain = sy.orchestra.launch(port=9081, deploy_to="remote")
+# italy_domain = sy.orchestra.launch(port=9082, deploy_to="remote")
+# canada_enclave = sy.orchestra.launch(port=9083, deploy_to="remote")
+
+# Default values
+PORT=9694
+HOST="0.0.0.0"
+FACTORY="--factory"
+RELOAD="--reload"
+
+# Parse command-line arguments
+while [ "$1" != "" ]; do
+    case $1 in
+        --port )           shift
+                           PORT=$1
+                           ;;
+        --name )           shift
+                           NAME=$1
+                           ;;
+        --processes )      shift
+                           PROCESSES=$1
+                           ;;
+        --reset )          shift
+                           RESET=$1
+                           ;;
+        --local_db )       shift
+                           LOCAL_DB=$1
+                           ;;
+        --node_type )      shift
+                           NODE_TYPE=$1
+                           ;;
+        --node_side_type ) shift
+                           NODE_SIDE_TYPE=$1
+                           ;;
+        * )                echo "Invalid option: $1"
+                           exit 1
+    esac
+    shift
+done
+
+# Set environment variables
+export NODE_NAME=${NAME:-testing-node}
+export PROCESSES=${PROCESSES:-1}
+export RESET=${RESET:-False}
+export LOCAL_DB=${LOCAL_DB:-True}
+export NODE_TYPE=${NODE_TYPE:-domain}
+export NODE_SIDE_TYPE=${NODE_SIDE_TYPE:-high}
+
+# Run uvicorn
+uvicorn syft.node.server:run_reloadable_app $FACTORY --host $HOST --port $PORT $RELOAD


### PR DESCRIPTION
Run the different uvicorn servers as follows:
```
bash scripts/reloadable_run.sh --port 9081 --name "canada-domain"
bash scripts/reloadable_run.sh --port 9082 --name "italy-domain" 
bash scripts/reloadable_run.sh --port 9083 --name "canada-enclave" --node_type "enclave"
```

And get the NodeHandlers as follows (note that the handlers point to the correct objects but are buggy in their attributes)
```
canada_domain = sy.orchestra.launch(port=9081, deploy_to="remote")
italy_domain = sy.orchestra.launch(port=9082, deploy_to="remote")
canada_enclave = sy.orchestra.launch(port=9083, deploy_to="remote")
```