### PR TITLE
fix: allow custom email and token_path in delete-syftbox recipe

### DIFF
--- a/packages/syft-enclave/Justfile
+++ b/packages/syft-enclave/Justfile
@@ -284,18 +284,19 @@ stop name=vm_default: _whoami
       --zone="$zone" \
       --quiet
 
-# Delete the enclave's syftbox (Drive files + local state)
-# Usage: just delete-syftbox enclave@example.com
+# Delete a syftbox (Drive files + local state). Defaults to the enclave
+# account/token, but any email + token_path can be passed (e.g. to wipe a
+# data owner or data scientist syftbox before redeploying).
+# Usage: just delete-syftbox [email] [token_path]
 [group('teardown')]
-delete-syftbox email:
+delete-syftbox email token_path="../../credentials/token_enclave.json":
     #!/bin/bash
     set -e
-    token="../../credentials/token_enclave.json"
-    [ -f "$token" ] || { echo "Error: $token not found" >&2; exit 1; }
-    echo "Deleting syftbox for {{email}}..."
+    [ -f "{{token_path}}" ] || { echo "Error: token file not found: {{token_path}}" >&2; exit 1; }
+    echo "Deleting syftbox for {{email}} (token: {{token_path}})..."
     uv run --project ../.. -- python -c "
     from syft_client.sync.utils.syftbox_utils import delete_syftbox
-    delete_syftbox(token_path='$token', email='{{email}}')
+    delete_syftbox(token_path='{{token_path}}', email='{{email}}')
     "
 
 # Tear down everything provisioned by `provision-secret-sa`:


### PR DESCRIPTION
The `delete-syftbox` recipe in `packages/syft-enclave/Justfile` hardcoded the token to the enclave credentials and only accepted an `email` arg, so it couldn't be used to wipe a data owner or data scientist syftbox.

## Changes
- Add an optional `token_path` parameter, still defaulting to `../../credentials/token_enclave.json` (existing behavior unchanged)
- Validate the token file exists at the given path
- Echo the token path being used for clarity

## Usage
- `just delete-syftbox enclave@example.com` — uses the enclave token (default)
- `just delete-syftbox koen@openmined.org ../../credentials/token_ds.json` — any email + token path

## Test plan
- Verified the recipe parses with `just --show delete-syftbox`
- Confirmed `delete_syftbox()` already accepts both `token_path` and `email`