### PR TITLE
Fix/rename worker pool var name

### DIFF
--- a/notebooks/scenarios/bigquery/020-configure-api.ipynb
+++ b/notebooks/scenarios/bigquery/020-configure-api.ipynb
@@ -185,7 +185,7 @@
     "    description=\"This endpoint allows to query Bigquery storage via SQL queries.\",\n",
     "    private_function=private_func,\n",
     "    mock_function=mock_func,\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")\n",
     "\n",
     "high_client.custom_api.add(endpoint=new_endpoint)"
@@ -376,7 +376,7 @@
     "    settings={\n",
     "        \"calls_per_min\": 5,\n",
     "    },\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")"
    ]
   },
@@ -431,7 +431,7 @@
    "outputs": [],
    "source": [
     "submit_query_function = make_submit_query(\n",
-    "    settings={}, worker_pool=this_worker_pool_name\n",
+    "    settings={}, worker_pool_name=this_worker_pool_name\n",
     ")"
    ]
   },

--- a/notebooks/scenarios/bigquery/sync/020-configure-api-and-sync.ipynb
+++ b/notebooks/scenarios/bigquery/sync/020-configure-api-and-sync.ipynb
@@ -166,7 +166,7 @@
     "    settings={\n",
     "        \"calls_per_min\": 5,\n",
     "    },\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")"
    ]
   },
@@ -270,7 +270,7 @@
     "    description=\"This endpoint allows to query Bigquery storage via SQL queries.\",\n",
     "    private_function=private_func,\n",
     "    mock_function=mock_func,\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")\n",
     "\n",
     "high_client.custom_api.add(endpoint=new_endpoint)"
@@ -393,7 +393,7 @@
    "outputs": [],
    "source": [
     "submit_query_function = make_submit_query(\n",
-    "    settings={}, worker_pool=this_worker_pool_name\n",
+    "    settings={}, worker_pool_name=this_worker_pool_name\n",
     ")"
    ]
   },
@@ -614,7 +614,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/scenarios/bigquery/upgradability/0.9.1_helpers/apis/live/schema.py
+++ b/notebooks/scenarios/bigquery/upgradability/0.9.1_helpers/apis/live/schema.py
@@ -7,7 +7,7 @@ from syft import test_settings
 from syft.rate_limiter import is_within_rate_limit
 
 
-def make_schema(settings: dict, worker_pool: str) -> Callable:
+def make_schema(settings: dict, worker_pool_name: str) -> Callable:
     updated_settings = {
         "calls_per_min": 5,
         "rate_limiter_enabled": True,
@@ -26,7 +26,7 @@ def make_schema(settings: dict, worker_pool: str) -> Callable:
         helper_functions=[
             is_within_rate_limit
         ],  # Adds ratelimit as this is also a method available to data scientists
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
     )
     def live_schema(
         context,

--- a/notebooks/scenarios/bigquery/upgradability/0.9.1_helpers/apis/mock/schema.py
+++ b/notebooks/scenarios/bigquery/upgradability/0.9.1_helpers/apis/mock/schema.py
@@ -9,7 +9,7 @@ from ..rate_limiter import is_within_rate_limit
 from .data import schema_dict
 
 
-def make_schema(settings, worker_pool) -> Callable:
+def make_schema(settings, worker_pool_name) -> Callable:
     updated_settings = {
         "calls_per_min": 5,
         "rate_limiter_enabled": True,
@@ -21,7 +21,7 @@ def make_schema(settings, worker_pool) -> Callable:
         description="This endpoint allows for visualising the metadata of tables available in BigQuery.",
         settings=updated_settings,
         helper_functions=[is_within_rate_limit],
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
     )
     def mock_schema(
         context,

--- a/notebooks/scenarios/bigquery/upgradability/0.9.1_helpers/apis/submit_query.py
+++ b/notebooks/scenarios/bigquery/upgradability/0.9.1_helpers/apis/submit_query.py
@@ -2,13 +2,13 @@
 import syft as sy
 
 
-def make_submit_query(settings, worker_pool):
-    updated_settings = {"user_code_worker": worker_pool} | settings
+def make_submit_query(settings, worker_pool_name):
+    updated_settings = {"user_code_worker": worker_pool_name} | settings
 
     @sy.api_endpoint(
         path="bigquery.submit_query",
         description="API endpoint that allows you to submit SQL queries to run on the private data.",
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
         settings=updated_settings,
     )
     def submit_query(

--- a/notebooks/scenarios/bigquery/upgradability/0.9.1_notebooks/020-configure-api.ipynb
+++ b/notebooks/scenarios/bigquery/upgradability/0.9.1_notebooks/020-configure-api.ipynb
@@ -216,7 +216,7 @@
     "    description=\"This endpoint allows to query Bigquery storage via SQL queries.\",\n",
     "    private_function=private_func,\n",
     "    mock_function=mock_func,\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")\n",
     "\n",
     "high_client.custom_api.add(endpoint=new_endpoint)"
@@ -407,7 +407,7 @@
     "    settings={\n",
     "        \"calls_per_min\": 5,\n",
     "    },\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")"
    ]
   },
@@ -462,7 +462,7 @@
    "outputs": [],
    "source": [
     "submit_query_function = make_submit_query(\n",
-    "    settings={}, worker_pool=this_worker_pool_name\n",
+    "    settings={}, worker_pool_name=this_worker_pool_name\n",
     ")"
    ]
   },

--- a/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/02-configure-api-and-sync.ipynb
+++ b/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/02-configure-api-and-sync.ipynb
@@ -176,7 +176,7 @@
     "    description=\"This endpoint allows to query Bigquery storage via SQL queries.\",\n",
     "    private_function=private_func,\n",
     "    mock_function=mock_func,\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")\n",
     "\n",
     "high_client.custom_api.add(endpoint=new_endpoint)"
@@ -221,7 +221,7 @@
     "    settings={\n",
     "        \"calls_per_min\": 5,\n",
     "    },\n",
-    "    worker_pool=this_worker_pool_name,\n",
+    "    worker_pool_name=this_worker_pool_name,\n",
     ")"
    ]
   },
@@ -282,7 +282,7 @@
    "outputs": [],
    "source": [
     "submit_query_function = make_submit_query(\n",
-    "    settings={}, worker_pool=this_worker_pool_name\n",
+    "    settings={}, worker_pool_name=this_worker_pool_name\n",
     ")"
    ]
   },

--- a/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/apis/live/schema.py
+++ b/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/apis/live/schema.py
@@ -9,7 +9,7 @@ from syft import test_settings
 from ..rate_limiter import is_within_rate_limit
 
 
-def make_schema(settings: dict, worker_pool: str) -> Callable:
+def make_schema(settings: dict, worker_pool_name: str) -> Callable:
     updated_settings = {
         "calls_per_min": 5,
         "rate_limiter_enabled": True,
@@ -28,7 +28,7 @@ def make_schema(settings: dict, worker_pool: str) -> Callable:
         helper_functions=[
             is_within_rate_limit
         ],  # Adds ratelimit as this is also a method available to data scientists
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
     )
     def live_schema(
         context,

--- a/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/apis/mock/schema.py
+++ b/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/apis/mock/schema.py
@@ -9,7 +9,7 @@ from ..rate_limiter import is_within_rate_limit
 from .data import schema_dict
 
 
-def make_schema(settings, worker_pool) -> Callable:
+def make_schema(settings, worker_pool_name) -> Callable:
     updated_settings = {
         "calls_per_min": 5,
         "rate_limiter_enabled": True,
@@ -21,7 +21,7 @@ def make_schema(settings, worker_pool) -> Callable:
         description="This endpoint allows for visualising the metadata of tables available in BigQuery.",
         settings=updated_settings,
         helper_functions=[is_within_rate_limit],
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
     )
     def mock_schema(
         context,

--- a/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/apis/submit_query.py
+++ b/notebooks/scenarios/bigquery/upgradability/sync/0.9.1_notebooks/apis/submit_query.py
@@ -2,13 +2,13 @@
 import syft as sy
 
 
-def make_submit_query(settings, worker_pool):
-    updated_settings = {"user_code_worker": worker_pool} | settings
+def make_submit_query(settings, worker_pool_name):
+    updated_settings = {"user_code_worker": worker_pool_name} | settings
 
     @sy.api_endpoint(
         path="bigquery.submit_query",
         description="API endpoint that allows you to submit SQL queries to run on the private data.",
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
         settings=updated_settings,
     )
     def submit_query(

--- a/packages/syft/src/syft/protocol/protocol_version.json
+++ b/packages/syft/src/syft/protocol/protocol_version.json
@@ -108,6 +108,27 @@
           "hash": "7659117222a461a959eac7aa1aaf280033c2ca4f1029f97e76051e0474e56759",
           "action": "add"
         }
+      },
+      "CustomAPIView": {
+        "2": {
+          "version": 2,
+          "hash": "7eb2cd60e9526299c3f989930733b8bfd2e81d4e93a1b82217dec2e0a786ba10",
+          "action": "add"
+        }
+      },
+      "CreateTwinAPIEndpoint": {
+        "2": {
+          "version": 2,
+          "hash": "f4048d6cf886ea519df25300af17912c818095288d42f7ef9183372c9c19db79",
+          "action": "add"
+        }
+      },
+      "TwinAPIEndpoint": {
+        "2": {
+          "version": 2,
+          "hash": "40229be687cd4290447fe8b409ba3dc1b8d410c5dac37cebb9856fb34d7507cd",
+          "action": "add"
+        }
       }
     }
   }

--- a/packages/syft/src/syft/server/server.py
+++ b/packages/syft/src/syft/server/server.py
@@ -1,3 +1,4 @@
+# futureserver.py
 # future
 from __future__ import annotations
 
@@ -1331,21 +1332,21 @@ class Server(AbstractServer):
         path: str,
         log_id: UID,
         *args: Any,
-        worker_pool: str | None = None,
+        worker_pool_name: str | None = None,
         **kwargs: Any,
     ) -> Job:
         job_id = UID()
         task_uid = UID()
         worker_settings = WorkerSettings.from_server(server=self)
 
-        if worker_pool is None:
-            worker_pool = self.get_default_worker_pool().unwrap()
+        if worker_pool_name is None:
+            worker_pool_name = self.get_default_worker_pool().unwrap()
         else:
-            worker_pool = self.get_worker_pool_by_name(worker_pool).unwrap()
+            worker_pool_name = self.get_worker_pool_by_name(worker_pool_name).unwrap()
 
         # Create a Worker pool reference object
         worker_pool_ref = LinkedObject.from_obj(
-            worker_pool,
+            worker_pool_name,
             service_type=SyftWorkerPoolService,
             server_uid=self.id,
         )

--- a/packages/syft/src/syft/service/api/api_service.py
+++ b/packages/syft/src/syft/service/api/api_service.py
@@ -337,7 +337,7 @@ class APIService(AbstractService):
             method,
             path,
             *args,
-            worker_pool=custom_endpoint.worker_pool,
+            worker_pool_name=custom_endpoint.worker_pool_name,
             log_id=log_id,
             **kwargs,
         )

--- a/packages/syft/src/syft/util/test_helpers/apis/live/schema.py
+++ b/packages/syft/src/syft/util/test_helpers/apis/live/schema.py
@@ -9,7 +9,7 @@ from ..... import test_settings
 from ..rate_limiter import is_within_rate_limit
 
 
-def make_schema(settings: dict, worker_pool: str) -> Callable:
+def make_schema(settings: dict, worker_pool_name: str) -> Callable:
     updated_settings = {
         "calls_per_min": 5,
         "rate_limiter_enabled": True,
@@ -28,7 +28,7 @@ def make_schema(settings: dict, worker_pool: str) -> Callable:
         helper_functions=[
             is_within_rate_limit
         ],  # Adds ratelimit as this is also a method available to data scientists
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
     )
     def live_schema(
         context,

--- a/packages/syft/src/syft/util/test_helpers/apis/mock/schema.py
+++ b/packages/syft/src/syft/util/test_helpers/apis/mock/schema.py
@@ -9,7 +9,7 @@ from ..rate_limiter import is_within_rate_limit
 from .data import schema_dict
 
 
-def make_schema(settings, worker_pool) -> Callable:
+def make_schema(settings, worker_pool_name) -> Callable:
     updated_settings = {
         "calls_per_min": 5,
         "rate_limiter_enabled": True,
@@ -21,7 +21,7 @@ def make_schema(settings, worker_pool) -> Callable:
         description="This endpoint allows for visualising the metadata of tables available in BigQuery.",
         settings=updated_settings,
         helper_functions=[is_within_rate_limit],
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
     )
     def mock_schema(
         context,

--- a/packages/syft/src/syft/util/test_helpers/apis/submit_query.py
+++ b/packages/syft/src/syft/util/test_helpers/apis/submit_query.py
@@ -2,13 +2,13 @@
 import syft as sy
 
 
-def make_submit_query(settings, worker_pool):
-    updated_settings = {"user_code_worker": worker_pool} | settings
+def make_submit_query(settings, worker_pool_name):
+    updated_settings = {"user_code_worker": worker_pool_name} | settings
 
     @sy.api_endpoint(
         path="bigquery.submit_query",
         description="API endpoint that allows you to submit SQL queries to run on the private data.",
-        worker_pool=worker_pool,
+        worker_pool_name=worker_pool_name,
         settings=updated_settings,
     )
     def submit_query(

--- a/tests/integration/local/twin_api_endpoint_test.py
+++ b/tests/integration/local/twin_api_endpoint_test.py
@@ -51,7 +51,7 @@ def get_twin_api_endpoint(worker_pool_name: str) -> TwinAPIEndpoint:
         mock_function=public_func,
         private_function=pvt_func,
         description="Lore ipsulum ...",
-        worker_pool=worker_pool_name,
+        worker_pool_name=worker_pool_name,
     )
 
     return new_endpoint

--- a/tests/scenarios/bigquery/helpers/make.py
+++ b/tests/scenarios/bigquery/helpers/make.py
@@ -213,7 +213,7 @@ async def create_endpoints_query(events, client, worker_pool_name: str, register
         description="This endpoint allows to query Bigquery storage via SQL queries.",
         private_function=private_query_function,
         mock_function=mock_query_function,
-        worker_pool=worker_pool_name,
+        worker_pool_name=worker_pool_name,
     )
 
     result = client.custom_api.add(endpoint=new_endpoint)
@@ -242,7 +242,7 @@ async def create_endpoints_schema(events, client, worker_pool_name: str, registe
         helper_functions=[
             is_within_rate_limit
         ],  # Adds ratelimit as this is also a method available to data scientists
-        worker_pool=worker_pool_name,
+        worker_pool_name=worker_pool_name,
     )
     def schema_function(
         context,
@@ -333,7 +333,7 @@ async def create_endpoints_submit_query(
     @sy.api_endpoint(
         path="bigquery.submit_query",
         description="API endpoint that allows you to submit SQL queries to run on the private data.",
-        worker_pool=worker_pool_name,
+        worker_pool_name=worker_pool_name,
         settings={"worker": worker_pool_name},
     )
     def submit_query(


### PR DESCRIPTION
## Description
Aims to fix parameter name incosistency between `syft_functions` and `twin_apis` [worker_pool/worker_pool_name issue](https://github.com/orgs/OpenMined/projects/88/views/16?pane=issue&itemId=79779247)

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
