### PR TITLE
Fix scary-looking wrong password error

### DIFF
--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -943,7 +943,6 @@ class SyftClient:
         except Exception as e:
             raise SyftException(public_message=str(e))
 
-
         signing_key = None if user_private_key is None else user_private_key.signing_key
 
         client = self.__class__(

--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -571,7 +571,7 @@ class PythonConnection(ServerConnection):
     def get_cache_key(self) -> str:
         return str(self.server.id)
 
-    def exchange_credentials(self, email: str, password: str) -> UserPrivateKey | None:
+    def exchange_credentials(self, email: str, password: str) -> SyftSuccess | None:
         context = self.server.get_unauthed_context(
             login_credentials=UserLoginCredentials(email=email, password=password)
         )
@@ -594,7 +594,7 @@ class PythonConnection(ServerConnection):
         password: str,
     ) -> SyftSigningKey | None:
         if self.proxy_target_uid:
-            obj = forward_message_to_proxy(
+            result = forward_message_to_proxy(
                 self.make_call,
                 proxy_target_uid=self.proxy_target_uid,
                 path="login",
@@ -602,8 +602,9 @@ class PythonConnection(ServerConnection):
             )
 
         else:
-            obj = self.exchange_credentials(email=email, password=password)
-        return obj
+            result = self.exchange_credentials(email=email, password=password)
+            result = post_process_result(result, unwrap_on_success=True)
+        return result
 
     def register(self, new_user: UserCreate) -> SyftSigningKey | None:
         if self.proxy_target_uid:

--- a/packages/syft/src/syft/client/client.py
+++ b/packages/syft/src/syft/client/client.py
@@ -392,7 +392,7 @@ class HTTPConnection(ServerConnection):
         else:
             response = self._make_post(self.routes.ROUTE_LOGIN.value, credentials)
             response = _deserialize(response, from_bytes=True)
-            response = post_process_result(response, unwrap_on_success=False)
+            response = post_process_result(response, unwrap_on_success=True)
 
         return response
 
@@ -941,7 +941,7 @@ class SyftClient:
         try:
             user_private_key = self.connection.login(email=email, password=password)
         except Exception as e:
-            raise SyftException(public_message=str(e))
+            raise SyftException(public_message=e.public_message)
 
         signing_key = None if user_private_key is None else user_private_key.signing_key
 

--- a/packages/syft/src/syft/server/routes.py
+++ b/packages/syft/src/syft/server/routes.py
@@ -228,16 +228,15 @@ def make_routes(worker: Worker) -> APIRouter:
         context = UnauthedServiceContext(
             server=server, login_credentials=login_credentials
         )
-        result = method(context=context)
-
-        if isinstance(result, SyftError):
-            logger.error(f"Login Error: {result.message}. user={email}")
-            response = result
-        else:
-            user_private_key = result
-            if not isinstance(user_private_key, UserPrivateKey):
-                raise Exception(f"Incorrect return type: {type(user_private_key)}")
-            response = user_private_key
+        try:
+            result = method(context=context).value
+            if not isinstance(result, UserPrivateKey):
+                response = SyftError(message=f"Incorrect return type: {type(result)}")
+            else:
+                response = result 
+        except SyftException as e:
+            logger.error(f"Login Error: {e}. user={email}")
+            response = SyftError(message=f"{e.public_message}")
 
         return Response(
             serialize(response, to_bytes=True),

--- a/packages/syft/src/syft/server/routes.py
+++ b/packages/syft/src/syft/server/routes.py
@@ -233,7 +233,7 @@ def make_routes(worker: Worker) -> APIRouter:
             if not isinstance(result, UserPrivateKey):
                 response = SyftError(message=f"Incorrect return type: {type(result)}")
             else:
-                response = result 
+                response = result
         except SyftException as e:
             logger.error(f"Login Error: {e}. user={email}")
             response = SyftError(message=f"{e.public_message}")

--- a/packages/syft/src/syft/service/user/user_service.py
+++ b/packages/syft/src/syft/service/user/user_service.py
@@ -564,12 +564,14 @@ class UserService(AbstractService):
                 and user.role == ServiceRole.ADMIN
             ):
                 # FIX: Replace with SyftException
-                raise SyftException(public_message=UserEnclaveAdminLoginError.public_message) 
+                raise SyftException(
+                    public_message=UserEnclaveAdminLoginError.public_message
+                )
         else:
             # FIX: Replace this below
             raise SyftException(public_message=CredentialsError.public_message)
 
-        return SyftSuccess(message="Login successful.",value=user.to(UserPrivateKey))
+        return SyftSuccess(message="Login successful.", value=user.to(UserPrivateKey))
 
     def admin_verify_key(self) -> SyftVerifyKey:
         # TODO: Remove passthrough method?

--- a/packages/syft/src/syft/service/user/user_service.py
+++ b/packages/syft/src/syft/service/user/user_service.py
@@ -545,7 +545,7 @@ class UserService(AbstractService):
 
         return uid
 
-    def exchange_credentials(self, context: UnauthedServiceContext) -> UserPrivateKey:
+    def exchange_credentials(self, context: UnauthedServiceContext) -> SyftSuccess:
         """Verify user
         TODO: We might want to use a SyftObject instead
         """
@@ -564,12 +564,12 @@ class UserService(AbstractService):
                 and user.role == ServiceRole.ADMIN
             ):
                 # FIX: Replace with SyftException
-                raise UserEnclaveAdminLoginError
+                raise SyftException(public_message=UserEnclaveAdminLoginError.public_message) 
         else:
             # FIX: Replace this below
-            raise CredentialsError
+            raise SyftException(public_message=CredentialsError.public_message)
 
-        return user.to(UserPrivateKey)
+        return SyftSuccess(message="Login successful.",value=user.to(UserPrivateKey))
 
     def admin_verify_key(self) -> SyftVerifyKey:
         # TODO: Remove passthrough method?

--- a/packages/syft/tests/syft/users/user_service_test.py
+++ b/packages/syft/tests/syft/users/user_service_test.py
@@ -714,8 +714,8 @@ def test_userservice_exchange_credentials(
     expected_user_private_key = guest_user.to(UserPrivateKey)
 
     response = user_service.exchange_credentials(unauthed_context)
-    assert isinstance(response, UserPrivateKey)
-    assert response == expected_user_private_key
+    assert isinstance(response.value, UserPrivateKey)
+    assert response.value == expected_user_private_key
 
 
 def test_userservice_exchange_credentials_invalid_user(

--- a/packages/syft/tests/syft/users/user_test.py
+++ b/packages/syft/tests/syft/users/user_test.py
@@ -282,7 +282,7 @@ def test_user_view_set_password(worker: Worker, root_client: DatasiteClient) -> 
     with pytest.raises(SyftException) as exc:
         worker.root_client.login(email=email, password="1234")
 
-    assert exc.type == CredentialsError
+    assert exc.type == SyftException 
     assert exc.value.public_message == "Invalid credentials."
 
     # log in again with the right password

--- a/packages/syft/tests/syft/users/user_test.py
+++ b/packages/syft/tests/syft/users/user_test.py
@@ -17,7 +17,6 @@ from syft.service.context import AuthedServiceContext
 from syft.service.user.user import ServiceRole
 from syft.service.user.user import UserCreate
 from syft.service.user.user import UserView
-from syft.types.errors import CredentialsError
 from syft.types.errors import SyftException
 
 GUEST_ROLES = [ServiceRole.GUEST]
@@ -282,7 +281,7 @@ def test_user_view_set_password(worker: Worker, root_client: DatasiteClient) -> 
     with pytest.raises(SyftException) as exc:
         worker.root_client.login(email=email, password="1234")
 
-    assert exc.type == SyftException 
+    assert exc.type == SyftException
     assert exc.value.public_message == "Invalid credentials."
 
     # log in again with the right password


### PR DESCRIPTION
## Description
Updates login to use new error handling which lets the Credentials Error pass through instead of a generic HTTP error. Makes the error more obvious on providing incorrect credentials for login.

![Screenshot 2024-08-30 at 2 47 58 PM](https://github.com/user-attachments/assets/f43b86e2-03da-4ccc-a2f7-1c67944d33bc)

Closes https://github.com/OpenMined/Heartbeat/issues/1798.
## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Updated unit tests
- Tested locally in notebook

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
