### PR TITLE
Rename deployment policy to runtime policy

### DIFF
--- a/notebooks/experimental/enclaves/01-ds-submit-project.ipynb
+++ b/notebooks/experimental/enclaves/01-ds-submit-project.ipynb
@@ -132,7 +132,7 @@
     "        italy_census_data=italy_census_data,\n",
     "    ),\n",
     "    output_policy=sy.SingleExecutionExactOutput(),\n",
-    "    deployment_policy=sy.RunOnEnclave(\n",
+    "    runtime_policy=sy.RunOnEnclave(\n",
     "        provider=enclave,\n",
     "        # image=sy.DockerWorkerConfig(dockerfile=dockerfile_str),\n",
     "        # workers_num=4,\n",

--- a/notebooks/experimental/enclaves/02-do-review-code.ipynb
+++ b/notebooks/experimental/enclaves/02-do-review-code.ipynb
@@ -131,10 +131,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Review the deployment policy\n",
-    "assert func.deployment_policy_type == sy.RunOnEnclave\n",
-    "deployment_provider = func.deployment_policy_init_kwargs[\"provider\"]\n",
-    "deployment_provider"
+    "# Review the runtime policy\n",
+    "assert func.runtime_policy_type == sy.RunOnEnclave\n",
+    "provider = func.runtime_policy_init_kwargs[\"provider\"]\n",
+    "provider"
    ]
   },
   {
@@ -192,7 +192,7 @@
     "func = request.code\n",
     "# TODO change below to 2 once we start showing assets from other domains\n",
     "assert len(func.assets) == 1\n",
-    "assert func.deployment_policy_type == sy.RunOnEnclave\n",
+    "assert func.runtime_policy_type == sy.RunOnEnclave\n",
     "\n",
     "request.approve()"
    ]

--- a/packages/syft/src/syft/protocol/protocol_version.json
+++ b/packages/syft/src/syft/protocol/protocol_version.json
@@ -293,7 +293,7 @@
         },
         "6": {
           "version": 6,
-          "hash": "e7d19463aba1de81b3cb956e0e42a9b40a4916308cc80c1c3c8e5f17cb21f9b4",
+          "hash": "4a7264ec6dfe00a2c3a6cbe2cb66f170b9782a5f99d9994b263408307934a6c0",
           "action": "add"
         }
       },
@@ -363,7 +363,7 @@
       "SubmitUserCode": {
         "5": {
           "version": 5,
-          "hash": "4bea63bf596ef7fdb42c6c962a41fce4676906e376fbac09f5a4280a979a32ba",
+          "hash": "4e826024b6440ee781c970b33ddf1d7813b33e46e190388ac566210badb26042",
           "action": "add"
         }
       },

--- a/packages/syft/src/syft/service/code/user_code.py
+++ b/packages/syft/src/syft/service/code/user_code.py
@@ -85,12 +85,12 @@ from ..output.output_service import OutputService
 from ..policy.policy import Constant
 from ..policy.policy import CustomInputPolicy
 from ..policy.policy import CustomOutputPolicy
-from ..policy.policy import DeploymentPolicy
-from ..policy.policy import EmptyDeploymentPolicy
+from ..policy.policy import EmptyRuntimePolicy
 from ..policy.policy import EmpyInputPolicy
 from ..policy.policy import ExactMatch
 from ..policy.policy import InputPolicy
 from ..policy.policy import OutputPolicy
+from ..policy.policy import RuntimePolicy
 from ..policy.policy import SingleExecutionExactOutput
 from ..policy.policy import SubmitUserPolicy
 from ..policy.policy import UserPolicy
@@ -357,9 +357,9 @@ class UserCode(SyncableSyftObject):
     output_policy_type: type[OutputPolicy] | UserPolicy
     output_policy_init_kwargs: dict[Any, Any] | None = None
     output_policy_state: bytes = b""
-    deployment_policy_type: type[DeploymentPolicy] | UserPolicy
-    deployment_policy_init_kwargs: dict[Any, Any] | None = None
-    deployment_policy_state: bytes = b""
+    runtime_policy_type: type[RuntimePolicy] | UserPolicy
+    runtime_policy_init_kwargs: dict[Any, Any] | None = None
+    runtime_policy_state: bytes = b""
     parsed_code: str
     service_func_name: str
     unique_func_name: str
@@ -413,9 +413,9 @@ class UserCode(SyncableSyftObject):
         "output_policy_type",
         "output_policy_init_kwargs",
         "output_policy_state",
-        "deployment_policy_type",
-        "deployment_policy_init_kwargs",
-        "deployment_policy_state",
+        "runtime_policy_type",
+        "runtime_policy_init_kwargs",
+        "runtime_policy_state",
     ]
 
     @field_validator("service_func_name", mode="after")
@@ -1003,8 +1003,8 @@ class SubmitUserCode(SyftObject):
     input_policy_init_kwargs: dict[Any, Any] | None = {}
     output_policy_type: SubmitUserPolicy | UID | type[OutputPolicy]
     output_policy_init_kwargs: dict[Any, Any] | None = {}
-    deployment_policy_type: SubmitUserPolicy | UID | type[DeploymentPolicy]
-    deployment_policy_init_kwargs: dict[Any, Any] | None = {}
+    runtime_policy_type: SubmitUserPolicy | UID | type[RuntimePolicy]
+    runtime_policy_init_kwargs: dict[Any, Any] | None = {}
     local_function: Callable | None = None
     input_kwargs: list[str]
     worker_pool_name: str | None = None
@@ -1247,7 +1247,7 @@ def replace_func_name(src: str, new_func_name: str) -> str:
 def syft_function(
     input_policy: InputPolicy | UID | None = None,
     output_policy: OutputPolicy | UID | None = None,
-    deployment_policy: DeploymentPolicy | UID | None = None,
+    runtime_policy: RuntimePolicy | UID | None = None,
     share_results_with_owners: bool = False,
     worker_pool_name: str | None = None,
     name: str | None = None,
@@ -1273,10 +1273,10 @@ def syft_function(
     else:
         output_policy_type = type(output_policy)
 
-    # Deployment policy
-    if deployment_policy is None:
-        deployment_policy = EmptyDeploymentPolicy()
-    deployment_policy_type = type(deployment_policy)
+    # Runtime policy
+    if runtime_policy is None:
+        runtime_policy = EmptyRuntimePolicy()
+    runtime_policy_type = type(runtime_policy)
 
     def decorator(f: Any) -> SubmitUserCode | SyftError:
         try:
@@ -1295,10 +1295,8 @@ def syft_function(
                 input_policy_init_kwargs=init_input_kwargs,
                 output_policy_type=output_policy_type,
                 output_policy_init_kwargs=getattr(output_policy, "init_kwargs", {}),
-                deployment_policy_type=deployment_policy_type,
-                deployment_policy_init_kwargs=getattr(
-                    deployment_policy, "init_kwargs", {}
-                ),
+                runtime_policy_type=runtime_policy_type,
+                runtime_policy_init_kwargs=getattr(runtime_policy, "init_kwargs", {}),
                 local_function=f,
                 input_kwargs=f.__code__.co_varnames[: f.__code__.co_argcount],
                 worker_pool_name=worker_pool_name,
@@ -1520,11 +1518,11 @@ def check_output_policy(context: TransformContext) -> TransformContext:
     return context
 
 
-def check_deployment_policy(context: TransformContext) -> TransformContext:
+def check_runtime_policy(context: TransformContext) -> TransformContext:
     if context.output is not None:
-        policy = context.output["deployment_policy_type"]
+        policy = context.output["runtime_policy_type"]
         policy = check_policy(policy=policy, context=context)
-        context.output["deployment_policy_type"] = policy
+        context.output["runtime_policy_type"] = policy
     return context
 
 
@@ -1619,7 +1617,7 @@ def submit_user_code_to_user_code() -> list[Callable]:
         generate_unique_func_name,
         check_input_policy,
         check_output_policy,
-        check_deployment_policy,
+        check_runtime_policy,
         new_check_code,
         locate_launch_jobs,
         add_credentials_for_key("user_verify_key"),
@@ -1646,8 +1644,8 @@ def user_code_to_submit_user_code() -> list[Callable]:
                 "input_policy_init_kwargs",
                 "output_policy_type",
                 "output_policy_init_kwargs",
-                "deployment_policy_type",
-                "deployment_policy_init_kwargs",
+                "runtime_policy_type",
+                "runtime_policy_init_kwargs",
                 "input_kwargs",
                 "worker_pool_name",
             ]

--- a/packages/syft/src/syft/service/enclave/enclave_service.py
+++ b/packages/syft/src/syft/service/enclave/enclave_service.py
@@ -105,11 +105,11 @@ class EnclaveService(AbstractService):
             return SyftError(
                 message=f"Status for code '{code.service_func_name}' is not Approved."
             )
-        if not code.deployment_policy_init_kwargs:
+        if not code.runtime_policy_init_kwargs:
             return SyftError(
-                message=f"Code '{code.service_func_name}' does not have a deployment policy."
+                message=f"Code '{code.service_func_name}' does not have a runtime policy."
             )
-        provider = code.deployment_policy_init_kwargs.get("provider")
+        provider = code.runtime_policy_init_kwargs.get("provider")
         if not isinstance(provider, EnclaveInstance):
             return SyftError(
                 message=f"Code '{code.service_func_name}' does not have an Enclave deployment provider."
@@ -192,11 +192,11 @@ class EnclaveService(AbstractService):
         [action_object.syft_action_data for action_object in action_objects]
 
         # Get the enclave client
-        if not code.deployment_policy_init_kwargs:
+        if not code.runtime_policy_init_kwargs:
             return SyftError(
-                message=f"Code '{code.service_func_name}' does not have a deployment policy."
+                message=f"Code '{code.service_func_name}' does not have a runtime policy."
             )
-        provider = code.deployment_policy_init_kwargs.get("provider")
+        provider = code.runtime_policy_init_kwargs.get("provider")
         if not isinstance(provider, EnclaveInstance):
             return SyftError(
                 message=f"Code '{code.service_func_name}' does not have an Enclave deployment provider."
@@ -312,11 +312,11 @@ class EnclaveService(AbstractService):
                 message=f"Code '{code.service_func_name}' is not approved."
             )
 
-        if not code.deployment_policy_init_kwargs:
+        if not code.runtime_policy_init_kwargs:
             return SyftError(
-                message=f"Code '{code.service_func_name}' does not have a deployment policy."
+                message=f"Code '{code.service_func_name}' does not have a runtime policy."
             )
-        provider = code.deployment_policy_init_kwargs.get("provider")
+        provider = code.runtime_policy_init_kwargs.get("provider")
         if not isinstance(provider, EnclaveInstance):
             return SyftError(
                 message=f"Code '{code.service_func_name}' does not have an Enclave deployment provider."

--- a/packages/syft/src/syft/service/policy/policy.py
+++ b/packages/syft/src/syft/service/policy/policy.py
@@ -797,18 +797,18 @@ class OutputPolicyExecuteOnce(OutputPolicyExecuteCount):
 SingleExecutionExactOutput = OutputPolicyExecuteOnce
 
 
-class DeploymentPolicy(Policy):
-    __canonical_name__ = "DeploymentPolicy"
+class RuntimePolicy(Policy):
+    __canonical_name__ = "RuntimePolicy"
     __version__ = SYFT_OBJECT_VERSION_1
 
 
-class EmptyDeploymentPolicy(DeploymentPolicy):
-    __canonical_name__ = "EmptyDeploymentPolicy"
+class EmptyRuntimePolicy(RuntimePolicy):
+    __canonical_name__ = "EmptyRuntimePolicy"
     __version__ = SYFT_OBJECT_VERSION_1
 
 
 @serializable()
-class RunOnEnclave(DeploymentPolicy):
+class RunOnEnclave(RuntimePolicy):
     __canonical_name__ = "RunOnEnclave"
     __version__ = SYFT_OBJECT_VERSION_1
 

--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -100,11 +100,11 @@ class DistributedProject(BaseModel):
     @field_validator("code", mode="before")
     @classmethod
     def verify_code(cls, code: UserCode | SubmitUserCode) -> UserCode | SubmitUserCode:
-        if not code.deployment_policy_init_kwargs:
-            raise ValueError("Deployment policy not found in code.")
-        provider = code.deployment_policy_init_kwargs.get("provider")
+        if not code.runtime_policy_init_kwargs:
+            raise ValueError("Runtime policy not found in code.")
+        provider = code.runtime_policy_init_kwargs.get("provider")
         if not provider:
-            raise ValueError("Provider not found in deployment policy.")
+            raise ValueError("Provider not found in runtime policy.")
         if not isinstance(provider, EnclaveInstance):
             raise SyftException(
                 "Only `EnclaveInstance` is supported as provider for now."
@@ -141,7 +141,7 @@ class DistributedProject(BaseModel):
         code = self.verify_code(self.code)
 
         # Request Enclave to be set up by its owner domain
-        provider = code.deployment_policy_init_kwargs.get("provider")
+        provider = code.runtime_policy_init_kwargs.get("provider")
         owner_node_id = provider.syft_node_location
         owner_client = self.clients.get(owner_node_id)
         if not owner_client:


### PR DESCRIPTION
## Description
Renames deployment policy to runtime policy.

Closes https://github.com/OpenMined/Heartbeat/issues/1554.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
Tested by running through enclave notebooks after rename.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
