### PR TITLE
Fix: Prevent Admin from demoting their own role (#9326)

### DIFF
--- a/packages/syft/src/syft/service/user/user_service.py
+++ b/packages/syft/src/syft/service/user/user_service.py
@@ -450,6 +450,17 @@ class UserService(AbstractService):
         # Get user to be updated by its UID
         user = self.stash.get_by_uid(credentials=context.credentials, uid=uid).unwrap()
 
+        # FIX: Prevent Admin from demoting themselves (Issue #9326)
+        if (
+            updates_role
+            and user.verify_key == context.credentials
+            and user.role == ServiceRole.ADMIN
+        ):
+            if user_update.role != ServiceRole.ADMIN:
+                raise SyftException(
+                    public_message="Admins cannot demote their own role!"
+                )
+
         immutable_fields = {"created_date", "updated_date", "deleted_date"}
         updated_fields = user_update.to_dict(
             exclude_none=True, exclude_empty=True
@@ -599,12 +610,12 @@ class UserService(AbstractService):
                 and context.server.server_type == ServerType.ENCLAVE
                 and user.role == ServiceRole.ADMIN
             ):
-                # FIX: Replace with SyftException
+                # FIX: Replacing with SyftException
                 raise SyftException(
                     public_message=UserEnclaveAdminLoginError.public_message
                 )
         else:
-            # FIX: Replace this below
+            # FIX: Replacing this below
             raise SyftException(public_message=CredentialsError.public_message)
 
         return SyftSuccess(message="Login successful.", value=user.to(UserPrivateKey))


### PR DESCRIPTION
## Description
This PR addresses Issue #9326.

I implemented a validation check in `user_service.py` (inside the `update` method) to prevent an Admin user from demoting their own role permissions. This fixes a logic gap where an admin could accidentally lock themselves out of administrative privileges.

Specifically:
- Added a check to verify if `uid` matches `context.credentials` (the user modifying themselves).
- Added a check to verify if the current user role is `ADMIN`.
- Raises a `SyftError` with the message "Admins cannot demote their own role!" if a demotion is attempted.

Fixes #9326

## Affected Dependencies
None. This change only modifies internal logic in `packages/syft/src/syft/service/user/user_service.py`.

## How has this been tested?
- [x] Manual Logic Verification
- I verified the code path in `user_service.py` to ensure the conditional logic correctly targets only self-updates by Admin users.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
