### PR TITLE
Added notification enabled text to domain settings

### DIFF
--- a/packages/syft/src/syft/service/settings/settings.py
+++ b/packages/syft/src/syft/service/settings/settings.py
@@ -112,6 +112,22 @@ class NodeSettings(SyftObject):
     )
 
     def _repr_html_(self) -> Any:
+        preferences = self._get_api().services.notifications.user_settings()
+        notifications = []
+        if preferences.email:
+            notifications.append("email")
+        if preferences.sms:
+            notifications.append("sms")
+        if preferences.slack:
+            notifications.append("slack")
+        if preferences.app:
+            notifications.append("app")
+
+        if notifications:
+            notifications_enabled = f"True via {', '.join(notifications)}"
+        else:
+            notifications_enabled = "False"
+
         return f"""
             <style>
             .syft-settings {{color: {SURFACE[options.color_theme]};}}
@@ -124,6 +140,7 @@ class NodeSettings(SyftObject):
                 <p><strong>Description: </strong>{self.description}</p>
                 <p><strong>Deployed on: </strong>{self.deployed_on}</p>
                 <p><strong>Signup enabled: </strong>{self.signup_enabled}</p>
+                <p><strong>Notifications enabled: </strong>{notifications_enabled}</p>
                 <p><strong>Admin email: </strong>{self.admin_email}</p>
             </div>
 


### PR DESCRIPTION
This PR adds the notification enabled to a `client.settings` call. This closes ticket [1586](https://github.com/OpenMined/Heartbeat/issues/1586).


Preview of the fix: 

![PR_testing](https://github.com/OpenMined/PySyft/assets/10202935/a1fc2052-59b8-44e9-a1df-88f14866e354)


Testing is done with Tauquir's incredible hotreloading and forcing the notification initialization manually. Added additional details when the notification is enabled.