### PR TITLE
Show input policy constant values in UserCode display within sync widget.

### DIFF
--- a/packages/syft/src/syft/service/sync/diff_state.py
+++ b/packages/syft/src/syft/service/sync/diff_state.py
@@ -50,6 +50,7 @@ from ..job.job_stash import Job
 from ..job.job_stash import JobType
 from ..log.log import SyftLog
 from ..output.output_service import ExecutionOutput
+from ..policy.policy import Constant
 from ..request.request import Request
 from ..response import SyftError
 from ..response import SyftSuccess
@@ -367,6 +368,14 @@ class ObjectDiff(SyftObject):  # StateTuple (compare 2 objects)
         for attr in repr_attrs:
             value = getattr(obj, attr)
             res[attr] = value
+
+        # if there are constants in UserCode input policy, add to repr
+        # type ignores since mypy thinks the code is unreachable for some reason
+        if isinstance(obj, UserCode) and obj.input_policy_init_kwargs is not None:  # type: ignore
+            for input_policy_kwarg in obj.input_policy_init_kwargs.values():  # type: ignore
+                for input_val in input_policy_kwarg.values():
+                    if isinstance(input_val, Constant):
+                        res[input_val.kw] = input_val.val
         return res
 
     def diff_attributes_str(self, side: str) -> str:


### PR DESCRIPTION
## Description
Add Constant input policy values to UserCode display in sync widget.

![Screenshot 2024-08-07 at 5 07 20 PM](https://github.com/user-attachments/assets/d3d90f5d-f605-491e-a6ae-9e7843ae9d5a)

Closes https://github.com/OpenMined/Heartbeat/issues/1633.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [] My changes are covered by tests
