### PR TITLE
Use torch 2.2.2

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -88,7 +88,7 @@ data_science =
     evaluate==0.4.2
     recordlinkage==0.16
     # backend.dockerfile installs torch separately, so update the version over there as well!
-    torch==2.3.1
+    torch==2.2.2
 
 dev =
     %(test_plugins)s


### PR DESCRIPTION
Torch 2.3.1 breaks syft installation for Mac with intel chips, as reported by @koenvanderveen.