### PR TITLE
Prevent server data reset due to Uvicorn hot-reload

### DIFF
--- a/packages/syft/src/syft/node/node.py
+++ b/packages/syft/src/syft/node/node.py
@@ -12,10 +12,8 @@ import json
 import logging
 import os
 from pathlib import Path
-import shutil
 import subprocess  # nosec
 import sys
-import tempfile
 from time import sleep
 import traceback
 from typing import Any
@@ -122,6 +120,9 @@ from ..util.util import thread_ident
 from .credentials import SyftSigningKey
 from .credentials import SyftVerifyKey
 from .service_registry import ServiceRegistry
+from .utils import get_named_node_uid
+from .utils import get_temp_dir_for_node
+from .utils import remove_temp_dir_for_node
 from .worker_settings import WorkerSettings
 
 logger = logging.getLogger(__name__)
@@ -655,7 +656,7 @@ class Node(AbstractNode):
         association_request_auto_approval: bool = False,
         background_tasks: bool = False,
     ) -> Node:
-        uid = UID.with_seed(name)
+        uid = get_named_node_uid(name)
         name_hash = hashlib.sha256(name.encode("utf8")).digest()
         key = SyftSigningKey(signing_key=SigningKey(name_hash))
         blob_storage_config = None
@@ -952,18 +953,13 @@ class Node(AbstractNode):
         Get a temporary directory unique to the node.
         Provide all dbs, blob dirs, and locks using this directory.
         """
-        root = os.getenv("SYFT_TEMP_ROOT", "syft")
-        p = Path(tempfile.gettempdir(), root, str(self.id), dir_name)
-        p.mkdir(parents=True, exist_ok=True)
-        return p
+        return get_temp_dir_for_node(self.id, dir_name)
 
     def remove_temp_dir(self) -> None:
         """
         Remove the temporary directory for this node.
         """
-        rootdir = self.get_temp_dir()
-        if rootdir.exists():
-            shutil.rmtree(rootdir, ignore_errors=True)
+        remove_temp_dir_for_node(self.id)
 
     def update_self(self, settings: NodeSettings) -> None:
         updateable_attrs = (

--- a/packages/syft/src/syft/node/utils.py
+++ b/packages/syft/src/syft/node/utils.py
@@ -1,0 +1,38 @@
+# future
+from __future__ import annotations
+
+# stdlib
+import os
+from pathlib import Path
+import shutil
+import tempfile
+
+# relative
+from ..types.uid import UID
+
+
+def get_named_node_uid(name: str) -> UID:
+    """
+    Get a unique identifier for a named node.
+    """
+    return UID.with_seed(name)
+
+
+def get_temp_dir_for_node(node_uid: UID, dir_name: str = "") -> Path:
+    """
+    Get a temporary directory unique to the node.
+    Provide all dbs, blob dirs, and locks using this directory.
+    """
+    root = os.getenv("SYFT_TEMP_ROOT", "syft")
+    p = Path(tempfile.gettempdir(), root, str(node_uid), dir_name)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def remove_temp_dir_for_node(node_uid: UID) -> None:
+    """
+    Remove the temporary directory for this node.
+    """
+    rootdir = get_temp_dir_for_node(node_uid)
+    if rootdir.exists():
+        shutil.rmtree(rootdir, ignore_errors=True)


### PR DESCRIPTION
## Description

### The Problem
- 🔄 Hot-reloading of the Uvicorn process is enabled if the `dev_mode` flag is set to `True`.
- 💥 Server data is nuked if the `reset` flag is set to `True`.
- ❌ When both flags are `True`, the server data is deleted every time Uvicorn performs a hot-reload.
- 🛠️ The goal is to ensure the reset process occurs only once at the initial startup of Uvicorn, not on each hot-reload.

### The Fix
- 🔧 Move the data reset logic out of the node initialization.
- 🚀 Call the reset logic before starting the Uvicorn server.
- ✅ After the reset is complete, set `reset=False` to prevent further resets during node operations while maintaining backwards compatibility.

### The Thread
🔗 https://openmined.slack.com/archives/C0787G91DSM/p1720579447208079
## Affected Dependencies
None

## How has this been tested?
- Tested manually on a notebook

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
