### PR TITLE
Temp fix tests by pinning ipython

### DIFF
--- a/packages/syft/setup.cfg
+++ b/packages/syft/setup.cfg
@@ -66,6 +66,7 @@ syft =
     jinja2==3.1.4
     tenacity==8.3.0
     nh3==0.2.17
+    ipython<8.27.0
 
 install_requires =
     %(syft)s


### PR DESCRIPTION
## Description

With ipython==8.27.0, the following assert breaks in `01-hello-syft.ipynb`

```
assert all(
    [
        "ds_client.code.get_all" in completions1,
        "ds_client.services.code" in completions2,
        "ds_client.api.services.code" in completions3,
        "ds_client.api.code" in completions4,
        "ds_client.api.parse_raw" not in completions4,  # no pydantic completions on api
    ]
)
```

1. The completions don't have the prefixes (ex: `ds_client.code` for completions1) anymore.
2. Some completions are passing through that shouldn't so the last item `"ds_client.api.parse_raw" not in completions4` fails even when the prefix issue in 1 is addressed.

Temporarily pinning to <8.27.0 and will add a ticket to look into this later.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
