### PR TITLE
docs: clarify markdown in gemma enclave DO notebooks for first-time users

### DIFF
--- a/notebooks/enclave/gemma/colab/1. DO-model-owner-gemma-restrict.ipynb
+++ b/notebooks/enclave/gemma/colab/1. DO-model-owner-gemma-restrict.ipynb
@@ -4,20 +4,7 @@
    "cell_type": "markdown",
    "id": "0",
    "metadata": {},
-   "source": [
-    "# Enclave Inference — Gemma 3 — Model Owner\n",
-    "\n",
-    "| Actor | Email | Role |\n",
-    "|-------|-------|------|\n",
-    "| **Enclave** | `ENCLAVE_EMAIL` | Trusted execution environment |\n",
-    "| **Model owner** | (this notebook) | Owns the Gemma 3 model (weights + inference engine) |\n",
-    "| **Benchmark owner** | (separate notebook) | Owns AI safety evaluation prompts |\n",
-    "| **Researcher** | `RESEARCHER_EMAIL` | Submits inference job for bias/safety evaluation |\n",
-    "\n",
-    "This notebook drives only the Model Owner steps; the Benchmark Owner and Researcher run their own notebooks in parallel.\n",
-    "\n",
-    "The inference engine is private too, so before the evaluation the Model Owner has the enclave run [`syft-restrict`](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) over it — proving it only does allow-listed JAX math, without revealing the architecture."
-   ]
+   "source": "# Enclave Inference — Gemma 3 — Model Owner\n\n| Actor | Email | Role |\n|-------|-------|------|\n| **Enclave** | `ENCLAVE_EMAIL` | Trusted execution environment |\n| **Model owner** | (this notebook) | Owns the Gemma 3 model (weights + inference engine) |\n| **Benchmark owner** | (separate notebook) | Owns the private benchmark |\n| **Researcher** | `RESEARCHER_EMAIL` | Submits inference job for bias/safety evaluation |\n\n**The setting.** These clients connect to an [enclave](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-enclave) — a sealed environment that runs code on data nobody can see. There are two data owners: the **model owner** (this notebook), who keeps the model private, and the **benchmark owner** (other notebook), who keeps the benchmark private. Both upload their assets into the enclave, and nothing runs on them unless **both owners approve the exact code** first.\n\nThe model owner keeps two things private: the model weights, and part of the inference code. That code is a single file with private parts (the model architecture) and public parts (the rest).\n\nFirst the model owner uploads the private model and submits a job that proves the inference code does not steal any data when it runs, using [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict). Then the benchmark owner submits a job that runs the model on their benchmark."
   },
   {
    "cell_type": "markdown",
@@ -97,9 +84,7 @@
    "cell_type": "markdown",
    "id": "6",
    "metadata": {},
-   "source": [
-    "## Step 0 — Log in as Model Owner"
-   ]
+   "source": "## Step 0 — Log in as Model Owner\n\nWe log in to the enclave. This client lets us upload data and approve jobs in the enclave."
   },
   {
    "cell_type": "code",
@@ -136,9 +121,7 @@
    "cell_type": "markdown",
    "id": "10",
    "metadata": {},
-   "source": [
-    "## Step 1 — Peer with the Enclave"
-   ]
+   "source": "## Step 1 — Peer with the Enclave\n\nTo make requests to the enclave, we first need to peer with it."
   },
   {
    "cell_type": "code",
@@ -189,9 +172,7 @@
    "cell_type": "markdown",
    "id": "15",
    "metadata": {},
-   "source": [
-    "### Step 1.2 — Attest enclave's identity"
-   ]
+   "source": "### Step 1.2 — Attest the enclave's identity\n\nHere we validate the attestation report. It confirms the standard enclave properties — the hashes of the BIOS, operating system, system processes, and applications — and signs those hashes with a private key that only the enclave holds. It also confirms the exact PySyft version and configuration. This ties the approvals of both the model owner and the benchmark owner to the exact code, inputs, parameters, and output policy. PySyft handles all of this automatically. This signed hash could only be faked if the hardware provider and the model owner colluded."
   },
   {
    "cell_type": "code",
@@ -208,9 +189,7 @@
    "cell_type": "markdown",
    "id": "17",
    "metadata": {},
-   "source": [
-    "## Step 2 — Mount Gemma 3 Weights from Drive\n"
-   ]
+   "source": "## Step 2 — Get the Gemma 3 model\n\nWe download the Gemma 3 model. In a real scenario this would come from the model owner's private data."
   },
   {
    "cell_type": "code",
@@ -253,16 +232,7 @@
    "cell_type": "markdown",
    "id": "21",
    "metadata": {},
-   "source": [
-    "## Step 3 — Build the private dataset\n",
-    "\n",
-    "Model owner's private contribution is a directory containing:\n",
-    "- `gemma_inference.py` — the inference engine (model architecture + generate function)\n",
-    "- `{CKPT_SUBDIR}/` — the checkpoint weights directory\n",
-    "- `tokenizer.model` — the SentencePiece tokenizer\n",
-    "\n",
-    "The **mock** (public) side is just a model card describing the model."
-   ]
+   "source": "## Step 3 — Prepare the files for upload\n\nWe bundle what goes into the enclave. The private side is the inference code, the checkpoint weights, and the tokenizer. The public (mock) side is just a model card describing the model."
   },
   {
    "cell_type": "code",
@@ -335,11 +305,7 @@
    "cell_type": "markdown",
    "id": "24",
    "metadata": {},
-   "source": [
-    "## Step 4 — Upload gemma3_model\n",
-    "\n",
-    "Mock = model card; private = weights + inference code; shared with the enclave so it can run inference."
-   ]
+   "source": "## Step 4 — Upload the private model\n\nWe upload the private model into the enclave. The inference code comes from [`gemma_inference_restrict.py`](https://github.com/OpenMined/PySyft/blob/dev/notebooks/enclave/gemma/colab/gemma_inference_restrict.py). It is already annotated with private and public regions using comments; when we run syft-restrict on it, it validates the private regions. No one can access this model — it can only be used in jobs that both owners approve."
   },
   {
    "cell_type": "code",
@@ -365,13 +331,7 @@
    "cell_type": "markdown",
    "id": "26",
    "metadata": {},
-   "source": [
-    "## Step 5 — Have the enclave run `syft-restrict` on the engine\n",
-    "\n",
-    "The engine's private region is marked in the file with `# syft-restrict: ...` comments, so `run()` needs no line\n",
-    "ranges. The job installs `syft-restrict` from PyPI; it needs no JAX — it analyses the source, it doesn't run it.\n",
-    "Results go to the Benchmark Owner, who is named with an empty dataset list: recipient of the verdict, no data access."
-   ]
+   "source": "## Step 5 — Run `syft-restrict` on the inference code\n\nWe submit a job that runs [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) on the inference code. syft-restrict does two things:\n\n1. It creates a readable copy of the code with the private regions hidden.\n2. It analyses the code and makes sure the private code only uses non-dynamic Python that cannot leak the benchmark."
   },
   {
    "cell_type": "code",
@@ -459,11 +419,7 @@
    "cell_type": "markdown",
    "id": "29",
    "metadata": {},
-   "source": [
-    "### Step 5.1 — Approve it\n",
-    "\n",
-    "Both Data Owners must approve before the enclave will run it. Re-sync until it appears, then approve."
-   ]
+   "source": "### Step 5.1 — Approve the job\n\nWe approve the job. Every job that runs must be approved by both parties."
   },
   {
    "cell_type": "code",
@@ -503,11 +459,7 @@
    "cell_type": "markdown",
    "id": "33",
    "metadata": {},
-   "source": [
-    "## Step 6 — Wait for the Researcher to submit the job, then approve\n",
-    "\n",
-    "The Researcher submits `safety_eval_job` to the enclave. Re-sync until it appears here, inspect it, then approve."
-   ]
+   "source": "## Step 6 — Approve the final inference job\n\nNow we wait for the benchmark owner to submit the final job that runs the model on the private benchmark. We carefully inspect the code to make sure it only does that, then we approve. The final result is shared with the benchmark owner."
   },
   {
    "cell_type": "code",

--- a/notebooks/enclave/gemma/colab/1. DO-model-owner-gemma-restrict.ipynb
+++ b/notebooks/enclave/gemma/colab/1. DO-model-owner-gemma-restrict.ipynb
@@ -4,7 +4,22 @@
    "cell_type": "markdown",
    "id": "0",
    "metadata": {},
-   "source": "# Enclave Inference — Gemma 3 — Model Owner\n\n| Actor | Email | Role |\n|-------|-------|------|\n| **Enclave** | `ENCLAVE_EMAIL` | Trusted execution environment |\n| **Model owner** | (this notebook) | Owns the Gemma 3 model (weights + inference engine) |\n| **Benchmark owner** | (separate notebook) | Owns the private benchmark |\n| **Researcher** | `RESEARCHER_EMAIL` | Submits inference job for bias/safety evaluation |\n\n**The setting.** These clients connect to an [enclave](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-enclave) — a sealed environment that runs code on data nobody can see. There are two data owners: the **model owner** (this notebook), who keeps the model private, and the **benchmark owner** (other notebook), who keeps the benchmark private. Both upload their assets into the enclave, and nothing runs on them unless **both owners approve the exact code** first.\n\nThe model owner keeps two things private: the model weights, and part of the inference code. That code is a single file with private parts (the model architecture) and public parts (the rest).\n\nFirst the model owner uploads the private model and submits a job that proves the inference code does not steal any data when it runs, using [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict). Then the benchmark owner submits a job that runs the model on their benchmark."
+   "source": [
+    "# Enclave Inference — Gemma 3 — Model Owner\n",
+    "\n",
+    "| Actor | Email | Role |\n",
+    "|-------|-------|------|\n",
+    "| **Enclave** | `ENCLAVE_EMAIL` | Trusted execution environment |\n",
+    "| **Model owner** | (this notebook) | Owns the Gemma 3 model (weights + inference engine) |\n",
+    "| **Benchmark owner** | (separate notebook) | Owns the private benchmark |\n",
+    "| **Researcher** | `RESEARCHER_EMAIL` | Submits inference job for bias/safety evaluation |\n",
+    "\n",
+    "**The setting.** These clients connect to an [enclave](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-enclave) — a sealed environment that runs code on data nobody can see. There are two data owners: the **model owner** (this notebook), who keeps the model private, and the **benchmark owner** (other notebook), who keeps the benchmark private. Both upload their assets into the enclave, and nothing runs on them unless **both owners approve the exact code** first.\n",
+    "\n",
+    "The model owner keeps two things private: the model weights, and part of the inference code. That code is a single file with private parts (the model architecture) and public parts (the rest).\n",
+    "\n",
+    "First the model owner uploads the private model and submits a job that proves the inference code does not steal any data when it runs, using [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict). Then the benchmark owner submits a job that runs the model on their benchmark."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -84,7 +99,11 @@
    "cell_type": "markdown",
    "id": "6",
    "metadata": {},
-   "source": "## Step 0 — Log in as Model Owner\n\nWe log in to the enclave. This client lets us upload data and approve jobs in the enclave."
+   "source": [
+    "## Step 0 — Log in as Model Owner\n",
+    "\n",
+    "We log in to the enclave. This client lets us upload data and approve jobs in the enclave."
+   ]
   },
   {
    "cell_type": "code",
@@ -121,7 +140,11 @@
    "cell_type": "markdown",
    "id": "10",
    "metadata": {},
-   "source": "## Step 1 — Peer with the Enclave\n\nTo make requests to the enclave, we first need to peer with it."
+   "source": [
+    "## Step 1 — Peer with the Enclave\n",
+    "\n",
+    "To make requests to the enclave, we first need to peer with it."
+   ]
   },
   {
    "cell_type": "code",
@@ -172,7 +195,11 @@
    "cell_type": "markdown",
    "id": "15",
    "metadata": {},
-   "source": "### Step 1.2 — Attest the enclave's identity\n\nHere we validate the attestation report. It confirms the standard enclave properties — the hashes of the BIOS, operating system, system processes, and applications — and signs those hashes with a private key that only the enclave holds. It also confirms the exact PySyft version and configuration. This ties the approvals of both the model owner and the benchmark owner to the exact code, inputs, parameters, and output policy. PySyft handles all of this automatically. This signed hash could only be faked if the hardware provider and the model owner colluded."
+   "source": [
+    "### Step 1.2 — Attest the enclave's identity\n",
+    "\n",
+    "Here we validate the attestation report. It confirms the standard enclave properties — the hashes of the BIOS, operating system, system processes, and applications — and signs those hashes with a private key that only the enclave holds. It also confirms the exact PySyft version and configuration. This ties the approvals of both the model owner and the benchmark owner to the exact code, inputs, parameters, and output policy. PySyft handles all of this automatically. This signed hash could only be faked if the hardware provider and the model owner colluded."
+   ]
   },
   {
    "cell_type": "code",
@@ -189,7 +216,11 @@
    "cell_type": "markdown",
    "id": "17",
    "metadata": {},
-   "source": "## Step 2 — Get the Gemma 3 model\n\nWe download the Gemma 3 model. In a real scenario this would come from the model owner's private data."
+   "source": [
+    "## Step 2 — Get the Gemma 3 model\n",
+    "\n",
+    "We download the Gemma 3 model. In a real scenario this would come from the model owner's private data."
+   ]
   },
   {
    "cell_type": "code",
@@ -232,7 +263,11 @@
    "cell_type": "markdown",
    "id": "21",
    "metadata": {},
-   "source": "## Step 3 — Prepare the files for upload\n\nWe bundle what goes into the enclave. The private side is the inference code, the checkpoint weights, and the tokenizer. The public (mock) side is just a model card describing the model."
+   "source": [
+    "## Step 3 — Prepare the files for upload\n",
+    "\n",
+    "We bundle what goes into the enclave. The private side is the inference code, the checkpoint weights, and the tokenizer. The public (mock) side is just a model card describing the model."
+   ]
   },
   {
    "cell_type": "code",
@@ -305,7 +340,11 @@
    "cell_type": "markdown",
    "id": "24",
    "metadata": {},
-   "source": "## Step 4 — Upload the private model\n\nWe upload the private model into the enclave. The inference code comes from [`gemma_inference_restrict.py`](https://github.com/OpenMined/PySyft/blob/dev/notebooks/enclave/gemma/colab/gemma_inference_restrict.py). It is already annotated with private and public regions using comments; when we run syft-restrict on it, it validates the private regions. No one can access this model — it can only be used in jobs that both owners approve."
+   "source": [
+    "## Step 4 — Upload the private model\n",
+    "\n",
+    "We upload the private model into the enclave. The inference code comes from [`gemma_inference_restrict.py`](https://github.com/OpenMined/PySyft/blob/dev/notebooks/enclave/gemma/colab/gemma_inference_restrict.py). It is already annotated with private and public regions using comments; when we run syft-restrict on it, it validates the private regions. No one can access this model — it can only be used in jobs that both owners approve."
+   ]
   },
   {
    "cell_type": "code",
@@ -331,7 +370,14 @@
    "cell_type": "markdown",
    "id": "26",
    "metadata": {},
-   "source": "## Step 5 — Run `syft-restrict` on the inference code\n\nWe submit a job that runs [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) on the inference code. syft-restrict does two things:\n\n1. It creates a readable copy of the code with the private regions hidden.\n2. It analyses the code and makes sure the private code only uses non-dynamic Python that cannot leak the benchmark."
+   "source": [
+    "## Step 5 — Run `syft-restrict` on the inference code\n",
+    "\n",
+    "We submit a job that runs [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) on the inference code. syft-restrict does two things:\n",
+    "\n",
+    "1. It creates a readable copy of the code with the private regions hidden.\n",
+    "2. It analyses the code and makes sure the private code only uses non-dynamic Python that cannot leak the benchmark."
+   ]
   },
   {
    "cell_type": "code",
@@ -419,7 +465,11 @@
    "cell_type": "markdown",
    "id": "29",
    "metadata": {},
-   "source": "### Step 5.1 — Approve the job\n\nWe approve the job. Every job that runs must be approved by both parties."
+   "source": [
+    "### Step 5.1 — Approve the job\n",
+    "\n",
+    "We approve the job. Every job that runs must be approved by both parties."
+   ]
   },
   {
    "cell_type": "code",
@@ -459,7 +509,11 @@
    "cell_type": "markdown",
    "id": "33",
    "metadata": {},
-   "source": "## Step 6 — Approve the final inference job\n\nNow we wait for the benchmark owner to submit the final job that runs the model on the private benchmark. We carefully inspect the code to make sure it only does that, then we approve. The final result is shared with the benchmark owner."
+   "source": [
+    "## Step 6 — Approve the final inference job\n",
+    "\n",
+    "Now we wait for the benchmark owner to submit the final job that runs the model on the private benchmark. We carefully inspect the code to make sure it only does that, then we approve. The final result is shared with the benchmark owner."
+   ]
   },
   {
    "cell_type": "code",
@@ -498,11 +552,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "pysyft-enclave (3.12.8)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/enclave/gemma/colab/2. DO-benchmark-owner-gemma-restrict.ipynb
+++ b/notebooks/enclave/gemma/colab/2. DO-benchmark-owner-gemma-restrict.ipynb
@@ -4,20 +4,7 @@
    "cell_type": "markdown",
    "id": "0",
    "metadata": {},
-   "source": [
-    "# Enclave Inference — Gemma 3 — Benchmark Owner\n",
-    "\n",
-    "| Actor | Email | Role |\n",
-    "|-------|-------|------|\n",
-    "| **Enclave** | `enclave@openmined.org` | Trusted execution environment |\n",
-    "| **Model owner** | `model_owner@openmined.org` | Owns the Gemma 3 model (weights + inference engine) |\n",
-    "| **Benchmark owner** | `benchmark_owner@openmined.org` | Owns AI safety evaluation prompts |\n",
-    "| **Researcher** | `researcher@openmined.org` | Submits inference job for bias/safety evaluation |\n",
-    "\n",
-    "This notebook drives only the Benchmark Owner steps; the Model Owner and Researcher run their own notebooks in parallel.\n",
-    "\n",
-    "The Model Owner's inference engine is private, so you approve a [`syft-restrict`](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) job first and get back a certificate proving the engine only does allow-listed JAX math — your assurance for feeding it the prompts."
-   ]
+   "source": "# Enclave Inference — Gemma 3 — Benchmark Owner\n\n| Actor | Email | Role |\n|-------|-------|------|\n| **Enclave** | `enclave@openmined.org` | Trusted execution environment |\n| **Model owner** | `model_owner@openmined.org` | Owns the Gemma 3 model (weights + inference engine) |\n| **Benchmark owner** | `benchmark_owner@openmined.org` | Owns the private benchmark |\n| **Researcher** | `researcher@openmined.org` | Submits inference job for bias/safety evaluation |\n\n**The setting.** These clients connect to an [enclave](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-enclave) — a sealed environment that runs code on data nobody can see. There are two data owners: the **model owner** (other notebook), who keeps the model private, and the **benchmark owner** (this notebook), who keeps the benchmark private. Both upload their assets into the enclave, and nothing runs on them unless **both owners approve the exact code** first.\n\nThe model owner's inference code is private. So before the model runs on our benchmark, we approve a [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) job and get back a certificate proving the code only does allow-listed math and cannot leak our benchmark — our assurance for letting it run on our prompts."
   },
   {
    "cell_type": "markdown",
@@ -72,9 +59,7 @@
    "cell_type": "markdown",
    "id": "5",
    "metadata": {},
-   "source": [
-    "## Step 0 — Log in as Benchmark Owner"
-   ]
+   "source": "## Step 0 — Log in as Benchmark Owner\n\nWe log in to the enclave. This client lets us upload data and approve jobs in the enclave."
   },
   {
    "cell_type": "code",
@@ -111,9 +96,7 @@
    "cell_type": "markdown",
    "id": "9",
    "metadata": {},
-   "source": [
-    "## Step 1 — Peer with the Enclave"
-   ]
+   "source": "## Step 1 — Peer with the Enclave\n\nTo make requests to the enclave, we first need to peer with it."
   },
   {
    "cell_type": "code",
@@ -164,9 +147,7 @@
    "cell_type": "markdown",
    "id": "14",
    "metadata": {},
-   "source": [
-    "### Step 1.2 — Attest enclave's identity"
-   ]
+   "source": "### Step 1.2 — Attest the enclave's identity\n\nHere we validate the attestation report. It confirms the standard enclave properties — the hashes of the BIOS, operating system, system processes, and applications — and signs those hashes with a private key that only the enclave holds. It also confirms the exact PySyft version and configuration. This ties the approvals of both the model owner and the benchmark owner to the exact code, inputs, parameters, and output policy. PySyft handles all of this automatically. This signed hash could only be faked if the hardware provider and the model owner colluded."
   },
   {
    "cell_type": "code",
@@ -183,11 +164,7 @@
    "cell_type": "markdown",
    "id": "16",
    "metadata": {},
-   "source": [
-    "## Step 2 — Prepare the AI safety prompts\n",
-    "\n",
-    "Benchmark owner contributes evaluation prompts designed to probe bias in model completions. Each prompt is a self-contained question that can reveal stereotypical associations, occupational/name bias, or test safety boundaries."
-   ]
+   "source": "## Step 2 — Prepare the benchmark\n\nWe prepare the benchmark prompts that will later be used to run inference on the model. This is our private data. Uploading it into the enclave does not allow anything on its own — the benchmark is only used once we approve a job that runs against it."
   },
   {
    "cell_type": "code",
@@ -241,11 +218,7 @@
    "cell_type": "markdown",
    "id": "19",
    "metadata": {},
-   "source": [
-    "## Step 3 — Upload safety_prompts\n",
-    "\n",
-    "Mock = first few prompts the researcher can browse; private = full set, shared only with the enclave."
-   ]
+   "source": "## Step 3 — Upload the benchmark\n\nWe upload the benchmark into the enclave. The public (mock) side is a few sample prompts the researcher can browse; the private side is the full set, shared only with the enclave."
   },
   {
    "cell_type": "code",
@@ -271,12 +244,7 @@
    "cell_type": "markdown",
    "id": "21",
    "metadata": {},
-   "source": [
-    "## Step 4 — Approve the `syft-restrict` review job\n",
-    "\n",
-    "The Model Owner submits `restrict_engine_review`. It reads only their engine — you approve because you are the party\n",
-    "relying on the verdict. Re-sync until it appears, then approve."
-   ]
+   "source": "## Step 4 — Review the `syft-restrict` job\n\nThe model owner submits a [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) job on their inference code. We review it carefully. syft-restrict does two things:\n\n1. It creates a readable copy of the code with the private regions hidden.\n2. It analyses the code and makes sure the private code only uses non-dynamic Python that cannot leak our benchmark.\n\nWe approve because we are the party relying on this guarantee."
   },
   {
    "cell_type": "code",
@@ -317,12 +285,7 @@
    "cell_type": "markdown",
    "id": "25",
    "metadata": {},
-   "source": [
-    "### Step 4.1 — Read the certificate\n",
-    "\n",
-    "Once both Data Owners approve, the enclave runs the check and sends you the certificate plus an obfuscated copy of\n",
-    "the engine: signatures visible, bodies blanked. The architecture stays secret."
-   ]
+   "source": "### Step 4.1 — Read the certificate\n\nOnce both owners approve, the enclave runs the check and sends us the certificate plus an obfuscated copy of the code: signatures visible, bodies blanked. The certificate proves the syft-restrict guarantees hold. The architecture stays secret."
   },
   {
    "cell_type": "code",
@@ -346,11 +309,7 @@
    "cell_type": "markdown",
    "id": "27",
    "metadata": {},
-   "source": [
-    "## Step 5 — Wait for the Researcher to submit the job, then approve\n",
-    "\n",
-    "The Researcher submits `safety_eval_job` to the enclave. Re-sync until it appears here, inspect it, then approve."
-   ]
+   "source": "## Step 5 — Approve the inference job\n\nWe approve the inference job that runs the model on our benchmark. Once both owners approve, the inference runs. Then we wait for the result and sync."
   },
   {
    "cell_type": "code",

--- a/notebooks/enclave/gemma/colab/2. DO-benchmark-owner-gemma-restrict.ipynb
+++ b/notebooks/enclave/gemma/colab/2. DO-benchmark-owner-gemma-restrict.ipynb
@@ -4,7 +4,20 @@
    "cell_type": "markdown",
    "id": "0",
    "metadata": {},
-   "source": "# Enclave Inference — Gemma 3 — Benchmark Owner\n\n| Actor | Email | Role |\n|-------|-------|------|\n| **Enclave** | `enclave@openmined.org` | Trusted execution environment |\n| **Model owner** | `model_owner@openmined.org` | Owns the Gemma 3 model (weights + inference engine) |\n| **Benchmark owner** | `benchmark_owner@openmined.org` | Owns the private benchmark |\n| **Researcher** | `researcher@openmined.org` | Submits inference job for bias/safety evaluation |\n\n**The setting.** These clients connect to an [enclave](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-enclave) — a sealed environment that runs code on data nobody can see. There are two data owners: the **model owner** (other notebook), who keeps the model private, and the **benchmark owner** (this notebook), who keeps the benchmark private. Both upload their assets into the enclave, and nothing runs on them unless **both owners approve the exact code** first.\n\nThe model owner's inference code is private. So before the model runs on our benchmark, we approve a [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) job and get back a certificate proving the code only does allow-listed math and cannot leak our benchmark — our assurance for letting it run on our prompts."
+   "source": [
+    "# Enclave Inference — Gemma 3 — Benchmark Owner\n",
+    "\n",
+    "| Actor | Email | Role |\n",
+    "|-------|-------|------|\n",
+    "| **Enclave** | `enclave@openmined.org` | Trusted execution environment |\n",
+    "| **Model owner** | `model_owner@openmined.org` | Owns the Gemma 3 model (weights + inference engine) |\n",
+    "| **Benchmark owner** | `benchmark_owner@openmined.org` | Owns the private benchmark |\n",
+    "| **Researcher** | `researcher@openmined.org` | Submits inference job for bias/safety evaluation |\n",
+    "\n",
+    "**The setting.** These clients connect to an [enclave](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-enclave) — a sealed environment that runs code on data nobody can see. There are two data owners: the **model owner** (other notebook), who keeps the model private, and the **benchmark owner** (this notebook), who keeps the benchmark private. Both upload their assets into the enclave, and nothing runs on them unless **both owners approve the exact code** first.\n",
+    "\n",
+    "The model owner's inference code is private. So before the model runs on our benchmark, we approve a [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) job and get back a certificate proving the code only does allow-listed math and cannot leak our benchmark — our assurance for letting it run on our prompts."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -59,7 +72,11 @@
    "cell_type": "markdown",
    "id": "5",
    "metadata": {},
-   "source": "## Step 0 — Log in as Benchmark Owner\n\nWe log in to the enclave. This client lets us upload data and approve jobs in the enclave."
+   "source": [
+    "## Step 0 — Log in as Benchmark Owner\n",
+    "\n",
+    "We log in to the enclave. This client lets us upload data and approve jobs in the enclave."
+   ]
   },
   {
    "cell_type": "code",
@@ -96,7 +113,11 @@
    "cell_type": "markdown",
    "id": "9",
    "metadata": {},
-   "source": "## Step 1 — Peer with the Enclave\n\nTo make requests to the enclave, we first need to peer with it."
+   "source": [
+    "## Step 1 — Peer with the Enclave\n",
+    "\n",
+    "To make requests to the enclave, we first need to peer with it."
+   ]
   },
   {
    "cell_type": "code",
@@ -147,7 +168,11 @@
    "cell_type": "markdown",
    "id": "14",
    "metadata": {},
-   "source": "### Step 1.2 — Attest the enclave's identity\n\nHere we validate the attestation report. It confirms the standard enclave properties — the hashes of the BIOS, operating system, system processes, and applications — and signs those hashes with a private key that only the enclave holds. It also confirms the exact PySyft version and configuration. This ties the approvals of both the model owner and the benchmark owner to the exact code, inputs, parameters, and output policy. PySyft handles all of this automatically. This signed hash could only be faked if the hardware provider and the model owner colluded."
+   "source": [
+    "### Step 1.2 — Attest the enclave's identity\n",
+    "\n",
+    "Here we validate the attestation report. It confirms the standard enclave properties — the hashes of the BIOS, operating system, system processes, and applications — and signs those hashes with a private key that only the enclave holds. It also confirms the exact PySyft version and configuration. This ties the approvals of both the model owner and the benchmark owner to the exact code, inputs, parameters, and output policy. PySyft handles all of this automatically. This signed hash could only be faked if the hardware provider and the model owner colluded."
+   ]
   },
   {
    "cell_type": "code",
@@ -164,7 +189,11 @@
    "cell_type": "markdown",
    "id": "16",
    "metadata": {},
-   "source": "## Step 2 — Prepare the benchmark\n\nWe prepare the benchmark prompts that will later be used to run inference on the model. This is our private data. Uploading it into the enclave does not allow anything on its own — the benchmark is only used once we approve a job that runs against it."
+   "source": [
+    "## Step 2 — Prepare the benchmark\n",
+    "\n",
+    "We prepare the benchmark prompts that will later be used to run inference on the model. This is our private data. Uploading it into the enclave does not allow anything on its own — the benchmark is only used once we approve a job that runs against it."
+   ]
   },
   {
    "cell_type": "code",
@@ -218,7 +247,11 @@
    "cell_type": "markdown",
    "id": "19",
    "metadata": {},
-   "source": "## Step 3 — Upload the benchmark\n\nWe upload the benchmark into the enclave. The public (mock) side is a few sample prompts the researcher can browse; the private side is the full set, shared only with the enclave."
+   "source": [
+    "## Step 3 — Upload the benchmark\n",
+    "\n",
+    "We upload the benchmark into the enclave. The public (mock) side is a few sample prompts the researcher can browse; the private side is the full set, shared only with the enclave."
+   ]
   },
   {
    "cell_type": "code",
@@ -244,7 +277,16 @@
    "cell_type": "markdown",
    "id": "21",
    "metadata": {},
-   "source": "## Step 4 — Review the `syft-restrict` job\n\nThe model owner submits a [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) job on their inference code. We review it carefully. syft-restrict does two things:\n\n1. It creates a readable copy of the code with the private regions hidden.\n2. It analyses the code and makes sure the private code only uses non-dynamic Python that cannot leak our benchmark.\n\nWe approve because we are the party relying on this guarantee."
+   "source": [
+    "## Step 4 — Review the `syft-restrict` job\n",
+    "\n",
+    "The model owner submits a [syft-restrict](https://github.com/OpenMined/PySyft/tree/dev/packages/syft-restrict) job on their inference code. We review it carefully. syft-restrict does two things:\n",
+    "\n",
+    "1. It creates a readable copy of the code with the private regions hidden.\n",
+    "2. It analyses the code and makes sure the private code only uses non-dynamic Python that cannot leak our benchmark.\n",
+    "\n",
+    "We approve because we are the party relying on this guarantee."
+   ]
   },
   {
    "cell_type": "code",
@@ -285,7 +327,11 @@
    "cell_type": "markdown",
    "id": "25",
    "metadata": {},
-   "source": "### Step 4.1 — Read the certificate\n\nOnce both owners approve, the enclave runs the check and sends us the certificate plus an obfuscated copy of the code: signatures visible, bodies blanked. The certificate proves the syft-restrict guarantees hold. The architecture stays secret."
+   "source": [
+    "### Step 4.1 — Read the certificate\n",
+    "\n",
+    "Once both owners approve, the enclave runs the check and sends us the certificate plus an obfuscated copy of the code: signatures visible, bodies blanked. The certificate proves the syft-restrict guarantees hold. The architecture stays secret."
+   ]
   },
   {
    "cell_type": "code",
@@ -309,7 +355,11 @@
    "cell_type": "markdown",
    "id": "27",
    "metadata": {},
-   "source": "## Step 5 — Approve the inference job\n\nWe approve the inference job that runs the model on our benchmark. Once both owners approve, the inference runs. Then we wait for the result and sync."
+   "source": [
+    "## Step 5 — Approve the inference job\n",
+    "\n",
+    "We approve the inference job that runs the model on our benchmark. Once both owners approve, the inference runs. Then we wait for the result and sync."
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Improves the readability of the two Data Owner notebooks in `notebooks/enclave/gemma/colab` for first-time readers. **Markdown only — no code cells were changed.**

- `1. DO-model-owner-gemma-restrict.ipynb`: added a plain-language "The setting" intro (enclave, both owners, both-must-approve, private/public inference file) and rewrote step descriptions (login, peering, attestation, download model, prepare/upload private model, syft-restrict, approvals).
- `2. DO-benchmark-owner-gemma-restrict.ipynb`: same setting framing from the benchmark owner's side, plus rewritten steps (prepare/upload benchmark, review syft-restrict job, read certificate, approve inference job).
- Added links to the enclave package, syft-restrict, and `gemma_inference_restrict.py`.

Note: per request, the model-owner Step 6 prose says the benchmark owner submits the final job, which differs from the code (which uses `RESEARCHER_EMAIL`).