### PR TITLE
[CD] downgrade `uv` back to `0.1.35`

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install tox
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13 tox tox-uv==1.9.0
+          pip install --upgrade pip==24.0 uv==0.1.35 tox tox-uv==1.9.0
           uv --version
 
       - name: Build the docs

--- a/.github/workflows/cd-post-release-tests.yml
+++ b/.github/workflows/cd-post-release-tests.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Install tox
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13 tox tox-uv==1.9.0
+          pip install --upgrade pip==24.0 uv==0.1.35 tox tox-uv==1.9.0
 
       - name: Run K8s tests
         env:
@@ -193,7 +193,7 @@ jobs:
 
       - name: Install tox and uv
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13 tox tox-uv==1.9.0 tox-current-env
+          pip install --upgrade pip==24.0 uv==0.1.35 tox tox-uv==1.9.0 tox-current-env
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/cd-syft.yml
+++ b/.github/workflows/cd-syft.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13 bump2version tox tox-uv==1.9.0
+          pip install --upgrade pip==24.0 uv==0.1.35 bump2version tox tox-uv==1.9.0
           uv --version
 
       - name: Get Release tag
@@ -386,7 +386,7 @@ jobs:
           python-version: "3.12"
       - name: Install dependencies
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13 tox tox-uv==1.9.0 setuptools wheel twine bump2version PyYAML
+          pip install --upgrade pip==24.0 uv==0.1.35 tox tox-uv==1.9.0 setuptools wheel twine bump2version PyYAML
           uv --version
 
       - name: Bump the Version

--- a/.github/workflows/e2e-tests-notebook.yml
+++ b/.github/workflows/e2e-tests-notebook.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install Deps
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13 tox tox-uv==1.9.0
+          pip install --upgrade pip==24.0 uv==0.1.35 tox tox-uv==1.9.0
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/pr-tests-frontend.yml
+++ b/.github/workflows/pr-tests-frontend.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.frontend == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir

--- a/.github/workflows/pr-tests-linting.yml
+++ b/.github/workflows/pr-tests-linting.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install pip packages
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir

--- a/.github/workflows/pr-tests-stack.yml
+++ b/.github/workflows/pr-tests-stack.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.stack == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir
@@ -113,7 +113,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.stack == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir
@@ -200,7 +200,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.stack == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir
@@ -353,7 +353,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.stack == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir

--- a/.github/workflows/pr-tests-syft.yml
+++ b/.github/workflows/pr-tests-syft.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.syft == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir
@@ -160,7 +160,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.syft == 'true'  || steps.changes.outputs.notebooks == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir
@@ -242,7 +242,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.stack == 'true' || steps.changes.outputs.notebooks == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir
@@ -343,7 +343,7 @@ jobs:
       - name: Upgrade pip
         if: steps.changes.outputs.syft == 'true'
         run: |
-          pip install --upgrade pip==24.0 uv==0.2.13
+          pip install --upgrade pip==24.0 uv==0.1.35
           uv --version
 
       - name: Get pip cache dir


### PR DESCRIPTION
Trying to fix this issue:
![image](https://github.com/OpenMined/PySyft/assets/88959106/05a14a0a-dc11-4f6a-8158-4470c43c939d)

The reason seems to be that either powershell not running as admin or uv is installing at a location that isn’t there in powershell path env.

Downgrading `uv` does not work either.