### PR TITLE
Fixed double hyphen on docker set up script

### DIFF
--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -58,11 +58,11 @@ while [[ "$#" -gt 0 ]]; do
             PORT="$2"
             shift 2
             ;;
-        -email|--root-email)
+        -email|--email|--root-email)
             DEFAULT_ROOT_EMAIL="$2"
             shift 2
             ;;
-        -password|--root-password)
+        -password|--password|--root-password)
             DEFAULT_ROOT_PASSWORD="$2"
             shift 2
             ;;


### PR DESCRIPTION
Currently the docker convenience script for mac is failing because in the docs it says to use a double hyphen before email and password but it was expecting a single hyphen in the file. I've updated the script so that both precedents work.

## Description
I was running through the demo and the convenience script was failing. After a very quick debug I found an inconsistency between the command instruction in the documentation and the script flags. I added an option for each for the command as it is given in the documentaion.

## Affected Dependencies
None

## How has this been tested?
I have run it in my terminal (OSX):
Before (the issue):

`(base) adamhall@Adams-MacBook-Pro scripts % bash docker-setup.sh -v 0.8.2-beta.6 -n my_server_1 -s high -t datasite -p 8081 --password mypassword --email myemail'

Usage: docker-setup.sh -v|--version <version> -n|--name <server_name> -t|--type <server_type> -p|--port <port> [-s|--side <server_side_type>] [-email|--root-email <default_root_email>] [--password|--root-password <default_root_password>]
(base) adamhall@Adams-MacBook-Pro scripts % `

After the edits (and I updated the server version as the one in the docs is no longer available):

`(base) Adams-MacBook-Pro:scripts adamhall$ bash docker-setup.sh -v 0.9.1-beta.11 -n my_server_1 -s high -t datasite -p 8081 --password mypassword --email myemail
VERSION: 0.9.1-beta.11
SERVER_NAME: my_server_1
SERVER_SIDE_TYPE: high
SERVER_TYPE: datasite
PORT: 8081
DEFAULT_ROOT_EMAIL: myemail
DEFAULT_ROOT_PASSWORD: mypassword
Unable to find image 'openmined/syft-backend:0.9.1-beta.11' locally
0.9.1-beta.11: Pulling from openmined/syft-backend
fc94bb2b60b6: Pull complete 
17f8ee582a51: Pull complete 
1483371d4790: Pull complete 
68a809891839: Downloading   13.4MB/315.3MB
fa13eea5e371: Waiting 
6f448285cc53: Waiting 
^C
got 3 SIGTERM/SIGINTs, forcefully exiting`

## Checklist
- [.] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [.] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [N] My changes are covered by tests
