### PR TITLE
Fix to remove duplicated search bar in repr

### DIFF
--- a/packages/syft/src/syft/util/patch_ipython.py
+++ b/packages/syft/src/syft/util/patch_ipython.py
@@ -83,7 +83,7 @@ def _patch_ipython_sanitization() -> None:
                 template = "\n".join(matching_table + matching_jobs)
                 sanitized_str = escaped_template.sub("", html_str)
                 sanitized_str = escaped_js_css.sub("", sanitized_str)
-                sanitized_str = jobs_pattern.sub("", html_str)
+                sanitized_str = jobs_pattern.sub("", sanitized_str)
                 sanitized_str = sanitize_html(sanitized_str)
                 return f"{css_reinsert} {sanitized_str} {template}"
         return None


### PR DESCRIPTION
## Description
Small fix to avoid duplicated search bar in html repr for datasets.

![Screenshot 2024-07-05 at 11 39 46 AM](https://github.com/OpenMined/PySyft/assets/14844011/10aaa1eb-8d59-4440-9a07-115254ab69e3)



Closes https://github.com/OpenMined/Heartbeat/issues/1529.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Tested manually to check that resolved in dataset view.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
