### PR TITLE
Check that code status is approved before requesting against enclave client

### DIFF
--- a/packages/syft/src/syft/service/enclave/enclave_service.py
+++ b/packages/syft/src/syft/service/enclave/enclave_service.py
@@ -107,6 +107,11 @@ class EnclaveService(AbstractService):
 
         code_service = context.node.get_service("usercodeservice")
         code: UserCode = code_service.get_by_uid(context=context, uid=user_code_id)
+        status = code.get_status(context)
+        if not status.approved:
+            return SyftError(
+                message=f"Status for code '{code.service_func_name}' is not Approved."
+            )
         if not code.deployment_policy_init_kwargs:
             return SyftError(
                 message=f"Code '{code.service_func_name}' does not have a deployment policy."
@@ -161,6 +166,11 @@ class EnclaveService(AbstractService):
         # Get the code
         code_service = context.node.get_service("usercodeservice")
         code: UserCode = code_service.get_by_uid(context=context, uid=user_code_id)
+        status = code.get_status(context)
+        if not status.approved:
+            return SyftError(
+                message=f"Status for code '{code.service_func_name}' is not Approved."
+            )
         if code.input_policy_init_kwargs is None:
             return SyftSuccess(message="No assets to transfer")
 


### PR DESCRIPTION
## Description
Checks that user code is approved before requesting against the enclave client in `request_enclave_for_code_execution` and `request_assets_transfer_to_enclave`.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Manually tested stepping through distributed project's `request_execution` method to check that the expected SyftError is raised when code is not approved and not raised when approved.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
