### PR TITLE
Fix Inconsistent use of UTC time in DateTime class

### DIFF
--- a/packages/syft/src/syft/service/dataset/dataset.py
+++ b/packages/syft/src/syft/service/dataset/dataset.py
@@ -134,8 +134,12 @@ class Asset(SyftObject):
         else:
             private_data_obj = private_data_res.ok_value
             if isinstance(private_data_obj, ActionObject):
-                df = pd.DataFrame(self.data.syft_action_data)
-                data_table_line = itable_template_from_df(df=private_data_obj.head(5))
+                if isinstance(private_data_obj.syft_action_data, ActionDataEmpty):
+                    data_table_line = "No data"
+                else:
+                    df = pd.DataFrame(self.data.syft_action_data)
+                    data_table_line = itable_template_from_df(df=df.head(5))
+
             elif isinstance(private_data_obj, pd.DataFrame):
                 data_table_line = itable_template_from_df(df=private_data_obj.head(5))
             else:
@@ -146,8 +150,11 @@ class Asset(SyftObject):
                     data_table_line = private_data_res.ok_value
 
         if isinstance(self.mock, ActionObject):
-            df = pd.DataFrame(self.mock.syft_action_data)
-            mock_table_line = itable_template_from_df(df=df.head(5))
+            if isinstance(self.mock.syft_action_data, ActionDataEmpty):
+                mock_table_line = "No data"
+            else:
+                df = pd.DataFrame(self.mock.syft_action_data)
+                mock_table_line = itable_template_from_df(df=df.head(5))
         elif isinstance(self.mock, pd.DataFrame):
             mock_table_line = itable_template_from_df(df=self.mock.head(5))
         else:

--- a/packages/syft/src/syft/types/datetime.py
+++ b/packages/syft/src/syft/types/datetime.py
@@ -1,6 +1,7 @@
 # stdlib
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from functools import total_ordering
 import re
 from typing import Any
@@ -33,23 +34,26 @@ class DateTime(SyftObject):
 
     @classmethod
     def now(cls) -> Self:
-        return cls(utc_timestamp=datetime.utcnow().timestamp())
+        utc_datetime = datetime.now(tz=timezone.utc)
+        return cls(utc_timestamp=utc_datetime.timestamp())
 
     @classmethod
     def from_str(cls, datetime_str: str) -> "DateTime":
-        dt = datetime.strptime(datetime_str, DATETIME_FORMAT)
-        return cls(utc_timestamp=dt.timestamp())
+        utc_datetime = datetime.strptime(datetime_str, DATETIME_FORMAT).replace(
+            tzinfo=timezone.utc
+        )
+        return cls(utc_timestamp=utc_datetime.timestamp())
 
     def __str__(self) -> str:
-        utc_datetime = datetime.utcfromtimestamp(self.utc_timestamp)
+        utc_datetime = datetime.fromtimestamp(self.utc_timestamp, tz=timezone.utc)
         return utc_datetime.strftime(DATETIME_FORMAT)
 
     def __hash__(self) -> int:
         return hash(self.utc_timestamp)
 
-    def __sub__(self, other: "DateTime") -> "DateTime":
-        res = self.utc_timestamp - other.utc_timestamp
-        return DateTime(utc_timestamp=res)
+    def __sub__(self, other: "DateTime") -> timedelta:
+        res = self.timedelta(other)
+        return res
 
     def __eq__(self, other: Any) -> bool:
         if other is None:

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -8,8 +8,8 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from collections.abc import Set
 from datetime import datetime
-from datetime import timezone
 from datetime import timedelta
+from datetime import timezone
 from functools import cache
 from functools import total_ordering
 from hashlib import sha256

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from collections.abc import Set
 from datetime import datetime
+from datetime import timezone
+from datetime import timedelta
 from functools import cache
 from functools import total_ordering
 from hashlib import sha256
@@ -324,18 +326,18 @@ class BaseDateTime(SyftObjectVersioned):
 
     @classmethod
     def now(cls) -> Self:
-        return cls(utc_timestamp=datetime.utcnow().timestamp())
+        return cls(utc_timestamp=datetime.now(timezone.utc).timestamp())
 
     def __str__(self) -> str:
-        utc_datetime = datetime.utcfromtimestamp(self.utc_timestamp)
+        utc_datetime = datetime.fromtimestamp(self.utc_timestamp, tz=timezone.utc)
         return utc_datetime.strftime("%Y-%m-%d %H:%M:%S")
 
     def __hash__(self) -> int:
         return hash(self.utc_timestamp)
 
-    def __sub__(self, other: Self) -> Self:
-        res = self.utc_timestamp - other.utc_timestamp
-        return BaseDateTime(utc_timestamp=res)
+    def __sub__(self, other: Self) -> timedelta:
+        res = timedelta(seconds=self.utc_timestamp - other.utc_timestamp)
+        return res
 
     def __eq__(self, other: Any) -> bool:
         if other is None:


### PR DESCRIPTION
## Description
Main change is to update the DateTime class to treat timezone consistently as UTC to avoid some inconsistencies between the use of UTC and local time.

Other minor updates:
- replace use of utctimestamp, utcnow functions in DateTime, BaseDateTime classes
- update sub op of DateTime / BaseDateTime to return timedelta instead of DateTime (not sure if it made sense before or was even being used)
- fixed Asset repr when either private or mock data was empty action object (noticed incidentally trying to replicate bug)

Closes https://github.com/OpenMined/Heartbeat/issues/1475.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Tested in notebook to make sure times / delta were correct in syncing widget.

## Checklist
- [] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
