### PR TITLE
Check that users receive approved / reject emails in bigquery L2 notebook

### DIFF
--- a/notebooks/scenarios/bigquery/040-do-review-requests.ipynb
+++ b/notebooks/scenarios/bigquery/040-do-review-requests.ipynb
@@ -231,10 +231,11 @@
     "    for k, v in job_emails.items()\n",
     "}\n",
     "expected_rejected_email_counts = Counter(\n",
-    "    map(lambda x: x.user_email, submitted_jobs_data_should_fail)\n",
+    "    job.user_email for job in submitted_jobs_data_should_fail\n",
     ")\n",
+    "\n",
     "expected_approved_email_counts = Counter(\n",
-    "    map(lambda x: x.user_email, submitted_jobs_data_should_succeed)\n",
+    "    job.user_email for job in submitted_jobs_data_should_succeed\n",
     ")"
    ]
   },
@@ -244,7 +245,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# if user's email notifications are enabled, should have received either approved or rejected email\n",
+    "# if user's email notifications are enabled,\n",
+    "# should have received either approved or rejected email\n",
     "for user_email, new_count in new_n_emails_per_job_user.items():\n",
     "    user = [u for u in users if u.email == user_email][0]\n",
     "    old_count = n_emails_per_job_user[user_email]\n",

--- a/notebooks/scenarios/bigquery/040-do-review-requests.ipynb
+++ b/notebooks/scenarios/bigquery/040-do-review-requests.ipynb
@@ -19,6 +19,7 @@
    "outputs": [],
    "source": [
     "# stdlib\n",
+    "from collections import Counter\n",
     "import random\n",
     "\n",
     "# syft absolute\n",
@@ -220,9 +221,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for user_email, new_count in new_n_emails_per_job_user.items():\n",
-    "#     old_count = n_emails_per_job_user[user_email]\n",
-    "#     assert new_count > old_count"
+    "job_emails = get_job_emails(submitted_jobs_data, high_client, email_server)\n",
+    "rejected_email_counts = {\n",
+    "    k: sum(\"rejected\" in email[\"email_content\"].lower() for email in v)\n",
+    "    for k, v in job_emails.items()\n",
+    "}\n",
+    "approved_email_counts = {\n",
+    "    k: sum(\"approved\" in email[\"email_content\"].lower() for email in v)\n",
+    "    for k, v in job_emails.items()\n",
+    "}\n",
+    "expected_rejected_email_counts = Counter(\n",
+    "    map(lambda x: x.user_email, submitted_jobs_data_should_fail)\n",
+    ")\n",
+    "expected_approved_email_counts = Counter(\n",
+    "    map(lambda x: x.user_email, submitted_jobs_data_should_succeed)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if user's email notifications are enabled, should have received either approved or rejected email\n",
+    "for user_email, new_count in new_n_emails_per_job_user.items():\n",
+    "    user = [u for u in users if u.email == user_email][0]\n",
+    "    old_count = n_emails_per_job_user[user_email]\n",
+    "    if not user.email_disabled:\n",
+    "        # greater than or equal to since duplicates can happen\n",
+    "        assert new_count > old_count\n",
+    "        assert rejected_email_counts.get(\n",
+    "            user_email, 0\n",
+    "        ) >= expected_rejected_email_counts.get(user_email, 0)\n",
+    "        assert approved_email_counts.get(\n",
+    "            user_email, 0\n",
+    "        ) >= expected_approved_email_counts.get(user_email, 0)\n",
+    "    else:\n",
+    "        assert new_count == old_count"
    ]
   },
   {
@@ -293,6 +329,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "syft",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -303,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
Updates previously commented out check that users receive approval / rejection emails in L2 flow. Updated check to account for user's email notifications potentially being disabled and to make sure they get the right type of email.

Closes https://github.com/OpenMined/Heartbeat/issues/1846.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
