### PR TITLE
Checking dataset upload perms earlier in the endpoint

### DIFF
--- a/packages/syft/src/syft/client/datasite_client.py
+++ b/packages/syft/src/syft/client/datasite_client.py
@@ -31,6 +31,7 @@ from ..service.response import SyftWarning
 from ..service.sync.diff_state import ResolvedSyncState
 from ..service.sync.sync_state import SyncState
 from ..service.user.roles import Roles
+from ..service.user.user import ServiceRole
 from ..service.user.user import UserView
 from ..types.blob_storage import BlobFile
 from ..types.uid import UID
@@ -103,6 +104,8 @@ class DatasiteClient(SyftClient):
             return SyftError(f"can't get user service for {self}")
 
         user = self.users.get_current_user()
+        if user.role not in [ServiceRole.DATA_OWNER, ServiceRole.ADMIN]:
+            return SyftError(message="You don't have permission to upload datasets.")
         dataset = add_default_uploader(user, dataset)
         for i in range(len(dataset.asset_list)):
             asset = dataset.asset_list[i]

--- a/packages/syft/tests/syft/api_test.py
+++ b/packages/syft/tests/syft/api_test.py
@@ -3,11 +3,10 @@ from collections.abc import Callable
 
 # third party
 import numpy as np
-import pytest
 
 # syft absolute
 import syft as sy
-from syft.service.response import SyftAttributeError
+from syft.service.response import SyftError
 from syft.service.user.user_roles import ServiceRole
 
 
@@ -58,8 +57,7 @@ def test_api_cache_invalidation_login(root_verify_key, worker):
     dataset = sy.Dataset(
         name="test2",
     )
-    with pytest.raises(SyftAttributeError):
-        assert guest_client.upload_dataset(dataset)
+    assert isinstance(guest_client.upload_dataset(dataset), SyftError)
 
     assert guest_client.api.services.user.update(uid=user_id, name="abcdef")
 


### PR DESCRIPTION
Fixes [1710](https://github.com/OpenMined/Heartbeat/issues/1710)

Before: 

![Screenshot 2024-08-06 at 11 21 23 AM](https://github.com/user-attachments/assets/5e65b6f5-85ba-4cba-8075-7ab9aa0c491d)

After: 
![Screenshot 2024-08-06 at 11 22 32 AM](https://github.com/user-attachments/assets/f5c0bb49-55e2-4073-a558-65db13890a1d)
