### PR TITLE
docs: rename OSX to macOS in getting_started index.rst

### DIFF
--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -10,7 +10,7 @@ Getting Started
 Welcome to the datasite deployment installation tutorials!
 This section of our documentation is designed to be the
 simplest way to get you started deploying your data to a datasite server
-on an OSX, Linux, or Windows machine and interacting with it
+on a macOS, Linux, or Windows machine and interacting with it
 as a data scientist using PySyft.
 
 .. note:: 
@@ -49,7 +49,7 @@ The first step of your journey is to figure out which operating system you are r
 and choose the right tutorial for installation. 
 There are 3 types of operating systems for you to choose from:
 
-#. `OSX <https://openmined.github.io/PySyft/install_tutorials/osx_11_5_1.html#>`__
+#. `macOS <https://openmined.github.io/PySyft/install_tutorials/osx_11_5_1.html#>`__
 
 #. `Linux <https://openmined.github.io/PySyft/install_tutorials/linux.html##>`__
 


### PR DESCRIPTION
Replaced outdated references to OSX with macOS in the getting_started guide, including the installation instruction and OS selection list.

## Description
This pull request updates the documentation to use the modern term “macOS” instead of “OSX” in the getting_started guide. It corrects the introductory text and the operating system list so that newcomers see macOS alongside Linux and Windows.

## Affected Dependencies
None – this change only modifies documentation and does not affect any code dependencies.

## How has this been tested?
No changes were made, so no tests are required. 
## Checklist
- [x] I have followed the Contribution Guidelines and Code of Conduct
- [x] I have commented my code following the OpenMined Styleguide
- [x] I have labeled this PR with the relevant Type labels
- [ ] My changes are covered by tests