### PR TITLE
Base the enclave image on Ubuntu 24.04 LTS

### DIFF
--- a/packages/syft-enclave/docker/Dockerfile
+++ b/packages/syft-enclave/docker/Dockerfile
@@ -1,6 +1,20 @@
-FROM python:3.12-slim
+FROM ubuntu:24.04
 
-RUN pip install uv
+# Ubuntu 24.04 LTS ships Python 3.12 as its system interpreter, which is the
+# version the workspace targets. python3-venv is separate on Debian/Ubuntu and
+# uv needs it to build /repo/.venv; ca-certificates is required for TLS to the
+# package index. uv is installed from its standalone distribution rather than
+# pip, since Ubuntu marks the system interpreter externally managed (PEP 668).
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-venv \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV UV_INSTALL_DIR=/usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && uv --version
 
 # Build context is the monorepo root (set by packages/syft-enclave/Justfile).
 # We install syft-enclave from the workspace so syft-client + its workspace


### PR DESCRIPTION
Moves the enclave container from `python:3.12-slim` (Debian 13 trixie) to **Ubuntu 24.04 LTS**, which ships Python 3.12 as its system interpreter — the version the workspace already targets.

### Changes

```
- FROM python:3.12-slim
+ FROM ubuntu:24.04
```

Two adjustments the base change requires:

- `python3-venv` is packaged separately on Ubuntu, and uv needs it to build `/repo/.venv`.
- uv is installed from its standalone distribution rather than via pip, because Ubuntu marks the system interpreter externally managed (PEP 668).

### Verified

Image builds clean, and reports:

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Python | 3.12.3 |
| uv | 0.12.1 |

`syft_client` (0.1.117), `syft_enclaves`, `fastapi`, `uvicorn` and the attestation server module all import in the built venv.

### Not yet done

The enclave test suite has not been run against this image — flagged for follow-up.

Worth noting separately: both `ubuntu:24.04` and the previous `python:3.12-slim` are floating tags, so rebuilds can pick up a different patch level and change the attested image digest. Pinning the base by digest would make enclave builds reproducible, but that is out of scope here.