### PR TITLE
Rename client.me to client.account

### DIFF
--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -830,7 +830,7 @@ class SyftClient:
         return None
 
     @property
-    def me(self) -> UserView | SyftError | None:
+    def account(self) -> UserView | SyftError | None:
         if self.api.has_service("user"):
             return self.api.services.user.get_current_user()
         return None
@@ -909,7 +909,7 @@ class SyftClient:
             if password == get_default_root_password():
                 message = (
                     "You are using a default password. Please change the password "
-                    "using `[your_client].me.set_password([new_password])`."
+                    "using `[your_client].account.set_password([new_password])`."
                 )
                 prompt_warning_message(message)
 

--- a/packages/syft/src/syft/service/project/project.py
+++ b/packages/syft/src/syft/service/project/project.py
@@ -1198,8 +1198,8 @@ class ProjectSubmit(SyftObject):
         self.users = [UserIdentity.from_client(client) for client in self.clients]
 
         # Assign logged in user name as project creator
-        if isinstance(self.clients[0].me, UserView):
-            self.username = self.clients[0].me.name
+        if isinstance(self.clients[0].account, UserView):
+            self.username = self.clients[0].account.name
         else:
             self.username = ""
 

--- a/packages/syft/tests/syft/action_test.py
+++ b/packages/syft/tests/syft/action_test.py
@@ -57,10 +57,10 @@ def test_new_admin_has_action_object_permission(
 
     admin = root_client.login(email=email, password=pw)
 
-    root_client.api.services.user.update(uid=admin.me.id, role=ServiceRole.ADMIN)
+    root_client.api.services.user.update(uid=admin.account.id, role=ServiceRole.ADMIN)
 
     if delete_original_admin:
-        res = root_client.api.services.user.delete(root_client.me.id)
+        res = root_client.api.services.user.delete(root_client.account.id)
         assert not isinstance(res, SyftError)
 
     assert admin.api.services.action.get(obj.id) == obj

--- a/packages/syft/tests/syft/users/user_code_test.py
+++ b/packages/syft/tests/syft/users/user_code_test.py
@@ -67,10 +67,10 @@ def test_new_admin_can_list_user_code(
 
     admin = root_client.login(email=email, password=pw)
 
-    root_client.api.services.user.update(uid=admin.me.id, role=ServiceRole.ADMIN)
+    root_client.api.services.user.update(uid=admin.account.id, role=ServiceRole.ADMIN)
 
     if delete_original_admin:
-        res = root_client.api.services.user.delete(root_client.me.id)
+        res = root_client.api.services.user.delete(root_client.account.id)
         assert not isinstance(res, SyftError)
 
     user_code_stash = worker.get_service("usercodeservice").stash


### PR DESCRIPTION
## Description
Renames`client.me` to `client.account`.

Closes https://github.com/OpenMined/Heartbeat/issues/1269.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
