### PR TITLE
docs: rewrite terraform production quickstart as pure terraform commands

### DIFF
--- a/packages/syft-enclave/docs/terraform.md
+++ b/packages/syft-enclave/docs/terraform.md
@@ -12,8 +12,8 @@ State is **local** (`terraform/terraform.tfstate`, gitignored): one operator = o
 ## Prerequisites
 
 - [Terraform](https://developer.hashicorp.com/terraform/install) ≥ 1.5
-- `gcloud` CLI (used for authentication and by `just tf-logs` / `tf-ssh` / `tf-attest`)
-- [`just`](https://github.com/casey/just)
+- `gcloud` CLI (used for authentication, the VM status check, and the dev-mode helpers)
+- [`just`](https://github.com/casey/just) (dev-mode helpers only)
 - A GCP project with billing enabled
 
 Run all commands from `packages/syft-enclave/`.
@@ -45,7 +45,7 @@ Then fill in:
 
 Optional overrides (commented in the example file): `vm_name`, `machine_type`, `boot_disk_size_gb`, `container_image`, `use_encryption`, `job_timeout_seconds`.
 
-Do **not** set `dev_mode` in tfvars — `just tf-apply` / `just tf-apply-dev` force it on the command line, which takes precedence, so a stray tfvars value can never produce the wrong deployment type.
+Do **not** set `dev_mode` in tfvars — pass it on the command line (`-var=dev_mode=false` for production, `just tf-apply-dev` for dev), which takes precedence, so a stray tfvars value can never produce the wrong deployment type.
 
 > ⚠️ **Token handling.** The token content is uploaded to Secret Manager _and_ stored in plaintext in the local `terraform.tfstate`. The state file is gitignored — never commit it, share it, or move it off your machine.
 
@@ -54,16 +54,33 @@ Do **not** set `dev_mode` in tfvars — `just tf-apply` / `just tf-apply-dev` fo
 Hardened image — no SSH, TEE enforcement, encryption on, container restart policy `Never`.
 
 ```bash
-just tf-init      # once: download providers, set up local state
-just tf-plan      # preview what will be created
-just tf-apply     # provision APIs, SA, IAM, secret, and the VM
-just tf-status    # RUNNING / TERMINATED / ...
-just tf-output    # IP, SA email, secret resource
+terraform -chdir=terraform init                       # once: download providers, set up local state
+terraform -chdir=terraform apply -var=dev_mode=false  # provision APIs, SA, IAM, secret, and the VM
+```
+
+Check the VM status (`RUNNING` / `TERMINATED` / ...):
+
+```bash
+gcloud compute instances describe \
+  "$(terraform -chdir=terraform output -raw vm_name)" \
+  --project="$(terraform -chdir=terraform output -raw project_id)" \
+  --zone="$(terraform -chdir=terraform output -raw zone)" \
+  --format='get(status)'
 ```
 
 Attestation on production cannot be fetched over the network (no open ports, no SSH) — it is delivered via the peer flow and verified by peers with `client.attest_peer()`.
 
-## Quickstart: dev mode
+## Teardown
+
+```bash
+terraform -chdir=terraform destroy
+```
+
+Deletes the VM, secret, service account, and IAM bindings. The enabled APIs are intentionally left on (`disable_on_destroy = false`) — disabling project-wide APIs could break other workloads in the project.
+
+## Dev
+
+### Quickstart: dev mode
 
 Debug image — SSH enabled, container logs redirected to serial output, encryption off (override with `use_encryption = true` in tfvars), restart policy `Always`.
 
@@ -76,16 +93,6 @@ just tf-attest      # attestation report, fetched via SSH + localhost
 
 > `tf-logs` prefers SSH + `journalctl` because the serial console caps redirected container output — chatty containers go quiet in serial logs after ~1MB. On production deployments (no SSH) it falls back to serial output, which mainly shows boot/launcher logs.
 
-## Teardown
-
-```bash
-just tf-destroy
-```
-
-Deletes the VM, secret, service account, and IAM bindings. The enabled APIs are intentionally left on (`disable_on_destroy = false`) — disabling project-wide APIs could break other workloads in the project.
-
-
-## Dev
 ### Iterating on the enclave code
 
 - **Pure local (no GCP):** unchanged — `just local-build` and `just local-run` run the container on your machine with `SYFT_ENCLAVE_REQUIRE_TEE=false`.
@@ -112,7 +119,6 @@ Deletes the VM, secret, service account, and IAM bindings. The enabled APIs are 
 | `oauth2: "invalid_grant"`            | ADC token expired/revoked — re-run `gcloud auth application-default login`.                                                                                                                                                                                                                                                                           |
 | Quota project warnings               | `gcloud auth application-default set-quota-project YOUR_PROJECT_ID`                                                                                                                                                                                                                                                                                   |
 | Attestation fails on first boot      | Check the enclave SA has `roles/confidentialcomputing.workloadUser` (Terraform grants it to the dedicated SA only, not the default compute SA). A fresh apply waits 120s for IAM propagation (`time_sleep.iam_propagation`); if the launcher still 403s and exits (`exit_code=4`, dead VM), reset the VM: `gcloud compute instances reset <vm_name>`. |
-
 
 ## Formatting and validation
 


### PR DESCRIPTION
- Production quickstart and teardown now use raw `terraform -chdir=terraform ...` commands instead of `just tf-*` recipes; dropped the `tf-plan` / `tf-output` steps
- Moved Teardown up (right after the production quickstart) and moved "Quickstart: dev mode" under the Dev section
- VM status check is a plain `gcloud compute instances describe` command; prerequisites scope `just` to the dev-mode helpers