### PR TITLE
Add distributed project ID that's shared with client projects

### DIFF
--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -32,7 +32,7 @@ from .project import ProjectSubmit
 
 class DistributedProject(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
+    id: UID = Field(default_factory=UID)
     name: str
     description: str = ""
     code: UserCode | SubmitUserCode  # only one code per project for this prototype
@@ -226,6 +226,7 @@ class DistributedProject(BaseModel):
             # Creating projects and code requests separately across each client
             # TODO handle failures in between
             new_project = ProjectSubmit(
+                id=self.id,
                 name=self.name,
                 description=self.description,
                 members=[client],


### PR DESCRIPTION
## Description
Adds new id field to DistributedProject that gets propagated to client projects' id when `.submit` is called. 

Closes https://github.com/OpenMined/Heartbeat/issues/1560.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
