### PR TITLE
Fix: documentation build by upgrading Sphinx to version 5 and replacing deprecated sphinx-panels with sphinx design

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,9 +7,9 @@ pydata-sphinx-theme==0.7.2
 pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
-sphinx==4.3.0
+sphinx>=5.0
 sphinx-autoapi==1.8.4
 sphinx-code-include==1.1.1
 sphinx-copybutton==0.4.0
-sphinx-panels==0.6.0
+sphinx-design>=0.5
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
-    "sphinx_panels",
+    "sphinx_design",#deleted sphinx panels as it is not supported in sphinx 5 and added sphinx design
 ]
 
 exclude_patterns = [


### PR DESCRIPTION
## Description
This PR fixes the documentation build failures related to Sphinx and deprecated extensions.

## Affected Dependencies
Changed docs/requirements.txt and docs/conf.py

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
