### PR TITLE
[WIP] - Adding Bigquery notebooks to cicd

### DIFF
--- a/.github/workflows/pr-tests-syft.yml
+++ b/.github/workflows/pr-tests-syft.yml
@@ -188,6 +188,30 @@ jobs:
           max_attempts: 3
           command: tox -e syft.test.notebook
 
+      # Create the settings.yaml file for the bigquery notebook config
+      - name: Create settings.yaml
+        if: steps.changes.outputs.syft == 'true' || steps.changes.outputs.notebooks == 'true'
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/notebooks/scenarios/bigquery
+          cat <<EOF > ${GITHUB_WORKSPACE}/notebooks/scenarios/bigquery/settings.yaml
+          default:
+            gce_region: "${{ secrets.TEST_GCE_REGION }}"
+            gce_project_id: "${{ secrets.TEST_GCE_PROJECT_ID }}"
+            gce_service_account: '${{ secrets.TEST_GCE_SERVICE_ACCOUNT }}'
+            external_registry: "${{ secrets.TEST_EXTERNAL_REGISTRY }}"
+            dataset_1: "${{ secrets.TEST_DATASET_1 }}"
+            dataset_2: "${{ secrets.TEST_DATASET_2 }}"
+            table_1: "${{ secrets.TEST_TABLE_1 }}"
+            table_2: "${{ secrets.TEST_TABLE_2 }}"
+            table_2_col_id: "${{ secrets.TEST_TABLE_2_COL_ID }}"
+            table_2_col_score: "${{ secrets.TEST_TABLE_2_COL_SCORE }}"
+          EOF
+        
+      - name: Run Bigquery Scenario Notebooks
+        if: steps.changes.outputs.syft == 'true' || steps.changes.outputs.notebooks == 'true'
+        run: |
+          tox -e syft.test.notebook.scenario
+
   pr-tests-syft-notebook-single-container:
     strategy:
       max-parallel: 99

--- a/.github/workflows/pr-tests-syft.yml
+++ b/.github/workflows/pr-tests-syft.yml
@@ -206,7 +206,7 @@ jobs:
             table_2_col_id: "${{ secrets.TEST_TABLE_2_COL_ID }}"
             table_2_col_score: "${{ secrets.TEST_TABLE_2_COL_SCORE }}"
           EOF
-        
+
       - name: Run Bigquery Scenario Notebooks
         if: steps.changes.outputs.syft == 'true' || steps.changes.outputs.notebooks == 'true'
         run: |

--- a/.github/workflows/pr-tests-syft.yml
+++ b/.github/workflows/pr-tests-syft.yml
@@ -207,6 +207,29 @@ jobs:
             table_2_col_score: "${{ secrets.TEST_TABLE_2_COL_SCORE }}"
           EOF
 
+      # Check if the settings.yaml file is created
+      - name: Check settings.yaml existence
+        if: steps.changes.outputs.syft == 'true' || steps.changes.outputs.notebooks == 'true'
+        run: |
+          if [ ! -f ${GITHUB_WORKSPACE}/notebooks/scenarios/bigquery/settings.yaml ]; then
+            echo "Error: settings.yaml file not found!"
+            exit 1
+          fi
+          echo "settings.yaml file found."
+
+      # Verify the content of the settings.yaml file
+      - name: Validate settings.yaml content
+        if: steps.changes.outputs.syft == 'true' || steps.changes.outputs.notebooks == 'true'
+        run: |
+          required_keys=("gce_region" "gce_project_id" "gce_service_account" "external_registry" "dataset_1" "dataset_2" "table_1" "table_2" "table_2_col_id" "table_2_col_score")
+          for key in "${required_keys[@]}"; do
+            if ! grep -q "$key" ${GITHUB_WORKSPACE}/notebooks/scenarios/bigquery/settings.yaml; then
+              echo "Error: $key not found in settings.yaml!"
+              exit 1
+            fi
+          done
+          echo "All required keys are present in settings.yaml."
+
       - name: Run Bigquery Scenario Notebooks
         if: steps.changes.outputs.syft == 'true' || steps.changes.outputs.notebooks == 'true'
         run: |


### PR DESCRIPTION
Working on part of https://github.com/OpenMined/Heartbeat/issues/1771

Adding on the `tox -e syft.test.notebook.scenario` (currently only python in-memory workers test; k8s will be done in https://github.com/OpenMined/Heartbeat/issues/1770)
- Added Bigquery notebooks tests to `pr-tests-syft.yml` 



Mindmap of the testing suite w.r.t Bigquery scenario notebooks
- Nightlies runs `pr-tests-syft.yml`
- Pre-release runs `pr-tests-syft.yml`
- Post-release only runs the k8s version of tests

When the PR for the notebooks to run over K8s is up, it should add the test to pr-tests-notebook-k8s in `pr-tests-stack.yml` (either in tox -e syft.test.helm or a new tox command called `tox -e syft.test.notebook.scenario.k8s` as suggested by Madhava).

