### PR TITLE
docs: link auth.md from terraform.md token_file row

### DIFF
--- a/packages/syft-enclave/docs/terraform.md
+++ b/packages/syft-enclave/docs/terraform.md
@@ -35,13 +35,13 @@ cp terraform/terraform.tfvars.example terraform/terraform.tfvars
 
 Then fill in:
 
-| Variable        | Meaning                                                                 |
-| --------------- | ----------------------------------------------------------------------- |
-| `project_id`    | GCP project ID (the ID, not the display name — `gcloud projects list`). |
-| `zone`          | Zone for the VM (default `us-central1-a`).                              |
-| `enclave_email` | The enclave datasite's email (`SYFT_ENCLAVE_EMAIL`).                    |
-| `data_owners`   | List of data-owner emails; **all** must approve every job.              |
-| `token_file`    | Absolute path to the enclave's Google Drive token JSON.                 |
+| Variable        | Meaning                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `project_id`    | GCP project ID (the ID, not the display name — `gcloud projects list`).                                      |
+| `zone`          | Zone for the VM (default `us-central1-a`).                                                                   |
+| `enclave_email` | The enclave datasite's email (`SYFT_ENCLAVE_EMAIL`).                                                         |
+| `data_owners`   | List of data-owner emails; **all** must approve every job.                                                   |
+| `token_file`    | Absolute path to the enclave's Google Drive token JSON (see [auth.md](../../../docs/auth.md) to create one). |
 
 Optional overrides (commented in the example file): `vm_name`, `machine_type`, `boot_disk_size_gb`, `container_image`, `use_encryption`, `job_timeout_seconds`.
 


### PR DESCRIPTION
Adds a relative link to `docs/auth.md` from the `token_file` row in the Terraform config table, so operators know how to create the Google Drive token JSON.

- Relative path (`../../../docs/auth.md`) so it works on GitHub and in local editors
- Table realigned by prettier (pre-commit)