### PR TITLE
chore: add a prefetch script to syft-pr-review and nest the tests section

### DIFF
--- a/.claude/skills/syft-pr-review/SKILL.md
+++ b/.claude/skills/syft-pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: syft-pr-review
 description: Write a review document for a syft pull request. Takes a PR number or URL, reads the diff, and produces a checkbox-structured summary of the flows that changed, what was added, each individual change, the tests, and any code-standards problems in the new code. Use when the user says "review PR 1234", "write me a review doc for <PR link>", or "what changed in this PR".
-allowed-tools: Bash(gh:*), Bash(git:*), Bash(cat:*), Bash(sed:*), Bash(grep:*), Bash(rg:*), Bash(mkdir:*), Bash(wc:*), Bash(ls:*), Read, Write, Glob, Grep
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(cat:*), Bash(sed:*), Bash(grep:*), Bash(rg:*), Bash(mkdir:*), Bash(wc:*), Bash(ls:*), Bash(jq:*), Bash(bash:*), Bash(./.claude/skills/syft-pr-review/prefetch.sh:*), Read, Write, Glob, Grep
 ---
 
 # Review a syft PR
@@ -14,36 +14,49 @@ bugs — that is `/code-review`.
 
 A PR number or URL. If none was given, ask for it.
 
-## Step 1 — Load the PR, and find the branch it really builds on
+## Step 1 — Prefetch, in one call
 
 ```bash
-gh pr view <N> --json title,body,author,state,baseRefName,headRefName,additions,deletions,changedFiles
-gh pr view <N> --json files -q '.files[] | "\(.additions)+ \(.deletions)- \(.path)"' | sort -rn
+./.claude/skills/syft-pr-review/prefetch.sh <N>       # writes /tmp/pr-<N>/
 ```
 
-If the description names a base branch other than the GitHub one, check whether it is merged yet:
-`git merge-base --is-ancestor origin/<named-base> origin/<default>`. If it is not, its commits land
-with this PR, so review those too — do not shrink the document to the author's own commits. Say so
-in one sentence at the top and tag each item with the branch it came from. The author's own commits:
+It prints an index and writes:
 
-```bash
-git log --oneline --no-merges origin/<head> ^origin/<default> ^origin/<named-base>
-```
+| file                  | what is in it                                                       |
+| --------------------- | ------------------------------------------------------------------- |
+| `meta.json`           | title, body, author, state, base, head, +/-, file count             |
+| `body.md`             | the description, to check its claims against the diff               |
+| `files.txt`           | every changed path with its +/-, largest first                      |
+| `files-skippable.txt` | lock files, notebooks and generated data — count these, do not read |
+| `commits.txt`         | non-merge commits on the head branch that are not in the base       |
+| `merges.txt`          | merge commits in that same range                                    |
+| `base-check.txt`      | every branch named in the body, and whether it has landed yet       |
+| `full.diff`           | the whole diff                                                      |
+| `diff-index.txt`      | `path<TAB>per-file diff`; `cat` the chunk you want                  |
+| `new-symbols.txt`     | every `def`/`class` the diff adds, with its line number on the head |
+| `new-tests.txt`       | every test function and class the diff adds                         |
+
+Read `base-check.txt` first. A branch marked NOT-MERGED is a base that has not landed, so its
+commits land with this PR and belong in the document — say so in one sentence at the top and tag
+each item with the branch it came from. `commits.txt` is the author's own work.
+
+`new-symbols.txt` is a candidate list, not the answer: it also catches a nested function and a
+pre-existing `def` whose signature changed. Confirm each one is really new before you call it new.
+
+**Keep the script in step with this file.** If a step below needs something `/tmp/pr-<N>/` does not
+hold — because the skill changed, or because this PR has a shape the script does not cover — add it
+to `prefetch.sh` and re-run, rather than running the command by hand. The point of the script is
+that one call answers the whole of steps 1 and 2.
 
 ## Step 2 — Read the diff, not the description
 
-```bash
-gh pr diff <N> > /tmp/pr-<N>.diff
-grep -n '^diff --git' /tmp/pr-<N>.diff    # file boundaries; read the chunks with sed
-```
-
-Read source files first, then the places that call them — that is where the flows are. For tests,
-read the name and what it asserts, not the whole body. Count and skip lock files, generated data,
-fixtures and reformatting, and say what you skipped. Open the changed file from the repo when a diff
-chunk alone is not enough to describe something correctly.
+`cat` the per-file chunks from `diff-index.txt`, source files first, then the places that call them
+— that is where the flows are. For tests, read the name and what it asserts, not the whole body.
+Say what you skipped, with counts, using `files-skippable.txt`. Open the changed file from the repo
+when a diff chunk alone is not enough to describe something correctly.
 
 Check before you write: whether a name is a method or a plain function, whether a folder is really a
-package, and whether each claim in the PR description is still true.
+package, and whether each claim in `body.md` is still true.
 
 ## Step 3 — Write it
 
@@ -87,9 +100,11 @@ Flows come first, because they are why the reader opened the document.
 
 - [ ] **4. Tests**
 
-  - [ ] **NEW `path/test_file.py`** — <n> tests: `test_a()` <what it checks>, `test_b()`
-        <what it checks>.
-  - [ ] **REWRITTEN `test_c()`** — now asserts <X> instead of <Y>, because <reason>.
+  - [ ] **NEW `path/test_file.py`** — <n> tests<, and how they are set up, when it is worth a clause>
+    - [ ] `test_a()` — <what it checks>
+    - [ ] `test_b()` — <what it checks>
+  - [ ] **REWRITTEN `test_c()`** — `path/test_file.py` — now asserts <X> instead of <Y>, because
+        <reason>.
   - [ ] **UPDATED for the new code** — <n> tests across <n> files follow the new
         `Class.method()` signature. Nothing is asserted differently.
   - [ ] Decision: <only when a test settles something a reader would otherwise wonder about>
@@ -121,16 +136,22 @@ line, and write nothing when there is nothing wrong. Look for:
 ## Rules
 
 - [ ] **Every bullet is a checkbox**, at every depth.
+- [ ] **Scannable, not prose.** Keep a bullet to two or three lines. When a bullet reaches for a
+      semicolon to join items, or repeats the same shape three times over, those items are separate
+      child bullets. The reader is looking for one thing, not reading front to back.
 - [ ] **Length follows the code.** A ten-line class gets a few words, not five bullets. Group small
       related additions under one bullet. Give something its own top-level bullet only when a reader
       needs it on its own.
 - [ ] **Say it once.** Section 2 describes code that was added. Section 3 covers what behaviour
       changed and what was deleted, and refers to new code by name rather than describing it again.
       Tests belong only in section 4.
-- [ ] **Tests, in proportion.** One sentence per new test, saying what it checks. Collapse tests
-      that only follow the new code — a changed call, a rebuilt fixture — into a single bullet with
-      a count, since nothing is asserted differently. Give a line to a test whose meaning actually
-      changed, and say why. Do not walk through test bodies.
+- [ ] **One test, one bullet, nested under its file.** Never a single bullet that lists several
+      tests separated by semicolons — a reader scans that list for one name and has to read a
+      paragraph instead. The file gets the parent bullet with the count; each test gets a child
+      bullet of `` `test_name()` — what it checks``, one sentence. Do not walk through test bodies.
+- [ ] **Tests, in proportion.** Collapse tests that only follow the new code — a changed call, a
+      rebuilt fixture — into a single bullet with a count, since nothing is asserted differently.
+      Give a bullet of its own to a test whose meaning actually changed, and say why.
 - [ ] **Standards: new code only.** Flag a standards problem only in lines this PR touched, and
       only when there is one. Never audit the surrounding code.
 - [ ] **No question list.** A reviewer can ask their own questions, so do not collect them. Only

--- a/.claude/skills/syft-pr-review/prefetch.sh
+++ b/.claude/skills/syft-pr-review/prefetch.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Gather everything the syft-pr-review skill reads, in one call.
+#
+# Usage: .claude/skills/syft-pr-review/prefetch.sh <pr-number> [outdir]
+#        outdir defaults to /tmp/pr-<pr-number>
+#
+# Writes to outdir and prints an index. Read-only with respect to the working
+# tree: it fetches refs and reads files out of them with `git show` / `git grep`,
+# so it never checks anything out and never needs the PR branch checked out.
+#
+# Keep this in step with SKILL.md. When the skill asks for something this does
+# not gather, add it here rather than running the command by hand.
+
+set -euo pipefail
+
+PR="${1:?usage: prefetch.sh <pr-number> [outdir]}"
+OUT="${2:-/tmp/pr-$PR}"
+
+rm -rf "$OUT/diff"
+mkdir -p "$OUT/diff"
+
+# ---------------------------------------------------------------- metadata ---
+gh pr view "$PR" \
+  --json title,body,author,state,baseRefName,headRefName,additions,deletions,changedFiles,url,isDraft,mergeable \
+  >"$OUT/meta.json"
+
+jq -r '.body // ""' "$OUT/meta.json" >"$OUT/body.md"
+
+HEAD_REF=$(jq -r .headRefName "$OUT/meta.json")
+BASE_REF=$(jq -r .baseRefName "$OUT/meta.json")
+DEFAULT_REF=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+
+# ------------------------------------------------------------------- files ---
+gh pr view "$PR" --json files \
+  -q '.files[] | "\(.additions)+ \(.deletions)- \(.path)"' \
+  | sort -rn >"$OUT/files.txt"
+
+# Lock files, notebooks and generated data are counted and skipped, not read.
+grep -E '(\.lock|lock\.json|\.ipynb|\.min\.(js|css)|\.svg|\.png|\.csv|\.parquet)$' \
+  "$OUT/files.txt" >"$OUT/files-skippable.txt" || true
+
+# ----------------------------------------------------------------- history ---
+git fetch -q origin "$HEAD_REF" "$BASE_REF" "$DEFAULT_REF" 2>/dev/null || true
+
+git log --oneline --no-merges "origin/$HEAD_REF" "^origin/$BASE_REF" >"$OUT/commits.txt"
+git log --oneline --merges "origin/$HEAD_REF" "^origin/$BASE_REF" >"$OUT/merges.txt"
+
+# Step 1 of the skill: does the description name a base branch that has not
+# landed yet? Every local branch named in the body is tested for ancestry, so
+# an unmerged base shows up as NOT-MERGED and its commits land with this PR.
+{
+  echo "head=$HEAD_REF base=$BASE_REF repo-default=$DEFAULT_REF"
+  for ref in $(grep -oE '\b[a-z0-9._-]+/[a-z0-9._/-]+\b' "$OUT/body.md" 2>/dev/null | sort -u); do
+    git rev-parse --verify -q "origin/$ref" >/dev/null 2>&1 || continue
+    if git merge-base --is-ancestor "origin/$ref" "origin/$DEFAULT_REF"; then
+      echo "named-base $ref MERGED into $DEFAULT_REF"
+    else
+      echo "named-base $ref NOT-MERGED into $DEFAULT_REF — its commits land with this PR"
+    fi
+  done
+} >"$OUT/base-check.txt"
+
+# -------------------------------------------------------------------- diff ---
+gh pr diff "$PR" >"$OUT/full.diff"
+
+# One file per changed path, so a chunk is `cat`-ed instead of hunted for with
+# `grep -n '^diff --git'` and `sed -n`.
+awk -v dir="$OUT/diff" '
+  /^diff --git / {
+    n++
+    path = $4
+    sub(/^b\//, "", path)
+    flat = path
+    gsub(/\//, "__", flat)
+    out = sprintf("%s/%03d_%s.diff", dir, n, flat)
+    print path "\t" out > (dir "/../diff-index.txt")
+  }
+  n { print > out }
+' "$OUT/full.diff"
+
+# --------------------------------------------------------- new definitions ---
+# Every def/class the diff adds, with its real line number on the PR head, so
+# `path/file.py:<line>` can be cited without a second pass per symbol.
+: >"$OUT/new-symbols.txt"
+while IFS=$'\t' read -r path chunk; do
+  case "$path" in *.py) ;; *) continue ;; esac
+  names=$(grep -hoE '^\+[[:space:]]*(async def|def|class)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' \
+    "$chunk" | awk '{print $NF}' | sort -u || true)
+  for name in $names; do
+    # No \b: git grep's ERE does not support it. A def is followed by "(",
+    # a class by "(" or ":", which is boundary enough to not match a prefix.
+    git grep -nE "^[[:space:]]*(async def|def|class)[[:space:]]+${name}[[:space:]]*[(:]" \
+      "origin/$HEAD_REF" -- "$path" 2>/dev/null \
+      | sed "s|^origin/$HEAD_REF:|  |" >>"$OUT/new-symbols.txt" || true
+  done
+done <"$OUT/diff-index.txt"
+sort -u -o "$OUT/new-symbols.txt" "$OUT/new-symbols.txt"
+
+# ------------------------------------------------------------------- tests ---
+# Test functions the diff adds, per file, so section 4 gets one bullet each
+# without re-reading the diff.
+grep -hE '^\+[[:space:]]*(async )?def test_|^\+class Test' "$OUT/full.diff" \
+  | sed -E 's/^\+[[:space:]]*//' >"$OUT/new-tests.txt" || true
+
+# ------------------------------------------------------------------- index ---
+cat <<SUMMARY
+prefetch for PR $PR -> $OUT
+
+  meta.json             $(jq -r '"\(.title)  [\(.state)] \(.author.login)  \(.headRefName) -> \(.baseRefName)  +\(.additions)/-\(.deletions) across \(.changedFiles) files"' "$OUT/meta.json")
+  body.md               PR description, to check its claims against the diff
+  files.txt             $(wc -l <"$OUT/files.txt" | tr -d ' ') changed files, largest first
+  files-skippable.txt   $(wc -l <"$OUT/files-skippable.txt" | tr -d ' ') lock/generated/notebook files — count them, do not read them
+  commits.txt           $(wc -l <"$OUT/commits.txt" | tr -d ' ') non-merge commits on $HEAD_REF not in $BASE_REF
+  merges.txt            $(wc -l <"$OUT/merges.txt" | tr -d ' ') merge commits in the same range
+  base-check.txt        $(sed -n '2,$p' "$OUT/base-check.txt" | wc -l | tr -d ' ') branch(es) named in the body, with ancestry
+  full.diff             $(wc -l <"$OUT/full.diff" | tr -d ' ') lines
+  diff-index.txt        path -> per-file diff, $(wc -l <"$OUT/diff-index.txt" | tr -d ' ') entries; cat the chunk you need
+  new-symbols.txt       $(wc -l <"$OUT/new-symbols.txt" | tr -d ' ') added def/class, with line numbers on $HEAD_REF
+  new-tests.txt         $(wc -l <"$OUT/new-tests.txt" | tr -d ' ') added test functions/classes
+
+$(cat "$OUT/base-check.txt")
+SUMMARY


### PR DESCRIPTION
## Summary

Two changes to the `syft-pr-review` skill.

## Changes

- **`prefetch.sh`** — one call gathers everything steps 1 and 2 read: PR metadata, the description, the changed-file list, the commit range, a base-branch ancestry check, the full diff **split one file per changed path**, the line number of every `def`/`class` the diff adds, and every added test. Reviewing PR 9497 (24 files, +958) previously took ~15 sequential tool calls, most of them one lookup each; the shell time was under 10s, so the cost was round-trips, not commands.
- **`SKILL.md`** — steps 1 and 2 now drive off the script, and the skill says to extend `prefetch.sh` when a step needs something it does not gather, rather than running the command by hand, so the two stay in step.
- **Section 4 format** — one bullet per test, nested under its file, plus a general scannability rule. It was producing a single bullet that joined eight tests with semicolons, which a reader has to read as a paragraph to find one name in.

## Testing

Ran `prefetch.sh 9497` end to end: 4.7s, 24 per-file diffs, 31 added definitions with line numbers, 19 added tests. `pre-commit` passes on both files.