### PR TITLE
L2 flow fixes

### DIFF
--- a/packages/syft/src/syft/service/job/job_stash.py
+++ b/packages/syft/src/syft/service/job/job_stash.py
@@ -862,9 +862,6 @@ class JobStash(BaseUIDStoreStash):
         if valid.is_err():
             return SyftError(message=valid.err())
 
-        # stdlib
-        import sys
-
         # Ensure we never save cached result data in the database,
         # as they can be arbitrarily large
         if (
@@ -872,11 +869,6 @@ class JobStash(BaseUIDStoreStash):
             and item.result.syft_blob_storage_entry_id is not None
         ):
             item.result._clear_cache()
-
-        print(
-            f"(CACHE CLEARED) SETTING RESULT {item.result} for job {item.id}",
-            file=sys.stderr,
-        )
 
         return super().update(credentials, item, add_permissions)
 

--- a/packages/syft/src/syft/service/job/job_stash.py
+++ b/packages/syft/src/syft/service/job/job_stash.py
@@ -156,9 +156,9 @@ class Job(SyncableSyftObject):
 
     @property
     def result_id(self) -> UID | None:
-        if self.result is None:
-            return None
-        return self.result.id.id
+        if isinstance(self.result, ActionObject):
+            return self.result.id.id
+        return None
 
     @property
     def action_display_name(self) -> str:
@@ -862,6 +862,9 @@ class JobStash(BaseUIDStoreStash):
         if valid.is_err():
             return SyftError(message=valid.err())
 
+        # stdlib
+        import sys
+
         # Ensure we never save cached result data in the database,
         # as they can be arbitrarily large
         if (
@@ -869,6 +872,11 @@ class JobStash(BaseUIDStoreStash):
             and item.result.syft_blob_storage_entry_id is not None
         ):
             item.result._clear_cache()
+
+        print(
+            f"(CACHE CLEARED) SETTING RESULT {item.result} for job {item.id}",
+            file=sys.stderr,
+        )
 
         return super().update(credentials, item, add_permissions)
 

--- a/packages/syft/src/syft/service/output/output_service.py
+++ b/packages/syft/src/syft/service/output/output_service.py
@@ -116,7 +116,7 @@ class ExecutionOutput(SyncableSyftObject):
         else:
             job_link = None
 
-        if input_ids:
+        if input_ids is not None:
             input_ids = {k: v for k, v in input_ids.items() if isinstance(v, UID)}
         return cls(
             output_ids=output_ids,

--- a/packages/syft/src/syft/service/output/output_service.py
+++ b/packages/syft/src/syft/service/output/output_service.py
@@ -115,6 +115,9 @@ class ExecutionOutput(SyncableSyftObject):
             )
         else:
             job_link = None
+
+        if input_ids:
+            input_ids = {k: v for k, v in input_ids.items() if isinstance(v, UID)}
         return cls(
             output_ids=output_ids,
             user_code_link=user_code_link,

--- a/packages/syft/src/syft/service/policy/policy.py
+++ b/packages/syft/src/syft/service/policy/policy.py
@@ -276,7 +276,13 @@ class Constant(PolicyRule):
         return Ok(self.val)
 
     def _get_dict_for_user_code_repr(self) -> dict[str, Any]:
-        return {"val": str(self.val), "type": self.klass.__qualname__}
+        return self._coll_repr_()
+
+    def _coll_repr_(self) -> dict[str, Any]:
+        return {
+            "klass": self.klass.__qualname__,
+            "val": str(self.val),
+        }
 
 
 @serializable()

--- a/packages/syft/src/syft/service/policy/policy.py
+++ b/packages/syft/src/syft/service/policy/policy.py
@@ -275,6 +275,9 @@ class Constant(PolicyRule):
                     return Ok(obj.syft_action_data)
         return Ok(self.val)
 
+    def _get_dict_for_user_code_repr(self) -> dict[str, Any]:
+        return {"val": str(self.val), "type": self.klass.__qualname__}
+
 
 @serializable()
 class UserOwned(PolicyRule):

--- a/packages/syft/src/syft/service/request/request.py
+++ b/packages/syft/src/syft/service/request/request.py
@@ -792,6 +792,8 @@ class Request(SyncableSyftObject):
         if input_policy is not None:
             for input_ in input_policy.inputs.values():
                 input_ids.update(input_)
+
+        input_ids = {k: v for k, v in input_ids.items() if isinstance(v, UID)}
         res = api.services.code.store_execution_output(
             user_code_id=code.id,
             outputs=result,
@@ -1088,6 +1090,7 @@ class Request(SyncableSyftObject):
                 for inps in code.input_policy.inputs.values():
                     input_ids.update(inps)
 
+            input_ids = {k: v for k, v in input_ids.items() if isinstance(v, UID)}
             res = api.services.code.store_execution_output(
                 user_code_id=code.id,
                 outputs=result,
@@ -1104,7 +1107,13 @@ class Request(SyncableSyftObject):
             else JobStatus.COMPLETED
         )
 
-        existing_result = job.result.id if job.result is not None else None
+        existing_result = None
+        if isinstance(job.result, ActionObject):
+            existing_result = job.result.id
+        elif isinstance(job.result, Err):
+            existing_result = job.result
+        else:
+            existing_result = job.result
         print(
             f"Job({job.id}) Setting new result {existing_result} -> {job_info.result.id}"
         )


### PR DESCRIPTION
## Description
Various fixes for L2 deposit_result flow

Fixes:
- Calling deposit_result on L2 request throws exception when input policy contains constants
- `ds_client.code.my_func(blocking=False)` starts a job that never finishes
    - new behaviour: job is started and errors because: not approved.
    - This is a quickfix. open issue: https://github.com/OpenMined/Heartbeat/issues/1750
- Custom API endpoint job that errors never finishes
    - Same as previous item
- usercode repr exception when input policy contains constants.
    - new behaviour:

![image](https://github.com/user-attachments/assets/3c2195ea-6b36-49b2-a83c-33e9cfb55d20)
 
Not fixed:
- when DS runs custom endpoint with `blocking=False`, a new job is created instead of retrieving existing job from cache
- New job.result contains unexpected datastructure with `CachedSyftObject`
    - To get result, have to call `job.result.result` 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
