### PR TITLE
Security: Path traversal in file_writer.py write_file method

### DIFF
--- a/packages/syft-permissions/src/syft_permissions/spec/ruleset.py
+++ b/packages/syft-permissions/src/syft_permissions/spec/ruleset.py
@@ -23,6 +23,10 @@ class RuleSet(BaseModel):
 
     def save(self, filepath: Path | None = None) -> None:
         target = filepath or Path(self.path) / PERMISSION_FILE_NAME
+        target = target.resolve()
+        base = Path(self.path).resolve()
+        if not str(target).startswith(str(base)):
+            raise ValueError(f"Path {target} is outside of base path {base}")
         data = self.model_dump(mode="json")
         with open(target, "w") as f:
             yaml.safe_dump(data, f, default_flow_style=False)

--- a/syft_client/sync/file_writer.py
+++ b/syft_client/sync/file_writer.py
@@ -14,8 +14,13 @@ class FileWriter(BaseModel):
         self.callbacks[on].append(callback)
 
     def write_file(self, path: str, content: str):
+        target_path = self.base_path / path
+        resolved_path = target_path.resolve()
+        resolved_base = self.base_path.resolve()
+        if not str(resolved_path).startswith(str(resolved_base)):
+            raise ValueError(f"Path {path} is outside of base_path {self.base_path}")
         if self.write_files:
-            with open(path, "w") as f:
+            with open(resolved_path, "w") as f:
                 f.write(content)
 
         for callback in self.callbacks.get("write_file", []):


### PR DESCRIPTION
## Problem

The `FileWriter.write_file()` method takes a `path` string and writes directly to it without sanitization or validation. If `path` contains directory traversal sequences like `../`, it could write files outside the intended `base_path`. The `base_path` is stored but never used to validate the write location.

**Severity**: `high`
**File**: `syft_client/sync/file_writer.py`

## Solution

Validate that the resolved path is within `base_path` before writing. Use `Path.resolve()` and check that the resolved path starts with `base_path.resolve()`.

## Changes

- `syft_client/sync/file_writer.py` (modified)
- `packages/syft-permissions/src/syft_permissions/spec/ruleset.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
