### PR TITLE
Enable mypy type checking for DictTuple

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,7 +150,6 @@ repos:
         name: "mypy: syft"
         always_run: true
         files: "^packages/syft/src/syft/"
-        exclude: "packages/syft/src/syft/types/dicttuple.py"
         args: [
             "--follow-imports=skip",
             "--ignore-missing-imports",

--- a/packages/syft/src/syft/protocol/protocol_version.json
+++ b/packages/syft/src/syft/protocol/protocol_version.json
@@ -23,6 +23,13 @@
           "hash": "cf6c1cb55d569af9823d8541ca038806bd350450a919345244ed4f432a099f34",
           "action": "add"
         }
+      },
+      "DatasetPageView": {
+        "2": {
+          "version": 2,
+          "hash": "be1ca6dcd0b3aa0481ce5dce737e78432d06a78ad0c701aaf136be407c798352",
+          "action": "add"
+        }
       }
     }
   }

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -26,6 +26,7 @@ from ...types.datetime import DateTime
 from ...types.dicttuple import DictTuple
 from ...types.syft_object import PartialSyftObject
 from ...types.syft_object import SYFT_OBJECT_VERSION_1
+from ...types.syft_object import SYFT_OBJECT_VERSION_2
 from ...types.syft_object import SyftObject
 from ...types.transforms import TransformContext
 from ...types.transforms import generate_id
@@ -596,6 +597,16 @@ def _check_asset_must_contain_mock(asset_list: list[CreateAsset]) -> None:
 
 @serializable()
 class DatasetPageView(SyftObject):
+    # version
+    __canonical_name__ = "DatasetPageView"
+    __version__ = SYFT_OBJECT_VERSION_2
+
+    datasets: DictTuple[str, Dataset]
+    total: int
+
+
+@serializable()
+class DatasetPageViewV1(SyftObject):
     # version
     __canonical_name__ = "DatasetPageView"
     __version__ = SYFT_OBJECT_VERSION_1

--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -597,7 +597,6 @@ def _check_asset_must_contain_mock(asset_list: list[CreateAsset]) -> None:
 
 @serializable()
 class DatasetPageView(SyftObject):
-    # version
     __canonical_name__ = "DatasetPageView"
     __version__ = SYFT_OBJECT_VERSION_2
 
@@ -607,7 +606,6 @@ class DatasetPageView(SyftObject):
 
 @serializable()
 class DatasetPageViewV1(SyftObject):
-    # version
     __canonical_name__ = "DatasetPageView"
     __version__ = SYFT_OBJECT_VERSION_1
 
@@ -617,7 +615,6 @@ class DatasetPageViewV1(SyftObject):
 
 @serializable()
 class CreateDataset(Dataset):
-    # version
     __canonical_name__ = "CreateDataset"
     __version__ = SYFT_OBJECT_VERSION_1
     asset_list: list[CreateAsset] = []

--- a/packages/syft/src/syft/service/dataset/dataset_service.py
+++ b/packages/syft/src/syft/service/dataset/dataset_service.py
@@ -143,7 +143,7 @@ class DatasetService(AbstractService):
         name: str,
         page_size: int | None = 0,
         page_index: int | None = 0,
-    ) -> DatasetPageView | SyftError:
+    ) -> DatasetPageView | DictTuple[str, Dataset] | SyftError:
         """Search a Dataset by name"""
         results = self.get_all(context)
 

--- a/packages/syft/src/syft/types/dicttuple.py
+++ b/packages/syft/src/syft/types/dicttuple.py
@@ -244,6 +244,13 @@ class DictTuple(tuple[_VT, ...], Generic[_KT, _VT], metaclass=_Meta):
     def items(self) -> Iterable[tuple[_KT, _VT]]:
         return zip(self.__mapping.keys(), self)
 
+    # https://docs.pydantic.dev/latest/concepts/types/#handling-custom-generic-classes
+    # pydantic validator
+    # this enables annotating a field with DictTuple[K, V] instead of just DictTuple
+    # inside a pydantic BaseModel, e.g.
+    #
+    # class DatasetPageView(BaseModel):
+    #     datasets: DictTuple[str, Dataset]
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
@@ -266,6 +273,10 @@ class DictTuple(tuple[_VT, ...], Generic[_KT, _VT], metaclass=_Meta):
             handler(v)
             return v
 
+        # pydantic validator for DictTuple[K, V]
+        # - check that object has type DictTuple
+        # - check that object is a tuple[V]
+        # - check that the keys have type K
         return core_schema.chain_schema(
             [
                 core_schema.is_instance_schema(cls),

--- a/packages/syft/src/syft/types/dicttuple.py
+++ b/packages/syft/src/syft/types/dicttuple.py
@@ -256,7 +256,7 @@ class DictTuple(tuple[_VT, ...], Generic[_KT, _VT], metaclass=_Meta):
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
         origin = get_origin(source_type)
-        if origin is None:  # used as `x: Owner` without params
+        if origin is None:
             origin = source_type
             kt, vt = (Any, Any)
         else:

--- a/packages/syft/src/syft/types/dicttuple.py
+++ b/packages/syft/src/syft/types/dicttuple.py
@@ -1,4 +1,5 @@
 # stdlib
+from abc import ABCMeta
 from collections import OrderedDict
 from collections import deque
 from collections.abc import Callable
@@ -18,10 +19,11 @@ from typing import overload
 # third party
 from pydantic import GetCoreSchemaHandler
 from pydantic import ValidatorFunctionWrapHandler
+from pydantic_core import CoreSchema
 from pydantic_core import core_schema
 from typing_extensions import Self
 
-_T = TypeVar("_T")
+_T = TypeVar("_T", bound="DictTuple")
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
 
@@ -46,27 +48,27 @@ _VT = TypeVar("_VT")
 # to customize the way __new__ and __init__ work together, by iterating over key_value_pairs
 # once to extract both keys and values, then passing keys to __new__, values to __init__
 # within the same function call.
-class _Meta(type):
+class _Meta(ABCMeta):
     @overload
-    def __call__(cls: type[_T]) -> _T: ...
+    def __call__(cls: type[_T], /) -> _T: ...  # type: ignore[misc]
 
     @overload
-    def __call__(cls: type[_T], __value: Iterable[tuple[_KT, _VT]]) -> _T: ...
+    def __call__(cls: type[_T], __value: Iterable[tuple[_KT, _VT]], /) -> _T: ...  # type: ignore[misc]
 
     @overload
-    def __call__(cls: type[_T], __value: Mapping[_KT, _VT]) -> _T: ...
+    def __call__(cls: type[_T], __value: Mapping[_KT, _VT], /) -> _T: ...  # type: ignore[misc]
 
     @overload
-    def __call__(
-        cls: type[_T], __value: Iterable[_VT], __key: Collection[_KT]
+    def __call__(  # type: ignore[misc]
+        cls: type[_T], __value: Iterable[_VT], __key: Collection[_KT], /
     ) -> _T: ...
 
     @overload
-    def __call__(
-        cls: type[_T], __value: Iterable[_VT], __key: Callable[[_VT], _KT]
+    def __call__(  # type: ignore[misc]
+        cls: type[_T], __value: Iterable[_VT], __key: Callable[[_VT], _KT], /
     ) -> _T: ...
 
-    def __call__(
+    def __call__(  # type: ignore[misc]
         cls: type[_T],
         __value: Iterable | None = None,
         __key: Callable | Collection | None = None,
@@ -75,7 +77,7 @@ class _Meta(type):
         # DictTuple()
         if __value is None and __key is None:
             obj = cls.__new__(cls)
-            obj.__init__()
+            obj.__init__()  # type: ignore[misc]
             return obj
 
         # DictTuple(DictTuple(...))
@@ -85,27 +87,27 @@ class _Meta(type):
         # DictTuple({"x": 123, "y": 456})
         elif isinstance(__value, Mapping) and __key is None:
             obj = cls.__new__(cls, __value.values())
-            obj.__init__(__value.keys())
+            obj.__init__(__value.keys())  # type: ignore[misc]
 
             return obj
 
         # DictTuple(EnhancedDictTuple(...))
         # EnhancedDictTuple(DictTuple(...))
         # where EnhancedDictTuple subclasses DictTuple
-        elif hasattr(__value, "items") and callable(__value.items):
-            return cls.__call__(__value.items())
+        elif callable(__value_items := getattr(__value, "items", None)):
+            return cls.__call__(__value_items())
 
         # DictTuple([("x", 123), ("y", 456)])
         elif isinstance(__value, Iterable) and __key is None:
             keys = OrderedDict()
-            values = deque()
+            values: deque = deque()
 
             for i, (k, v) in enumerate(__value):
                 keys[k] = i
                 values.append(v)
 
             obj = cls.__new__(cls, values)
-            obj.__init__(keys)
+            obj.__init__(keys)  # type: ignore[misc]
 
             return obj
 
@@ -114,15 +116,15 @@ class _Meta(type):
             keys = OrderedDict((k, i) for i, k in enumerate(__key))
 
             obj = cls.__new__(cls, __value)
-            obj.__init__(keys)
+            obj.__init__(keys)  # type: ignore[misc]
 
             return obj
 
         # DictTuple(["abc", "xyz"], lambda x: x[0])
         # equivalent to DictTuple({"a": "abc", "x": "xyz"})
         elif isinstance(__value, Iterable) and isinstance(__key, Callable):
-            obj = cls.__new__(cls, __value)
-            obj.__init__(__key)
+            obj = cls.__new__(cls, __value)  # type: ignore[misc]
+            obj.__init__(__key)  # type: ignore[misc]
 
             return obj
 
@@ -171,21 +173,23 @@ class DictTuple(tuple[_VT, ...], Generic[_KT, _VT], metaclass=_Meta):
 
     # These overloads are copied from _Meta.__call__ just for IDE hints
     @overload
-    def __init__(self) -> None: ...
+    def __init__(self, /) -> None: ...
 
     @overload
-    def __init__(self, __value: Iterable[tuple[_KT, _VT]]) -> None: ...
+    def __init__(self, __value: Iterable[tuple[_KT, _VT]], /) -> None: ...
 
     @overload
-    def __init__(self, __value: Mapping[_KT, _VT]) -> None: ...
+    def __init__(self, __value: Mapping[_KT, _VT], /) -> None: ...
 
     @overload
-    def __init__(self, __value: Iterable[_VT], __key: Collection[_KT]) -> None: ...
+    def __init__(self, __value: Iterable[_VT], __key: Collection[_KT], /) -> None: ...
 
     @overload
-    def __init__(self, __value: Iterable[_VT], __key: Callable[[_VT], _KT]) -> None: ...
+    def __init__(
+        self, __value: Iterable[_VT], __key: Callable[[_VT], _KT], /
+    ) -> None: ...
 
-    def __init__(self, __value=None, /):
+    def __init__(self, __value: Any = None, /) -> None:  # type: ignore[misc]
         if isinstance(__value, MappingProxyType):
             self.__mapping = __value
         elif isinstance(__value, Mapping):
@@ -210,16 +214,16 @@ class DictTuple(tuple[_VT, ...], Generic[_KT, _VT], metaclass=_Meta):
                 "or implement `__index__()`"
             )
 
-    @overload
-    def __getitem__(self, __key: _KT) -> _VT: ...
+    @overload  # type: ignore[override]
+    def __getitem__(self, __key: _KT, /) -> _VT: ...
+
+    @overload  # type: ignore[overload-overlap]
+    def __getitem__(self, __key: slice, /) -> Self: ...
 
     @overload
-    def __getitem__(self, __key: slice) -> Self: ...
+    def __getitem__(self, __key: SupportsIndex, /) -> _VT: ...
 
-    @overload
-    def __getitem__(self, __key: SupportsIndex) -> _VT: ...
-
-    def __getitem__(self, __key, /):
+    def __getitem__(self, __key: _KT | slice | SupportsIndex, /) -> _VT | Self:
         if isinstance(__key, slice):
             return self.__class__(
                 super().__getitem__(__key),
@@ -243,7 +247,7 @@ class DictTuple(tuple[_VT, ...], Generic[_KT, _VT], metaclass=_Meta):
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
-    ):
+    ) -> CoreSchema:
         origin = get_origin(source_type)
         if origin is None:  # used as `x: Owner` without params
             origin = source_type

--- a/packages/syft/src/syft/util/patch_ipython.py
+++ b/packages/syft/src/syft/util/patch_ipython.py
@@ -78,8 +78,8 @@ def _patch_ipython_sanitization() -> None:
     escaped_itable_template = re.compile(itable_template, re.DOTALL)
 
     def display_sanitized_html(obj: SyftObject | DictTuple) -> str | None:
-        if callable(getattr(obj, "_repr_html_", None)):
-            html_str = obj._repr_html_()
+        if callable(obj_repr_html_ := getattr(obj, "_repr_html_", None)):
+            html_str = obj_repr_html_()
             if html_str is not None:
                 # find matching table and jobs
                 matching_table = escaped_template.findall(html_str)


### PR DESCRIPTION
- Fix typing and enable mypy type checking for `DictTuple`.
- Enable annotating a field with `DictTuple[K, V]` (instead of just DictTuple) inside a `pydantic.BaseModel`, e.g.
    ```py
    class DatasetCollection(BaseModel):
        datasets: DictTuple[str, Dataset]
    ```
    by specifying a [custom validator](https://docs.pydantic.dev/latest/concepts/types/#handling-custom-generic-classes) for `DictTuple`. 