### PR TITLE
quickfix: typing + autocomplete for node services

### DIFF
--- a/packages/syft/src/syft/node/node.py
+++ b/packages/syft/src/syft/node/node.py
@@ -42,48 +42,30 @@ from ..protocol.data_protocol import PROTOCOL_TYPE
 from ..protocol.data_protocol import get_data_protocol
 from ..service.action.action_object import Action
 from ..service.action.action_object import ActionObject
-from ..service.action.action_service import ActionService
 from ..service.action.action_store import ActionStore
 from ..service.action.action_store import DictActionStore
 from ..service.action.action_store import MongoActionStore
 from ..service.action.action_store import SQLiteActionStore
-from ..service.api.api_service import APIService
-from ..service.attestation.attestation_service import AttestationService
 from ..service.blob_storage.service import BlobStorageService
-from ..service.code.status_service import UserCodeStatusService
 from ..service.code.user_code_service import UserCodeService
 from ..service.code.user_code_stash import UserCodeStash
-from ..service.code_history.code_history_service import CodeHistoryService
 from ..service.context import AuthedServiceContext
 from ..service.context import NodeServiceContext
 from ..service.context import UnauthedServiceContext
 from ..service.context import UserLoginCredentials
-from ..service.data_subject.data_subject_member_service import DataSubjectMemberService
-from ..service.data_subject.data_subject_service import DataSubjectService
-from ..service.dataset.dataset_service import DatasetService
-from ..service.enclave.enclave_service import EnclaveService
-from ..service.job.job_service import JobService
 from ..service.job.job_stash import Job
 from ..service.job.job_stash import JobStash
 from ..service.job.job_stash import JobStatus
 from ..service.job.job_stash import JobType
-from ..service.log.log_service import LogService
-from ..service.metadata.metadata_service import MetadataService
 from ..service.metadata.node_metadata import NodeMetadata
-from ..service.migration.migration_service import MigrationService
 from ..service.network.network_service import NetworkService
 from ..service.network.utils import PeerHealthCheckTask
-from ..service.notification.notification_service import NotificationService
 from ..service.notifier.notifier_service import NotifierService
-from ..service.output.output_service import OutputService
-from ..service.policy.policy_service import PolicyService
-from ..service.project.project_service import ProjectService
 from ..service.queue.base_queue import AbstractMessageHandler
 from ..service.queue.base_queue import QueueConsumer
 from ..service.queue.base_queue import QueueProducer
 from ..service.queue.queue import APICallMessageHandler
 from ..service.queue.queue import QueueManager
-from ..service.queue.queue_service import QueueService
 from ..service.queue.queue_stash import APIEndpointQueueItem
 from ..service.queue.queue_stash import ActionQueueItem
 from ..service.queue.queue_stash import QueueItem
@@ -91,23 +73,19 @@ from ..service.queue.queue_stash import QueueStash
 from ..service.queue.zmq_queue import QueueConfig
 from ..service.queue.zmq_queue import ZMQClientConfig
 from ..service.queue.zmq_queue import ZMQQueueConfig
-from ..service.request.request_service import RequestService
 from ..service.response import SyftError
 from ..service.service import AbstractService
 from ..service.service import ServiceConfigRegistry
 from ..service.service import UserServiceConfigRegistry
 from ..service.settings.settings import NodeSettings
 from ..service.settings.settings import NodeSettingsUpdate
-from ..service.settings.settings_service import SettingsService
 from ..service.settings.settings_stash import SettingsStash
-from ..service.sync.sync_service import SyncService
 from ..service.user.user import User
 from ..service.user.user import UserCreate
 from ..service.user.user import UserView
 from ..service.user.user_roles import ServiceRole
 from ..service.user.user_service import UserService
 from ..service.user.user_stash import UserStash
-from ..service.worker.image_registry_service import SyftImageRegistryService
 from ..service.worker.utils import DEFAULT_WORKER_IMAGE_TAG
 from ..service.worker.utils import DEFAULT_WORKER_POOL_NAME
 from ..service.worker.utils import create_default_image
@@ -115,7 +93,6 @@ from ..service.worker.worker_image_service import SyftWorkerImageService
 from ..service.worker.worker_pool import WorkerPool
 from ..service.worker.worker_pool_service import SyftWorkerPoolService
 from ..service.worker.worker_pool_stash import SyftWorkerPoolStash
-from ..service.worker.worker_service import WorkerService
 from ..service.worker.worker_stash import WorkerStash
 from ..store.blob_storage import BlobStorageConfig
 from ..store.blob_storage.on_disk import OnDiskBlobStorageClientConfig
@@ -144,6 +121,7 @@ from ..util.util import str_to_bool
 from ..util.util import thread_ident
 from .credentials import SyftSigningKey
 from .credentials import SyftVerifyKey
+from .service_registry import ServiceRegistry
 from .worker_settings import WorkerSettings
 
 logger = logging.getLogger(__name__)
@@ -416,7 +394,7 @@ class Node(AbstractNode):
         )
 
         # construct services only after init stores
-        self._construct_services()
+        self.services: ServiceRegistry = ServiceRegistry(node=self)
 
         create_admin_new(  # nosec B106
             name=root_username,
@@ -732,7 +710,7 @@ class Node(AbstractNode):
             credentials=self.verify_key,
             role=ServiceRole.ADMIN,
         )
-        migration_state_service = self.get_service(MigrationService)
+        migration_state_service = self.services.migration
 
         klasses_to_be_migrated = []
 
@@ -888,65 +866,74 @@ class Node(AbstractNode):
         return self.get_service("workerservice").stash
 
     def _construct_services(self) -> None:
-        service_path_map: dict[str, AbstractService] = {}
-        initialized_services: list[AbstractService] = []
+        self.services = ServiceRegistry(node=self)
 
-        # A dict of service and init kwargs.
-        # - "svc" expects a callable (class or function)
-        #     - The callable must return AbstractService or None
-        # - "store" expects a store type
-        #     - By default all services get the document store
-        #     - Pass a custom "store" to override this
-        default_services: list[dict] = [
-            {"svc": ActionService, "store": self.action_store},
-            {"svc": UserService},
-            {"svc": AttestationService},
-            {"svc": WorkerService},
-            {"svc": SettingsService},
-            {"svc": DatasetService},
-            {"svc": UserCodeService},
-            {"svc": LogService},
-            {"svc": RequestService},
-            {"svc": QueueService},
-            {"svc": JobService},
-            {"svc": APIService},
-            {"svc": DataSubjectService},
-            {"svc": NetworkService},
-            {"svc": PolicyService},
-            {"svc": NotifierService},
-            {"svc": NotificationService},
-            {"svc": DataSubjectMemberService},
-            {"svc": ProjectService},
-            {"svc": EnclaveService},
-            {"svc": CodeHistoryService},
-            {"svc": MetadataService},
-            {"svc": BlobStorageService},
-            {"svc": MigrationService},
-            {"svc": SyftWorkerImageService},
-            {"svc": SyftWorkerPoolService},
-            {"svc": SyftImageRegistryService},
-            {"svc": SyncService},
-            {"svc": OutputService},
-            {"svc": UserCodeStatusService},  # this is lazy
-        ]
+    @property
+    def service_path_map(self) -> dict[str, AbstractService]:
+        return self.services.service_path_map
 
-        for svc_kwargs in default_services:
-            ServiceCls = svc_kwargs.pop("svc")
-            svc_kwargs.setdefault("store", self.document_store)
+    @property
+    def initialized_services(self) -> list[AbstractService]:
+        return self.services.services
+        # service_path_map: dict[str, AbstractService] = {}
+        # initialized_services: list[AbstractService] = []
 
-            svc_instance = ServiceCls(**svc_kwargs)
-            if not svc_instance:
-                continue
-            elif not isinstance(svc_instance, AbstractService):
-                raise ValueError(
-                    f"Service {ServiceCls.__name__} must be an instance of AbstractService"
-                )
+        # # A dict of service and init kwargs.
+        # # - "svc" expects a callable (class or function)
+        # #     - The callable must return AbstractService or None
+        # # - "store" expects a store type
+        # #     - By default all services get the document store
+        # #     - Pass a custom "store" to override this
+        # default_services: list[dict] = [
+        #     {"svc": ActionService, "store": self.action_store},
+        #     {"svc": UserService},
+        #     {"svc": AttestationService},
+        #     {"svc": WorkerService},
+        #     {"svc": SettingsService},
+        #     {"svc": DatasetService},
+        #     {"svc": UserCodeService},
+        #     {"svc": LogService},
+        #     {"svc": RequestService},
+        #     {"svc": QueueService},
+        #     {"svc": JobService},
+        #     {"svc": APIService},
+        #     {"svc": DataSubjectService},
+        #     {"svc": NetworkService},
+        #     {"svc": PolicyService},
+        #     {"svc": NotifierService},
+        #     {"svc": NotificationService},
+        #     {"svc": DataSubjectMemberService},
+        #     {"svc": ProjectService},
+        #     {"svc": EnclaveService},
+        #     {"svc": CodeHistoryService},
+        #     {"svc": MetadataService},
+        #     {"svc": BlobStorageService},
+        #     {"svc": MigrationService},
+        #     {"svc": SyftWorkerImageService},
+        #     {"svc": SyftWorkerPoolService},
+        #     {"svc": SyftImageRegistryService},
+        #     {"svc": SyncService},
+        #     {"svc": OutputService},
+        #     {"svc": UserCodeStatusService},  # this is lazy
+        # ]
 
-            service_path_map[ServiceCls.__name__.lower()] = svc_instance
-            initialized_services.append(ServiceCls)
+        # for svc_kwargs in default_services:
+        #     ServiceCls = svc_kwargs.pop("svc")
+        #     svc_kwargs.setdefault("store", self.document_store)
 
-        self.services = initialized_services
-        self.service_path_map = service_path_map
+        #     svc_instance = ServiceCls(**svc_kwargs)
+        #     if not svc_instance:
+        #         continue
+        #     elif not isinstance(svc_instance, AbstractService):
+        #         raise ValueError(
+        #             f"Service {ServiceCls.__name__} must be an instance of AbstractService"
+        #         )
+
+        #     service_path_map[ServiceCls.__name__.lower()] = svc_instance
+        #     initialized_services.append(ServiceCls)
+
+        # self.services = initialized_services
+        # self.service_path_map = service_path_map
 
     def get_service_method(self, path_or_func: str | Callable) -> Callable:
         if callable(path_or_func):
@@ -954,21 +941,12 @@ class Node(AbstractNode):
         return self._get_service_method_from_path(path_or_func)
 
     def get_service(self, path_or_func: str | Callable) -> AbstractService:
-        if callable(path_or_func):
-            path_or_func = path_or_func.__qualname__
-        return self._get_service_from_path(path_or_func)
-
-    def _get_service_from_path(self, path: str) -> AbstractService:
-        path_list = path.split(".")
-        if len(path_list) > 1:
-            _ = path_list.pop()
-        service_name = path_list.pop()
-        return self.service_path_map[service_name.lower()]
+        return self.services.get_service(path_or_func)
 
     def _get_service_method_from_path(self, path: str) -> Callable:
         path_list = path.split(".")
         method_name = path_list.pop()
-        service_obj = self._get_service_from_path(path=path)
+        service_obj = self.services._get_service_from_path(path=path)
 
         return getattr(service_obj, method_name)
 

--- a/packages/syft/src/syft/node/node.py
+++ b/packages/syft/src/syft/node/node.py
@@ -394,7 +394,7 @@ class Node(AbstractNode):
         )
 
         # construct services only after init stores
-        self.services: ServiceRegistry = ServiceRegistry(node=self)
+        self.services: ServiceRegistry = ServiceRegistry.for_node(self)
 
         create_admin_new(  # nosec B106
             name=root_username,
@@ -864,9 +864,6 @@ class Node(AbstractNode):
     @property
     def worker_stash(self) -> WorkerStash:
         return self.get_service("workerservice").stash
-
-    def _construct_services(self) -> None:
-        self.services = ServiceRegistry(node=self)
 
     @property
     def service_path_map(self) -> dict[str, AbstractService]:

--- a/packages/syft/src/syft/node/service_registry.py
+++ b/packages/syft/src/syft/node/service_registry.py
@@ -1,0 +1,116 @@
+# stdlib
+from collections.abc import Callable
+import typing
+
+# relative
+from ..service.action.action_service import ActionService
+from ..service.action.action_store import ActionStore
+from ..service.api.api_service import APIService
+from ..service.attestation.attestation_service import AttestationService
+from ..service.blob_storage.service import BlobStorageService
+from ..service.code.status_service import UserCodeStatusService
+from ..service.code.user_code_service import UserCodeService
+from ..service.code_history.code_history_service import CodeHistoryService
+from ..service.data_subject.data_subject_member_service import DataSubjectMemberService
+from ..service.data_subject.data_subject_service import DataSubjectService
+from ..service.dataset.dataset_service import DatasetService
+from ..service.enclave.enclave_service import EnclaveService
+from ..service.job.job_service import JobService
+from ..service.log.log_service import LogService
+from ..service.metadata.metadata_service import MetadataService
+from ..service.migration.migration_service import MigrationService
+from ..service.network.network_service import NetworkService
+from ..service.notification.notification_service import NotificationService
+from ..service.notifier.notifier_service import NotifierService
+from ..service.output.output_service import OutputService
+from ..service.policy.policy_service import PolicyService
+from ..service.project.project_service import ProjectService
+from ..service.queue.queue_service import QueueService
+from ..service.request.request_service import RequestService
+from ..service.service import AbstractService
+from ..service.settings.settings_service import SettingsService
+from ..service.sync.sync_service import SyncService
+from ..service.user.user_service import UserService
+from ..service.worker.image_registry_service import SyftImageRegistryService
+from ..service.worker.worker_image_service import SyftWorkerImageService
+from ..service.worker.worker_pool_service import SyftWorkerPoolService
+from ..service.worker.worker_service import WorkerService
+from .node import Node
+
+
+class ServiceRegistry:
+    # Services
+    action: ActionService
+    user: UserService
+    attestation: AttestationService
+    worker: WorkerService
+    settings: SettingsService
+    dataset: DatasetService
+    user_code: UserCodeService
+    log: LogService
+    request: RequestService
+    queue: QueueService
+    job: JobService
+    api: APIService
+    data_subject: DataSubjectService
+    network: NetworkService
+    policy: PolicyService
+    notifier: NotifierService
+    notification: NotificationService
+    data_subject_member: DataSubjectMemberService
+    project: ProjectService
+    enclave: EnclaveService
+    code_history: CodeHistoryService
+    metadata: MetadataService
+    blob_storage: BlobStorageService
+    migration: MigrationService
+    syft_worker_image: SyftWorkerImageService
+    syft_worker_pool: SyftWorkerPoolService
+    syft_image_registry: SyftImageRegistryService
+    sync: SyncService
+    output: OutputService
+    user_code_status: UserCodeStatusService
+
+    def __init__(self, node: Node) -> None:
+        self.node = node
+        self.service_classes = self.get_service_classes()
+        self.services: list[AbstractService] = []
+        self.service_path_map: dict[str, AbstractService] = {}
+        self._construct_services()
+
+    @classmethod
+    def get_service_classes(
+        cls,
+    ) -> dict[str, type[AbstractService]]:
+        return {
+            name: cls
+            for name, cls in typing.get_type_hints(cls).items()
+            if issubclass(cls, AbstractService)
+        }
+
+    def _construct_services(self) -> None:
+        for field_name, service_cls in self.get_service_classes().items():
+            if issubclass(service_cls.store_type, ActionStore):
+                svc_kwargs = {"store": self.node.action_store}
+            else:
+                svc_kwargs = {"store": self.node.document_store}
+
+            service = service_cls(**svc_kwargs)
+            setattr(self, field_name, service)
+            self.services.append(service)
+            self.service_path_map[service.__class__.__name__.lower()] = service
+
+    def get_service(self, path_or_func: str | Callable) -> AbstractService:
+        if callable(path_or_func):
+            path_or_func = path_or_func.__qualname__
+        return self._get_service_from_path(path_or_func)
+
+    def _get_service_from_path(self, path: str) -> AbstractService:
+        try:
+            path_list = path.split(".")
+            if len(path_list) > 1:
+                _ = path_list.pop()
+            service_name = path_list.pop()
+            return self.service_path_map[service_name.lower()]
+        except KeyError:
+            raise ValueError(f"Service {path} not found.")

--- a/packages/syft/src/syft/node/service_registry.py
+++ b/packages/syft/src/syft/node/service_registry.py
@@ -1,6 +1,8 @@
 # stdlib
 from collections.abc import Callable
 import typing
+from typing import Any
+from typing import TYPE_CHECKING
 
 # relative
 from ..service.action.action_service import ActionService
@@ -35,7 +37,10 @@ from ..service.worker.image_registry_service import SyftImageRegistryService
 from ..service.worker.worker_image_service import SyftWorkerImageService
 from ..service.worker.worker_pool_service import SyftWorkerPoolService
 from ..service.worker.worker_service import WorkerService
-from .node import Node
+
+if TYPE_CHECKING:
+    # relative
+    from .node import Node
 
 
 class ServiceRegistry:
@@ -71,7 +76,7 @@ class ServiceRegistry:
     output: OutputService
     user_code_status: UserCodeStatusService
 
-    def __init__(self, node: Node) -> None:
+    def __init__(self, node: "Node") -> None:
         self.node = node
         self.service_classes = self.get_service_classes()
         self.services: list[AbstractService] = []
@@ -90,10 +95,11 @@ class ServiceRegistry:
 
     def _construct_services(self) -> None:
         for field_name, service_cls in self.get_service_classes().items():
+            svc_kwargs: dict[str, Any] = {}
             if issubclass(service_cls.store_type, ActionStore):
-                svc_kwargs = {"store": self.node.action_store}
+                svc_kwargs["store"] = self.node.action_store
             else:
-                svc_kwargs = {"store": self.node.document_store}
+                svc_kwargs["store"] = self.node.document_store
 
             service = service_cls(**svc_kwargs)
             setattr(self, field_name, service)

--- a/packages/syft/src/syft/service/action/action_service.py
+++ b/packages/syft/src/syft/service/action/action_service.py
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 
 @serializable()
 class ActionService(AbstractService):
+    store_type = ActionStore
+
     def __init__(self, store: ActionStore) -> None:
         self.store = store
 

--- a/packages/syft/src/syft/service/service.py
+++ b/packages/syft/src/syft/service/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable
 from copy import deepcopy
+import functools
 from functools import partial
 import inspect
 from inspect import Parameter
@@ -31,6 +32,7 @@ from ..serde.serializable import serializable
 from ..serde.signature import Signature
 from ..serde.signature import signature_remove_context
 from ..serde.signature import signature_remove_self
+from ..store.document_store import DocumentStore
 from ..store.linked_obj import LinkedObject
 from ..types.syft_object import SYFT_OBJECT_VERSION_2
 from ..types.syft_object import SyftBaseObject
@@ -57,6 +59,7 @@ SERVICE_TO_TYPES: defaultdict = defaultdict(set)
 class AbstractService:
     node: AbstractNode
     node_uid: UID
+    store_type: type = DocumentStore
 
     def resolve_link(
         self,
@@ -351,6 +354,7 @@ def service_method(
 
         input_signature = deepcopy(signature)
 
+        @functools.wraps(func)
         def _decorator(self: Any, *args: Any, **kwargs: Any) -> Callable:
             communication_protocol = kwargs.pop("communication_protocol", None)
 


### PR DESCRIPTION
## Description

issue: current service locator function `node.get_service("myservice")` does not (cannot?) infer the service type. no typing = no autocomplete + hard to refactor service methods.

fix:
- added a `node.services: ServiceRegistry` that initializes all services with type annotations.
    - example usage: instead of `node.get_service("usercodeservice") -> AbstractService`, `node.services.user_code -> UserCodeService` 
- fix service_method decorator to keep function signature

todo
- remove all references to get_service, waiting for this until after current big PRs are merged


![image](https://github.com/OpenMined/PySyft/assets/7243409/bf5291d7-f9bc-467d-affc-5f831a1d4105)




## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
