### PR TITLE
Adding Scikit-learn as additional dependency in Data Science Setup Extra

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -85,7 +85,8 @@ data_science =
     transformers==4.41.2
     opendp==0.9.2
     evaluate==0.4.2
-    recordlinkage==0.16
+    # recordlinkage==0.16
+    scikit-learn==1.5.1
     # backend.dockerfile installs torch separately, so update the version over there as well!
     torch==2.2.2
 


### PR DESCRIPTION
Scikit-learn is necessary to complete the (full) getting started tutorial that we feature in the documentation.

Moreover, recordlinkage has been tempoarily commented out as it is not required for documentation so far.
