### PR TITLE
Show requesting domain (for DistributedProject as well as base Requests)

### DIFF
--- a/packages/syft/src/syft/service/project/distributed_project.py
+++ b/packages/syft/src/syft/service/project/distributed_project.py
@@ -14,8 +14,9 @@ from ...client.api import NodeIdentity
 from ...client.client import SyftClient
 from ...client.client import SyftClientSessionCache
 from ...types.uid import UID
-from ...util import options
-from ...util.colors import SURFACE
+from ...util.notebook_ui.components.tabulator_template import (
+    build_tabulator_table_with_data,
+)
 from ...util.util import human_friendly_join
 from ..code.user_code import SubmitUserCode
 from ..code.user_code import UserCode
@@ -49,16 +50,28 @@ class DistributedProject(BaseModel):
         }
 
     def _repr_html_(self) -> str:
+        request_rows = [request._coll_repr_with_domain_() for request in self.requests]
+        metadata = {
+            "name": "Project Requests",
+            "columns": [
+                "id",
+                "Description",
+                "Requested By",
+                "Requested On",
+                "Creation Time",
+                "Status",
+            ],
+            "icon": None,
+        }
+        request_table_html = (
+            build_tabulator_table_with_data(request_rows, metadata) or ""
+        )
+
         return (
-            f"""
-            <style>
-            .syft-project {{color: {SURFACE[options.color_theme]};}}
-            </style>
-            """
-            + "<div class='syft-project'>"
+            "<div class='syft-project'>"
             + f"<h3>{self.name}</h3>"
             + f"<p>{self.description}</p>"
-            + self.requests._repr_html_()
+            + request_table_html
             + "</div>"
         )
 

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -570,6 +570,28 @@ class Request(SyncableSyftObject):
             self.requesting_user_institution,
         ]
 
+        return {
+            "Description": self.html_description,
+            "Requested By": "\n".join(user_data),
+            "Creation Time": str(self.request_time),
+            "Status": status_badge,
+        }
+
+    def _coll_repr_with_domain_(self) -> dict[str, str | dict[str, str]]:
+        if self.status == RequestStatus.APPROVED:
+            badge_color = "badge-green"
+        elif self.status == RequestStatus.PENDING:
+            badge_color = "badge-gray"
+        else:
+            badge_color = "badge-red"
+
+        status_badge = {"value": self.status.name.capitalize(), "type": badge_color}
+
+        user_data = [
+            self.requesting_user_name,
+            self.requesting_user_email,
+            self.requesting_user_institution,
+        ]
         api = APIRegistry.api_for(
             self.node_uid,
             self.syft_client_verify_key,
@@ -578,6 +600,7 @@ class Request(SyncableSyftObject):
             node_name = api.node_name.capitalize() if api.node_name is not None else ""
 
         return {
+            "id": str(self.id),
             "Description": self.html_description,
             "Requested By": "\n".join(user_data),
             "Requested On": node_name,

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -570,9 +570,17 @@ class Request(SyncableSyftObject):
             self.requesting_user_institution,
         ]
 
+        api = APIRegistry.api_for(
+            self.node_uid,
+            self.syft_client_verify_key,
+        )
+        if api is not None:
+            node_name = api.node_name.capitalize() if api.node_name is not None else ""
+
         return {
             "Description": self.html_description,
             "Requested By": "\n".join(user_data),
+            "Requested On": node_name,
             "Creation Time": str(self.request_time),
             "Status": status_badge,
         }


### PR DESCRIPTION
This changes the output to show the domain name at which the request was made. Tagging for PM review since I change the base object `Request`'s repr. The output looks as follows (Requested on added):

![Screenshot 2024-06-27 at 10 51 39 AM](https://github.com/OpenMined/PySyft/assets/10202935/859815a7-6015-4d45-84c4-756ec20ce95d)

The implementation may not be optimal since I am making the API call (I can take a look at the relation between `_coll_repr_` and `_repr_html_` to see if I can do this efficiently if that is promising).