### PR TITLE
ci: report README badge status from dev

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@ name: 'PR: Unit Tests'
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, dev]
 
   workflow_call:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 > **`syft` 0.10+ is the successor of `syft-client`.** `syft` is the sync engine (`import syft as sy`); datasets and jobs live in `syft-rds` (`from syft_rds import login_do, login_ds`). If you depend on the legacy PySyft ≤0.9 API, pin `syft<0.10`.
 
-[![Unit Tests](https://github.com/OpenMined/pysyft/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/OpenMined/PySyft/actions/workflows/unit-tests.yml)
-[![Integration Tests](https://github.com/OpenMined/pysyft/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/OpenMined/pysyft/actions/workflows/integration-tests.yml)
+[![Unit Tests](https://github.com/OpenMined/pysyft/actions/workflows/unit-tests.yml/badge.svg?branch=dev)](https://github.com/OpenMined/PySyft/actions/workflows/unit-tests.yml?query=branch%3Adev)
+[![Integration Tests](https://github.com/OpenMined/pysyft/actions/workflows/integration-tests.yml/badge.svg?branch=dev)](https://github.com/OpenMined/pysyft/actions/workflows/integration-tests.yml?query=branch%3Adev)
 [![PyPI](https://img.shields.io/pypi/v/syft)](https://pypi.org/project/syft/)
 [![Python 3.10+](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FOpenMined%2Fpysyft%2Fdev%2Fpyproject.toml)](https://github.com/OpenMined/pysyft)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/OpenMined/pysyft/blob/main/pyproject.toml)


### PR DESCRIPTION
## Problem

The **Unit Tests** badge in the README was red, but not because dev is broken. `unit-tests.yml` only triggers on `pull_request` and `push: [main]`, so it has **never** run on dev. A badge with no `?branch=` falls back to the workflow's latest run, which happened to be a failing PR branch (`pjwerneck/restrict-allowed-audit`, missing `jax`). Dev's unit tests pass locally — 218 passed for `just test-unit-restrict`.

## Change

- `unit-tests.yml`: `branches: [main]` → `branches: [main, dev]`, so merges to dev produce a dev-branch run for the badge to point at.
- `README.md`: both workflow badges get `?branch=dev`, and the links go to `?query=branch%3Adev` so clicking through shows only dev runs.

PR runs are unaffected — the `pull_request:` trigger is untouched, and `push` only fires when something lands on dev.

## Notes

- The **Integration Tests** badge needed no trigger change; the nightly cron is already attributed to dev. It will keep showing red until the three failing GDrive integration tests on dev are fixed (`test_do_cache_aware_sync_gdrive`, `test_pagination_and_early_termination`, `test_google_drive_connection_load_state`) — that is a genuine dev failure, not badge noise.
- The **Unit Tests** badge will read "no status" until the first push to dev after this merges, then go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)