### PR TITLE
Avoid data access error on asset repr

### DIFF
--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -290,7 +290,7 @@ class Asset(SyftObject):
         Retrieves the private data associated with this asset.
 
         Returns:
-            Result[Any, str]: A Result object containing the private data if the user has permission (or None if no API is registered),
+            Result[Any, str]: A Result object containing the private data if the user has permission
             otherwise an Err object with the message "You do not have permission to access private data."
         """
         api = APIRegistry.api_for(

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -286,6 +286,13 @@ class Asset(SyftObject):
         )
 
     def _private_data(self) -> Result[Any, str]:
+        """
+        Retrieves the private data associated with this asset.
+
+        Returns:
+            Result[Any, str]: A Result object containing the private data if the user has permission (or None if no API is registered),
+            otherwise an Err object with the message "You do not have permission to access private data."
+        """
         api = APIRegistry.api_for(
             server_uid=self.server_uid,
             user_verify_key=self.syft_client_verify_key,


### PR DESCRIPTION
## Description

Avoids displaying "You do not have permission to access private data." error for the asset repr. Presumably the user is just trying to understand the asset rather than trying to access the private data here so an error doesn't make sense to show. This message is instead displayed as information in the `Data` part of the repr now. The SyftError will still display if asset.data is called since the user should be warned in that case. 


![Screenshot 2024-07-24 at 3 26 40 PM](https://github.com/user-attachments/assets/ccc2a489-52ac-4c12-baf2-b7d5f5b56f2e)

![Screenshot 2024-07-24 at 3 26 52 PM](https://github.com/user-attachments/assets/b46cf98d-bffa-4b93-9965-dadf3a642a38)

Closes https://github.com/OpenMined/Heartbeat/issues/1646.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
