### PR TITLE
Shift to Single Checkpoint Files

### DIFF
--- a/notebooks/Experimental/1-checkpoint.ipynb
+++ b/notebooks/Experimental/1-checkpoint.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "034a332d-517f-486f-8713-eeed53d35067",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# syft absolute\n",
+    "import syft as sy\n",
+    "from syft.util.test_helpers.checkpoint import create_checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53cebce4-5e50-48f0-bd38-cf82cba9e71c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client = sy.login(email=\"info@openmined.org\", password=\"changethis\", port=8080)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "957c101e-f048-4ba0-b5e8-22af97e6c9b1",
+   "metadata": {},
+   "source": [
+    "### Scaling Default Worker Pool"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7217d39-fd2e-4a6c-b7c7-8013703b83ce",
+   "metadata": {},
+   "source": [
+    "We should see a default worker pool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7018e9bf-1639-4204-9bf3-19d296cc8572",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.worker_pools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87cbd371-a23a-4229-b305-ed834c2eb3d1",
+   "metadata": {},
+   "source": [
+    "Scale up to 3 workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acc5c6ba-cd25-420e-9491-2db0f67fb763",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.api.services.worker_pool.scale(number=3, pool_name=\"default-pool\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4696855-8848-4182-9513-0753893eaf5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = datasite_client.api.services.worker_pool.get_by_name(pool_name=\"default-pool\")\n",
+    "assert len(result.workers) == 3, str(result.to_dict())\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d8b5827-464b-4954-acc1-52773829ca65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_checkpoint(name=\"1-checkpoint-v1\", client=datasite_client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27f441fc-f3c0-445c-aa68-85ab92feaa57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "839af9a0-a76d-42bc-b8f9-7e67d9da7e7a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Experimental/2-checkpoint.ipynb
+++ b/notebooks/Experimental/2-checkpoint.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bdea5a57-7ec9-45e0-8684-662ae52145cd",
+   "metadata": {},
+   "source": [
+    "# 2 - Checkpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b978f6c-6778-4880-934a-e751d55bec97",
+   "metadata": {},
+   "source": [
+    "- Create a fresh cluster and load the checkpoint from notebook 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b53b0926-8ee0-4bfa-876c-f66bce750dc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# syft absolute\n",
+    "import syft as sy\n",
+    "from syft.util.test_helpers.checkpoint import load_from_checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bbee80c-e1fa-4b47-a8d2-cd5099838a8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client = sy.login(email=\"info@openmined.org\", password=\"changethis\", port=8080)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "949f759d-e9ce-493a-ab2e-a5a6e817ed85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1d9e708-43f9-4ba4-9e43-6eeb94b89800",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.worker_pools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7234d846-9c38-437a-a901-4ff67dfd92b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = datasite_client.api.services.worker_pool.get_by_name(pool_name=\"default-pool\")\n",
+    "assert len(result.workers) == 3, str(result.to_dict())\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c964b66b-9992-42c4-8ce6-432ee3a50dc3",
+   "metadata": {},
+   "source": [
+    "Scale down to 1 worker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eaf07b5b-da13-4c22-a0a1-8cb8ffcf9469",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.api.services.worker_pool.scale(number=1, pool_name=\"default-pool\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd269fbb-87af-44de-8bf9-2752ac8ef703",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = datasite_client.api.services.worker_pool.get_by_name(pool_name=\"default-pool\")\n",
+    "assert len(result.workers) == 1, str(result.to_dict())\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9764f5b8-1449-4c8d-8458-b9add6fc938f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_worker_pool = datasite_client.api.services.worker_pool.get_by_name(\n",
+    "    pool_name=\"default-pool\"\n",
+    ")\n",
+    "default_worker_pool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac2cfc1f-d817-436a-9304-ed5e15c3fad2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_from_checkpoint(name=\"1-checkpoint-v1\", client=datasite_client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3442b39a-0606-44f2-83ca-4fc91a584881",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.worker_pools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f586f08-9d2b-42c3-8a6d-80af7786ba55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasite_client.worker_pools[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00f1af3c-718e-45df-b548-bec02ee69645",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description
The PR shifts checkpoints to single files, for easy portability.
It also adds the ability to load checkpoints from custom paths


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
