### PR TITLE
Fix mongo size issues for Job results

### DIFF
--- a/packages/grid/backend/grid/core/config.py
+++ b/packages/grid/backend/grid/core/config.py
@@ -155,7 +155,7 @@ class Settings(BaseSettings):
     ASSOCIATION_REQUEST_AUTO_APPROVAL: bool = str_to_bool(
         os.getenv("ASSOCIATION_REQUEST_AUTO_APPROVAL", "False")
     )
-    MIN_SIZE_BLOB_STORAGE_MB: int = int(os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 0))
+    MIN_SIZE_BLOB_STORAGE_MB: int = int(os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 1))
     REVERSE_TUNNEL_ENABLED: bool = str_to_bool(
         os.getenv("REVERSE_TUNNEL_ENABLED", "false")
     )

--- a/packages/grid/backend/grid/core/config.py
+++ b/packages/grid/backend/grid/core/config.py
@@ -155,7 +155,7 @@ class Settings(BaseSettings):
     ASSOCIATION_REQUEST_AUTO_APPROVAL: bool = str_to_bool(
         os.getenv("ASSOCIATION_REQUEST_AUTO_APPROVAL", "False")
     )
-    MIN_SIZE_BLOB_STORAGE_MB: int = int(os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 16))
+    MIN_SIZE_BLOB_STORAGE_MB: int = int(os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 0))
     REVERSE_TUNNEL_ENABLED: bool = str_to_bool(
         os.getenv("REVERSE_TUNNEL_ENABLED", "false")
     )

--- a/packages/syft/src/syft/client/datasite_client.py
+++ b/packages/syft/src/syft/client/datasite_client.py
@@ -194,7 +194,6 @@ class DatasiteClient(SyftClient):
         items = resolved_state.create_objs + resolved_state.update_objs
 
         action_objects = [x for x in items if isinstance(x, ActionObject)]
-
         for action_object in action_objects:
             action_object.reload_cache()
             # NOTE permissions are added separately server side

--- a/packages/syft/src/syft/server/server.py
+++ b/packages/syft/src/syft/server/server.py
@@ -471,7 +471,7 @@ class Server(AbstractServer):
             )
             config_ = OnDiskBlobStorageConfig(
                 client_config=client_config,
-                min_blob_size=os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 16),
+                min_blob_size=os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 0),
             )
         else:
             config_ = config

--- a/packages/syft/src/syft/server/server.py
+++ b/packages/syft/src/syft/server/server.py
@@ -471,7 +471,7 @@ class Server(AbstractServer):
             )
             config_ = OnDiskBlobStorageConfig(
                 client_config=client_config,
-                min_blob_size=os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 0),
+                min_blob_size=os.getenv("MIN_SIZE_BLOB_STORAGE_MB", 1),
             )
         else:
             config_ = config

--- a/packages/syft/src/syft/service/job/job_stash.py
+++ b/packages/syft/src/syft/service/job/job_stash.py
@@ -846,6 +846,15 @@ class JobStash(BaseUIDStoreStash):
         valid = self.check_type(item, self.object_type)
         if valid.is_err():
             return SyftError(message=valid.err())
+
+        # Ensure we never save cached result data in the database,
+        # as they can be arbitrarily large
+        if (
+            isinstance(item.result, ActionObject)
+            and item.result.syft_blob_storage_entry_id is not None
+        ):
+            item.result._clear_cache()
+
         return super().update(credentials, item, add_permissions)
 
     def get_by_result_id(

--- a/packages/syft/src/syft/service/sync/sync_service.py
+++ b/packages/syft/src/syft/service/sync/sync_service.py
@@ -224,27 +224,29 @@ class SyncService(AbstractService):
                 else:
                     return SyftError(message=f"Failed to sync {res.err()}")
 
+        # NOTE include_items=False to avoid snapshotting the database
+        # Snapshotting is disabled to avoid mongo size limit and performance issues
         res = self.build_current_state(
             context,
             new_items=items,
             new_ignored_batches=ignored_batches,
             new_unignored_batches=unignored_batches,
+            include_items=False,
         )
 
         if res.is_err():
             return SyftError(message=res.message)
-        else:
-            new_state = res.ok()
-            res = self.stash.set(context.credentials, new_state)
-            if res.is_err():
-                return SyftError(message=res.message)
-            else:
-                message = f"Synced {len(items)} items"
-                if len(ignored_batches) > 0:
-                    message += f", ignored {len(ignored_batches)} batches"
-                if len(unignored_batches) > 0:
-                    message += f", unignored {len(unignored_batches)} batches"
-                return SyftSuccess(message=message)
+        new_state = res.ok()
+        res = self.stash.set(context.credentials, new_state)
+        if res.is_err():
+            return SyftError(message=res.message)
+
+        message = f"Synced {len(items)} items"
+        if len(ignored_batches) > 0:
+            message += f", ignored {len(ignored_batches)} batches"
+        if len(unignored_batches) > 0:
+            message += f", unignored {len(unignored_batches)} batches"
+        return SyftSuccess(message=message)
 
     @service_method(
         path="sync.get_permissions",
@@ -370,7 +372,7 @@ class SyncService(AbstractService):
         new_items: list[SyncableSyftObject] | None = None,
         new_ignored_batches: dict[UID, int] | None = None,
         new_unignored_batches: set[UID] | None = None,
-        include_job_results: bool = False,
+        include_items: bool = True,
     ) -> Result[SyncState, str]:
         new_items = new_items if new_items is not None else []
         new_ignored_batches = (
@@ -379,12 +381,19 @@ class SyncService(AbstractService):
         unignored_batches: set[UID] = (
             new_unignored_batches if new_unignored_batches is not None else set()
         )
-        objects_res = self.get_all_syncable_items(context)
-        if objects_res.is_err():
-            return objects_res
 
-        objects, errors = objects_res.ok()
-        permissions, storage_permissions = self.get_permissions(context, objects)
+        if include_items:
+            objects_res = self.get_all_syncable_items(context)
+            if objects_res.is_err():
+                return objects_res
+
+            objects, errors = objects_res.ok()
+            permissions, storage_permissions = self.get_permissions(context, objects)
+        else:
+            objects = []
+            errors = {}
+            permissions = {}
+            storage_permissions = {}
 
         previous_state = self.stash.get_latest(context=context)
         if previous_state.is_err():

--- a/packages/syft/src/syft/service/sync/sync_service.py
+++ b/packages/syft/src/syft/service/sync/sync_service.py
@@ -370,6 +370,7 @@ class SyncService(AbstractService):
         new_items: list[SyncableSyftObject] | None = None,
         new_ignored_batches: dict[UID, int] | None = None,
         new_unignored_batches: set[UID] | None = None,
+        include_job_results: bool = False,
     ) -> Result[SyncState, str]:
         new_items = new_items if new_items is not None else []
         new_ignored_batches = (

--- a/packages/syft/tests/syft/blob_storage/blob_storage_test.py
+++ b/packages/syft/tests/syft/blob_storage/blob_storage_test.py
@@ -117,8 +117,8 @@ def test_action_obj_send_save_to_blob_storage(worker):
     action_obj.send(root_client)
     assert action_obj.syft_blob_storage_entry_id is None
 
-    # big object that should be saved to blob storage
-    assert min_size_for_blob_storage_upload(root_client.api.metadata) == 16
+    # big object that should be saved to blob storage (in mb)
+    assert min_size_for_blob_storage_upload(root_client.api.metadata) == 1
     num_elements = 20 * 1024 * 1024
     data_big = np.random.randint(0, 100, size=num_elements)  # 4 bytes per int32
     action_obj_2 = ActionObject.from_obj(data_big)

--- a/packages/syft/tests/syft/service/sync/sync_resolve_single_test.py
+++ b/packages/syft/tests/syft/service/sync/sync_resolve_single_test.py
@@ -125,10 +125,10 @@ def test_diff_state(low_worker, high_worker):
         from_client=high_client, to_client=low_client
     )
 
-    high_state = high_client.get_sync_state()
-    low_state = high_client.get_sync_state()
-    assert high_state.get_previous_state_diff().is_same
-    assert low_state.get_previous_state_diff().is_same
+    # high_state = high_client.get_sync_state()
+    # low_state = high_client.get_sync_state()
+    # assert high_state.get_previous_state_diff().is_same
+    # assert low_state.get_previous_state_diff().is_same
     assert diff_state_after.is_same
 
     client_low_ds.refresh()
@@ -177,10 +177,10 @@ def test_diff_state_with_dataset(low_worker: Worker, high_worker: Worker):
         from_client=high_client, to_client=low_client
     )
 
-    high_state = high_client.get_sync_state()
-    low_state = high_client.get_sync_state()
-    assert high_state.get_previous_state_diff().is_same
-    assert low_state.get_previous_state_diff().is_same
+    # high_state = high_client.get_sync_state()
+    # low_state = high_client.get_sync_state()
+    # assert high_state.get_previous_state_diff().is_same
+    # assert low_state.get_previous_state_diff().is_same
     assert diff_state_after.is_same
 
     client_low_ds.refresh()

--- a/packages/syft/tests/syft/settings/fixtures.py
+++ b/packages/syft/tests/syft/settings/fixtures.py
@@ -73,7 +73,7 @@ def metadata_json(faker) -> ServerMetadataJSON:
         server_side_type=ServerSideType.LOW_SIDE.value,
         show_warnings=False,
         server_type=ServerType.DATASITE.value,
-        min_size_blob_storage_mb=0,
+        min_size_blob_storage_mb=1,
     )
 
 

--- a/packages/syft/tests/syft/settings/fixtures.py
+++ b/packages/syft/tests/syft/settings/fixtures.py
@@ -73,7 +73,7 @@ def metadata_json(faker) -> ServerMetadataJSON:
         server_side_type=ServerSideType.LOW_SIDE.value,
         show_warnings=False,
         server_type=ServerType.DATASITE.value,
-        min_size_blob_storage_mb=16,
+        min_size_blob_storage_mb=0,
     )
 
 


### PR DESCRIPTION
## Description
- Set MIN_SIZE_BLOB_STORAGE_MB to 1 (from 16) to reduce db performance impact
- Do not save items and permissions in the database when making the syncstate snapshot, to avoid mongo size issues + improve performance
- always clear result cache on job_stash.set_result, we should never save cache in db unless its a non-blobstorage actionobject

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
