### PR TITLE
add synchronous message handler

### DIFF
--- a/packages/syft/src/syft/orchestra.py
+++ b/packages/syft/src/syft/orchestra.py
@@ -28,6 +28,7 @@ from .server.datasite import Datasite
 from .server.enclave import Enclave
 from .server.gateway import Gateway
 from .server.uvicorn import serve_server
+from .service.queue.queue import Handler
 from .service.response import SyftInfo
 from .types.errors import SyftException
 from .util.util import get_random_available_port
@@ -182,6 +183,7 @@ def deploy_to_python(
     log_level: str | int | None = None,
     debug: bool = False,
     migrate: bool = False,
+    handler_type: Handler | None = None,
 ) -> ServerHandle:
     worker_classes = {
         ServerType.DATASITE: Datasite,
@@ -213,6 +215,7 @@ def deploy_to_python(
         "debug": debug,
         "migrate": migrate,
         "deployment_type": deployment_type_enum,
+        "handler_type": handler_type,
     }
 
     if port:
@@ -325,6 +328,7 @@ class Orchestra:
         debug: bool = False,
         migrate: bool = False,
         from_state_folder: str | Path | None = None,
+        handler_type: Handler | None = None,
     ) -> ServerHandle:
         if from_state_folder is not None:
             with open(f"{from_state_folder}/config.json") as f:
@@ -373,6 +377,7 @@ class Orchestra:
                 background_tasks=background_tasks,
                 debug=debug,
                 migrate=migrate,
+                handler_type=handler_type,
             )
             display(
                 SyftInfo(

--- a/packages/syft/src/syft/orchestra.py
+++ b/packages/syft/src/syft/orchestra.py
@@ -28,7 +28,7 @@ from .server.datasite import Datasite
 from .server.enclave import Enclave
 from .server.gateway import Gateway
 from .server.uvicorn import serve_server
-from .service.queue.queue import Handler
+from .service.queue.queue import ConsumerType
 from .service.response import SyftInfo
 from .types.errors import SyftException
 from .util.util import get_random_available_port
@@ -183,7 +183,7 @@ def deploy_to_python(
     log_level: str | int | None = None,
     debug: bool = False,
     migrate: bool = False,
-    handler_type: Handler | None = None,
+    consumer_type: ConsumerType | None = None,
 ) -> ServerHandle:
     worker_classes = {
         ServerType.DATASITE: Datasite,
@@ -215,7 +215,7 @@ def deploy_to_python(
         "debug": debug,
         "migrate": migrate,
         "deployment_type": deployment_type_enum,
-        "handler_type": handler_type,
+        "consumer_type": consumer_type,
     }
 
     if port:
@@ -328,7 +328,7 @@ class Orchestra:
         debug: bool = False,
         migrate: bool = False,
         from_state_folder: str | Path | None = None,
-        handler_type: Handler | None = None,
+        consumer_type: ConsumerType | None = None,
     ) -> ServerHandle:
         if from_state_folder is not None:
             with open(f"{from_state_folder}/config.json") as f:
@@ -377,7 +377,7 @@ class Orchestra:
                 background_tasks=background_tasks,
                 debug=debug,
                 migrate=migrate,
-                handler_type=handler_type,
+                consumer_type=consumer_type,
             )
             display(
                 SyftInfo(

--- a/packages/syft/src/syft/server/server.py
+++ b/packages/syft/src/syft/server/server.py
@@ -61,7 +61,7 @@ from ..service.queue.base_queue import AbstractMessageHandler
 from ..service.queue.base_queue import QueueConsumer
 from ..service.queue.base_queue import QueueProducer
 from ..service.queue.queue import APICallMessageHandler
-from ..service.queue.queue import Handler
+from ..service.queue.queue import ConsumerType
 from ..service.queue.queue import QueueManager
 from ..service.queue.queue_stash import APIEndpointQueueItem
 from ..service.queue.queue_stash import ActionQueueItem
@@ -339,7 +339,7 @@ class Server(AbstractServer):
         smtp_host: str | None = None,
         association_request_auto_approval: bool = False,
         background_tasks: bool = False,
-        handler_type: Handler | None = None,
+        consumer_type: ConsumerType | None = None,
     ):
         # 🟡 TODO 22: change our ENV variable format and default init args to make this
         # less horrible or add some convenience functions
@@ -383,13 +383,15 @@ class Server(AbstractServer):
 
         self.association_request_auto_approval = association_request_auto_approval
 
-        handler_type = (
-            handler_type or Handler.Thread if thread_workers else Handler.Process
+        consumer_type = (
+            consumer_type or ConsumerType.Thread
+            if thread_workers
+            else ConsumerType.Process
         )
         self.queue_config = self.create_queue_config(
             n_consumers=n_consumers,
             create_producer=create_producer,
-            handler_type=handler_type,
+            consumer_type=consumer_type,
             queue_port=queue_port,
             queue_config=queue_config,
         )
@@ -583,7 +585,7 @@ class Server(AbstractServer):
         self,
         n_consumers: int,
         create_producer: bool,
-        handler_type: Handler,
+        consumer_type: ConsumerType,
         queue_port: int | None,
         queue_config: QueueConfig | None,
     ) -> QueueConfig:
@@ -599,7 +601,7 @@ class Server(AbstractServer):
                     queue_port=queue_port,
                     n_consumers=n_consumers,
                 ),
-                handler_type=handler_type,
+                consumer_type=consumer_type,
             )
         else:
             queue_config_ = ZMQQueueConfig()
@@ -733,7 +735,7 @@ class Server(AbstractServer):
         in_memory_workers: bool = True,
         association_request_auto_approval: bool = False,
         background_tasks: bool = False,
-        handler_type: Handler | None = None,
+        consumer_type: ConsumerType | None = None,
     ) -> Server:
         uid = get_named_server_uid(name)
         name_hash = hashlib.sha256(name.encode("utf8")).digest()
@@ -764,7 +766,7 @@ class Server(AbstractServer):
             reset=reset,
             association_request_auto_approval=association_request_auto_approval,
             background_tasks=background_tasks,
-            handler_type=handler_type,
+            consumer_type=consumer_type,
         )
 
     def is_root(self, credentials: SyftVerifyKey) -> bool:

--- a/packages/syft/src/syft/service/queue/zmq_client.py
+++ b/packages/syft/src/syft/service/queue/zmq_client.py
@@ -16,6 +16,7 @@ from .base_queue import AbstractMessageHandler
 from .base_queue import QueueClient
 from .base_queue import QueueClientConfig
 from .base_queue import QueueConfig
+from .queue import Handler
 from .queue_stash import QueueStash
 from .zmq_consumer import ZMQConsumer
 from .zmq_producer import ZMQProducer
@@ -76,6 +77,7 @@ class ZMQClient(QueueClient):
             else:
                 port = self.config.queue_port
 
+        print(f"Adding producer for queue: {queue_name} on: {get_queue_address(port)}")
         producer = ZMQProducer(
             queue_name=queue_name,
             queue_stash=queue_stash,
@@ -183,8 +185,8 @@ class ZMQQueueConfig(QueueConfig):
         self,
         client_type: type[ZMQClient] | None = None,
         client_config: ZMQClientConfig | None = None,
-        thread_workers: bool = False,
+        handler_type: Handler = Handler.Process,
     ):
         self.client_type = client_type or ZMQClient
         self.client_config: ZMQClientConfig = client_config or ZMQClientConfig()
-        self.thread_workers = thread_workers
+        self.handler_type = handler_type

--- a/packages/syft/src/syft/service/queue/zmq_client.py
+++ b/packages/syft/src/syft/service/queue/zmq_client.py
@@ -16,7 +16,7 @@ from .base_queue import AbstractMessageHandler
 from .base_queue import QueueClient
 from .base_queue import QueueClientConfig
 from .base_queue import QueueConfig
-from .queue import Handler
+from .queue import ConsumerType
 from .queue_stash import QueueStash
 from .zmq_consumer import ZMQConsumer
 from .zmq_producer import ZMQProducer
@@ -185,8 +185,8 @@ class ZMQQueueConfig(QueueConfig):
         self,
         client_type: type[ZMQClient] | None = None,
         client_config: ZMQClientConfig | None = None,
-        handler_type: Handler = Handler.Process,
+        consumer_type: ConsumerType = ConsumerType.Process,
     ):
         self.client_type = client_type or ZMQClient
         self.client_config: ZMQClientConfig = client_config or ZMQClientConfig()
-        self.handler_type = handler_type
+        self.consumer_type = consumer_type

--- a/packages/syft/src/syft/service/queue/zmq_consumer.py
+++ b/packages/syft/src/syft/service/queue/zmq_consumer.py
@@ -1,5 +1,6 @@
 # stdlib
 import logging
+import subprocess
 import threading
 from threading import Event
 
@@ -28,6 +29,26 @@ from .zmq_common import ZMQ_SOCKET_LOCK
 logger = logging.getLogger(__name__)
 
 
+def last_created_port() -> int:
+    command = (
+        "lsof -i -P -n | grep '*:[0-9]* (LISTEN)' | grep python | awk '{print $9, $1, $2}' | "
+        "sort -k2,2 -k3,3n | tail -n 1 | awk '{print $1}' | cut -d':' -f2"
+    )
+    # 1. Lists open files (including network connections) with lsof -i -P -n
+    # 2. Filters for listening ports with grep '*:[0-9]* (LISTEN)'
+    # 3. Further filters for Python processes with grep python
+    # 4. Sorts based on the 9th field (which is likely the port number) with sort -k9
+    # 5. Takes the last 10 entries with tail -n 10
+    # 6. Prints only the 9th field (port and address) with awk '{print $9}'
+    # 7. Extracts only the port number with cut -d':' -f2
+
+    process = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    out, err = process.communicate()
+    return int(out.decode("utf-8").strip())
+
+
 @serializable(attrs=["_subscriber"], canonical_name="ZMQConsumer", version=1)
 class ZMQConsumer(QueueConsumer):
     def __init__(
@@ -53,6 +74,36 @@ class ZMQConsumer(QueueConsumer):
         self.syft_worker_id = syft_worker_id
         self.worker_stash = worker_stash
         self.post_init()
+
+    @classmethod
+    def default(cls, address: str | None = None, **kwargs: dict) -> "ZMQConsumer":
+        # relative
+        from ...types.uid import UID
+        from ..worker.utils import DEFAULT_WORKER_POOL_NAME
+        from .queue import APICallMessageHandler
+
+        if address is None:
+            try:
+                address = f"tcp://localhost:{last_created_port()}"
+            except Exception:
+                raise Exception(
+                    "Could not auto-assign ZMQConsumer address. Please provide one."
+                )
+            print(f"Auto-assigning ZMQConsumer address: {address}. Please verify.")
+        default_kwargs = {
+            "message_handler": APICallMessageHandler,
+            "queue_name": APICallMessageHandler.queue_name,
+            "service_name": DEFAULT_WORKER_POOL_NAME,
+            "syft_worker_id": UID(),
+            "verbose": True,
+            "address": address,
+        }
+
+        for key, value in kwargs.items():
+            if key in default_kwargs:
+                default_kwargs[key] = value
+
+        return cls(**default_kwargs)
 
     def reconnect_to_producer(self) -> None:
         """Connect or reconnect to producer"""

--- a/packages/syft/src/syft/service/queue/zmq_consumer.py
+++ b/packages/syft/src/syft/service/queue/zmq_consumer.py
@@ -1,6 +1,6 @@
 # stdlib
 import logging
-import subprocess
+import subprocess  # nosec
 import threading
 from threading import Event
 
@@ -42,7 +42,7 @@ def last_created_port() -> int:
     # 6. Prints only the 9th field (port and address) with awk '{print $9}'
     # 7. Extracts only the port number with cut -d':' -f2
 
-    process = subprocess.Popen(
+    process = subprocess.Popen(  # nosec
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
     out, err = process.communicate()


### PR DESCRIPTION
Notebook 1 - Start the server as usual, but add handler_type=Handler.Synchronous so the consumer does not use any threads.
```
server = sy.orchestra.launch(
    name="my_node",
    n_consumers=0,
    create_producer=True,
    handler_type=Handler.Synchronous,
)
# Prints: Adding producer for queue: api_call on: tcp://localhost:53022
```

Notebook 2 - Consume requests in the same thread.
```
consumer = ZMQConsumer.default()
# Queue port is auto deduced based on creation time.
consumer._run()
```