### PR TITLE
fix: correct JobRef import path in test_datasets_jobs_repr

### DIFF
--- a/tests/unit/test_datasets_jobs_repr.py
+++ b/tests/unit/test_datasets_jobs_repr.py
@@ -1,9 +1,9 @@
 """Tests for SyftDatasetManager and JobsList repr and indexing."""
 
 import pytest
-
 from syft_client.sync.syftbox_manager import SyftboxManager
 from syft_job.job import JobInfo, JobsList
+
 from tests.unit.utils import create_tmp_dataset_files
 
 
@@ -141,7 +141,7 @@ def _make_job_info(name: str, status: str = "pending") -> JobInfo:
 
     from syft_job.client import JobClient
     from syft_job.config import SyftJobConfig
-    from syft_job.manager import JobRef
+    from syft_job.job_ref import JobRef
     from syft_job.models import JobState, JobStatus, JobSubmissionMetadata
 
     config = SyftJobConfig(


### PR DESCRIPTION
## Summary
`tests/unit/test_datasets_jobs_repr.py` imported `JobRef` from `syft_job.manager`, but `manager.py` was renamed and `JobRef` now lives in `syft_job.job_ref`. This broke the unit tests on `dev`.

This applies the fix from commit `2bc561af` (Pedro Werneck), correcting the import to `from syft_job.job_ref import JobRef`.

## Testing
- `uv run pytest ./tests/unit/test_datasets_jobs_repr.py` → 16 passed
- `just test-unit-fast` → 406 passed, 9 deselected