### PR TITLE
feat(syft_exc): change client and server side response handling

### DIFF
--- a/packages/syft/src/syft/client/api.py
+++ b/packages/syft/src/syft/client/api.py
@@ -93,6 +93,10 @@ IPYNB_BACKGROUND_METHODS = {
 IPYNB_BACKGROUND_PREFIXES = ["_ipy", "_repr", "__ipython", "__pydantic"]
 
 
+# Temporary list of services that have been updated to the new error handling/result types
+UNWRAPPABLE_SERVICES_LIST: list[str] = []
+
+
 def _has_config_dict(t: Any) -> bool:
     return (
         # Use this instead of `issubclass`` to be compatible with python 3.10
@@ -369,6 +373,13 @@ class RemoteFunction(SyftObject):
             [result], kwargs={}, to_latest_protocol=True
         )
         result = result[0]
+
+        if any(path.startswith(x) for x in UNWRAPPABLE_SERVICES_LIST):
+            if isinstance(result, SyftError):
+                raise SyftException(public_message=result.message)
+            if self.unwrap_on_success:
+                result = result.unwrap_value()
+
         return result
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:

--- a/packages/syft/src/syft/service/response.py
+++ b/packages/syft/src/syft/service/response.py
@@ -104,9 +104,14 @@ class SyftError(SyftResponseMessage):
 
 @serializable()
 class SyftSuccess(SyftResponseMessage):
+    value: Any | None = None
+
     @property
     def _repr_html_class_(self) -> str:
         return "alert-success"
+
+    def unwrap_value(self) -> Any:
+        return self.value
 
 
 @serializable()

--- a/packages/syft/src/syft/service/service.py
+++ b/packages/syft/src/syft/service/service.py
@@ -32,8 +32,8 @@ from ..serde.signature import Signature
 from ..serde.signature import signature_remove_context
 from ..serde.signature import signature_remove_self
 from ..store.linked_obj import LinkedObject
-from ..types.syft_object import SYFT_OBJECT_VERSION_2
-from ..types.syft_object import SyftBaseObject
+from ..types.syft_object import SYFT_OBJECT_VERSION_1
+from ..types.syft_object import SYFT_OBJECT_VERSION_3
 from ..types.syft_object import SyftObject
 from ..types.syft_object import attach_attribute_to_syft_object
 from ..types.uid import UID
@@ -86,9 +86,9 @@ class AbstractService:
 
 
 @serializable()
-class BaseConfig(SyftBaseObject):
+class BaseConfig(SyftObject):
     __canonical_name__ = "BaseConfig"
-    __version__ = SYFT_OBJECT_VERSION_2
+    __version__ = SYFT_OBJECT_VERSION_3
 
     public_path: str
     private_path: str
@@ -98,11 +98,14 @@ class BaseConfig(SyftBaseObject):
     signature: Signature | None = None
     is_from_lib: bool = False
     warning: APIEndpointWarning | None = None
+    unwrap_on_success: bool = True
 
 
 @serializable()
 class ServiceConfig(BaseConfig):
     __canonical_name__ = "ServiceConfig"
+    __version__ = SYFT_OBJECT_VERSION_1
+
     permissions: list
     roles: list[ServiceRole]
 
@@ -336,6 +339,7 @@ def service_method(
     roles: list[ServiceRole] | None = None,
     autosplat: list[str] | None = None,
     warning: APIEndpointWarning | None = None,
+    unwrap_on_success: bool = True,
 ) -> Callable:
     if roles is None or len(roles) == 0:
         # TODO: this is dangerous, we probably want to be more conservative
@@ -395,6 +399,7 @@ def service_method(
             roles=roles,
             permissions=["Guest"],
             warning=warning,
+            unwrap_on_success=unwrap_on_success,
         )
         ServiceConfigRegistry.register(config)
 


### PR DESCRIPTION
## Description
- Adds `unwrap_on_success` attribute to the service method decorator
- Wraps server side service results in `SyftSuccess`
- Unwraps service results on the client side based on `unwrap_on_success` attribute of the service method called
- Adds a temporary list of services where the unboxing should be evaluated

Part of #8883