### PR TITLE
Fix multiple warning when accessing self.data in Assets

### DIFF
--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -2,7 +2,6 @@
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
-from functools import cached_property
 import logging
 import textwrap
 from typing import Any
@@ -250,7 +249,7 @@ class Asset(SyftObject):
         if api is not None and api.services is not None:
             return api.services.action.get_pointer(self.action_id)
 
-    @cached_property
+    @property
     def mock(self) -> SyftError | Any:
         api = APIRegistry.api_for(
             server_uid=self.server_uid,
@@ -279,7 +278,7 @@ class Asset(SyftObject):
             and data_result.endswith("denied")
         )
 
-    @cached_property
+    @property
     def data(self) -> Any:
         # relative
 
@@ -296,7 +295,7 @@ class Asset(SyftObject):
             warning = SyftError(
                 message="You do not have permission to access private data."
             )
-            display(warning)
+            display(warning, clear=True)
             return None
 
 

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -2,6 +2,7 @@
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
+from functools import cached_property
 import logging
 import textwrap
 from typing import Any
@@ -249,7 +250,7 @@ class Asset(SyftObject):
         if api is not None and api.services is not None:
             return api.services.action.get_pointer(self.action_id)
 
-    @property
+    @cached_property
     def mock(self) -> SyftError | Any:
         api = APIRegistry.api_for(
             server_uid=self.server_uid,
@@ -278,7 +279,7 @@ class Asset(SyftObject):
             and data_result.endswith("denied")
         )
 
-    @property
+    @cached_property
     def data(self) -> Any:
         # relative
 


### PR DESCRIPTION
## Description

**Problem**
accessing self.data property in Asset class shows warning at each call, since self.data is invoked at multiple places in Asset.

**Solution**

Clear display every time self.data is called. This ensures there is only one instance of the warning at each call.

![image](https://github.com/user-attachments/assets/e1bf76cb-5565-452d-958d-f4fe39c88796)


## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
