### PR TITLE
"Enabled" flag added in Helm chart and Postgres templates

### DIFF
--- a/packages/grid/helm/syft/templates/postgres/postgres-headless-service.yaml
+++ b/packages/grid/helm/syft/templates/postgres/postgres-headless-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: postgres
+{{- end }}

--- a/packages/grid/helm/syft/templates/postgres/postgres-secret.yaml
+++ b/packages/grid/helm/syft/templates/postgres/postgres-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 {{- $secretName := "postgres-secret" }}
 apiVersion: v1
 kind: Secret
@@ -15,3 +16,4 @@ data:
     "default" .Values.postgres.secret.rootPassword
     "context" $)
   }}
+{{- end }}

--- a/packages/grid/helm/syft/templates/postgres/postgres-service.yaml
+++ b/packages/grid/helm/syft/templates/postgres/postgres-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
       port: 5432
       protocol: TCP
       targetPort: 5432
+{{- end }}

--- a/packages/grid/helm/syft/templates/postgres/postgres-statefuleset.yaml
+++ b/packages/grid/helm/syft/templates/postgres/postgres-statefuleset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -45,9 +46,9 @@ spec:
                   key: rootPassword
             - name: POSTGRES_DB
               value: {{ .Values.postgres.dbname | required "postgres.dbname is required" | quote }}
-            {{- if .Values.postgres.env }}
-            {{- toYaml .Values.postgres.env | nindent 12 }}
-            {{- end }}
+              {{- if .Values.postgres.env }}
+              {{- toYaml .Values.postgres.env | nindent 12 }}
+              {{- end }}
           volumeMounts:
             - mountPath: tmp/data/db
               name: postgres-data
@@ -69,4 +70,5 @@ spec:
       resources:
         requests:
           storage: {{ .Values.postgres.storageSize | quote }}
+{{- end }}
 

--- a/packages/grid/helm/syft/values.yaml
+++ b/packages/grid/helm/syft/values.yaml
@@ -15,6 +15,7 @@ global:
 # =================================================================================
 
 postgres:
+  enabled: true
 # Postgres config
   port: 5432
   username: syft_postgres
@@ -52,6 +53,7 @@ frontend:
 
   # Pod Resource Limits
   resourcesPreset: medium
+  postgres:
   resources: null
 
 # =================================================================================


### PR DESCRIPTION
## Description
Addresses [Issue 9357](https://github.com/OpenMined/PySyft/issues/9357) by ensuring that postgres related templates are called upon only when postgres is enabled in the helm chart

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
Starting up using helm should be enough to test the change.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
