### PR TITLE
fix: correct spelling errors in codebase

### DIFF
--- a/packages/syft/src/syft/protocol/data_protocol.py
+++ b/packages/syft/src/syft/protocol/data_protocol.py
@@ -224,12 +224,12 @@ class DataProtocol:
     def diff_state(self, state: dict) -> tuple[dict, dict]:
         compare_dict: dict = defaultdict(dict)  # what versions are in the latest code
         object_diff: dict = defaultdict(dict)  # diff in latest code with saved json
-        all_serde_propeties = [
+        all_serde_properties = [
             serde_properties
             for version_dict in SyftObjectRegistry.__object_serialization_registry__.values()
             for serde_properties in version_dict.values()
         ]
-        for serde_properties in all_serde_propeties:
+        for serde_properties in all_serde_properties:
             cls, version = serde_properties[7], serde_properties[9]
             if issubclass(cls, SyftBaseObject):
                 canonical_name = cls.__canonical_name__

--- a/packages/syft/src/syft/service/code/user_code.py
+++ b/packages/syft/src/syft/service/code/user_code.py
@@ -1286,7 +1286,7 @@ class SubmitUserCode(SyftObject):
         def task() -> None:
             if "blocking" in kwargs and not kwargs["blocking"]:
                 time.sleep(time_alive)
-            print(SyftInfo(message="Landing the ephmeral server..."))
+            print(SyftInfo(message="Landing the ephemeral server..."))
             ep_server.land()
             print(SyftInfo(message="Server Landed!"))
 

--- a/packages/syft/src/syft/service/log/log_service.py
+++ b/packages/syft/src/syft/service/log/log_service.py
@@ -85,7 +85,7 @@ class LogService(AbstractService):
     @service_method(path="log.delete", name="delete", roles=DATA_SCIENTIST_ROLE_LEVEL)
     def delete(self, context: AuthedServiceContext, uid: UID) -> SyftSuccess:
         self.stash.delete_by_uid(context.credentials, uid).unwrap()
-        return SyftSuccess(message=f"log {uid} succesfully deleted")
+        return SyftSuccess(message=f"log {uid} successfully deleted")
 
     @service_method(
         path="log.has_storage_permission",

--- a/packages/syft/src/syft/service/notifier/notifier_service.py
+++ b/packages/syft/src/syft/service/notifier/notifier_service.py
@@ -242,7 +242,7 @@ class NotifierService(AbstractService):
         notifier.active = False
         self.stash.update(credentials=context.credentials, obj=notifier).unwrap()
         context.server.services.settings.update(context, notifications_enabled=False)
-        return SyftSuccess(message="Notifications disabled succesfullly")
+        return SyftSuccess(message="Notifications disabled successfully")
 
     @as_result(SyftException)
     def activate(

--- a/packages/syft/src/syft/service/queue/zmq_consumer.py
+++ b/packages/syft/src/syft/service/queue/zmq_consumer.py
@@ -212,7 +212,7 @@ class ZMQConsumer(QueueConsumer):
                         logger.error(f"ZMQConsumer invalid recv: {msg}")
                         continue
 
-                    # Message frames recieved by consumer:
+                    # Message frames received by consumer:
                     # [empty, header, command, ...data]
                     (_, _, command, *data) = msg
 

--- a/packages/syft/src/syft/types/syft_object.py
+++ b/packages/syft/src/syft/types/syft_object.py
@@ -555,7 +555,7 @@ class SyftObject(SyftObjectVersioned):
     def to(self, projection: type[T], context: Context | None = None) -> T:
         # relative
 
-        # 🟡 TODO 19: Could we do an mro style inheritence conversion? Risky?
+        # 🟡 TODO 19: Could we do an mro style inheritance conversion? Risky?
         transform = SyftObjectRegistry.get_transform(type(self), projection)
         return transform(self, context)
 
@@ -792,7 +792,7 @@ aggressive_set_attr(tuple, "_repr_html_", build_tabulator_table)
 
 class StorableObjectType:
     def to(self, projection: type, context: Context | None = None) -> Any:
-        # 🟡 TODO 19: Could we do an mro style inheritence conversion? Risky?
+        # 🟡 TODO 19: Could we do an mro style inheritance conversion? Risky?
         # relative
 
         transform = SyftObjectRegistry.get_transform(type(self), projection)

--- a/packages/syft/src/syft/util/test_helpers/apis/live/schema.py
+++ b/packages/syft/src/syft/util/test_helpers/apis/live/schema.py
@@ -97,12 +97,12 @@ def make_schema(settings: dict, worker_pool_name: str) -> Callable:
             if not hasattr(e, "_errors"):
                 output = f"got exception e: {type(e)} {str(e)}"
                 raise SyftException(
-                    public_message=f"An error occured executing the API call {output}"
+                    public_message=f"An error occurred executing the API call {output}"
                 )
 
             # Should add appropriate error handling for what should be exposed to the data scientists.
             raise SyftException(
-                public_message="An error occured executing the API call, please contact the domain owner."
+                public_message="An error occurred executing the API call, please contact the domain owner."
             )
 
     return live_schema

--- a/packages/syft/src/syft/util/test_helpers/apis/live/test_query.py
+++ b/packages/syft/src/syft/util/test_helpers/apis/live/test_query.py
@@ -79,7 +79,7 @@ def make_test_query(settings) -> Callable:
             if not hasattr(e, "_errors"):
                 output = f"got exception e: {type(e)} {str(e)}"
                 raise SyftException(
-                    public_message=f"An error occured executing the API call {output}"
+                    public_message=f"An error occurred executing the API call {output}"
                 )
 
             # Treat all errors that we would like to be forwarded to the data scientists
@@ -102,12 +102,12 @@ def make_test_query(settings) -> Callable:
                 "timeout",
             ]:
                 raise SyftException(
-                    public_message="Error occured during the call: "
+                    public_message="Error occurred during the call: "
                     + e._errors[0]["message"]
                 )
             else:
                 raise SyftException(
-                    public_message="An error occured executing the API call, please contact the domain owner."
+                    public_message="An error occurred executing the API call, please contact the domain owner."
                 )
 
     return live_test_query


### PR DESCRIPTION
## Summary

This PR fixes several spelling errors across the codebase:

| Typo | Correct | Files |
|------|---------|-------|
| occured | occurred | test_query.py, schema.py |
| recieved | received | zmq_consumer.py |
| ephmeral | ephemeral | user_code.py |
| propeties | properties | data_protocol.py |
| succesfullly | successfully | notifier_service.py |
| succesfully | successfully | log_service.py |
| inheritence | inheritance | syft_object.py |

## Changes
- Fixed 8 files with 13 spelling corrections
- No functional changes, only string/comment corrections

## Test plan
- [x] Python syntax validation passed
- [x] Changes are limited to string literals and comments