### PR TITLE
feat: add syft-migration package foundation

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -156,3 +156,26 @@ jobs:
 
       - name: Run enclave model API tests
         run: just test-unit-enclave-model-api
+
+  migration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install the project
+        run: uv sync --all-extras
+
+      - name: Install just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
+      - name: Run migration tests
+        run: just test-unit-migration

--- a/Justfile
+++ b/Justfile
@@ -30,6 +30,10 @@ test-unit-job:
     #!/bin/bash
     uv run pytest -v ./packages/syft-job/tests
 
+test-unit-migration:
+    #!/bin/bash
+    uv run pytest -n auto ./packages/syft-migration/tests
+
 
 test-unit-enclave:
     #!/bin/bash

--- a/packages/syft-migration/README.md
+++ b/packages/syft-migration/README.md
@@ -1,0 +1,24 @@
+# syft-migration
+
+Versioning and on-the-fly migration foundation for Syft objects.
+
+Lets peers running different package versions exchange data by upgrading or downgrading
+serialized objects to a version the other side understands.
+
+## Building blocks
+
+- `MigratableObject` — base for any versioned object (`canonical_name` + `version`),
+  auto-registers via `__init_subclass__`.
+- `PackageProtocolSchema` — the protocol surface of one release of one package
+  (`protocol_name`, `package_name`, `package_version`, one version per object).
+- `MigrationRegistry` — per-package registry of all object versions, migration edges, and
+  the current + historical protocol schemas.
+- `MigrationService` — upgrades/downgrades objects, including to the version a peer's
+  package version supports.
+
+## Dev
+
+```bash
+uv pip install -e packages/syft-migration
+just test-unit-migration
+```

--- a/packages/syft-migration/pyproject.toml
+++ b/packages/syft-migration/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "syft-migration"
+version = "0.1.0"
+description = "Versioning and on-the-fly migration foundation for Syft objects"
+authors = [{ name = "OpenMined", email = "info@openmined.org" }]
+license = { text = "Apache-2.0" }
+requires-python = ">=3.10"
+
+dependencies = [
+    "pydantic>=2.11.7",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/syft_migration"]

--- a/packages/syft-migration/src/syft_migration/__init__.py
+++ b/packages/syft-migration/src/syft_migration/__init__.py
@@ -1,0 +1,16 @@
+from syft_migration.base import MigratableObject
+from syft_migration.registry import MigrationError, MigrationRegistry, default_registry
+from syft_migration.schema import PackageProtocolSchema
+from syft_migration.service import MigrationService
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "MigratableObject",
+    "MigrationError",
+    "MigrationRegistry",
+    "MigrationService",
+    "PackageProtocolSchema",
+    "default_registry",
+    "__version__",
+]

--- a/packages/syft-migration/src/syft_migration/base.py
+++ b/packages/syft-migration/src/syft_migration/base.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+from syft_migration.registry import MigrationRegistry, default_registry
+
+
+class MigratableObject(BaseModel):
+    """Base class for any versioned object that can be migrated across versions.
+
+    Subclasses pin their identity by overriding the field defaults, e.g.::
+
+        class JobV2(MigratableObject):
+            canonical_name: str = "job"
+            version: str = "2"
+
+    ``canonical_name`` is the stable logical name shared across all versions of the
+    object; ``version`` is the schema version. Concrete subclasses auto-register into
+    a :class:`MigrationRegistry` on definition. Pass ``registry=`` as a class keyword
+    argument to register into a non-default registry (handy for test isolation).
+    """
+
+    canonical_name: str
+    version: str
+
+    def __init_subclass__(
+        cls, *, registry: Optional[MigrationRegistry] = None, **kwargs: object
+    ) -> None:
+        # Capture the chosen registry here; defer registration to
+        # __pydantic_init_subclass__ where model_fields is fully built.
+        if registry is not None:
+            cls.__migration_registry__ = registry
+        super().__init_subclass__(**kwargs)
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: object) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        registry: MigrationRegistry = getattr(
+            cls, "__migration_registry__", default_registry
+        )
+        registry.register_object(cls)

--- a/packages/syft-migration/src/syft_migration/base.py
+++ b/packages/syft-migration/src/syft_migration/base.py
@@ -40,4 +40,4 @@ class MigratableObject(BaseModel):
         registry: MigrationRegistry = getattr(
             cls, "__migration_registry__", default_registry
         )
-        registry.register_object(cls)
+        registry.register_object_version(cls)

--- a/packages/syft-migration/src/syft_migration/registry.py
+++ b/packages/syft-migration/src/syft_migration/registry.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:
+    from syft_migration.base import MigratableObject
+    from syft_migration.schema import PackageProtocolSchema
+
+# A migration transforms one MigratableObject instance into another version.
+MigrationFn = Callable[["MigratableObject"], "MigratableObject"]
+
+
+class MigrationError(Exception):
+    """Raised when an object cannot be registered, located, or migrated."""
+
+
+def _identity(cls: type[MigratableObject]) -> Optional[tuple[str, str]]:
+    """Return (canonical_name, version) for a concrete subclass, else None.
+
+    The base class and abstract intermediates leave the fields required (no
+    default), so they have no identity and are not registered.
+    """
+    name_field = cls.model_fields.get("canonical_name")
+    version_field = cls.model_fields.get("version")
+    if name_field is None or version_field is None:
+        return None
+    if name_field.is_required() or version_field.is_required():
+        return None
+    return str(name_field.default), str(version_field.default)
+
+
+class MigrationRegistry:
+    """All known object versions, migrations, and protocol schemas for ONE package."""
+
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], type[MigratableObject]] = {}
+        self.migrations: dict[str, dict[tuple[str, str], MigrationFn]] = {}
+        self.current_protocol_schema: Optional[PackageProtocolSchema] = None
+        self.history_protocol_schemas: dict[str, PackageProtocolSchema] = {}
+
+    # -- objects -----------------------------------------------------------
+    def register_object(self, cls: type[MigratableObject]) -> None:
+        identity = _identity(cls)
+        if identity is None:
+            return
+        existing = self.objects.get(identity)
+        if existing is not None and existing is not cls:
+            raise MigrationError(
+                f"Object {identity} already registered as {existing.__name__}, "
+                f"cannot re-register as {cls.__name__}"
+            )
+        self.objects[identity] = cls
+
+    def get_class(self, canonical_name: str, version: str) -> type[MigratableObject]:
+        try:
+            return self.objects[(canonical_name, version)]
+        except KeyError:
+            raise MigrationError(
+                f"No object registered for {(canonical_name, version)}"
+            )
+
+    def versions(self, canonical_name: str) -> list[str]:
+        return [v for (name, v) in self.objects if name == canonical_name]
+
+    def latest_version(self, canonical_name: str) -> str:
+        schema = self.current_protocol_schema
+        if schema is not None and canonical_name in schema.objects:
+            return schema.objects[canonical_name]
+        versions = self.versions(canonical_name)
+        if not versions:
+            raise MigrationError(f"No versions registered for {canonical_name!r}")
+        return max(versions)
+
+    # -- migrations --------------------------------------------------------
+    def register_migration(
+        self,
+        canonical_name: str,
+        from_version: str,
+        to_version: str,
+        fn: Optional[MigrationFn] = None,
+    ) -> Callable[[MigrationFn], MigrationFn] | None:
+        edges = self.migrations.setdefault(canonical_name, {})
+
+        def _add(func: MigrationFn) -> MigrationFn:
+            edges[(from_version, to_version)] = func
+            return func
+
+        if fn is None:
+            return _add
+        _add(fn)
+        return None
+
+    def migration_path(
+        self, canonical_name: str, from_version: str, to_version: str
+    ) -> list[MigrationFn]:
+        """Return the migration functions to apply, in order, via BFS over edges."""
+        if from_version == to_version:
+            return []
+        edges = self.migrations.get(canonical_name, {})
+        queue: deque[tuple[str, list[MigrationFn]]] = deque([(from_version, [])])
+        seen = {from_version}
+        while queue:
+            current, path = queue.popleft()
+            for (src, dst), func in edges.items():
+                if src != current or dst in seen:
+                    continue
+                next_path = [*path, func]
+                if dst == to_version:
+                    return next_path
+                seen.add(dst)
+                queue.append((dst, next_path))
+        raise MigrationError(
+            f"No migration path for {canonical_name!r} from {from_version} to {to_version}"
+        )
+
+    # -- protocol schemas --------------------------------------------------
+    def register_protocol_schema(
+        self, schema: PackageProtocolSchema, *, current: bool = True
+    ) -> None:
+        """Register a schema, keeping the object registry and schemas in sync.
+
+        Every object the schema ships is registered first (added if absent, raising
+        on a conflicting class), then the schema is stored.
+        """
+        for cls in schema.object_classes():
+            self.register_object(cls)
+        self.history_protocol_schemas[schema.package_version] = schema
+        if current:
+            self.current_protocol_schema = schema
+
+    def schema_for_package_version(self, package_version: str) -> PackageProtocolSchema:
+        if (
+            self.current_protocol_schema is not None
+            and self.current_protocol_schema.package_version == package_version
+        ):
+            return self.current_protocol_schema
+        try:
+            return self.history_protocol_schemas[package_version]
+        except KeyError:
+            raise MigrationError(
+                f"No protocol schema registered for package version {package_version!r}"
+            )
+
+
+# Default per-import registry used by MigratableObject.__init_subclass__.
+default_registry = MigrationRegistry()

--- a/packages/syft-migration/src/syft_migration/registry.py
+++ b/packages/syft-migration/src/syft_migration/registry.py
@@ -15,8 +15,8 @@ class MigrationError(Exception):
     """Raised when an object cannot be registered, located, or migrated."""
 
 
-def _identity(cls: type[MigratableObject]) -> Optional[tuple[str, str]]:
-    """Return (canonical_name, version) for a concrete subclass, else None.
+def _has_identity(cls: type[MigratableObject]) -> bool:
+    """Whether ``cls`` pins both identity fields (i.e. is a concrete version).
 
     The base class and abstract intermediates leave the fields required (no
     default), so they have no identity and are not registered.
@@ -24,49 +24,65 @@ def _identity(cls: type[MigratableObject]) -> Optional[tuple[str, str]]:
     name_field = cls.model_fields.get("canonical_name")
     version_field = cls.model_fields.get("version")
     if name_field is None or version_field is None:
-        return None
-    if name_field.is_required() or version_field.is_required():
-        return None
-    return str(name_field.default), str(version_field.default)
+        return False
+    return not (name_field.is_required() or version_field.is_required())
+
+
+def _identity(cls: type[MigratableObject]) -> tuple[str, str]:
+    """Return (canonical_name, version) for a concrete subclass.
+
+    Raises ``MigrationError`` if ``cls`` does not pin both fields (the base class
+    and abstract intermediates leave them required, so they have no identity).
+    """
+    if not _has_identity(cls):
+        raise MigrationError(
+            f"{cls.__name__} does not pin canonical_name/version and has no identity"
+        )
+    return (
+        str(cls.model_fields["canonical_name"].default),
+        str(cls.model_fields["version"].default),
+    )
 
 
 class MigrationRegistry:
     """All known object versions, migrations, and protocol schemas for ONE package."""
 
     def __init__(self) -> None:
-        self.objects: dict[tuple[str, str], type[MigratableObject]] = {}
+        # canonical_name -> {version: object_class}
+        self.objects: dict[str, dict[str, type[MigratableObject]]] = {}
+        # canonical_name -> {(from_version, to_version): migration_fn}
         self.migrations: dict[str, dict[tuple[str, str], MigrationFn]] = {}
         self.current_protocol_schema: Optional[PackageProtocolSchema] = None
         self.history_protocol_schemas: dict[str, PackageProtocolSchema] = {}
 
     # -- objects -----------------------------------------------------------
-    def register_object(self, cls: type[MigratableObject]) -> None:
-        identity = _identity(cls)
-        if identity is None:
+    def register_object_version(self, cls: type[MigratableObject]) -> None:
+        if not _has_identity(cls):
             return
-        existing = self.objects.get(identity)
+        canonical_name, version = _identity(cls)
+        existing = self.objects.get(canonical_name, {}).get(version)
         if existing is not None and existing is not cls:
             raise MigrationError(
-                f"Object {identity} already registered as {existing.__name__}, "
-                f"cannot re-register as {cls.__name__}"
+                f"Object {(canonical_name, version)} already registered as "
+                f"{existing.__name__}, cannot re-register as {cls.__name__}"
             )
-        self.objects[identity] = cls
+        self.objects.setdefault(canonical_name, {})[version] = cls
 
     def get_class(self, canonical_name: str, version: str) -> type[MigratableObject]:
         try:
-            return self.objects[(canonical_name, version)]
+            return self.objects[canonical_name][version]
         except KeyError:
             raise MigrationError(
                 f"No object registered for {(canonical_name, version)}"
             )
 
     def versions(self, canonical_name: str) -> list[str]:
-        return [v for (name, v) in self.objects if name == canonical_name]
+        return list(self.objects.get(canonical_name, {}))
 
     def latest_version(self, canonical_name: str) -> str:
         schema = self.current_protocol_schema
-        if schema is not None and canonical_name in schema.objects:
-            return schema.objects[canonical_name]
+        if schema is not None and canonical_name in schema.object_versions:
+            return schema.object_versions[canonical_name]
         versions = self.versions(canonical_name)
         if not versions:
             raise MigrationError(f"No versions registered for {canonical_name!r}")
@@ -78,18 +94,27 @@ class MigrationRegistry:
         canonical_name: str,
         from_version: str,
         to_version: str,
-        fn: Optional[MigrationFn] = None,
-    ) -> Callable[[MigrationFn], MigrationFn] | None:
+        fn: MigrationFn,
+    ) -> None:
+        """Register ``fn`` as the migration from ``from_version`` to ``to_version``."""
         edges = self.migrations.setdefault(canonical_name, {})
+        edges[(from_version, to_version)] = fn
 
-        def _add(func: MigrationFn) -> MigrationFn:
-            edges[(from_version, to_version)] = func
-            return func
+    def migration(
+        self, canonical_name: str, from_version: str, to_version: str
+    ) -> Callable[[MigrationFn], MigrationFn]:
+        """Decorator form of :meth:`register_migration` for named functions."""
 
-        if fn is None:
-            return _add
-        _add(fn)
-        return None
+        def decorator(fn: MigrationFn) -> MigrationFn:
+            self.register_migration(
+                canonical_name=canonical_name,
+                from_version=from_version,
+                to_version=to_version,
+                fn=fn,
+            )
+            return fn
+
+        return decorator
 
     def migration_path(
         self, canonical_name: str, from_version: str, to_version: str
@@ -97,8 +122,11 @@ class MigrationRegistry:
         """Return the migration functions to apply, in order, via BFS over edges."""
         if from_version == to_version:
             return []
+        # all migrations for this class
         edges = self.migrations.get(canonical_name, {})
+        # BFS queue of (current_version, path_to_current)
         queue: deque[tuple[str, list[MigrationFn]]] = deque([(from_version, [])])
+        # seen versions
         seen = {from_version}
         while queue:
             current, path = queue.popleft()
@@ -120,11 +148,12 @@ class MigrationRegistry:
     ) -> None:
         """Register a schema, keeping the object registry and schemas in sync.
 
-        Every object the schema ships is registered first (added if absent, raising
-        on a conflicting class), then the schema is stored.
+        Every object the schema pins must already be registered (objects auto-register
+        when their class is defined); registering a schema that references an unknown
+        object/version raises before the schema is stored.
         """
-        for cls in schema.object_classes():
-            self.register_object(cls)
+        for canonical_name, version in schema.object_versions.items():
+            self.get_class(canonical_name=canonical_name, version=version)
         self.history_protocol_schemas[schema.package_version] = schema
         if current:
             self.current_protocol_schema = schema

--- a/packages/syft-migration/src/syft_migration/schema.py
+++ b/packages/syft-migration/src/syft_migration/schema.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel
 
 from syft_migration.registry import MigrationError, _identity
 
@@ -25,13 +25,8 @@ class PackageProtocolSchema(BaseModel):
     protocol_name: str
     package_name: str
     package_version: str
-    objects: dict[str, str] = {}
-
-    # Class references for the pinned objects. Not serialized; only present on schemas
-    # built in code (a schema loaded from metadata has the version map but no classes).
-    _object_classes: dict[str, type[MigratableObject]] = PrivateAttr(
-        default_factory=dict
-    )
+    # canonical_name -> version
+    object_versions: dict[str, str] = {}
 
     @classmethod
     def from_objects(
@@ -41,34 +36,21 @@ class PackageProtocolSchema(BaseModel):
         package_version: str,
         classes: list[type[MigratableObject]],
     ) -> PackageProtocolSchema:
-        objects: dict[str, str] = {}
-        object_classes: dict[str, type[MigratableObject]] = {}
+        object_versions: dict[str, str] = {}
         for klass in classes:
-            identity = _identity(klass)
-            if identity is None:
-                raise MigrationError(
-                    f"{klass.__name__} has no canonical_name/version and cannot be "
-                    "added to a protocol schema"
-                )
-            canonical_name, version = identity
-            if canonical_name in objects:
+            canonical_name, version = _identity(klass)
+            if canonical_name in object_versions:
                 raise MigrationError(
                     f"Protocol schema may only pin one version per object, but "
                     f"{canonical_name!r} was given twice"
                 )
-            objects[canonical_name] = version
-            object_classes[canonical_name] = klass
-        schema = cls(
+            object_versions[canonical_name] = version
+        return cls(
             protocol_name=protocol_name,
             package_name=package_name,
             package_version=package_version,
-            objects=objects,
+            object_versions=object_versions,
         )
-        schema._object_classes = object_classes
-        return schema
-
-    def object_classes(self) -> list[type[MigratableObject]]:
-        return list(self._object_classes.values())
 
     def save(self, path: PathLike) -> None:
         Path(path).write_text(self.model_dump_json(indent=2))

--- a/packages/syft-migration/src/syft_migration/schema.py
+++ b/packages/syft-migration/src/syft_migration/schema.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, PrivateAttr
+
+from syft_migration.registry import MigrationError, _identity
+
+if TYPE_CHECKING:
+    from syft_migration.base import MigratableObject
+
+PathLike = str | Path
+
+
+class PackageProtocolSchema(BaseModel):
+    """The protocol surface of one release of one package.
+
+    Pins exactly one ``version`` per object (``canonical_name``) that the package ships
+    at ``package_version``. ``protocol_name`` is a hardcoded, language-agnostic
+    identifier for the protocol and is intentionally distinct from ``package_name``.
+    """
+
+    protocol_name: str
+    package_name: str
+    package_version: str
+    objects: dict[str, str] = {}
+
+    # Class references for the pinned objects. Not serialized; only present on schemas
+    # built in code (a schema loaded from metadata has the version map but no classes).
+    _object_classes: dict[str, type[MigratableObject]] = PrivateAttr(
+        default_factory=dict
+    )
+
+    @classmethod
+    def from_objects(
+        cls,
+        protocol_name: str,
+        package_name: str,
+        package_version: str,
+        classes: list[type[MigratableObject]],
+    ) -> PackageProtocolSchema:
+        objects: dict[str, str] = {}
+        object_classes: dict[str, type[MigratableObject]] = {}
+        for klass in classes:
+            identity = _identity(klass)
+            if identity is None:
+                raise MigrationError(
+                    f"{klass.__name__} has no canonical_name/version and cannot be "
+                    "added to a protocol schema"
+                )
+            canonical_name, version = identity
+            if canonical_name in objects:
+                raise MigrationError(
+                    f"Protocol schema may only pin one version per object, but "
+                    f"{canonical_name!r} was given twice"
+                )
+            objects[canonical_name] = version
+            object_classes[canonical_name] = klass
+        schema = cls(
+            protocol_name=protocol_name,
+            package_name=package_name,
+            package_version=package_version,
+            objects=objects,
+        )
+        schema._object_classes = object_classes
+        return schema
+
+    def object_classes(self) -> list[type[MigratableObject]]:
+        return list(self._object_classes.values())
+
+    def save(self, path: PathLike) -> None:
+        Path(path).write_text(self.model_dump_json(indent=2))
+
+    @classmethod
+    def load(cls, path: PathLike) -> PackageProtocolSchema:
+        return cls.model_validate(json.loads(Path(path).read_text()))

--- a/packages/syft-migration/src/syft_migration/service.py
+++ b/packages/syft-migration/src/syft_migration/service.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from syft_migration.base import MigratableObject
+from syft_migration.registry import MigrationError, MigrationRegistry
+from syft_migration.schema import PackageProtocolSchema
+
+
+class MigrationService:
+    """Upgrades and downgrades migratable objects using a package's registry."""
+
+    def __init__(self, registry: MigrationRegistry) -> None:
+        self.registry = registry
+
+    def migrate(self, obj: MigratableObject, target_version: str) -> MigratableObject:
+        """Migrate ``obj`` to ``target_version`` by applying the registered path."""
+        path = self.registry.migration_path(
+            obj.canonical_name, obj.version, target_version
+        )
+        result = obj
+        for migration in path:
+            result = migration(result)
+        return result
+
+    def migrate_to_schema(
+        self, obj: MigratableObject, schema: PackageProtocolSchema
+    ) -> MigratableObject:
+        """Migrate ``obj`` to the version pinned by ``schema`` (the on-the-fly downgrade)."""
+        target_version = schema.objects.get(obj.canonical_name)
+        if target_version is None:
+            raise MigrationError(
+                f"Protocol schema {schema.package_name}@{schema.package_version} does "
+                f"not include object {obj.canonical_name!r}"
+            )
+        return self.migrate(obj, target_version)
+
+    def downgrade_for_package_version(
+        self, obj: MigratableObject, package_version: str
+    ) -> MigratableObject:
+        """Migrate ``obj`` to the version a peer running ``package_version`` understands."""
+        schema = self.registry.schema_for_package_version(package_version)
+        return self.migrate_to_schema(obj, schema)
+
+    def load(
+        self, data: dict[str, Any], target_version: Optional[str] = None
+    ) -> MigratableObject:
+        """Deserialize ``data`` into its historical class, optionally migrating it."""
+        try:
+            canonical_name = data["canonical_name"]
+            version = data["version"]
+        except KeyError as exc:
+            raise MigrationError(f"Serialized object is missing {exc} field")
+        cls = self.registry.get_class(canonical_name, version)
+        obj = cls.model_validate(data)
+        if target_version is not None:
+            return self.migrate(obj, target_version)
+        return obj

--- a/packages/syft-migration/src/syft_migration/service.py
+++ b/packages/syft-migration/src/syft_migration/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from syft_migration.base import MigratableObject
-from syft_migration.registry import MigrationError, MigrationRegistry
+from syft_migration.registry import MigrationError, MigrationFn, MigrationRegistry
 from syft_migration.schema import PackageProtocolSchema
 
 
@@ -15,7 +15,7 @@ class MigrationService:
 
     def migrate(self, obj: MigratableObject, target_version: str) -> MigratableObject:
         """Migrate ``obj`` to ``target_version`` by applying the registered path."""
-        path = self.registry.migration_path(
+        path: list[MigrationFn] = self.registry.migration_path(
             obj.canonical_name, obj.version, target_version
         )
         result = obj
@@ -27,7 +27,7 @@ class MigrationService:
         self, obj: MigratableObject, schema: PackageProtocolSchema
     ) -> MigratableObject:
         """Migrate ``obj`` to the version pinned by ``schema`` (the on-the-fly downgrade)."""
-        target_version = schema.objects.get(obj.canonical_name)
+        target_version = schema.object_versions.get(obj.canonical_name)
         if target_version is None:
             raise MigrationError(
                 f"Protocol schema {schema.package_name}@{schema.package_version} does "

--- a/packages/syft-migration/tests/conftest.py
+++ b/packages/syft-migration/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from mocks import mock_registry
+
+from syft_migration import MigrationRegistry, MigrationService
+
+
+@pytest.fixture
+def registry() -> MigrationRegistry:
+    return mock_registry
+
+
+@pytest.fixture
+def service() -> MigrationService:
+    return MigrationService(mock_registry)

--- a/packages/syft-migration/tests/conftest.py
+++ b/packages/syft-migration/tests/conftest.py
@@ -11,4 +11,4 @@ def registry() -> MigrationRegistry:
 
 @pytest.fixture
 def service() -> MigrationService:
-    return MigrationService(mock_registry)
+    return MigrationService(registry=mock_registry)

--- a/packages/syft-migration/tests/mocks.py
+++ b/packages/syft-migration/tests/mocks.py
@@ -29,17 +29,36 @@ class JobV3(MigratableObject, registry=mock_registry):
     priority: int = 0
 
 
-mock_registry.register_migration("job", "1", "2", lambda obj: JobV2(name=obj.name))
 mock_registry.register_migration(
-    "job", "2", "3", lambda obj: JobV3(name=obj.name, owner=obj.owner)
+    canonical_name="job",
+    from_version="1",
+    to_version="2",
+    fn=lambda obj: JobV2(name=obj.name),
 )
-mock_registry.register_migration("job", "2", "1", lambda obj: JobV1(name=obj.name))
+mock_registry.register_migration(
+    canonical_name="job",
+    from_version="2",
+    to_version="3",
+    fn=lambda obj: JobV3(name=obj.name, owner=obj.owner),
+)
+mock_registry.register_migration(
+    canonical_name="job",
+    from_version="2",
+    to_version="1",
+    fn=lambda obj: JobV1(name=obj.name),
+)
 
 schema_v1 = PackageProtocolSchema.from_objects(
-    "mock-proto", "syft-mock", "1.0.0", [JobV1]
+    protocol_name="mock-proto",
+    package_name="syft-mock",
+    package_version="1.0.0",
+    classes=[JobV1],
 )
 schema_v2 = PackageProtocolSchema.from_objects(
-    "mock-proto", "syft-mock", "1.1.0", [JobV2]
+    protocol_name="mock-proto",
+    package_name="syft-mock",
+    package_version="1.1.0",
+    classes=[JobV2],
 )
-mock_registry.register_protocol_schema(schema_v1, current=False)
-mock_registry.register_protocol_schema(schema_v2, current=True)
+mock_registry.register_protocol_schema(schema=schema_v1, current=False)
+mock_registry.register_protocol_schema(schema=schema_v2, current=True)

--- a/packages/syft-migration/tests/mocks.py
+++ b/packages/syft-migration/tests/mocks.py
@@ -1,0 +1,45 @@
+from syft_migration import (
+    MigratableObject,
+    MigrationRegistry,
+    PackageProtocolSchema,
+)
+
+# Isolated registry so the mock objects never touch the global default_registry.
+mock_registry = MigrationRegistry()
+
+
+class JobV1(MigratableObject, registry=mock_registry):
+    canonical_name: str = "job"
+    version: str = "1"
+    name: str
+
+
+class JobV2(MigratableObject, registry=mock_registry):
+    canonical_name: str = "job"
+    version: str = "2"
+    name: str
+    owner: str = "unknown"
+
+
+class JobV3(MigratableObject, registry=mock_registry):
+    canonical_name: str = "job"
+    version: str = "3"
+    name: str
+    owner: str = "unknown"
+    priority: int = 0
+
+
+mock_registry.register_migration("job", "1", "2", lambda obj: JobV2(name=obj.name))
+mock_registry.register_migration(
+    "job", "2", "3", lambda obj: JobV3(name=obj.name, owner=obj.owner)
+)
+mock_registry.register_migration("job", "2", "1", lambda obj: JobV1(name=obj.name))
+
+schema_v1 = PackageProtocolSchema.from_objects(
+    "mock-proto", "syft-mock", "1.0.0", [JobV1]
+)
+schema_v2 = PackageProtocolSchema.from_objects(
+    "mock-proto", "syft-mock", "1.1.0", [JobV2]
+)
+mock_registry.register_protocol_schema(schema_v1, current=False)
+mock_registry.register_protocol_schema(schema_v2, current=True)

--- a/packages/syft-migration/tests/test_migration.py
+++ b/packages/syft-migration/tests/test_migration.py
@@ -11,16 +11,16 @@ from mocks import JobV1, JobV2, JobV3
 
 
 def test_subclass_auto_registers(registry):
-    assert registry.get_class("job", "1") is JobV1
-    assert registry.get_class("job", "2") is JobV2
-    assert set(registry.versions("job")) == {"1", "2", "3"}
+    assert registry.get_class(canonical_name="job", version="1") is JobV1
+    assert registry.get_class(canonical_name="job", version="2") is JobV2
+    assert set(registry.versions(canonical_name="job")) == {"1", "2", "3"}
 
 
 def test_protocol_schema_stored_as_current_and_history(registry):
     assert registry.current_protocol_schema.package_version == "1.1.0"
-    assert registry.current_protocol_schema.objects == {"job": "2"}
-    assert registry.history_protocol_schemas["1.0.0"].objects == {"job": "1"}
-    assert registry.latest_version("job") == "2"
+    assert registry.current_protocol_schema.object_versions == {"job": "2"}
+    assert registry.history_protocol_schemas["1.0.0"].object_versions == {"job": "1"}
+    assert registry.latest_version(canonical_name="job") == "2"
 
 
 def test_register_schema_adds_objects_and_syncs():
@@ -31,98 +31,113 @@ def test_register_schema_adds_objects_and_syncs():
         version: str = "1"
 
     # Object known, but not yet part of any schema (the "rare case").
-    assert reg.get_class("widget", "1") is WidgetV1
+    assert reg.get_class(canonical_name="widget", version="1") is WidgetV1
     assert reg.current_protocol_schema is None
 
-    schema = PackageProtocolSchema.from_objects("p", "pkg", "1.0.0", [WidgetV1])
-    reg.register_protocol_schema(schema)
+    schema = PackageProtocolSchema.from_objects(
+        protocol_name="p",
+        package_name="pkg",
+        package_version="1.0.0",
+        classes=[WidgetV1],
+    )
+    reg.register_protocol_schema(schema=schema)
     assert reg.current_protocol_schema is schema
 
 
-def test_register_schema_raises_on_conflicting_object():
+def test_register_schema_raises_on_unregistered_object():
     reg = MigrationRegistry()
 
-    class AlphaV1(MigratableObject, registry=reg):
-        canonical_name: str = "thing"
-        version: str = "1"
-
     class BetaV1(MigratableObject, registry=reg.__class__()):
-        # Different class with the same identity, registered into a throwaway registry.
+        # Registered into a throwaway registry, so ``reg`` has never seen it.
         canonical_name: str = "thing"
         version: str = "1"
 
-    schema = PackageProtocolSchema.from_objects("p", "pkg", "1.0.0", [BetaV1])
+    schema = PackageProtocolSchema.from_objects(
+        protocol_name="p",
+        package_name="pkg",
+        package_version="1.0.0",
+        classes=[BetaV1],
+    )
     with pytest.raises(MigrationError):
-        reg.register_protocol_schema(schema)
+        reg.register_protocol_schema(schema=schema)
 
 
-def test_register_object_idempotent_for_same_class(registry):
-    registry.register_object(JobV1)  # already registered; must not raise
-    assert registry.get_class("job", "1") is JobV1
+def test_register_object_version_idempotent_for_same_class(registry):
+    registry.register_object_version(cls=JobV1)  # already registered; must not raise
+    assert registry.get_class(canonical_name="job", version="1") is JobV1
 
 
 def test_migrate_upgrades_single_step(service):
-    result = service.migrate(JobV1(name="x"), "2")
+    result = service.migrate(obj=JobV1(name="x"), target_version="2")
     assert isinstance(result, JobV2)
     assert result.name == "x" and result.owner == "unknown"
 
 
 def test_migrate_chains_multiple_steps(service):
-    result = service.migrate(JobV1(name="x"), "3")
+    result = service.migrate(obj=JobV1(name="x"), target_version="3")
     assert isinstance(result, JobV3)
     assert result.version == "3"
 
 
 def test_migrate_downgrades(service):
-    result = service.migrate(JobV2(name="x", owner="bob"), "1")
+    result = service.migrate(obj=JobV2(name="x", owner="bob"), target_version="1")
     assert isinstance(result, JobV1)
     assert result.name == "x"
 
 
 def test_migrate_same_version_is_noop(service):
     job = JobV2(name="x")
-    assert service.migrate(job, "2") is job
+    assert service.migrate(obj=job, target_version="2") is job
 
 
 def test_migrate_missing_path_raises(service):
     with pytest.raises(MigrationError):
-        service.migrate(JobV3(name="x"), "1")
+        service.migrate(obj=JobV3(name="x"), target_version="1")
 
 
 def test_downgrade_for_package_version(service):
     result = service.downgrade_for_package_version(
-        JobV2(name="x", owner="bob"), "1.0.0"
+        obj=JobV2(name="x", owner="bob"), package_version="1.0.0"
     )
     assert isinstance(result, JobV1)
     assert result.name == "x"
 
 
 def test_load_deserializes_into_historical_class(service):
-    obj = service.load({"canonical_name": "job", "version": "1", "name": "x"})
+    obj = service.load(data={"canonical_name": "job", "version": "1", "name": "x"})
     assert isinstance(obj, JobV1)
-    migrated = service.migrate(obj, service.registry.latest_version("job"))
+    migrated = service.migrate(
+        obj=obj, target_version=service.registry.latest_version(canonical_name="job")
+    )
     assert isinstance(migrated, JobV2)
 
 
 def test_load_unknown_object_raises(service):
     with pytest.raises(MigrationError):
-        service.load({"canonical_name": "job", "version": "99"})
+        service.load(data={"canonical_name": "job", "version": "99"})
 
 
 def test_schema_save_load_roundtrip(tmp_path):
     schema = PackageProtocolSchema.from_objects(
-        "mock-proto", "syft-mock", "1.1.0", [JobV2]
+        protocol_name="mock-proto",
+        package_name="syft-mock",
+        package_version="1.1.0",
+        classes=[JobV2],
     )
     path = tmp_path / "protocol.json"
-    schema.save(path)
-    loaded = PackageProtocolSchema.load(path)
+    schema.save(path=path)
+    loaded = PackageProtocolSchema.load(path=path)
     assert loaded.protocol_name == "mock-proto"
     assert loaded.package_name == "syft-mock"
     assert loaded.package_version == "1.1.0"
-    assert loaded.objects == {"job": "2"}
-    assert loaded.object_classes() == []  # class refs are not serialized
+    assert loaded.object_versions == {"job": "2"}
 
 
 def test_schema_rejects_two_versions_of_same_object():
     with pytest.raises(MigrationError):
-        PackageProtocolSchema.from_objects("p", "pkg", "1.0.0", [JobV1, JobV2])
+        PackageProtocolSchema.from_objects(
+            protocol_name="p",
+            package_name="pkg",
+            package_version="1.0.0",
+            classes=[JobV1, JobV2],
+        )

--- a/packages/syft-migration/tests/test_migration.py
+++ b/packages/syft-migration/tests/test_migration.py
@@ -1,0 +1,128 @@
+import pytest
+
+from syft_migration import (
+    MigratableObject,
+    MigrationError,
+    MigrationRegistry,
+    PackageProtocolSchema,
+)
+
+from mocks import JobV1, JobV2, JobV3
+
+
+def test_subclass_auto_registers(registry):
+    assert registry.get_class("job", "1") is JobV1
+    assert registry.get_class("job", "2") is JobV2
+    assert set(registry.versions("job")) == {"1", "2", "3"}
+
+
+def test_protocol_schema_stored_as_current_and_history(registry):
+    assert registry.current_protocol_schema.package_version == "1.1.0"
+    assert registry.current_protocol_schema.objects == {"job": "2"}
+    assert registry.history_protocol_schemas["1.0.0"].objects == {"job": "1"}
+    assert registry.latest_version("job") == "2"
+
+
+def test_register_schema_adds_objects_and_syncs():
+    reg = MigrationRegistry()
+
+    class WidgetV1(MigratableObject, registry=reg):
+        canonical_name: str = "widget"
+        version: str = "1"
+
+    # Object known, but not yet part of any schema (the "rare case").
+    assert reg.get_class("widget", "1") is WidgetV1
+    assert reg.current_protocol_schema is None
+
+    schema = PackageProtocolSchema.from_objects("p", "pkg", "1.0.0", [WidgetV1])
+    reg.register_protocol_schema(schema)
+    assert reg.current_protocol_schema is schema
+
+
+def test_register_schema_raises_on_conflicting_object():
+    reg = MigrationRegistry()
+
+    class AlphaV1(MigratableObject, registry=reg):
+        canonical_name: str = "thing"
+        version: str = "1"
+
+    class BetaV1(MigratableObject, registry=reg.__class__()):
+        # Different class with the same identity, registered into a throwaway registry.
+        canonical_name: str = "thing"
+        version: str = "1"
+
+    schema = PackageProtocolSchema.from_objects("p", "pkg", "1.0.0", [BetaV1])
+    with pytest.raises(MigrationError):
+        reg.register_protocol_schema(schema)
+
+
+def test_register_object_idempotent_for_same_class(registry):
+    registry.register_object(JobV1)  # already registered; must not raise
+    assert registry.get_class("job", "1") is JobV1
+
+
+def test_migrate_upgrades_single_step(service):
+    result = service.migrate(JobV1(name="x"), "2")
+    assert isinstance(result, JobV2)
+    assert result.name == "x" and result.owner == "unknown"
+
+
+def test_migrate_chains_multiple_steps(service):
+    result = service.migrate(JobV1(name="x"), "3")
+    assert isinstance(result, JobV3)
+    assert result.version == "3"
+
+
+def test_migrate_downgrades(service):
+    result = service.migrate(JobV2(name="x", owner="bob"), "1")
+    assert isinstance(result, JobV1)
+    assert result.name == "x"
+
+
+def test_migrate_same_version_is_noop(service):
+    job = JobV2(name="x")
+    assert service.migrate(job, "2") is job
+
+
+def test_migrate_missing_path_raises(service):
+    with pytest.raises(MigrationError):
+        service.migrate(JobV3(name="x"), "1")
+
+
+def test_downgrade_for_package_version(service):
+    result = service.downgrade_for_package_version(
+        JobV2(name="x", owner="bob"), "1.0.0"
+    )
+    assert isinstance(result, JobV1)
+    assert result.name == "x"
+
+
+def test_load_deserializes_into_historical_class(service):
+    obj = service.load({"canonical_name": "job", "version": "1", "name": "x"})
+    assert isinstance(obj, JobV1)
+    migrated = service.migrate(obj, service.registry.latest_version("job"))
+    assert isinstance(migrated, JobV2)
+
+
+def test_load_unknown_object_raises(service):
+    with pytest.raises(MigrationError):
+        service.load({"canonical_name": "job", "version": "99"})
+
+
+def test_schema_save_load_roundtrip(tmp_path):
+    schema = PackageProtocolSchema.from_objects(
+        "mock-proto", "syft-mock", "1.1.0", [JobV2]
+    )
+    path = tmp_path / "protocol.json"
+    schema.save(path)
+    loaded = PackageProtocolSchema.load(path)
+    assert loaded.protocol_name == "mock-proto"
+    assert loaded.package_name == "syft-mock"
+    assert loaded.package_version == "1.1.0"
+    assert loaded.objects == {"job": "2"}
+    assert loaded.object_classes() == []  # class refs are not serialized
+
+
+def test_schema_rejects_two_versions_of_same_object():
+    with pytest.raises(MigrationError):
+        PackageProtocolSchema.from_objects("p", "pkg", "1.0.0", [JobV1, JobV2])

--- a/packages/syft-restrict/README.md
+++ b/packages/syft-restrict/README.md
@@ -5,7 +5,7 @@
 `syft-restrict` is inspired by [**RestrictedPython**](https://github.com/zopefoundation/RestrictedPython): it **default-denies** every dynamic part of Python. It differs in a few ways:
 
 - **Syft-restrict analyzes, it doesn't run.** syft-restrict statically analyzes a source file and **raises if the analyzed part uses any dynamic Python**. Its output is a **report** (the violations, or — on success — an attestation) plus an **obfuscated copy** of the code.
-- **syft-restrict is currently tailored for analysis of machine learning inference code** 
+- **syft-restrict is currently tailored for analysis of machine learning inference code**
 - **Public / private split.** The user marks some lines of the file _private_ and leaves the rest _public_. restrict analyzes only the **AST of the private part**, and only those private lines are **hidden (obfuscated)** in the emitted artifact; the public lines are copied through and read directly.
 - **Imports are allowed (and therefore trusted).** Unlike RestrictedPython, the analyzed code may **import allowlisted libraries** and call into them — which means the reader of the output **needs to trust those imported classes/functions** (only their allow-listed paths; see §3).
 - **Dynamic Python lives in the public part.** Anything dynamic the author needs (file/tokenizer loading, the generation loop, wrappers around library methods) must be written in the **public** region — where it is read directly — and may be **called by** the private part.
@@ -28,6 +28,7 @@ result = restrict.run(
 ```
 
 This command reads **[examples/gemma_inference.py](examples/gemma_inference.py)** and generates **[examples/gemma_inference.obfuscated.py](examples/gemma_inference.obfuscated.py)**. If we can assume that syft-restrict was executed on the true inference file and the library was not modified, for instance because it was executed in a [TEE](https://en.wikipedia.org/wiki/Trusted_execution_environment), this proves:
+
 1. this code is an inference pipelines for a jax model, where the model architecture is hidden in the report
 2. this code does not steal the inputs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ members = ["packages/*"]
 "syft-enclave" = { workspace = true }
 "enclave-model-api-example" = { workspace = true }
 "syft-restrict" = { workspace = true }
+"syft-migration" = { workspace = true }
 
 [project.urls]
 Homepage = "https://github.com/OpenMined/PySyft"
@@ -180,5 +181,6 @@ test = [
     "enclave-model-api-example[test]",  # pulls fastapi/httpx for the inference server tests
     "syft-enclave",
     "syft-restrict",
+    "syft-migration",
     "pyarrow",  # only used by parquet test fixtures (tests/unit/utils.py)
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ members = [
     "syft-dataset",
     "syft-enclave",
     "syft-job",
+    "syft-migration",
     "syft-notebook-ui",
     "syft-permissions",
     "syft-perms",
@@ -3776,6 +3777,7 @@ test = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-xdist" },
     { name = "syft-enclave" },
+    { name = "syft-migration" },
     { name = "syft-restrict" },
 ]
 
@@ -3825,6 +3827,7 @@ test = [
     { name = "pytest-rerunfailures", specifier = ">=14.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
     { name = "syft-enclave", editable = "packages/syft-enclave" },
+    { name = "syft-migration", editable = "packages/syft-migration" },
     { name = "syft-restrict", editable = "packages/syft-restrict" },
 ]
 
@@ -3906,6 +3909,17 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "syft-perms", editable = "packages/syft-perms" },
 ]
+
+[[package]]
+name = "syft-migration"
+version = "0.1.0"
+source = { editable = "packages/syft-migration" }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2.11.7" }]
 
 [[package]]
 name = "syft-notebook-ui"


### PR DESCRIPTION
Foundational first ticket of the migrations epic (Asana 1216142685366749). Adds a new `syft-migration` workspace package with the building blocks for on-the-fly object migration across syft packages, so peers running different package versions can exchange data by upgrading/downgrading objects.

## What's included
- **`MigratableObject`** — pydantic base carrying `canonical_name` (stable logical name, e.g. `job`) + `version` (e.g. `2`); concrete subclasses auto-register via `__pydantic_init_subclass__` (with a `registry=` class kwarg for test isolation).
- **`PackageProtocolSchema`** — protocol surface of one release of one package (`protocol_name`, `package_name`, `package_version`, one version per object); JSON `save`/`load` for package metadata.
- **`MigrationRegistry`** — per-package store of all object versions, migration edges (BFS path-finding for multi-step + downgrade), and current/historical protocol schemas. `register_protocol_schema` enforces the schema↔object sync invariant (raises on conflicting class).
- **`MigrationService`** — `migrate`, `migrate_to_schema`, `downgrade_for_package_version` (peer-version downgrade), `load`.
- Wired into the uv workspace (`[tool.uv.sources]` + `test` group) and added a `test-unit-migration` Justfile target.

No production objects are touched; the classes are exercised against mock objects in tests. Retrofitting real objects, per-package metadata wiring, and concrete migrations are left to later epic tickets.

## Test plan
- `just test-unit-migration` — 15 unit tests pass (auto-registration, sync invariant/conflict raise, current/history storage, multi-step upgrade, downgrade, peer-version downgrade, metadata round-trip, load).
- `just test-unit-fast` — 406 tests, unaffected.
- `pre-commit run --all-files` — clean.