### PR TITLE
Remove ALL_READ permission for requests

### DIFF
--- a/packages/syft/src/syft/service/request/request_service.py
+++ b/packages/syft/src/syft/service/request/request_service.py
@@ -8,8 +8,6 @@ from ...store.document_store import DocumentStore
 from ...store.linked_obj import LinkedObject
 from ...types.uid import UID
 from ...util.telemetry import instrument
-from ..action.action_permissions import ActionObjectPermission
-from ..action.action_permissions import ActionPermission
 from ..context import AuthedServiceContext
 from ..notification.email_templates import RequestEmailTemplate
 from ..notification.email_templates import RequestUpdateEmailTemplate
@@ -58,15 +56,7 @@ class RequestService(AbstractService):
         """Submit a Request"""
         try:
             req = request.to(Request, context=context)
-            result = self.stash.set(
-                context.credentials,
-                req,
-                add_permissions=[
-                    ActionObjectPermission(
-                        uid=req.id, permission=ActionPermission.ALL_READ
-                    ),
-                ],
-            )
+            result = self.stash.set(context.credentials, req)
             if result.is_ok():
                 request = result.ok()
                 link = LinkedObject.with_context(request, context=context)

--- a/packages/syft/tests/conftest.py
+++ b/packages/syft/tests/conftest.py
@@ -190,6 +190,27 @@ def guest_datasite_client(root_datasite_client) -> DatasiteClient:
 
 
 @pytest.fixture
+def ds_client(
+    faker: Faker, root_datasite_client: DatasiteClient, guest_client: DatasiteClient
+):
+    guest_email = faker.email()
+    password = "mysecretpassword"
+    root_datasite_client.register(
+        name=faker.name(),
+        email=guest_email,
+        password=password,
+        password_verify=password,
+    )
+    ds_client = guest_client.login(email=guest_email, password=password)
+    yield ds_client
+
+
+@pytest.fixture
+def ds_verify_key(ds_client: DatasiteClient):
+    yield ds_client.credentials.verify_key
+
+
+@pytest.fixture
 def document_store(worker):
     yield worker.document_store
     worker.document_store.reset()

--- a/packages/syft/tests/syft/request/fixtures.py
+++ b/packages/syft/tests/syft/request/fixtures.py
@@ -7,6 +7,7 @@ from syft.client.client import SyftClient
 from syft.server.credentials import SyftVerifyKey
 from syft.server.worker import Worker
 from syft.service.context import AuthedServiceContext
+from syft.service.request.request_service import RequestService
 from syft.service.request.request_stash import RequestStash
 from syft.store.document_store import DocumentStore
 
@@ -22,3 +23,8 @@ def authed_context_guest_datasite_client(
 ) -> AuthedServiceContext:
     verify_key: SyftVerifyKey = guest_datasite_client.credentials.verify_key
     yield AuthedServiceContext(credentials=verify_key, server=worker)
+
+
+@pytest.fixture
+def request_service(document_store: DocumentStore):
+    yield RequestService(store=document_store)

--- a/packages/syft/tests/syft/request/request_code_accept_deny_test.py
+++ b/packages/syft/tests/syft/request/request_code_accept_deny_test.py
@@ -1,7 +1,3 @@
-# third party
-from faker import Faker
-import pytest
-
 # syft absolute
 import syft
 from syft.client.client import SyftClient
@@ -15,17 +11,10 @@ from syft.service.request.request import ActionStoreChange
 from syft.service.request.request import ObjectMutation
 from syft.service.request.request import RequestStatus
 from syft.service.request.request import UserCodeStatusChange
-from syft.service.request.request_service import RequestService
 from syft.service.response import SyftError
 from syft.service.response import SyftSuccess
 from syft.service.settings.settings_service import SettingsService
-from syft.store.document_store import DocumentStore
 from syft.store.linked_obj import LinkedObject
-
-
-@pytest.fixture
-def request_service(document_store: DocumentStore):
-    yield RequestService(store=document_store)
 
 
 def test_object_mutation(worker: Worker):
@@ -62,7 +51,7 @@ def test_object_mutation(worker: Worker):
     assert setting.organization == original_name
 
 
-def test_action_store_change(faker: Faker, worker: Worker, ds_client: SyftClient):
+def test_action_store_change(worker: Worker, ds_client: SyftClient):
     root_client = worker.root_client
     dummy_data = [1, 2, 3]
     data = ActionObject.from_obj(dummy_data)
@@ -100,7 +89,7 @@ def test_action_store_change(faker: Faker, worker: Worker, ds_client: SyftClient
     assert isinstance(result, SyftError)
 
 
-def test_user_code_status_change(faker: Faker, worker: Worker, ds_client: SyftClient):
+def test_user_code_status_change(worker: Worker, ds_client: SyftClient):
     root_client = worker.root_client
     dummy_data = [1, 2, 3]
     data = ActionObject.from_obj(dummy_data)
@@ -146,7 +135,7 @@ def test_user_code_status_change(faker: Faker, worker: Worker, ds_client: SyftCl
     assert not user_code.status.approved
 
 
-def test_code_accept_deny(faker: Faker, worker: Worker, ds_client: SyftClient):
+def test_code_accept_deny(worker: Worker, ds_client: SyftClient):
     root_client = worker.root_client
     dummy_data = [1, 2, 3]
     data = ActionObject.from_obj(dummy_data)

--- a/packages/syft/tests/syft/request/request_code_permissions_test.py
+++ b/packages/syft/tests/syft/request/request_code_permissions_test.py
@@ -1,0 +1,72 @@
+# third party
+from faker import Faker
+
+# syft absolute
+import syft
+from syft.client.client import SyftClient
+from syft.server.worker import Worker
+from syft.service.action.action_object import ActionObject
+from syft.service.code.user_code import UserCode
+from syft.service.response import SyftSuccess
+
+
+def test_code_request_submitted_by_admin_only_admin_can_view(
+    faker: Faker, worker: Worker, ds_client: SyftClient
+):
+    root_client = worker.root_client
+    dummy_data = [1, 2, 3]
+    data = ActionObject.from_obj(dummy_data)
+    action_obj = data.send(root_client)
+
+    @syft.syft_function(
+        input_policy=syft.ExactMatch(data=action_obj),
+        output_policy=syft.SingleExecutionExactOutput(),
+    )
+    def simple_function(data):
+        return sum(data)
+
+    project = syft.Project(name="test", members=[root_client])
+
+    result = project.create_code_request(simple_function, root_client)
+    assert isinstance(result, SyftSuccess)
+
+    # only root should be able to see request and access code
+    ds_request_all = ds_client.requests.get_all()
+    assert len(ds_request_all) == 0
+
+    root_request_all = root_client.requests.get_all()
+    assert len(root_request_all) == 1
+    root_code_access = root_request_all[0].code
+    assert isinstance(root_code_access, UserCode)
+
+
+def test_code_request_submitted_by_ds_root_and_ds_can_view(
+    faker: Faker, worker: Worker, ds_client: SyftClient
+):
+    root_client = worker.root_client
+    dummy_data = [1, 2, 3]
+    data = ActionObject.from_obj(dummy_data)
+    action_obj = data.send(root_client)
+
+    @syft.syft_function(
+        input_policy=syft.ExactMatch(data=action_obj),
+        output_policy=syft.SingleExecutionExactOutput(),
+    )
+    def simple_function(data):
+        return sum(data)
+
+    project = syft.Project(name="test", members=[ds_client])
+
+    result = project.create_code_request(simple_function, ds_client)
+    assert isinstance(result, SyftSuccess)
+
+    # both root and ds should be able to see request and access code
+    ds_request_all = ds_client.requests.get_all()
+    assert len(ds_request_all) == 1
+    ds_code_access = ds_request_all[0].code
+    assert isinstance(ds_code_access, UserCode)
+
+    root_request_all = root_client.requests.get_all()
+    assert len(root_request_all) == 1
+    root_code_access = root_request_all[0].code
+    assert isinstance(root_code_access, UserCode)

--- a/packages/syft/tests/syft/request/request_code_permissions_test.py
+++ b/packages/syft/tests/syft/request/request_code_permissions_test.py
@@ -1,6 +1,3 @@
-# third party
-from faker import Faker
-
 # syft absolute
 import syft
 from syft.client.client import SyftClient
@@ -11,7 +8,7 @@ from syft.service.response import SyftSuccess
 
 
 def test_code_request_submitted_by_admin_only_admin_can_view(
-    faker: Faker, worker: Worker, ds_client: SyftClient
+    worker: Worker, ds_client: SyftClient
 ):
     root_client = worker.root_client
     dummy_data = [1, 2, 3]
@@ -41,7 +38,7 @@ def test_code_request_submitted_by_admin_only_admin_can_view(
 
 
 def test_code_request_submitted_by_ds_root_and_ds_can_view(
-    faker: Faker, worker: Worker, ds_client: SyftClient
+    worker: Worker, ds_client: SyftClient
 ):
     root_client = worker.root_client
     dummy_data = [1, 2, 3]

--- a/packages/syft/tests/syft/worker_pool/worker_pool_service_test.py
+++ b/packages/syft/tests/syft/worker_pool/worker_pool_service_test.py
@@ -4,6 +4,7 @@ import pytest
 
 # syft absolute
 import syft as sy
+from syft.client.client import SyftClient
 from syft.custom_worker.config import DockerWorkerConfig
 from syft.custom_worker.config import PrebuiltWorkerConfig
 from syft.custom_worker.config import WorkerConfig
@@ -12,9 +13,6 @@ from syft.service.request.request import CreateCustomWorkerPoolChange
 from syft.service.response import SyftSuccess
 from syft.service.worker.worker_image import SyftWorkerImage
 from syft.service.worker.worker_pool import WorkerPool
-
-# relative
-from ..request.request_code_accept_deny_test import get_ds_client
 
 PREBUILT_IMAGE_TAG = f"docker.io/openmined/syft-backend:{sy.__version__}"
 
@@ -43,7 +41,11 @@ WORKER_CONFIG_TEST_CASES = [
 
 @pytest.mark.parametrize("docker_tag,worker_config", WORKER_CONFIG_TEST_CASES)
 def test_create_image_and_pool_request_accept(
-    faker: Faker, worker: Worker, docker_tag: str, worker_config: WorkerConfig
+    faker: Faker,
+    worker: Worker,
+    docker_tag: str,
+    worker_config: WorkerConfig,
+    ds_client: SyftClient,
 ) -> None:
     """
     Test the functionality of `SyftWorkerPoolService.create_image_and_pool_request`
@@ -51,7 +53,6 @@ def test_create_image_and_pool_request_accept(
     """
     # construct a root client and data scientist client for a datasite
     root_client = worker.root_client
-    ds_client = get_ds_client(faker, root_client, worker.guest_client)
     assert root_client.credentials != ds_client.credentials
 
     # the DS makes a request to create an image and a pool based on the image
@@ -99,6 +100,7 @@ def test_create_pool_request_accept(
     docker_tag: str,
     worker_config: WorkerConfig,
     n_images: int,
+    ds_client: SyftClient,
 ) -> None:
     """
     Test the functionality of `SyftWorkerPoolService.create_pool_request`
@@ -106,7 +108,6 @@ def test_create_pool_request_accept(
     """
     # construct a root client and data scientist client for a datasite
     root_client = worker.root_client
-    ds_client = get_ds_client(faker, root_client, worker.guest_client)
     assert root_client.credentials != ds_client.credentials
 
     # the DO submits the docker config to build an image

--- a/packages/syft/tests/syft/worker_pool/worker_pool_service_test.py
+++ b/packages/syft/tests/syft/worker_pool/worker_pool_service_test.py
@@ -1,5 +1,4 @@
 # third party
-from faker import Faker
 import pytest
 
 # syft absolute
@@ -41,7 +40,6 @@ WORKER_CONFIG_TEST_CASES = [
 
 @pytest.mark.parametrize("docker_tag,worker_config", WORKER_CONFIG_TEST_CASES)
 def test_create_image_and_pool_request_accept(
-    faker: Faker,
     worker: Worker,
     docker_tag: str,
     worker_config: WorkerConfig,
@@ -95,7 +93,6 @@ def test_create_image_and_pool_request_accept(
     WORKER_CONFIG_TEST_CASES_WITH_N_IMAGES,
 )
 def test_create_pool_request_accept(
-    faker: Faker,
     worker: Worker,
     docker_tag: str,
     worker_config: WorkerConfig,


### PR DESCRIPTION
## Description
If a DS user calls requests.get_all, it currently retrieves all requests regardless of whether the calling user has read permission on the linked code. This causes issues in the repr when the user is not able to resolve the linked code. 

This PR removes ALL_READ from being added to the permissions for requests so that when get_all is called, it'll function similarly to code.get_all where it only retrieves the requests where that user has read permissions (unless they are an admin in which case it will be all requests). 

Closes https://github.com/OpenMined/Heartbeat/issues/1561 
(and most likely https://github.com/OpenMined/Heartbeat/issues/1637 too). 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
