### PR TITLE
Add InfraScan audit workflow to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.5
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           chmod 777 infrascan-reports
 
       - name: Run InfraScan
-        uses: soldevelo/infrascan@v1.0.5
+        uses: soldevelo/infrascan@v1.0.6
         with:
           scanner: comprehensive
           format: html


### PR DESCRIPTION
## Description
This PR adds a new GitHub Actions workflow (`.github/workflows/main.yml`) to integrate **InfraScan** into the CI pipeline. 

**Motivation:** To automate comprehensive infrastructure and security scanning. The workflow is configured to trigger on every `push` and `pull_request`. It uses the `soldevelo/infrascan@v1.0.5` action to generate an HTML report, which is then automatically uploaded as a GitHub artifact (retained for 14 days). This allows maintainers and contributors to easily review scan results directly from the Actions tab.

## Affected Dependencies
This workflow introduces the following GitHub Actions dependencies:
* `actions/checkout@v4`
* `soldevelo/infrascan@v1.0.5`
* `actions/upload-artifact@v4`

## How has this been tested?
- **Workflow trigger validation:** Verified that the workflow triggers correctly on push/PR events.
- **Artifact generation:** Checked that the `infrascan-reports` directory is created with proper permissions and that the HTML report is successfully generated by the action.
- **To reproduce:** Push a new commit to this branch and navigate to the "Actions" tab. Open the "InfraScan Audit" workflow run and verify that the `infrascan-report` artifact is available for download at the bottom of the summary page.
- **Test configuration:** Executed on the `ubuntu-latest` GitHub-hosted runner.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] My changes are covered by tests *(Note: N/A for CI/CD workflow configuration)*