### PR TITLE
FIX URL in setup.cfg to point to Documentation page

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -7,7 +7,7 @@ author_email = info@openmined.org
 license = Apache-2.0
 long_description = file: PYPI.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
-url = https://openmined.github.io/PySyft/
+url = https://docs.openmined.org
 project_urls =
     Source=https://github.com/OpenMined/PySyft
     Tracker=https://github.com/OpenMined/PySyft/issues


### PR DESCRIPTION
Hot fix of the `url` directive in `setup.cfg` to point to the official PySyft documentation
